### PR TITLE
Runtime validation for critical external payloads

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -96,6 +96,22 @@ export {
   isSocketProtocolCompatible,
 } from "./version.js";
 
+// Runtime payload guards for critical external boundaries
+export {
+  parseViewerEventEnvelope,
+  parseViewerConnectedEnvelope,
+  parseHubStateSnapshot,
+  parseHubMetaEvent,
+  parseMetaRelayEvent,
+  parseSpawnResponse,
+  normalizeSessionMetaState,
+} from "./payload-guards.js";
+export type {
+  ViewerEventEnvelope,
+  ViewerConnectedEnvelope,
+  SpawnResponse,
+} from "./payload-guards.js";
+
 // /runners namespace (Browser runner feed)
 export type {
   RunnersClientToServerEvents,

--- a/packages/protocol/src/payload-guards.test.ts
+++ b/packages/protocol/src/payload-guards.test.ts
@@ -86,6 +86,28 @@ describe("parseViewerConnectedEnvelope", () => {
     expect(result.value).toEqual(input);
   });
 
+  test("omits sessionName key when field is absent", () => {
+    const result = parseViewerConnectedEnvelope({ sessionId: "sess-1" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.prototype.hasOwnProperty.call(result.value, "sessionName")).toBe(false);
+  });
+
+  test("preserves explicit null sessionName as a clear signal", () => {
+    const result = parseViewerConnectedEnvelope({ sessionId: "sess-1", sessionName: null });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.prototype.hasOwnProperty.call(result.value, "sessionName")).toBe(true);
+    expect(result.value.sessionName).toBeNull();
+  });
+
+  test("preserves explicit string sessionName", () => {
+    const result = parseViewerConnectedEnvelope({ sessionId: "sess-1", sessionName: "My session" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sessionName).toBe("My session");
+  });
+
   const malformed = [
     { label: "primitive", value: 123, expectOk: false },
     { label: "missing sessionId", value: { lastSeq: 1 }, expectOk: false },

--- a/packages/protocol/src/payload-guards.test.ts
+++ b/packages/protocol/src/payload-guards.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseViewerEventEnvelope,
+  parseViewerConnectedEnvelope,
+  parseHubStateSnapshot,
+  parseHubMetaEvent,
+  parseMetaRelayEvent,
+  parseSpawnResponse,
+  normalizeSessionMetaState,
+  type ViewerEventEnvelope,
+  type ViewerConnectedEnvelope,
+  type SpawnResponse,
+} from "./payload-guards.js";
+
+// ============================================================================
+// Table-driven runtime decoder tests
+// ============================================================================
+
+describe("parseViewerEventEnvelope", () => {
+  test("accepts valid minimal envelope", () => {
+    const result = parseViewerEventEnvelope({ event: { type: "heartbeat" } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.event).toEqual({ type: "heartbeat" });
+    expect(result.value.seq).toBeUndefined();
+    expect(result.value.generation).toBeUndefined();
+  });
+
+  test("accepts full envelope", () => {
+    const input: ViewerEventEnvelope = {
+      event: { type: "message_update", content: "hi" },
+      seq: 42,
+      replay: true,
+      deltaReplay: true,
+      generation: 7,
+    };
+    const result = parseViewerEventEnvelope(input);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(input);
+  });
+
+  const malformed = [
+    { label: "null", value: null, expectOk: false },
+    { label: "string", value: "bad", expectOk: false },
+    { label: "missing event", value: { seq: 1 }, expectOk: false },
+    { label: "seq is string", value: { event: {}, seq: "42" }, expectOk: true, expectUndefined: "seq" },
+    { label: "generation is string", value: { event: {}, generation: "1" }, expectOk: true, expectUndefined: "generation" },
+  ];
+
+  for (const { label, value, expectOk, expectUndefined } of malformed) {
+    test(`handles ${label}`, () => {
+      const result = parseViewerEventEnvelope(value);
+      expect(result.ok).toBe(expectOk);
+      if (expectOk && result.ok && expectUndefined) {
+        expect(result.value[expectUndefined as keyof ViewerEventEnvelope]).toBeUndefined();
+      }
+      if (!result.ok) expect(result.error).toMatch(/viewer event envelope/);
+    });
+  }
+});
+
+describe("parseViewerConnectedEnvelope", () => {
+  test("accepts minimal connected envelope", () => {
+    const result = parseViewerConnectedEnvelope({ sessionId: "sess-1" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sessionId).toBe("sess-1");
+    expect(result.value.meta_source).toBeUndefined();
+  });
+
+  test("accepts full envelope", () => {
+    const input: ViewerConnectedEnvelope = {
+      sessionId: "sess-2",
+      lastSeq: 10,
+      replayOnly: true,
+      isActive: false,
+      lastHeartbeatAt: null,
+      sessionName: "My session",
+      meta_source: "hub",
+      generation: 3,
+    };
+    const result = parseViewerConnectedEnvelope(input);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(input);
+  });
+
+  const malformed = [
+    { label: "primitive", value: 123, expectOk: false },
+    { label: "missing sessionId", value: { lastSeq: 1 }, expectOk: false },
+    { label: "empty sessionId", value: { sessionId: "" }, expectOk: false },
+    { label: "meta_source not hub", value: { sessionId: "s", meta_source: "other" }, expectOk: true },
+    { label: "generation string", value: { sessionId: "s", generation: "2" }, expectOk: true },
+  ];
+
+  for (const { label, value, expectOk } of malformed) {
+    test(`handles ${label}`, () => {
+      const result = parseViewerConnectedEnvelope(value);
+      expect(result.ok).toBe(expectOk);
+      if (!result.ok) expect(result.error).toMatch(/viewer connected envelope/);
+    });
+  }
+});
+
+describe("normalizeSessionMetaState", () => {
+  test("returns null for non-object", () => {
+    expect(normalizeSessionMetaState(null)).toBeNull();
+    expect(normalizeSessionMetaState("bad")).toBeNull();
+  });
+
+  test("returns null when version is missing", () => {
+    expect(normalizeSessionMetaState({})).toBeNull();
+  });
+
+  test("normalizes a valid full state", () => {
+    const state = {
+      version: 5,
+      todoList: [{ id: 1, text: "t", status: "pending" }],
+      pendingQuestion: {
+        toolCallId: "tc1",
+        questions: [{ question: "Q?", options: ["a", "b"], type: "radio" }],
+      },
+      pendingPlan: { toolCallId: "tc2", title: "Plan", steps: [{ title: "Step" }] },
+      planModeEnabled: true,
+      isCompacting: true,
+      retryState: { errorMessage: "e", detectedAt: 1 },
+      pendingPluginTrust: { promptId: "p1", pluginNames: ["x"], pluginSummaries: ["s"] },
+      mcpStartupReport: { slow: true, ts: 123 },
+      tokenUsage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0.1 },
+      providerUsage: { anthropic: { tokens: 1 } },
+      thinkingLevel: "high",
+      authSource: "oauth",
+      model: { provider: "a", id: "m", name: "M" },
+      goal: { id: "g1", description: "G", status: "active", turnCount: 1, tokenSpend: 0, costSpend: 0 },
+    };
+    const result = normalizeSessionMetaState(state);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.version).toBe(5);
+    expect(result.todoList).toHaveLength(1);
+    expect(result.pendingQuestion?.toolCallId).toBe("tc1");
+    expect(result.pendingPlan?.title).toBe("Plan");
+    expect(result.planModeEnabled).toBe(true);
+    expect(result.isCompacting).toBe(true);
+    expect(result.retryState?.errorMessage).toBe("e");
+    expect(result.pendingPluginTrust?.promptId).toBe("p1");
+    expect(result.mcpStartupReport).toEqual({ slow: true, ts: 123 });
+    expect(result.tokenUsage?.cost).toBe(0.1);
+    expect(result.providerUsage).toEqual({ anthropic: { tokens: 1 } });
+    expect(result.thinkingLevel).toBe("high");
+    expect(result.authSource).toBe("oauth");
+    expect(result.model?.id).toBe("m");
+    expect(result.goal?.status).toBe("active");
+  });
+
+  test("replaces invalid fields with safe defaults instead of crashing", () => {
+    const state = {
+      version: 1,
+      todoList: "not-an-array",
+      pendingQuestion: "bad",
+      pendingPlan: 123,
+      planModeEnabled: "yes",
+      isCompacting: "no",
+      retryState: "oops",
+      pendingPluginTrust: null,
+      mcpStartupReport: null,
+      tokenUsage: "nope",
+      providerUsage: [],
+      thinkingLevel: 42,
+      authSource: 42,
+      model: "none",
+      goal: "none",
+    };
+    const result = normalizeSessionMetaState(state);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.todoList).toEqual([]);
+    expect(result.pendingQuestion).toBeNull();
+    expect(result.pendingPlan).toBeNull();
+    expect(result.planModeEnabled).toBe(false);
+    expect(result.isCompacting).toBe(false);
+    expect(result.retryState).toBeNull();
+    expect(result.tokenUsage).toBeNull();
+    expect(result.providerUsage).toBeNull();
+    expect(result.thinkingLevel).toBeNull();
+    expect(result.authSource).toBeNull();
+    expect(result.model).toBeNull();
+    expect(result.goal).toBeNull();
+  });
+
+  test("preserves legacy modelId field", () => {
+    const result = normalizeSessionMetaState({
+      version: 1,
+      model: { provider: "a", modelId: "legacy-model" },
+    });
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.model?.id).toBe("legacy-model");
+  });
+});
+
+describe("parseHubStateSnapshot", () => {
+  test("accepts valid snapshot", () => {
+    const result = parseHubStateSnapshot({ sessionId: "s1", state: { version: 1 } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sessionId).toBe("s1");
+    expect(result.value.state.version).toBe(1);
+  });
+
+  const malformed = [
+    { label: "non-object", value: "bad" },
+    { label: "missing sessionId", value: { state: { version: 1 } } },
+    { label: "missing state", value: { sessionId: "s1" } },
+    { label: "state missing version", value: { sessionId: "s1", state: {} } },
+  ];
+
+  for (const { label, value } of malformed) {
+    test(`rejects ${label}`, () => {
+      const result = parseHubStateSnapshot(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/hub state snapshot/);
+    });
+  }
+});
+
+describe("parseMetaRelayEvent", () => {
+  test("accepts all known event types with required fields", () => {
+    const cases: Array<{ input: Record<string, unknown>; check: (ev: ReturnType<typeof parseMetaRelayEvent>) => void }> = [
+      { input: { type: "todo_updated", todoList: [] }, check: (ev) => expect(ev?.type).toBe("todo_updated") },
+      { input: { type: "question_pending", question: { toolCallId: "tc", questions: [{ question: "Q", options: [] }] } }, check: (ev) => expect(ev?.type).toBe("question_pending") },
+      { input: { type: "question_cleared", toolCallId: "tc" }, check: (ev) => expect(ev?.type).toBe("question_cleared") },
+      { input: { type: "plan_pending", plan: { toolCallId: "tc", title: "T" } }, check: (ev) => expect(ev?.type).toBe("plan_pending") },
+      { input: { type: "plan_cleared", toolCallId: "tc" }, check: (ev) => expect(ev?.type).toBe("plan_cleared") },
+      { input: { type: "plan_mode_toggled", enabled: true }, check: (ev) => expect(ev?.type).toBe("plan_mode_toggled") },
+      { input: { type: "compact_started" }, check: (ev) => expect(ev?.type).toBe("compact_started") },
+      { input: { type: "retry_state_changed", state: null }, check: (ev) => expect(ev?.type).toBe("retry_state_changed") },
+      { input: { type: "retry_state_changed", state: { errorMessage: "e", detectedAt: 1 } }, check: (ev) => expect((ev as any).state?.errorMessage).toBe("e") },
+      { input: { type: "plugin_trust_required", prompt: { promptId: "p", pluginNames: ["x"] } }, check: (ev) => expect(ev?.type).toBe("plugin_trust_required") },
+      { input: { type: "plugin_trust_resolved", promptId: "p" }, check: (ev) => expect(ev?.type).toBe("plugin_trust_resolved") },
+      { input: { type: "mcp_startup_report", report: { slow: true }, ts: 1 }, check: (ev) => expect(ev?.type).toBe("mcp_startup_report") },
+      { input: { type: "token_usage_updated", tokenUsage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 }, providerUsage: {} }, check: (ev) => expect(ev?.type).toBe("token_usage_updated") },
+      { input: { type: "thinking_level_changed", level: null }, check: (ev) => expect(ev?.type).toBe("thinking_level_changed") },
+      { input: { type: "auth_source_changed", source: null }, check: (ev) => expect(ev?.type).toBe("auth_source_changed") },
+      { input: { type: "model_changed", model: null }, check: (ev) => expect(ev?.type).toBe("model_changed") },
+      { input: { type: "goal_updated", goal: null }, check: (ev) => expect(ev?.type).toBe("goal_updated") },
+    ];
+
+    for (const { input, check } of cases) {
+      const ev = parseMetaRelayEvent(input);
+      expect(ev).not.toBeNull();
+      check(ev);
+    }
+  });
+
+  test("rejects events with missing required fields", () => {
+    const missing = [
+      { type: "todo_updated" },
+      { type: "question_pending" },
+      { type: "question_cleared" },
+      { type: "plan_pending", plan: { title: "T" } },
+      { type: "plan_mode_toggled" },
+      { type: "plugin_trust_resolved" },
+      { type: "token_usage_updated", tokenUsage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 } },
+      { type: "mcp_startup_report", report: { slow: true } },
+      { type: "model_changed", model: { name: "M" } },
+      { type: "goal_updated", goal: { id: "g" } },
+    ];
+
+    for (const input of missing) {
+      expect(parseMetaRelayEvent(input)).toBeNull();
+    }
+  });
+
+  test("rejects unknown discriminator", () => {
+    expect(parseMetaRelayEvent({ type: "not_real" })).toBeNull();
+  });
+
+  test("rejects legacy flat mcp_startup_report on the meta path", () => {
+    // Legacy CLI emits slow/errors/ts on the event root. It must still reach
+    // relay viewers, but it is intentionally not a valid hub meta event.
+    const legacy = { type: "mcp_startup_report", slow: true, ts: 123 };
+    expect(parseMetaRelayEvent(legacy)).toBeNull();
+  });
+});
+
+describe("parseHubMetaEvent", () => {
+  test("accepts valid meta event envelope", () => {
+    const result = parseHubMetaEvent({
+      sessionId: "s1",
+      version: 2,
+      type: "todo_updated",
+      todoList: [],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sessionId).toBe("s1");
+    expect(result.value.version).toBe(2);
+    expect(result.value.event.type).toBe("todo_updated");
+  });
+
+  const malformed = [
+    { label: "non-object", value: "bad" },
+    { label: "missing sessionId", value: { version: 1, type: "todo_updated", todoList: [] } },
+    { label: "missing version", value: { sessionId: "s1", type: "todo_updated", todoList: [] } },
+    { label: "invalid payload", value: { sessionId: "s1", version: 1, type: "todo_updated" } },
+  ];
+
+  for (const { label, value } of malformed) {
+    test(`rejects ${label}`, () => {
+      const result = parseHubMetaEvent(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/hub meta event/);
+    });
+  }
+});
+
+describe("parseSpawnResponse", () => {
+  test("accepts valid response", () => {
+    const input: SpawnResponse & { ok: true } = {
+      ok: true,
+      runnerId: "r1",
+      sessionId: "s1",
+      pending: true,
+    };
+    const result = parseSpawnResponse(input);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({ runnerId: "r1", sessionId: "s1", pending: true });
+  });
+
+  test("accepts response without pending", () => {
+    const result = parseSpawnResponse({ ok: true, runnerId: "r1", sessionId: "s1" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pending).toBeUndefined();
+  });
+
+  const malformed = [
+    { label: "non-object", value: "bad" },
+    { label: "ok false", value: { ok: false, runnerId: "r1", sessionId: "s1" } },
+    { label: "missing ok", value: { runnerId: "r1", sessionId: "s1" } },
+    { label: "missing runnerId", value: { ok: true, sessionId: "s1" } },
+    { label: "missing sessionId", value: { ok: true, runnerId: "r1" } },
+    { label: "sessionId not string", value: { ok: true, runnerId: "r1", sessionId: 123 } },
+  ];
+
+  for (const { label, value } of malformed) {
+    test(`rejects ${label}`, () => {
+      const result = parseSpawnResponse(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/spawn response/);
+    });
+  }
+});

--- a/packages/protocol/src/payload-guards.ts
+++ b/packages/protocol/src/payload-guards.ts
@@ -1,0 +1,436 @@
+// ============================================================================
+// payload-guards.ts — Minimal runtime decoders for critical external payloads
+//
+// Hand-written, dependency-free guards that validate shape at the first trusted
+// boundary (viewer sockets, hub meta sockets, and the runner spawn HTTP API).
+// They return typed data on success and a plain-text error on failure.
+//
+// Scope is intentionally narrow: these guards check the envelope and required
+// fields for the three boundaries called out in the security/reliability review.
+// They do NOT attempt to validate every internal relay event object.
+// ============================================================================
+
+import {
+  defaultMetaState,
+  META_RELAY_EVENT_TYPES,
+  type MetaGoalStatus,
+  type MetaMcpReport,
+  type MetaModelInfo,
+  type MetaPendingPlan,
+  type MetaPendingQuestion,
+  type MetaPluginTrustPrompt,
+  type MetaProviderUsage,
+  type MetaRelayEvent,
+  type MetaRetryState,
+  type MetaTokenUsage,
+  type SessionMetaState,
+} from "./meta.js";
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return value === true ? true : undefined;
+}
+
+function optionalStringOrNull(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "string") return value;
+  return undefined;
+}
+
+function normalizeModel(value: unknown): MetaModelInfo | null {
+  if (!isPlainObject(value)) return null;
+  const provider = typeof value.provider === "string" ? value.provider.trim() : "";
+  const id =
+    (typeof value.id === "string" ? value.id.trim() : "") ||
+    (typeof value.modelId === "string" ? value.modelId.trim() : "");
+  if (!provider || !id) return null;
+  return {
+    provider,
+    id,
+    name: typeof value.name === "string" ? value.name : undefined,
+    reasoning: typeof value.reasoning === "boolean" ? value.reasoning : undefined,
+    contextWindow: typeof value.contextWindow === "number" ? value.contextWindow : undefined,
+  };
+}
+
+function normalizePendingQuestion(value: unknown): MetaPendingQuestion | null {
+  if (!isPlainObject(value)) return null;
+  const toolCallId = typeof value.toolCallId === "string" ? value.toolCallId : "";
+  if (!toolCallId) return null;
+  if (!Array.isArray(value.questions)) return null;
+  const questions: MetaPendingQuestion["questions"] = [];
+  for (const raw of value.questions) {
+    if (!isPlainObject(raw)) continue;
+    const q = typeof raw.question === "string" ? raw.question.trim() : "";
+    if (!q) continue;
+    const opts = Array.isArray(raw.options)
+      ? raw.options
+          .filter((o): o is string => typeof o === "string" && o.trim().length > 0)
+          .map((o) => o.trim())
+      : [];
+    const type = raw.type === "checkbox" ? "checkbox" : raw.type === "ranked" ? "ranked" : "radio";
+    questions.push({ question: q, options: opts, type });
+  }
+  if (questions.length === 0) return null;
+  return {
+    toolCallId,
+    questions,
+    display: typeof value.display === "string" ? value.display : undefined,
+  };
+}
+
+function normalizePendingPlan(value: unknown): MetaPendingPlan | null {
+  if (!isPlainObject(value)) return null;
+  const toolCallId = typeof value.toolCallId === "string" ? value.toolCallId : "";
+  const title = typeof value.title === "string" ? value.title.trim() : "";
+  if (!toolCallId || !title) return null;
+  const steps = Array.isArray(value.steps)
+    ? value.steps
+        .filter((s): s is Record<string, unknown> => isPlainObject(s))
+        .map((s) => ({
+          title: typeof s.title === "string" ? s.title : "",
+          description: typeof s.description === "string" ? s.description : undefined,
+        }))
+        .filter((s) => s.title.trim().length > 0)
+    : undefined;
+  return {
+    toolCallId,
+    title,
+    description: value.description === null || typeof value.description === "string" ? value.description : null,
+    steps,
+  };
+}
+
+function normalizeRetryState(value: unknown): MetaRetryState | null {
+  if (!isPlainObject(value)) return null;
+  const errorMessage = typeof value.errorMessage === "string" ? value.errorMessage : "";
+  const detectedAt = typeof value.detectedAt === "number" ? value.detectedAt : NaN;
+  if (!errorMessage || !Number.isFinite(detectedAt)) return null;
+  return { errorMessage, detectedAt };
+}
+
+function normalizePluginTrustPrompt(value: unknown): MetaPluginTrustPrompt | null {
+  if (!isPlainObject(value)) return null;
+  const promptId = typeof value.promptId === "string" ? value.promptId : "";
+  const pluginNames = Array.isArray(value.pluginNames)
+    ? value.pluginNames.filter((n): n is string => typeof n === "string" && n.length > 0)
+    : [];
+  if (!promptId || pluginNames.length === 0) return null;
+  const pluginSummaries = Array.isArray(value.pluginSummaries)
+    ? value.pluginSummaries.filter((n): n is string => typeof n === "string")
+    : pluginNames;
+  return { promptId, pluginNames, pluginSummaries };
+}
+
+function normalizeMcpReport(value: unknown): MetaMcpReport | null {
+  return isPlainObject(value) ? (value as MetaMcpReport) : null;
+}
+
+function normalizeTokenUsage(value: unknown): MetaTokenUsage | null {
+  if (!isPlainObject(value)) return null;
+  const input = typeof value.input === "number" ? value.input : NaN;
+  const output = typeof value.output === "number" ? value.output : NaN;
+  const cacheRead = typeof value.cacheRead === "number" ? value.cacheRead : NaN;
+  const cacheWrite = typeof value.cacheWrite === "number" ? value.cacheWrite : NaN;
+  const cost = typeof value.cost === "number" ? value.cost : NaN;
+  if (!Number.isFinite(input + output + cacheRead + cacheWrite + cost)) return null;
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    cost,
+    contextTokens:
+      value.contextTokens === null || typeof value.contextTokens === "number" ? value.contextTokens : null,
+  };
+}
+
+function normalizeProviderUsage(value: unknown): MetaProviderUsage | null {
+  return isPlainObject(value) ? (value as MetaProviderUsage) : null;
+}
+
+function normalizeGoal(value: unknown): MetaGoalStatus | null {
+  if (!isPlainObject(value)) return null;
+  const id = typeof value.id === "string" ? value.id : "";
+  const description = typeof value.description === "string" ? value.description : "";
+  const status = value.status;
+  const turnCount = typeof value.turnCount === "number" ? value.turnCount : NaN;
+  const tokenSpend = typeof value.tokenSpend === "number" ? value.tokenSpend : NaN;
+  const costSpend = typeof value.costSpend === "number" ? value.costSpend : NaN;
+  if (!id || !description || !Number.isFinite(turnCount)) return null;
+  if (!Number.isFinite(tokenSpend) || !Number.isFinite(costSpend)) return null;
+  if (status !== "active" && status !== "met" && status !== "failed" && status !== "cancelled") return null;
+  return {
+    id,
+    description,
+    status,
+    turnCount,
+    tokenSpend,
+    costSpend,
+    maxTurns: typeof value.maxTurns === "number" ? value.maxTurns : undefined,
+    maxTokens: typeof value.maxTokens === "number" ? value.maxTokens : undefined,
+    maxCost: typeof value.maxCost === "number" ? value.maxCost : undefined,
+    lastReason: typeof value.lastReason === "string" ? value.lastReason : undefined,
+  };
+}
+
+// ── Viewer event envelope ───────────────────────────────────────────────────
+
+export interface ViewerEventEnvelope {
+  event: unknown;
+  seq?: number;
+  replay?: boolean;
+  deltaReplay?: boolean;
+  generation?: number;
+}
+
+export function parseViewerEventEnvelope(raw: unknown): ParseResult<ViewerEventEnvelope> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: "viewer event envelope is not an object" };
+  }
+  if (!("event" in raw)) {
+    return { ok: false, error: "viewer event envelope missing required 'event' field" };
+  }
+  return {
+    ok: true,
+    value: {
+      event: raw.event,
+      seq: optionalNumber(raw.seq),
+      replay: optionalBoolean(raw.replay),
+      deltaReplay: optionalBoolean(raw.deltaReplay),
+      generation: optionalNumber(raw.generation),
+    },
+  };
+}
+
+// ── Viewer connected envelope ───────────────────────────────────────────────
+
+export interface ViewerConnectedEnvelope {
+  sessionId: string;
+  lastSeq?: number;
+  replayOnly?: boolean;
+  isActive?: boolean;
+  lastHeartbeatAt?: string | null;
+  sessionName?: string | null;
+  meta_source?: "hub";
+  generation?: number;
+}
+
+export function parseViewerConnectedEnvelope(raw: unknown): ParseResult<ViewerConnectedEnvelope> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: "viewer connected envelope is not an object" };
+  }
+  if (typeof raw.sessionId !== "string" || raw.sessionId.length === 0) {
+    return { ok: false, error: "viewer connected envelope missing string sessionId" };
+  }
+  const meta_source = raw.meta_source === "hub" ? "hub" : undefined;
+  return {
+    ok: true,
+    value: {
+      sessionId: raw.sessionId,
+      lastSeq: optionalNumber(raw.lastSeq),
+      replayOnly: optionalBoolean(raw.replayOnly),
+      isActive: typeof raw.isActive === "boolean" ? raw.isActive : undefined,
+      lastHeartbeatAt: optionalStringOrNull(raw.lastHeartbeatAt),
+      sessionName: optionalStringOrNull(raw.sessionName),
+      meta_source,
+      generation: optionalNumber(raw.generation),
+    },
+  };
+}
+
+// ── Hub state snapshot ────────────────────────────────────────────────────
+
+export function normalizeSessionMetaState(raw: unknown): SessionMetaState | null {
+  if (!isPlainObject(raw)) return null;
+  if (typeof raw.version !== "number") return null;
+
+  const base = defaultMetaState();
+  return {
+    version: raw.version,
+    todoList: Array.isArray(raw.todoList) ? raw.todoList : base.todoList,
+    pendingQuestion: normalizePendingQuestion(raw.pendingQuestion),
+    pendingPlan: normalizePendingPlan(raw.pendingPlan),
+    planModeEnabled: typeof raw.planModeEnabled === "boolean" ? raw.planModeEnabled : base.planModeEnabled,
+    isCompacting: typeof raw.isCompacting === "boolean" ? raw.isCompacting : base.isCompacting,
+    retryState: normalizeRetryState(raw.retryState),
+    pendingPluginTrust: normalizePluginTrustPrompt(raw.pendingPluginTrust),
+    mcpStartupReport: normalizeMcpReport(raw.mcpStartupReport),
+    tokenUsage: normalizeTokenUsage(raw.tokenUsage),
+    providerUsage: normalizeProviderUsage(raw.providerUsage),
+    thinkingLevel: raw.thinkingLevel === null || typeof raw.thinkingLevel === "string" ? raw.thinkingLevel : base.thinkingLevel,
+    authSource: raw.authSource === null || typeof raw.authSource === "string" ? raw.authSource : base.authSource,
+    model: normalizeModel(raw.model),
+    goal: normalizeGoal(raw.goal),
+  };
+}
+
+export function parseHubStateSnapshot(
+  raw: unknown,
+): ParseResult<{ sessionId: string; state: SessionMetaState }> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: "hub state snapshot is not an object" };
+  }
+  if (typeof raw.sessionId !== "string" || raw.sessionId.length === 0) {
+    return { ok: false, error: "hub state snapshot missing string sessionId" };
+  }
+  const state = normalizeSessionMetaState(raw.state);
+  if (!state) {
+    return { ok: false, error: "hub state snapshot has malformed state" };
+  }
+  return { ok: true, value: { sessionId: raw.sessionId, state } };
+}
+
+// ── Meta relay event ────────────────────────────────────────────────────────
+
+export function parseMetaRelayEvent(raw: unknown): MetaRelayEvent | null {
+  if (!isPlainObject(raw)) return null;
+  const type = raw.type;
+  if (typeof type !== "string" || !META_RELAY_EVENT_TYPES.has(type)) return null;
+
+  switch (type) {
+    case "todo_updated":
+      return Array.isArray(raw.todoList) ? { type, todoList: raw.todoList } : null;
+
+    case "question_pending": {
+      const question = normalizePendingQuestion(raw.question);
+      return question ? { type, question } : null;
+    }
+
+    case "question_cleared":
+    case "plan_cleared":
+      return typeof raw.toolCallId === "string" ? { type, toolCallId: raw.toolCallId } : null;
+
+    case "plan_pending": {
+      const plan = normalizePendingPlan(raw.plan);
+      return plan ? { type, plan } : null;
+    }
+
+    case "plan_mode_toggled":
+      return typeof raw.enabled === "boolean" ? { type, enabled: raw.enabled } : null;
+
+    case "compact_started":
+    case "compact_ended":
+      return { type };
+
+    case "retry_state_changed": {
+      if (raw.state === null) return { type, state: null };
+      const state = normalizeRetryState(raw.state);
+      return state ? { type, state } : null;
+    }
+
+    case "plugin_trust_required": {
+      const prompt = normalizePluginTrustPrompt(raw.prompt);
+      return prompt ? { type, prompt } : null;
+    }
+
+    case "plugin_trust_resolved":
+      return typeof raw.promptId === "string" ? { type, promptId: raw.promptId } : null;
+
+    case "mcp_startup_report": {
+      // New (nested) format only. The legacy flat format (slow/errors/ts on the
+      // event root) is explicitly preserved on the relay viewer path, not the
+      // hub meta path, so this decoder intentionally rejects it here.
+      const report = normalizeMcpReport(raw.report);
+      return report && typeof raw.ts === "number" ? { type, report, ts: raw.ts } : null;
+    }
+
+    case "token_usage_updated": {
+      const tokenUsage = normalizeTokenUsage(raw.tokenUsage);
+      const providerUsage = normalizeProviderUsage(raw.providerUsage);
+      return tokenUsage && providerUsage ? { type, tokenUsage, providerUsage } : null;
+    }
+
+    case "thinking_level_changed":
+      return raw.level === null || typeof raw.level === "string"
+        ? { type, level: raw.level }
+        : null;
+
+    case "auth_source_changed":
+      return raw.source === null || typeof raw.source === "string"
+        ? { type, source: raw.source }
+        : null;
+
+    case "model_changed": {
+      if (raw.model === null) return { type, model: null };
+      const model = normalizeModel(raw.model);
+      return model ? { type, model } : null;
+    }
+
+    case "goal_updated": {
+      if (raw.goal === null) return { type, goal: null };
+      const goal = normalizeGoal(raw.goal);
+      return goal ? { type, goal } : null;
+    }
+  }
+
+  return null;
+}
+
+// ── Hub meta event envelope ─────────────────────────────────────────────────
+
+export function parseHubMetaEvent(
+  raw: unknown,
+): ParseResult<{ sessionId: string; version: number; event: MetaRelayEvent }> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: "hub meta event is not an object" };
+  }
+  if (typeof raw.sessionId !== "string" || raw.sessionId.length === 0) {
+    return { ok: false, error: "hub meta event missing string sessionId" };
+  }
+  if (typeof raw.version !== "number") {
+    return { ok: false, error: "hub meta event missing numeric version" };
+  }
+
+  const { sessionId, version, ...eventRaw } = raw;
+  const event = parseMetaRelayEvent(eventRaw);
+  if (!event) {
+    return { ok: false, error: "hub meta event payload is not a recognized meta relay event" };
+  }
+
+  return { ok: true, value: { sessionId, version, event } };
+}
+
+// ── Runner spawn API response ───────────────────────────────────────────────
+
+export interface SpawnResponse {
+  runnerId: string;
+  sessionId: string;
+  pending?: boolean;
+}
+
+export function parseSpawnResponse(raw: unknown): ParseResult<SpawnResponse> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: "spawn response is not an object" };
+  }
+  if (raw.ok !== true) {
+    return { ok: false, error: "spawn response ok is not true" };
+  }
+  if (typeof raw.runnerId !== "string" || raw.runnerId.length === 0) {
+    return { ok: false, error: "spawn response missing string runnerId" };
+  }
+  if (typeof raw.sessionId !== "string" || raw.sessionId.length === 0) {
+    return { ok: false, error: "spawn response missing string sessionId" };
+  }
+  return {
+    ok: true,
+    value: {
+      runnerId: raw.runnerId,
+      sessionId: raw.sessionId,
+      pending: raw.pending === true ? true : undefined,
+    },
+  };
+}

