### PR TITLE
test: relax browser smoke runner timeout

### DIFF
--- a/packages/server/tests/browser-smoke.test.ts
+++ b/packages/server/tests/browser-smoke.test.ts
@@ -230,7 +230,7 @@ describe("browser smoke — sandbox UI", () => {
 
             // Verify the default sandbox runner appears.
             await page.click('button:has-text("Runners")');
-            await page.waitForSelector('button:has-text("sandbox-runner")', { timeout: 10_000 });
+            await page.waitForSelector('button:has-text("sandbox-runner")', { timeout: 30_000 });
 
             // Back to sessions.
             await page.click('button:has-text("Sessions")');

--- a/packages/server/tests/browser-smoke.test.ts
+++ b/packages/server/tests/browser-smoke.test.ts
@@ -232,8 +232,9 @@ describe("browser smoke — sandbox UI", () => {
             await page.click('button:has-text("Runners")');
             await page.waitForSelector('button:has-text("sandbox-runner")', { timeout: 30_000 });
 
-            // Back to sessions.
+            // Back to sessions. Wait for React to render the list before counting it.
             await page.click('button:has-text("Sessions")');
+            await page.waitForSelector('[data-session-row]', { timeout: 20_000 });
             const initialRows = await page.locator('[data-session-row]').count();
             expect(initialRows).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
## Summary
- allow the sandbox runner feed 30 seconds to appear under CI load

## Verification
- `bun test --max-concurrency=1 packages/server/tests/browser-smoke.test.ts`
- `git diff --check`