### PR TITLE
feat(cli): add local-first startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ pizzapi
 
 The first time you run `pizzapi`, a setup wizard walks you through connecting to a relay server. It takes about 30 seconds.
 
-## Self-Host the Relay
+## Self-Host the Relay (One Command)
+
+```bash
+pizzapi local
+```
+
+One command starts the local relay, web UI, and runner and opens your browser at **http://localhost:7492**. Re-running is safe and idempotent. The relay stays running after the command exits; stop it with `pizzapi web stop`.
+
+For production Docker hosting with persistent config and HTTPS, use `pizzapi web`:
 
 ```bash
 pizzapi web

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -78,6 +78,12 @@ async function main() {
         return;
     }
 
+    if (args[0] === "local") {
+        const { runLocal } = await import("./local.js");
+        await runLocal(args.slice(1));
+        return;
+    }
+
     if (args[0] === "setup") {
         await runSetup({ force: true, scan: args.includes("--scan") });
         return;
@@ -337,6 +343,7 @@ async function main() {
         log.info("");
         log.info(c.label("Commands"));
         log.info(`  ${c.cmd("pizza")}                       Start an interactive agent session`);
+        log.info(`  ${c.cmd("pizza local")} ${c.dim("[flags]")}         Start local relay + runner in one command`);
         log.info(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}           Manage the PizzaPi web hub (Docker)`);
         log.info(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
         log.info(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);

--- a/packages/cli/src/local.test.ts
+++ b/packages/cli/src/local.test.ts
@@ -1,0 +1,507 @@
+import { describe, test, expect } from "bun:test";
+import {
+    buildLocalBrowserUrl,
+    buildLocalRelayUrl,
+    buildLocalWsRelayUrl,
+    hasLocalCredentials,
+    isLocalRelayUrl,
+    isRemoteConfig,
+    isRunnerRunning,
+    openBrowserCommand,
+    parseLocalArgs,
+    planLocalActions,
+    pollRelayHealth,
+    runLocal,
+} from "./local.js";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setGlobalConfigDir } from "./config/io.js";
+
+const originalHome = process.env.HOME;
+
+function withTmpHome(testFn: (tmpDir: string) => void | Promise<void>): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-local-test-"));
+        process.env.HOME = tmpDir;
+        _setGlobalConfigDir(join(tmpDir, ".pizzapi"));
+        process.env.PIZZAPI_RUNNER_STATE_PATH = join(tmpDir, ".pizzapi", "runner.json");
+        (async () => {
+            try {
+                await testFn(tmpDir);
+            } finally {
+                process.env.HOME = originalHome;
+                _setGlobalConfigDir(null);
+                delete process.env.PIZZAPI_RUNNER_STATE_PATH;
+                try {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                } catch {}
+            }
+            resolve();
+        })().catch(reject);
+    });
+}
+
+describe("parseLocalArgs", () => {
+    test("defaults to port 7492 and browser open", () => {
+        const r = parseLocalArgs([]);
+        expect(r.port).toBe(7492);
+        expect(r.noBrowser).toBe(false);
+        expect(r.help).toBe(false);
+    });
+
+    test("--port sets custom port", () => {
+        expect(parseLocalArgs(["--port", "8080"]).port).toBe(8080);
+    });
+
+    test("--no-browser disables browser open", () => {
+        const r = parseLocalArgs(["--no-browser"]);
+        expect(r.noBrowser).toBe(true);
+        expect(r.port).toBe(7492);
+    });
+
+    test("--help sets help flag", () => {
+        expect(parseLocalArgs(["--help"]).help).toBe(true);
+        expect(parseLocalArgs(["-h"]).help).toBe(true);
+    });
+
+    test("rejects invalid port", () => {
+        const exitCalls: number[] = [];
+        const originalExit = process.exit;
+        (process as any).exit = (code: number) => {
+            exitCalls.push(code);
+            throw new Error(`exit:${code}`);
+        };
+        try {
+            expect(() => parseLocalArgs(["--port", "abc"])).toThrow("exit:1");
+            expect(() => parseLocalArgs(["--port", "123abc"])).toThrow("exit:1");
+            expect(() => parseLocalArgs(["--port"])).toThrow("exit:1");
+            expect(() => parseLocalArgs(["--port", "0"])).toThrow("exit:1");
+            expect(() => parseLocalArgs(["--port", "70000"])).toThrow("exit:1");
+        } finally {
+            (process as any).exit = originalExit;
+        }
+    });
+});
+
+describe("URL builders", () => {
+    test("build local relay, ws, and browser URLs", () => {
+        expect(buildLocalRelayUrl(7492)).toBe("http://localhost:7492");
+        expect(buildLocalWsRelayUrl(7492)).toBe("ws://localhost:7492");
+        expect(buildLocalBrowserUrl(7492)).toBe("http://localhost:7492");
+        expect(buildLocalBrowserUrl(8080)).toBe("http://localhost:8080");
+    });
+});
+
+describe("isLocalRelayUrl", () => {
+    test("matches localhost and 127.0.0.1 with the configured port", () => {
+        expect(isLocalRelayUrl("ws://localhost:7492", 7492)).toBe(true);
+        expect(isLocalRelayUrl("wss://localhost:7492", 7492)).toBe(true);
+        expect(isLocalRelayUrl("http://localhost:7492", 7492)).toBe(true);
+        expect(isLocalRelayUrl("https://127.0.0.1:7492", 7492)).toBe(true);
+    });
+
+    test("rejects wrong port or remote hosts", () => {
+        expect(isLocalRelayUrl("ws://localhost:8080", 7492)).toBe(false);
+        expect(isLocalRelayUrl("wss://relay.example.com", 7492)).toBe(false);
+        expect(isLocalRelayUrl("http://192.168.1.1:7492", 7492)).toBe(false);
+    });
+
+    test("rejects missing url", () => {
+        expect(isLocalRelayUrl(undefined, 7492)).toBe(false);
+    });
+});
+
+describe("credential classification", () => {
+    test("hasLocalCredentials requires apiKey + local relayUrl", () => {
+        expect(hasLocalCredentials({ apiKey: "k", relayUrl: "ws://localhost:7492" }, 7492)).toBe(true);
+        expect(hasLocalCredentials({ apiKey: "k", relayUrl: "wss://remote.example.com" }, 7492)).toBe(false);
+        expect(hasLocalCredentials({ relayUrl: "ws://localhost:7492" }, 7492)).toBe(false);
+        expect(hasLocalCredentials({ apiKey: "k" }, 7492)).toBe(false);
+    });
+
+    test("isRemoteConfig detects saved remote credentials", () => {
+        expect(isRemoteConfig({ apiKey: "k", relayUrl: "wss://remote.example.com" }, 7492)).toBe(true);
+        expect(isRemoteConfig({ apiKey: "k", relayUrl: "ws://localhost:7492" }, 7492)).toBe(false);
+        expect(isRemoteConfig({ relayUrl: "wss://remote.example.com" }, 7492)).toBe(false);
+        expect(isRemoteConfig({}, 7492)).toBe(false);
+    });
+});
+
+describe("planLocalActions", () => {
+    test("starts relay when not healthy", () => {
+        const plan = planLocalActions({
+            relayHealthy: false,
+            hasLocalApiKey: false,
+            hasRemoteConfig: false,
+            runnerRunning: false,
+            noBrowser: false,
+        });
+        expect(plan).toEqual({
+            startRelay: true,
+            runSetup: false,
+            startRunner: false,
+            openBrowser: false,
+        });
+    });
+
+    test("remote config blocks before starting local relay", () => {
+        const plan = planLocalActions({
+            relayHealthy: false,
+            hasLocalApiKey: false,
+            hasRemoteConfig: true,
+            runnerRunning: false,
+            noBrowser: false,
+        });
+        expect(plan.fatal).toContain("remote relay");
+        expect(plan.startRelay).toBe(false);
+    });
+
+    test("runs setup when relay is healthy but no credentials exist", () => {
+        const plan = planLocalActions({
+            relayHealthy: true,
+            hasLocalApiKey: false,
+            hasRemoteConfig: false,
+            runnerRunning: false,
+            noBrowser: false,
+        });
+        expect(plan).toEqual({
+            startRelay: false,
+            runSetup: true,
+            startRunner: false,
+            openBrowser: false,
+        });
+    });
+
+    test("fails with remote config blocking local runner", () => {
+        const plan = planLocalActions({
+            relayHealthy: true,
+            hasLocalApiKey: false,
+            hasRemoteConfig: true,
+            runnerRunning: false,
+            noBrowser: false,
+        });
+        expect(plan.fatal).toContain("remote relay");
+        expect(plan.startRunner).toBe(false);
+    });
+
+    test("starts runner when healthy + local apiKey + runner not running", () => {
+        const plan = planLocalActions({
+            relayHealthy: true,
+            hasLocalApiKey: true,
+            hasRemoteConfig: false,
+            runnerRunning: false,
+            noBrowser: false,
+        });
+        expect(plan).toEqual({
+            startRelay: false,
+            runSetup: false,
+            startRunner: true,
+            openBrowser: true,
+        });
+    });
+
+    test("does not start runner when already running", () => {
+        const plan = planLocalActions({
+            relayHealthy: true,
+            hasLocalApiKey: true,
+            hasRemoteConfig: false,
+            runnerRunning: true,
+            noBrowser: false,
+        });
+        expect(plan.startRunner).toBe(false);
+        expect(plan.openBrowser).toBe(true);
+        expect(plan.note).toBe("Runner is already running.");
+    });
+
+    test("honors --no-browser", () => {
+        const plan = planLocalActions({
+            relayHealthy: true,
+            hasLocalApiKey: true,
+            hasRemoteConfig: false,
+            runnerRunning: false,
+            noBrowser: true,
+        });
+        expect(plan.openBrowser).toBe(false);
+        expect(plan.startRunner).toBe(true);
+    });
+});
+
+describe("pollRelayHealth", () => {
+    test("returns true when signup-status is reachable", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (input: RequestInfo | URL) => {
+            const url = input.toString();
+            if (url === "http://localhost:7492/api/signup-status") {
+                return new Response(JSON.stringify({ signupEnabled: true }), { status: 200 });
+            }
+            return originalFetch(input);
+        }) as unknown as typeof fetch;
+        try {
+            const ok = await pollRelayHealth("http://localhost:7492", { timeoutMs: 500, pollMs: 100 });
+            expect(ok).toBe(true);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("returns false when signup-status never responds", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => {
+            await new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 10));
+            return new Response("", { status: 500 });
+        }) as unknown as typeof fetch;
+        try {
+            const ok = await pollRelayHealth("http://localhost:7492", { timeoutMs: 250, pollMs: 100 });
+            expect(ok).toBe(false);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+describe("isRunnerRunning", () => {
+    test("returns false when state file is missing", () => {
+        return withTmpHome(() => {
+            expect(isRunnerRunning()).toBe(false);
+        });
+    });
+
+    test("returns false for missing or unreadable state file", () => {
+        return withTmpHome((tmpDir) => {
+            mkdirSync(join(tmpDir, ".pizzapi"), { recursive: true });
+            const statePath = join(tmpDir, ".pizzapi", "runner.json");
+            writeFileSync(statePath, "not json", "utf-8");
+            expect(isRunnerRunning()).toBe(false);
+        });
+    });
+
+    test("returns false when recorded PIDs are not running", () => {
+        return withTmpHome((tmpDir) => {
+            mkdirSync(join(tmpDir, ".pizzapi"), { recursive: true });
+            const statePath = join(tmpDir, ".pizzapi", "runner.json");
+            writeFileSync(
+                statePath,
+                JSON.stringify({ pid: 99999999, supervisorPid: 99999998 }),
+                "utf-8",
+            );
+            expect(isRunnerRunning()).toBe(false);
+        });
+    });
+});
+
+describe("openBrowserCommand", () => {
+    test("selects platform-specific opener", () => {
+        const originalPlatform = process.platform;
+        const cases: { platform: NodeJS.Platform; command: string; args: string[] }[] = [
+            { platform: "darwin", command: "open", args: ["__URL__"] },
+            { platform: "win32", command: "cmd", args: ["/c", "start", "", "__URL__"] },
+            { platform: "linux", command: "xdg-open", args: ["__URL__"] },
+        ];
+        for (const c of cases) {
+            Object.defineProperty(process, "platform", { value: c.platform });
+            const result = openBrowserCommand();
+            expect(result.command).toBe(c.command);
+            expect(result.args).toEqual(c.args);
+        }
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+    });
+});
+
+describe("runLocal orchestration", () => {
+    function makeDeps(overrides: Partial<Awaited<typeof import("./local.js")["defaultLocalDeps"]>> = {}) {
+        const calls = {
+            runWeb: [] as string[][],
+            runSetup: [] as { force?: boolean; relayDefault?: string }[],
+            runSupervisor: 0,
+            openBrowser: [] as string[],
+            logs: [] as string[],
+            exits: [] as number[],
+        };
+        const deps = {
+            runWeb: async (args: string[]) => {
+                calls.runWeb.push(args);
+            },
+            runSetup: async (opts: { force?: boolean; relayDefault?: string }) => {
+                calls.runSetup.push(opts);
+                return false;
+            },
+            runSupervisor: async () => {
+                calls.runSupervisor++;
+                return 0;
+            },
+            loadGlobalConfig: () => ({} as Partial<{ apiKey?: string; relayUrl?: string }>),
+            pollRelayHealth: async () => false,
+            isRunnerRunning: () => false,
+            openBrowser: (url: string) => {
+                calls.openBrowser.push(url);
+            },
+            log: {
+                info: (msg: string) => calls.logs.push(`info:${msg}`),
+                warn: (msg: string) => calls.logs.push(`warn:${msg}`),
+                error: (msg: string) => calls.logs.push(`error:${msg}`),
+            },
+            processExit: (code: number) => {
+                calls.exits.push(code);
+                throw new Error(`exit:${code}`);
+            },
+            ...overrides,
+        };
+        return { deps, calls };
+    }
+
+    test("existing healthy relay skips web start and runs setup if no api key", async () => {
+        let setupCalled = false;
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            runSetup: async (opts: { force?: boolean; relayDefault?: string }) => {
+                calls.runSetup.push(opts);
+                setupCalled = true;
+                return true;
+            },
+            loadGlobalConfig: () => {
+                if (!setupCalled) return {};
+                return { apiKey: "k", relayUrl: "ws://localhost:7492" };
+            },
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("exit:0");
+        expect(calls.runWeb).toHaveLength(0);
+        expect(setupCalled).toBe(true);
+        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://localhost:7492" }]);
+        expect(calls.runSupervisor).toBe(1);
+        expect(calls.openBrowser).toEqual(["http://localhost:7492"]);
+    });
+
+    test("web failure exits with actionable message", async () => {
+        const { deps, calls } = makeDeps({
+            runWeb: async () => {
+                throw new Error("docker unavailable");
+            },
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("docker unavailable");
+        expect(calls.exits).toHaveLength(0);
+    });
+
+    test("relay unhealthy after runWeb exits with actionable message", async () => {
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => false,
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("exit:1");
+        expect(calls.runWeb).toHaveLength(1);
+        expect(calls.exits).toEqual([1]);
+        const errorLog = calls.logs.find((l) => l.startsWith("error:"));
+        expect(errorLog).toContain("did not become healthy");
+    });
+
+    test("setup cancellation leaves relay running and does not start runner", async () => {
+        let setupCalled = false;
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            runSetup: async () => {
+                setupCalled = true;
+                return false;
+            },
+        });
+        await runLocal([], deps as any);
+        expect(calls.runWeb).toHaveLength(0);
+        expect(setupCalled).toBe(true);
+        expect(calls.runSupervisor).toBe(0);
+        expect(calls.openBrowser).toHaveLength(0);
+        const infoLog = calls.logs.find((l) => l.includes("Setup cancelled"));
+        expect(infoLog).toBeDefined();
+    });
+
+    test("existing healthy relay + local apiKey skips setup and starts runner", async () => {
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "ws://localhost:7492" }),
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("exit:0");
+        expect(calls.runWeb).toHaveLength(0);
+        expect(calls.runSetup).toHaveLength(0);
+        expect(calls.runSupervisor).toBe(1);
+        expect(calls.openBrowser).toEqual(["http://localhost:7492"]);
+    });
+
+    test("existing runner is reported and command exits cleanly", async () => {
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "ws://localhost:7492" }),
+            isRunnerRunning: () => true,
+        });
+        await runLocal([], deps as any);
+        expect(calls.runSupervisor).toBe(0);
+        const noteLog = calls.logs.find((l) => l.includes("already running"));
+        expect(noteLog).toBeDefined();
+    });
+
+    test("runner exit code is forwarded", async () => {
+        let supervisorCalled = false;
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "ws://localhost:7492" }),
+            runSupervisor: async () => {
+                supervisorCalled = true;
+                return 42;
+            },
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("exit:42");
+        expect(supervisorCalled).toBe(true);
+    });
+
+    test("remote config blocks local runner start", async () => {
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "wss://remote.example.com" }),
+        });
+        await expect(runLocal([], deps as any)).rejects.toThrow("exit:1");
+        expect(calls.runSetup).toHaveLength(0);
+        expect(calls.runSupervisor).toBe(0);
+        const errorLog = calls.logs.find((l) => l.includes("remote relay"));
+        expect(errorLog).toBeDefined();
+    });
+
+    test("--no-browser skips openBrowser", async () => {
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "ws://localhost:7492" }),
+        });
+        await expect(runLocal(["--no-browser"], deps as any)).rejects.toThrow("exit:0");
+        expect(calls.openBrowser).toHaveLength(0);
+        expect(calls.runSupervisor).toBe(1);
+    });
+
+    test("--port is passed to runWeb", async () => {
+        let webStarted = false;
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => webStarted,
+            runWeb: async (args: string[]) => {
+                webStarted = true;
+                calls.runWeb.push(args);
+            },
+            loadGlobalConfig: () => ({ apiKey: "k", relayUrl: "ws://localhost:8080" }),
+        });
+        await expect(runLocal(["--port", "8080"], deps as any)).rejects.toThrow("exit:0");
+        expect(calls.runWeb).toEqual([["--port", "8080"]]);
+        expect(calls.openBrowser).toEqual(["http://localhost:8080"]);
+    });
+
+    test("--port is passed to setup default relay", async () => {
+        let setupCalled = false;
+        const { deps, calls } = makeDeps({
+            pollRelayHealth: async () => true,
+            runSetup: async (opts: { force?: boolean; relayDefault?: string }) => {
+                calls.runSetup.push(opts);
+                setupCalled = true;
+                return true;
+            },
+            loadGlobalConfig: () => {
+                if (!setupCalled) return {};
+                return { apiKey: "k", relayUrl: "ws://localhost:8080" };
+            },
+        });
+        await expect(runLocal(["--port", "8080", "--no-browser"], deps as any)).rejects.toThrow("exit:0");
+        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://localhost:8080" }]);
+        expect(calls.runSupervisor).toBe(1);
+    });
+});