--- a/packages/protocol/src/payload-guards.ts
+++ b/packages/protocol/src/payload-guards.ts
@@ -237,19 +237,19 @@ export function parseViewerConnectedEnvelope(raw: unknown): ParseResult<ViewerCo
     return { ok: false, error: "viewer connected envelope missing string sessionId" };
   }
   const meta_source = raw.meta_source === "hub" ? "hub" : undefined;
-  return {
-    ok: true,
-    value: {
-      sessionId: raw.sessionId,
-      lastSeq: optionalNumber(raw.lastSeq),
-      replayOnly: optionalBoolean(raw.replayOnly),
-      isActive: typeof raw.isActive === "boolean" ? raw.isActive : undefined,
-      lastHeartbeatAt: optionalStringOrNull(raw.lastHeartbeatAt),
-      sessionName: optionalStringOrNull(raw.sessionName),
-      meta_source,
-      generation: optionalNumber(raw.generation),
-    },
+  const value: ViewerConnectedEnvelope = {
+    sessionId: raw.sessionId,
+    lastSeq: optionalNumber(raw.lastSeq),
+    replayOnly: optionalBoolean(raw.replayOnly),
+    isActive: typeof raw.isActive === "boolean" ? raw.isActive : undefined,
+    lastHeartbeatAt: optionalStringOrNull(raw.lastHeartbeatAt),
+    meta_source,
+    generation: optionalNumber(raw.generation),
   };
+  if (raw.sessionName !== undefined) {
+    value.sessionName = optionalStringOrNull(raw.sessionName);
+  }
+  return { ok: true, value };
 }
 
 // ── Hub state snapshot ────────────────────────────────────────────────────

