### PR TITLE
fix(list_models): include cached Ollama Cloud models

### DIFF
--- a/packages/cli/src/extensions/spawn-session.test.ts
+++ b/packages/cli/src/extensions/spawn-session.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSessionExtension } from "./spawn-session.js";
+import type { OllamaCloudModel } from "../ollama-cloud-models.js";
+
+// list_models must surface dynamically-discovered Ollama Cloud models (cached
+// on disk, never in the static ModelRegistry) alongside the disk registry's
+// static models. See ollama-cloud-models.ts for why they're separate.
+
+const originalHome = process.env.HOME;
+const originalKey = process.env.OLLAMA_API_KEY;
+
+function createMockPi() {
+    const tools = new Map<string, any>();
+    return {
+        tools,
+        registerTool(tool: any) {
+            tools.set(tool.name, tool);
+        },
+        on: () => {},
+        registerCommand: () => {},
+    };
+}
+
+function fakeDiskModel(id: string) {
+    return { provider: "anthropic", id, name: id, reasoning: false, contextWindow: 200000, maxTokens: 8192 };
+}
+
+function fakeCtx(hasOllamaAuth: boolean) {
+    return {
+        modelRegistry: {
+            getAll: () => [fakeDiskModel("claude-x")],
+            getAvailable: () => [fakeDiskModel("claude-x")],
+            authStorage: { hasAuth: (provider: string) => hasOllamaAuth && provider === "ollama-cloud" },
+        },
+    } as any;
+}
+
+describe("list_models tool — Ollama Cloud merge", () => {
+    let tempHome: string;
+
+    beforeEach(() => {
+        tempHome = mkdtempSync(join(tmpdir(), "list-models-test-"));
+        process.env.HOME = tempHome;
+        delete process.env.OLLAMA_API_KEY;
+        delete process.env.PIZZAPI_HIDDEN_MODELS;
+
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        const cached: OllamaCloudModel[] = [
+            {
+                id: "glm-5.2",
+                name: "glm-5.2",
+                provider: "ollama-cloud",
+                api: "openai-completions",
+                baseUrl: "https://ollama.com/v1",
+                reasoning: true,
+                input: ["text"],
+                contextWindow: 1000000,
+                maxTokens: 32768,
+            },
+        ];
+        writeFileSync(join(dir, "ollama-cloud-models-cache.json"), JSON.stringify({ models: cached, fetchedAt: Date.now() }));
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        if (originalKey === undefined) delete process.env.OLLAMA_API_KEY;
+        else process.env.OLLAMA_API_KEY = originalKey;
+        delete process.env.PIZZAPI_HIDDEN_MODELS;
+        try {
+            rmSync(tempHome, { recursive: true, force: true });
+        } catch {
+            // ignore
+        }
+    });
+
+    test("includes cached Ollama Cloud models when credentials are configured", async () => {
+        const pi = createMockPi();
+        spawnSessionExtension(pi as any);
+        const tool = pi.tools.get("list_models");
+
+        const result = await tool.execute("call-1", {}, undefined, undefined, fakeCtx(true));
+        const ids = (result.details.models as any[]).map((m) => `${m.provider}/${m.id}`);
+
+        expect(ids).toContain("ollama-cloud/glm-5.2");
+        expect(ids).toContain("anthropic/claude-x");
+    });
+
+    test("omits Ollama Cloud models when no credentials are configured", async () => {
+        const pi = createMockPi();
+        spawnSessionExtension(pi as any);
+        const tool = pi.tools.get("list_models");
+
+        const result = await tool.execute("call-1", {}, undefined, undefined, fakeCtx(false));
+        const ids = (result.details.models as any[]).map((m) => `${m.provider}/${m.id}`);
+
+        expect(ids).not.toContain("ollama-cloud/glm-5.2");
+        expect(ids).toContain("anthropic/claude-x");
+    });
+});

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { loadConfig } from "../config.js";
+import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../ollama-cloud-models.js";
+import { mergeModelLists } from "../session-models-cache.js";
 import { getRelaySessionId } from "./remote.js";
 import { buildProviderUsage, refreshAllUsage } from "./remote-provider-usage.js";
 import { formatProviderUsage, getUsageKey, normalizeUsageKeys } from "./format-usage.js";
@@ -289,8 +291,19 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
             const isHidden = (m: { provider: string | symbol; id: string }) =>
                 hiddenModelKeys.has(`${String(m.provider)}/${m.id}`);
 
-            const allModels = ctx.modelRegistry.getAll().filter((m) => !isHidden(m));
-            const availableModels = ctx.modelRegistry.getAvailable().filter((m) => !isHidden(m));
+            // Ollama Cloud models are discovered dynamically (fetched live from ollama.com,
+            // not baked into the static registry) — merge in the runner's cached list, same
+            // as the Web UI and `pizza models` do, so newly-pulled cloud models show up here.
+            const hasOllamaAuth = ctx.modelRegistry.authStorage.hasAuth("ollama-cloud") || !!process.env.OLLAMA_API_KEY;
+            const ollamaModels = hasOllamaAuth
+                ? (getCachedOllamaCloudModels() ?? []).map(toOllamaCloudRuntimeModel).filter((m) => !isHidden(m))
+                : [];
+
+            const allModels = mergeModelLists(ctx.modelRegistry.getAll().filter((m) => !isHidden(m)), ollamaModels);
+            const availableModels = mergeModelLists(
+                ctx.modelRegistry.getAvailable().filter((m) => !isHidden(m)),
+                ollamaModels,
+            );
             const availableKeys = new Set(availableModels.map((m) => `${m.provider}:${m.id}`));
 
             const models = params.onlyAvailable ? availableModels : allModels;


### PR DESCRIPTION
## Problem

The `list_models` tool (used by agents to discover what models are valid for `spawn_session`) only reads `ctx.modelRegistry.getAll()`/`getAvailable()` — the static, disk-backed model registry.

Ollama Cloud models are discovered dynamically (fetched live from `https://ollama.com/v1/models`, cached at `~/.pizzapi/ollama-cloud-models-cache.json`) and intentionally never land in that static registry (see `ollama-cloud-models.ts`). So a model you just pulled/grabbed via Ollama Cloud never showed up in `list_models`, even though:
- the Web UI's model pickers already merge the cache in (`daemon.ts`'s `listConfiguredModels`)
- `pizza models` CLI already merges it in (`models-command.ts`)
- `spawn_session` could still target the model directly by id — it just wasn't discoverable via `list_models`.

## Fix

Merge the runner's cached Ollama Cloud model list into `list_models`' output, gated on `ollama-cloud` credentials being configured — same pattern already used by the daemon and CLI command. Reuses the existing `mergeModelLists` dedup helper (disk registry wins on id conflicts) and reads from the on-disk cache only (no live network fetch inside the tool call — the runner already refreshes that cache every 12h independent of session activity).

## Testing

Added `spawn-session.test.ts` covering:
- cached Ollama Cloud models appear in `list_models` output when credentials are configured
- they're omitted when no `ollama-cloud` credentials exist

```
bun test src/extensions/spawn-session.test.ts
2 pass, 0 fail
```

Also ran the full extensions suite (1315 tests) and typecheck — clean.