--- a/packages/cli/src/local.ts
+++ b/packages/cli/src/local.ts
@@ -1,0 +1,372 @@
+/**
+ * `pizza local` — One-command local-first PizzaPi startup.
+ *
+ * This is a thin sequencer over the existing relay/UI, setup, and runner
+ * commands. It does not duplicate their config, process, or health logic.
+ *
+ * Ownership:
+ *   - Relay + web UI are started/reused via `runWeb()` (Docker Compose) and
+ *     remain managed by `pizza web` / `pizza web stop`. They keep running
+ *     after this command exits.
+ *   - Runner is started in the foreground via `runSupervisor()`. This command
+ *     owns the process, so Ctrl+C stops the runner without leaving an orphan
+ *     daemon behind.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { c } from "./cli-colors.js";
+import { createLogger } from "@pizzapi/tools";
+import { loadGlobalConfig } from "./config.js";
+import { runSetup } from "./setup.js";
+import { runWeb } from "./web.js";
+import { runSupervisor } from "./runner/supervisor.js";
+import { defaultStatePath, isPidRunning } from "./runner/runner-state.js";
+
+const log = createLogger("local");
+
+const DEFAULT_PORT = 7492;
+const HEALTH_TIMEOUT_MS = 120_000;
+const HEALTH_POLL_MS = 1_000;
+
+export interface LocalArgs {
+    port: number;
+    noBrowser: boolean;
+    help: boolean;
+}
+
+export interface LocalPlan {
+    startRelay: boolean;
+    runSetup: boolean;
+    startRunner: boolean;
+    openBrowser: boolean;
+    note?: string;
+    fatal?: string;
+}
+
+export interface LocalDeps {
+    runWeb: (args: string[]) => Promise<void>;
+    runSetup: (opts: { force?: boolean; relayDefault?: string }) => Promise<boolean>;
+    runSupervisor: () => Promise<number>;
+    loadGlobalConfig: () => Partial<{ apiKey?: string; relayUrl?: string }>;
+    pollRelayHealth: (relayUrl: string, opts?: { timeoutMs?: number; pollMs?: number }) => Promise<boolean>;
+    isRunnerRunning: () => boolean;
+    openBrowser: (url: string) => void;
+    log: {
+        info: (msg: string) => void;
+        warn: (msg: string) => void;
+        error: (msg: string) => void;
+    };
+    processExit: (code: number) => never;
+}
+
+export function parseLocalArgs(args: string[]): LocalArgs {
+    const result: LocalArgs = { port: DEFAULT_PORT, noBrowser: false, help: false };
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === "--no-browser") {
+            result.noBrowser = true;
+        } else if (arg === "--port") {
+            const value = args[i + 1];
+            const p = value && /^\d+$/.test(value) ? Number(value) : NaN;
+            if (!Number.isFinite(p) || p < 1 || p > 65535) {
+                log.error("Invalid port number");
+                process.exit(1);
+            }
+            result.port = p;
+            i++;
+        } else if (arg === "--help" || arg === "-h") {
+            result.help = true;
+        }
+    }
+    return result;
+}
+
+export function printLocalHelp(): void {
+    log.info("");
+    log.info(`${c.brand("pizza local")} ${c.dim("— Start the local relay + runner in one command")}`);
+    log.info("");
+    log.info("Starts the local PizzaPi relay and web UI (via `pizza web`),");
+    log.info("guides through first-time setup if needed, then starts the runner");
+    log.info("in the foreground. The relay keeps running after this command exits;");
+    log.info("stop it with `pizza web stop`.");
+    log.info("");
+    log.info(c.label("Flags"));
+    log.info(`  ${c.flag("--port")} ${c.dim("<port>")}  Use a custom relay port ${c.dim("(default: 7492)")}`);
+    log.info(`  ${c.flag("--no-browser")}  Don't open the browser, just print the URL`);
+    log.info(`  ${c.flag("-h, --help")}  Show this help`);
+    log.info("");
+    log.info(c.label("Examples"));
+    log.info(`  ${c.dim("pizza local")}              Start local relay and runner`);
+    log.info(`  ${c.dim("pizza local --port 8080")}  Use port 8080`);
+    log.info("");
+}
+
+export function buildLocalRelayUrl(port: number): string {
+    return `http://localhost:${port}`;
+}
+
+export function buildLocalWsRelayUrl(port: number): string {
+    return `ws://localhost:${port}`;
+}
+
+export function buildLocalBrowserUrl(port: number): string {
+    return `http://localhost:${port}`;
+}
+
+export function isLocalRelayUrl(relayUrl: string | undefined, port: number): boolean {
+    if (!relayUrl) return false;
+    const normalized = relayUrl
+        .replace(/^wss?:\/\//, "")
+        .replace(/^https?:\/\//, "")
+        .replace(/\/$/, "");
+    return normalized === `localhost:${port}` || normalized === `127.0.0.1:${port}`;
+}
+
+export function hasLocalCredentials(
+    config: Partial<{ apiKey?: string; relayUrl?: string }>,
+    port: number,
+): boolean {
+    return !!config.apiKey && isLocalRelayUrl(config.relayUrl, port);
+}
+
+export function isRemoteConfig(
+    config: Partial<{ apiKey?: string; relayUrl?: string }>,
+    port: number,
+): boolean {
+    return !!config.apiKey && !!config.relayUrl && !isLocalRelayUrl(config.relayUrl, port);
+}
+
+export function planLocalActions(opts: {
+    relayHealthy: boolean;
+    hasLocalApiKey: boolean;
+    hasRemoteConfig: boolean;
+    runnerRunning: boolean;
+    noBrowser: boolean;
+}): LocalPlan {
+    if (opts.hasRemoteConfig && !opts.hasLocalApiKey) {
+        return {
+            startRelay: false,
+            runSetup: false,
+            startRunner: false,
+            openBrowser: false,
+            fatal: "A remote relay is already configured. Run `pizzapi setup` to switch to the local relay, or start the runner manually with PIZZAPI_RELAY_URL set.",
+        };
+    }
+    if (!opts.relayHealthy) {
+        return { startRelay: true, runSetup: false, startRunner: false, openBrowser: false };
+    }
+    if (!opts.hasLocalApiKey) {
+        return { startRelay: false, runSetup: true, startRunner: false, openBrowser: false };
+    }
+    return {
+        startRelay: false,
+        runSetup: false,
+        startRunner: !opts.runnerRunning,
+        openBrowser: !opts.noBrowser,
+        note: opts.runnerRunning ? "Runner is already running." : undefined,
+    };
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function pollRelayHealth(
+    relayUrl: string,
+    opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<boolean> {
+    const timeoutMs = opts.timeoutMs ?? HEALTH_TIMEOUT_MS;
+    const pollMs = opts.pollMs ?? HEALTH_POLL_MS;
+    const deadline = Date.now() + timeoutMs;
+    const healthUrl = `${relayUrl.replace(/\/$/, "")}/api/signup-status`;
+    while (Date.now() < deadline) {
+        try {
+            const res = await fetch(healthUrl, { signal: AbortSignal.timeout(pollMs) });
+            if (res.ok) return true;
+        } catch {
+            // not ready yet
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        await sleep(Math.min(pollMs, remaining));
+    }
+    return false;
+}
+
+export function isRunnerRunning(): boolean {
+    const statePath = defaultStatePath();
+    if (!existsSync(statePath)) return false;
+    let state: { pid?: number; supervisorPid?: number };
+    try {
+        state = JSON.parse(readFileSync(statePath, "utf-8")) as { pid?: number; supervisorPid?: number };
+    } catch {
+        return false;
+    }
+    const supervisorPid = typeof state.supervisorPid === "number" ? state.supervisorPid : 0;
+    const pid = typeof state.pid === "number" ? state.pid : 0;
+    if (supervisorPid > 0 && isPidRunning(supervisorPid)) return true;
+    if (pid > 0 && isPidRunning(pid)) return true;
+    return false;
+}
+
+export function openBrowserCommand(): { command: string; args: string[] } {
+    const url = "__URL__";
+    switch (process.platform) {
+        case "darwin":
+            return { command: "open", args: [url] };
+        case "win32":
+            return { command: "cmd", args: ["/c", "start", "", url] };
+        default:
+            return { command: "xdg-open", args: [url] };
+    }
+}
+
+export function openBrowser(url: string): void {
+    const { command, args } = openBrowserCommand();
+    const resolvedArgs = args.map((a) => (a === "__URL__" ? url : a));
+    try {
+        const child = spawn(command, resolvedArgs, { stdio: "ignore" });
+        child.on("error", (err) => log.warn(`Could not open browser: ${err.message}`));
+        child.unref();
+    } catch (err) {
+        log.warn(`Could not open browser: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+export function defaultLocalDeps(): LocalDeps {
+    return {
+        runWeb,
+        runSetup,
+        runSupervisor,
+        loadGlobalConfig,
+        pollRelayHealth,
+        isRunnerRunning,
+        openBrowser,
+        log: {
+            info: (msg) => log.info(msg),
+            warn: (msg) => log.warn(msg),
+            error: (msg) => log.error(msg),
+        },
+        processExit: (code) => process.exit(code),
+    };
+}
+
+export async function runLocal(args: string[] = [], deps: LocalDeps = defaultLocalDeps()): Promise<void> {
+    const parsed = parseLocalArgs(args);
+    if (parsed.help) {
+        printLocalHelp();
+        return;
+    }
+
+    const port = parsed.port;
+    const relayUrl = buildLocalRelayUrl(port);
+    const wsRelayUrl = buildLocalWsRelayUrl(port);
+    const browserUrl = buildLocalBrowserUrl(port);
+
+    deps.log.info("");
+    deps.log.info(`${c.brand("🍕 PizzaPi local")} ${c.dim(`— relay on port ${port}`)}`);
+    deps.log.info("");
+
+    // Decide what to do based on current state.
+    const initialHealthy = await deps.pollRelayHealth(relayUrl, { timeoutMs: 2_000, pollMs: 500 });
+    const config = deps.loadGlobalConfig();
+    const initialPlan = planLocalActions({
+        relayHealthy: initialHealthy,
+        hasLocalApiKey: hasLocalCredentials(config, port),
+        hasRemoteConfig: isRemoteConfig(config, port),
+        runnerRunning: deps.isRunnerRunning(),
+        noBrowser: parsed.noBrowser,
+    });
+
+    if (initialPlan.fatal) {
+        deps.log.error(`\n${c.error("✗")} ${initialPlan.fatal}`);
+        deps.log.info(`  Relay/UI is at ${c.accent(browserUrl)}`);
+        deps.processExit(1);
+    }
+
+    // Start the relay if it is not already healthy.
+    if (initialPlan.startRelay) {
+        deps.log.info("Starting local relay + web UI (this may take a minute)…");
+        const webArgs = port !== DEFAULT_PORT ? ["--port", String(port)] : [];
+        await deps.runWeb(webArgs);
+        const healthy = await deps.pollRelayHealth(relayUrl);
+        if (!healthy) {
+            deps.log.error(`\n${c.error("✗")} Local relay did not become healthy.`);
+            deps.log.error("  Check Docker status and run `pizza web logs` for details.");
+            deps.processExit(1);
+        }
+    } else {
+        deps.log.info(`Local relay is already healthy at ${c.accent(relayUrl)}`);
+    }
+
+    // Re-evaluate after any relay start.
+    const postRelayConfig = deps.loadGlobalConfig();
+    const postPlan = planLocalActions({
+        relayHealthy: true,
+        hasLocalApiKey: hasLocalCredentials(postRelayConfig, port),
+        hasRemoteConfig: isRemoteConfig(postRelayConfig, port),
+        runnerRunning: deps.isRunnerRunning(),
+        noBrowser: parsed.noBrowser,
+    });
+
+    if (postPlan.fatal) {
+        deps.log.error(`\n${c.error("✗")} ${postPlan.fatal}`);
+        deps.log.info(`  Relay/UI is at ${c.accent(browserUrl)}`);
+        deps.processExit(1);
+    }
+
+    // Mutable outcome flags. Setup may change the credential state, so we may
+    // need to update these after the setup block below.
+    let startRunner = postPlan.startRunner;
+    let openBrowser = postPlan.openBrowser;
+    let note = postPlan.note;
+
+    if (postPlan.runSetup) {
+        deps.log.info("\nNo local API key found. Starting first-time setup…");
+        const ok = await deps.runSetup({ force: false, relayDefault: relayUrl });
+        if (!ok) {
+            deps.log.info("\nSetup cancelled. The relay is running; run `pizza local` again to complete setup.");
+            return;
+        }
+        const afterSetup = deps.loadGlobalConfig();
+        if (!hasLocalCredentials(afterSetup, port)) {
+            deps.log.error("\nSetup completed but no local API key was saved.");
+            deps.log.info("The relay is running. Run `pizza local` again to retry.");
+            return;
+        }
+        // Credentials are now present; decide runner/browser like a normal
+        // post-setup plan.
+        const runnerRunning = deps.isRunnerRunning();
+        startRunner = !runnerRunning;
+        openBrowser = !parsed.noBrowser;
+        note = runnerRunning ? "Runner is already running." : undefined;
+    }
+
+    // Open or link the browser UI.
+    if (openBrowser) {
+        deps.log.info(`\nOpening ${c.accent(browserUrl)}…`);
+        deps.openBrowser(browserUrl);
+    } else {
+        deps.log.info(`\nLocal UI: ${c.accent(browserUrl)}`);
+    }
+
+    if (note) {
+        deps.log.info(note);
+    }
+
+    // Start the runner in the foreground unless it is already running.
+    if (!startRunner) {
+        deps.log.info("\nLocal PizzaPi is ready.");
+        deps.log.info(`  Relay/UI: ${c.accent(browserUrl)}`);
+        if (note) deps.log.info(`  Runner: ${note.toLowerCase()}`);
+        deps.log.info("\nThe relay keeps running. Stop it with `pizza web stop`.");
+        return;
+    }
+
+    deps.log.info("\nStarting runner in the foreground…");
+    deps.log.info("Press Ctrl+C to stop the runner. The relay keeps running.\n");
+    const code = await deps.runSupervisor();
+    deps.processExit(code);
+}

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -182,11 +182,12 @@ export async function runQrSetup(relayUrl: string, pollIntervalMs = 2000): Promi
  *
  * Returns true if setup completed successfully, false if skipped/aborted.
  */