--- a/packages/ui/src/App.payload-validation.test.ts
+++ b/packages/ui/src/App.payload-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * Integration-style wiring tests for the runtime payload guards in App.tsx.
+ *
+ * These tests verify that the protocol-level decoders are wired at the first
+ * external boundary (viewer socket, hub socket, and HTTP spawn response) so
+ * malformed payloads are caught before they can mutate session state.
+ */
+
+describe("App payload validation wiring", () => {
+  const sourceText = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
+  const lifecycleSourceText = readFileSync(new URL("./lib/use-session-lifecycle.ts", import.meta.url), "utf8");
+
+  test("imports the protocol decoders", () => {
+    expect(sourceText).toMatch(/parseViewerEventEnvelope/);
+    expect(sourceText).toMatch(/parseViewerConnectedEnvelope/);
+    expect(sourceText).toMatch(/parseHubStateSnapshot/);
+    expect(sourceText).toMatch(/parseHubMetaEvent/);
+    expect(sourceText).toMatch(/parseSpawnResponse/);
+  });
+
+  test("validates viewer event envelope before using generation or event", () => {
+    expect(sourceText).toMatch(/parseViewerEventEnvelope\(data\)/);
+    expect(sourceText).toMatch(/logFrontendEvent\("viewer", "warning", "Malformed viewer event envelope"/);
+  });
+
+  test("validates viewer connected envelope before reading sessionId", () => {
+    expect(sourceText).toMatch(/parseViewerConnectedEnvelope\(data\)/);
+    expect(sourceText).toMatch(/logFrontendEvent\("viewer", "warning", "Malformed viewer connected envelope"/);
+  });
+
+  test("validates hub state snapshot before applying meta state", () => {
+    expect(sourceText).toMatch(/parseHubStateSnapshot\(raw\)/);
+    expect(sourceText).toMatch(/logFrontendEvent\("hub", "warning", "Malformed state snapshot"/);
+  });
+
+  test("validates hub meta event before calling metaEventToStatePatch", () => {
+    expect(sourceText).toMatch(/parseHubMetaEvent\(raw\)/);
+    expect(sourceText).toMatch(/logFrontendEvent\("hub", "warning", "Malformed meta event"/);
+  });
+
+  test("validates spawn HTTP responses before opening sessions", () => {
+    const combinedSource = sourceText + lifecycleSourceText;
+    const spawnCalls = combinedSource.match(/fetch\("\/api\/runners\/spawn"/g) ?? [];
+    const parseCalls = combinedSource.match(/parseSpawnResponse\(body\)/g) ?? [];
+    expect(parseCalls.length).toBe(spawnCalls.length);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -23,7 +23,7 @@ import type {
   HubClientToServerEvents,
   SessionMetaState,
 } from "@pizzapi/protocol";
-import { isMetaRelayEvent, SOCKET_PROTOCOL_VERSION } from "@pizzapi/protocol";
+import { SOCKET_PROTOCOL_VERSION, parseViewerEventEnvelope, parseViewerConnectedEnvelope, parseHubStateSnapshot, parseHubMetaEvent, parseSpawnResponse } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { shouldCenterTopSpanFullWidth, shouldCenterBottomSpanFullWidth } from "@/utils/panelLayoutHelpers";
@@ -179,6 +179,10 @@ function PanelFallback({ label }: { label?: string }) {
 }
 
 const log = createLogger("relay");
+
+function isPayloadObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
 // Sync all CSS animations (pulse, chase-spin, etc.) to the same phase globally.
 initAnimationSync();
@@ -2946,7 +2950,13 @@ export function App() {
     hubSocketRef.current = socket;
     setHubSocket(socket);
 
-    const handleStateSnapshot = ({ sessionId, state }: { sessionId: string; state: SessionMetaState }) => {
+    const handleStateSnapshot = (raw: unknown) => {
+      const parsed = parseHubStateSnapshot(raw);
+      if (!parsed.ok) {
+        logFrontendEvent("hub", "warning", "Malformed state snapshot", parsed.error);
+        return;
+      }
+      const { sessionId, state } = parsed.value;
       const currentSessionId = lifecycleRefs.activeSessionId.current;
 
       // For background sessions: extract pendingQuestion/pendingPlan from the
@@ -2985,19 +2995,26 @@ export function App() {
       applyMetaStateSnapshot(state);
     };
 
-    const handleMetaEvent = (payload: { sessionId: string; version: number } & Record<string, unknown>) => {
+    const handleMetaEvent = (raw: unknown) => {
+      const parsed = parseHubMetaEvent(raw);
+      if (!parsed.ok) {
+        logFrontendEvent("hub", "warning", "Malformed meta event", parsed.error);
+        return;
+      }
+      const { sessionId, version, event } = parsed.value;
+
       // Update the sidebar pending-question badge for ANY session's meta event,
       // not just the active one.  Background sessions emit pendingQuestion
       // and pendingPlan updates into their own meta rooms; the badge must
       // reflect all of them.
-      if (Object.prototype.hasOwnProperty.call(payload, "pendingQuestion") ||
-          Object.prototype.hasOwnProperty.call(payload, "pendingPlan")) {
+      if (event.type === "question_pending" || event.type === "question_cleared" ||
+          event.type === "plan_pending" || event.type === "plan_cleared") {
         setSessionsAwaitingInput((prev) => {
           const next = new Set(prev);
-          if (payload.pendingQuestion || payload.pendingPlan) {
-            next.add(payload.sessionId);
+          if (event.type === "question_cleared" || event.type === "plan_cleared") {
+            next.delete(sessionId);
           } else {
-            next.delete(payload.sessionId);
+            next.add(sessionId);
           }
           return next;
         });
@@ -3006,21 +3023,20 @@ export function App() {
       // Track compaction state for ANY session's meta event (same pattern as
       // sessionsAwaitingInput above) so the sidebar shows the yellow chase
       // indicator even for background sessions.
-      if (payload.type === "compact_started" || payload.type === "compact_ended") {
+      if (event.type === "compact_started" || event.type === "compact_ended") {
         setSessionsCompacting((prev) => {
           const next = new Set(prev);
-          if (payload.type === "compact_started") {
-            next.add(payload.sessionId);
+          if (event.type === "compact_started") {
+            next.add(sessionId);
           } else {
-            next.delete(payload.sessionId);
+            next.delete(sessionId);
           }
           return next;
         });
       }
 
       const currentSessionId = lifecycleRefs.activeSessionId.current;
-      if (payload.sessionId !== currentSessionId) return;
-      const { sessionId, version, ...event } = payload;
+      if (sessionId !== currentSessionId) return;
       const seen = metaVersionsRef.current.get(sessionId) ?? 0;
       if (version <= seen) return;
       metaVersionsRef.current.set(sessionId, version);
@@ -3280,34 +3296,40 @@ export function App() {
       });
 
       nextSocket.on("connected", (data) => {
+        const envelope = parseViewerConnectedEnvelope(data);
+        if (!envelope.ok) {
+          logFrontendEvent("viewer", "warning", "Malformed viewer connected envelope", envelope.error);
+          return;
+        }
+        const payload = envelope.value;
         if (!isActiveViewerSessionPayload(
           lifecycleRefs.activeSessionId.current,
-          data.sessionId,
+          payload.sessionId,
           lifecycleRefs.generation.current,
-          data.generation,
+          payload.generation,
         )) {
           return;
         }
         lastViewerEventAtRef.current = Date.now();
 
-        metaSourceHubRef.current = data.meta_source === "hub";
+        metaSourceHubRef.current = payload.meta_source === "hub";
         onViewerConnected({
-          replayOnly: data.replayOnly,
-          isActive: data.isActive,
-          meta_source: data.meta_source,
+          replayOnly: payload.replayOnly,
+          isActive: payload.isActive,
+          meta_source: payload.meta_source,
         });
 
-        if (typeof data.lastSeq === "number") {
-          lastSeqRef.current = mergeConnectedSeq(lastSeqRef.current, data.lastSeq);
+        if (typeof payload.lastSeq === "number") {
+          lastSeqRef.current = mergeConnectedSeq(lastSeqRef.current, payload.lastSeq);
         }
 
-        if (typeof data.isActive === "boolean") {
-          setAgentActive(data.isActive);
-          patchSessionCache({ agentActive: data.isActive });
+        if (typeof payload.isActive === "boolean") {
+          setAgentActive(payload.isActive);
+          patchSessionCache({ agentActive: payload.isActive });
         }
 
-        if (Object.prototype.hasOwnProperty.call(data, "sessionName")) {
-          const nextName = normalizeSessionName(data.sessionName);
+        if (Object.prototype.hasOwnProperty.call(payload, "sessionName")) {
+          const nextName = normalizeSessionName(payload.sessionName);
           setSessionName(nextName);
           patchSessionCache({ sessionName: nextName });
         }
@@ -3316,20 +3338,26 @@ export function App() {
       });
 
       nextSocket.on("event", (data) => {
+        const envelope = parseViewerEventEnvelope(data);
+        if (!envelope.ok) {
+          logFrontendEvent("viewer", "warning", "Malformed viewer event envelope", envelope.error);
+          return;
+        }
+        const { event: rawEvent, seq: envelopeSeq, deltaReplay, generation } = envelope.value;
+
         // During session switch, only accept events that explicitly match our generation.
         // This prevents events without generation tags from old sessions being processed
         // while we're awaiting the snapshot for the new session.
         if (lifecycleRefs.awaitingSnapshot.current) {
-          if (data.generation !== lifecycleRefs.generation.current) {
+          if (generation !== lifecycleRefs.generation.current) {
             return;
           }
-        } else if (!matchesViewerGeneration(lifecycleRefs.generation.current, data.generation)) {
+        } else if (!matchesViewerGeneration(lifecycleRefs.generation.current, generation)) {
           return;
         }
         if (!lifecycleRefs.activeSessionId.current) return;
         lastViewerEventAtRef.current = Date.now();
 
-        const rawEvent = data.event;
         const eventType =
           rawEvent && typeof rawEvent === "object" && typeof (rawEvent as Record<string, unknown>).type === "string"
             ? (rawEvent as Record<string, unknown>).type as string
@@ -3343,9 +3371,9 @@ export function App() {
           return;
         }
 
-        const seq = typeof data.seq === "number" ? data.seq : null;
+        const seq = envelopeSeq ?? null;
         if (seq !== null) {
-          if (data.deltaReplay === true) {
+          if (deltaReplay === true) {
             lastSeqRef.current = seq;
           } else {
             const allowOutOfOrderHydrationSnapshot = shouldAllowOutOfOrderSnapshotDuringHydration(
@@ -3370,7 +3398,7 @@ export function App() {
           }
         }
 
-        handleRelayEvent(data.event, seq ?? undefined);
+        handleRelayEvent(rawEvent, seq ?? undefined);
       });
 
       nextSocket.on("session_messages_page", (data) => {
@@ -5457,22 +5485,23 @@ export function App() {
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify(payload),
               });
-              const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
+              const body: unknown = await res.json().catch(() => null);
               if (!res.ok) {
-                setLifecycleStatus(body?.error ?? "Failed to resume session");
+                const error = isPayloadObject(body) && typeof body.error === "string" ? body.error : undefined;
+                setLifecycleStatus(error ?? "Failed to resume session");
                 return;
               }
-              const newSessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
-              if (!newSessionId) {
-                setLifecycleStatus("Resume failed: missing sessionId");
+              const parsed = parseSpawnResponse(body);
+              if (!parsed.ok) {
+                setLifecycleStatus(parsed.error);
                 return;
               }
-              const live = await waitForSessionToGoLive(newSessionId, 30_000);
+              const live = await waitForSessionToGoLive(parsed.value.sessionId, 30_000);
               if (!live) {
                 setLifecycleStatus("Session is starting…");
                 return;
               }
-              handleOpenSession(newSessionId);
+              handleOpenSession(parsed.value.sessionId);
               setLifecycleStatus("Connecting…");
             } catch (err) {
               setLifecycleStatus("Failed to resume session");

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3040,17 +3040,15 @@ export function App() {
       const seen = metaVersionsRef.current.get(sessionId) ?? 0;
       if (version <= seen) return;
       metaVersionsRef.current.set(sessionId, version);
-      if (isMetaRelayEvent(event)) {
-        applyMetaPatch(metaEventToStatePatch(event));
-        if (event.type === "mcp_startup_report" && event.report) {
-          // Buffer if session not yet hydrated — the new slim CLI no longer retries
-          // in heartbeats, so without this the report would be lost for live events
-          // that race session_active delivery.
-          if (lifecycleRefs.hydrated.current) {
-            applyMcpReport(event.report);
-          } else {
-            pendingMcpReportRef.current = event.report as Record<string, unknown>;
-          }
+      applyMetaPatch(metaEventToStatePatch(event));
+      if (event.type === "mcp_startup_report" && event.report) {
+        // Buffer if session not yet hydrated — the new slim CLI no longer retries
+        // in heartbeats, so without this the report would be lost for live events
+        // that race session_active delivery.
+        if (lifecycleRefs.hydrated.current) {
+          applyMcpReport(event.report);
+        } else {
+          pendingMcpReportRef.current = event.report as Record<string, unknown>;
         }
       }
     };

--- a/packages/ui/src/lib/use-session-lifecycle.test.ts
+++ b/packages/ui/src/lib/use-session-lifecycle.test.ts
@@ -47,7 +47,7 @@ describe("useSessionLifecycle", () => {
   beforeEach(() => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(JSON.stringify({ sessionId: "session-abc" }), { status: 200 }),
+        new Response(JSON.stringify({ ok: true, runnerId: "runner-1", sessionId: "session-abc" }), { status: 200 }),
       ),
     ) as unknown as typeof fetch;
   });
@@ -95,7 +95,7 @@ describe("useSessionLifecycle", () => {
           setTimeout(
             () =>
               resolve(
-                new Response(JSON.stringify({ sessionId: "session-abc" }), { status: 200 }),
+                new Response(JSON.stringify({ ok: true, runnerId: "runner-1", sessionId: "session-abc" }), { status: 200 }),
               ),
             50,
           ),

--- a/packages/ui/src/lib/use-session-lifecycle.ts
+++ b/packages/ui/src/lib/use-session-lifecycle.ts
@@ -9,6 +9,7 @@
  */
 
 import * as React from "react";
+import { parseSpawnResponse } from "@pizzapi/protocol";
 import type { HubSession } from "@/components/SessionSidebar";
 import { mapUserError } from "@/lib/user-error-message";
 import {
@@ -247,10 +248,7 @@ export function useSessionLifecycle(
       if (agent) payload.agent = agent;
 
       let res: Response;
-      let body: {
-        error?: string;
-        sessionId?: string;
-      } | null;
+      let body: unknown;
       try {
         res = await fetch("/api/runners/spawn", {
           method: "POST",
@@ -258,7 +256,7 @@ export function useSessionLifecycle(
           headers: { "content-type": "application/json" },
           body: JSON.stringify(payload),
         });
-        body = (await res.json().catch(() => null)) as typeof body;
+        body = await res.json().catch(() => null);
       } catch (err) {
         const mapped = mapUserError({
           error: err,
@@ -269,25 +267,22 @@ export function useSessionLifecycle(
       }
 
       if (!res.ok) {
-        const mapped = mapUserError({
-          error: body?.error,
-          statusCode: res.status,
-          context: "session_spawn",
-        });
+        const error = body && typeof body === "object" && "error" in body && typeof body.error === "string"
+          ? body.error
+          : undefined;
+        const mapped = mapUserError({ error, statusCode: res.status, context: "session_spawn" });
         dispatch(lifecycleActions.spawnFailed(mapped.userMessage));
         throw new Error(mapped.userMessage);
       }
 
-      const sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
-      if (!sessionId) {
-        const mapped = mapUserError({
-          error: "Spawn failed: missing sessionId",
-          context: "session_spawn",
-        });
+      const parsed = parseSpawnResponse(body);
+      if (!parsed.ok) {
+        const mapped = mapUserError({ error: parsed.error, context: "session_spawn" });
         dispatch(lifecycleActions.spawnFailed(mapped.userMessage));
         throw new Error(mapped.userMessage);
       }
 
+      const { sessionId } = parsed.value;
       dispatch(lifecycleActions.spawnSucceeded(sessionId));
       const live = await waitForSessionToGoLive(sessionId, spawnTimeoutMs ?? SPAWN_TIMEOUT_MS);
       if (!live) {


### PR DESCRIPTION
Implements recommendation 4: hand-written runtime decoders in `packages/protocol` for viewer envelopes, hub snapshot/meta events, and runner spawn responses, wired into `packages/ui/src/App.tsx`.\n\n- Adds table-driven tests for valid, malformed, missing, and legacy cases.\n- Adds a UI wiring test verifying the decoders are invoked at each boundary.\n\nCloses main work for idea [[idea:zisVk9xP]].