-export async function runSetup(opts: { force?: boolean; scan?: boolean } = {}): Promise<boolean> {
+export async function runSetup(opts: { force?: boolean; scan?: boolean; relayDefault?: string } = {}): Promise<boolean> {
     const iface = rl();
 
     try {
         const configPath = join(homedir(), ".pizzapi", "config.json");
+        const relayDefault = opts.relayDefault ?? RELAY_DEFAULT;
 
         const frame = c.label("─".repeat(43));
         log.info("");
@@ -208,17 +209,17 @@ export async function runSetup(opts: { force?: boolean; scan?: boolean } = {}): 
 
         // QR-code setup path
         if (opts.scan) {
-            const relayInput = await ask(iface, `Relay server URL [${RELAY_DEFAULT}]: `);
-            const relayUrl = (relayInput.trim() || RELAY_DEFAULT).replace(/\/$/, "");
+            const relayInput = await ask(iface, `Relay server URL [${relayDefault}]: `);
+            const relayUrl = (relayInput.trim() || relayDefault).replace(/\/$/, "");
             return await runQrSetup(relayUrl, process.env.CI ? 100 : 2000);
         }
 
         // Relay URL
         const relayInput = await ask(
             iface,
-            `Relay server URL [${RELAY_DEFAULT}]: `,
+            `Relay server URL [${relayDefault}]: `,
         );
-        const relayUrl = (relayInput.trim() || RELAY_DEFAULT).replace(/\/$/, "");
+        const relayUrl = (relayInput.trim() || relayDefault).replace(/\/$/, "");
 
         // Identity
         const name = (await ask(iface, "Your name (leave blank if account already exists): ")).trim();

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -20,6 +20,7 @@ Run `pizzapi --help` for a quick summary of all commands:
 
 Commands:
   pizza                       Start an interactive agent session
+  pizza local [flags]         Start local relay + runner in one command
   pizza web [flags]           Manage the PizzaPi web hub (Docker)
   pizza runner [args]         Manage the background runner daemon
   pizza runner stop           Stop the runner daemon
@@ -86,6 +87,42 @@ When startup takes longer than 5 seconds, a warning is displayed in both the TUI
 
 <Aside type="tip">
   See the [Safe Mode & Startup Performance guide](/PizzaPi/security/sandbox/) for detailed troubleshooting, timeout tuning, and per-server diagnostics.
+</Aside>
+
+---
+
+### `pizzapi local`
+
+Start the **local relay, web UI, and runner** in one command. This is the fastest way to get a self-hosted PizzaPi running on your own machine.
+
+```bash
+pizzapi local
+pizzapi local --port 8080
+pizzapi local --no-browser
+```
+
+What it does:
+
+1. Starts the local relay + web UI via `pizza web` (Docker Compose) if it is not already healthy.
+2. Runs the first-time setup wizard if no API key for the local relay is saved.
+3. Opens the browser to the local UI (unless `--no-browser` is passed).
+4. Starts the runner in the **foreground**.
+
+Process ownership:
+
+- The **relay** is managed by Docker / `pizza web`. It keeps running after this command exits; stop it with `pizza web stop`.
+- The **runner** is owned by this command. Press `Ctrl+C` to stop the runner. No orphan daemon is left behind.
+
+Re-running `pizzapi local` is safe and idempotent: an already-healthy relay is reused, an already-running runner is reported, and an existing local API key is preserved.
+
+| Flag | Description |
+|------|-------------|
+| `--port <number>` | Relay port (default: `7492`) |
+| `--no-browser` | Print the UI URL instead of opening the browser |
+| `-h, --help` | Show help |
+
+<Aside type="note">
+  Requires **Docker** with Docker Compose. If a remote relay is already configured, `pizzapi local` will not overwrite it; run `pizzapi setup` to switch to the local relay, or start the runner manually with `PIZZAPI_RELAY_URL` set.
 </Aside>
 
 ---


### PR DESCRIPTION
## Summary
- add `pizza local` / `pizzapi local` to start local relay + runner in one command
- reuse existing `pizza web`, setup, and runner supervisor flows
- document the command and cover orchestration with CLI tests

## Checks
- `bun test packages/cli/src/local.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- smoke: `bun packages/cli/src/index.ts local --help` and top-level `--help`

Note: attempted subagent review, but Anthropic credentials were unavailable in this runner.