### PR TITLE
fix(windows): tunnel 502s (IPv6 loopback fallback) + usage projectShort on backslash paths

### DIFF
--- a/packages/cli/src/usage/aggregator.test.ts
+++ b/packages/cli/src/usage/aggregator.test.ts
@@ -242,6 +242,34 @@ describe("Aggregator", () => {
     db.close();
   });
 
+  test("projectShort handles Windows-style paths", () => {
+    const db = createTestDb();
+    const now = Date.now();
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at,
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "C:\\Users\\jordan\\Projects\\PizzaPi", null, now, now + 60000, 1, 100, 50, 0, 0, 2.0, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "C:\\Users\\jordan\\Projects\\PizzaPi", now, "anthropic", "claude-opus", 100, 50, 0, 0, 2.0, 1.2, 0.8, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.byProject[0].projectShort).toBe("PizzaPi");
+    expect(data.recentSessions[0].projectShort).toBe("PizzaPi");
+
+    db.close();
+  });
+
   test("summary excludes null costs", () => {
     const db = createTestDb();
     const now = Date.now();

--- a/packages/cli/src/usage/aggregator.ts
+++ b/packages/cli/src/usage/aggregator.ts
@@ -181,7 +181,7 @@ export function getUsageData(db: Database, range: UsageRange = "90d"): UsageData
 
   const byProject = byProjectRaw.map((p: (typeof byProjectRaw)[number]) => ({
     project: p.project,
-    projectShort: p.project.split("/").pop() || p.project,
+    projectShort: p.project.split(/[\\/]/).pop() || p.project,
     sessions: p.sessions,
     cost: p.cost,
     inputTokens: p.inputTokens,
@@ -222,7 +222,7 @@ export function getUsageData(db: Database, range: UsageRange = "90d"): UsageData
   const recentSessions = recentSessionsRaw.map((s: (typeof recentSessionsRaw)[number]) => ({
     id: s.id,
     project: s.project,
-    projectShort: s.project.split("/").pop() || s.project,
+    projectShort: s.project.split(/[\\/]/).pop() || s.project,
     sessionName: s.sessionName,
     startedAt: new Date(s.startedAt).toISOString(),
     endedAt: s.endedAt ? new Date(s.endedAt).toISOString() : null,

--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -379,6 +379,73 @@ describe("TunnelClient", () => {
   });
 });
 
+describe("TunnelClient loopback fallback", () => {
+  test("retries [::1] and replays the body when 127.0.0.1 is refused (IPv6-only local server)", async () => {
+    let received = "";
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        received = body;
+        res.writeHead(200);
+        res.end("v6ok");
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "::1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+    } catch {
+      return; // no IPv6 loopback on this machine — nothing to test
+    }
+
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Failed to bind test server");
+    const port = address.port;
+
+    try {
+      const client = new TunnelClient({
+        runnerId: "r1",
+        apiKey: "key1",
+        relayUrl: "ws://localhost:9999/_tunnel",
+        autoReconnect: false,
+      });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+
+      (client as any).handleMessage(
+        JSON.stringify({ type: "request-start", id: "req-v6", port, method: "POST", url: "/", headers: {} }),
+      );
+      (client as any).handleMessage(JSON.stringify({ type: "request-data", id: "req-v6", data: "payload" }));
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-v6" }));
+
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-end"));
+
+      const messages = decodeSent(sent);
+      expect(messages.find((message) => message.type === "response-start")).toMatchObject({
+        id: "req-v6",
+        statusCode: 200,
+      });
+      const body = messages
+        .filter((message) => message.type === "response-data")
+        .map((message) => Buffer.from(message.data, "binary"))
+        .reduce((all, chunk) => Buffer.concat([all, chunk]), Buffer.alloc(0))
+        .toString("utf-8");
+      expect(body).toBe("v6ok");
+      expect(received).toBe("payload");
+      // Working family is cached so the next request skips the failed attempt.
+      expect((client as any).loopbackHost.get(port)).toBe("[::1]");
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+});
+
 describe("TunnelClient backoff and failure handling", () => {
   test("currentReconnectDelay uses exponential backoff", () => {
     const client = new TunnelClient({

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -64,6 +64,15 @@ const HOP_BY_HOP = new Set([
 
 const STRIP_AUTH = new Set(["cookie", "authorization", "x-api-key"]);
 
+type LoopbackHost = "127.0.0.1" | "[::1]";
+
+function otherLoopback(host: LoopbackHost): LoopbackHost {
+  return host === "127.0.0.1" ? "[::1]" : "127.0.0.1";
+}
+
+/** Max request-body bytes buffered to allow a loopback-family retry replay. */
+const RETRY_BODY_BUFFER_LIMIT = 4 * 1024 * 1024;
+
 function parseMessageText(raw: string | Buffer | ArrayBuffer | ArrayBufferView): string {
   if (typeof raw === "string") return raw;
   if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString("utf-8");
@@ -97,7 +106,23 @@ export class TunnelClient extends EventEmitter {
   private connectionStartedAt = 0;
 
   /** Active HTTP requests: requestId → { controller, req } */
-  private activeRequests = new Map<string, { controller: AbortController; req: http.ClientRequest }>();
+  private activeRequests = new Map<
+    string,
+    {
+      controller: AbortController;
+      req: http.ClientRequest;
+      /** Body chunks buffered for loopback retry replay; null once connected or over limit. */
+      bodyChunks: Buffer[] | null;
+      bodyBytes: number;
+      bodyEnded: boolean;
+    }
+  >();
+  /**
+   * ponytail: on Windows `localhost` often resolves to ::1 first, so local dev
+   * servers can be IPv6-only and 127.0.0.1 gets ECONNREFUSED. We retry the
+   * other loopback family once and cache the working family per port.
+   */
+  private loopbackHost = new Map<number, LoopbackHost>();
   /** Active local WebSocket connections: wsId → WebSocket */
   private activeWs = new Map<string, WebSocket>();
 
@@ -333,14 +358,20 @@ export class TunnelClient extends EventEmitter {
     forwardHeaders.host = `127.0.0.1:${port}`;
 
     const controller = new AbortController();
+    const attempt = (hostname: LoopbackHost, canRetry: boolean): http.ClientRequest => {
+    const target = new URL(parsed.toString());
+    target.hostname = hostname;
     const req = http.request(
-      parsed,
+      target,
       {
         method,
         headers: forwardHeaders,
         signal: controller.signal,
       },
       (response) => {
+        this.loopbackHost.set(port, hostname);
+        const active = this.activeRequests.get(id);
+        if (active) active.bodyChunks = null; // connected — replay buffer no longer needed
         const responseHeaders: Record<string, string | string[]> = {};
         for (const [key, value] of Object.entries(response.headers)) {
           if (value === undefined) continue;
@@ -378,14 +409,25 @@ export class TunnelClient extends EventEmitter {
       },
     );
 
-    this.activeRequests.set(id, { controller, req });
-
     req.on("error", (error) => {
-      this.activeRequests.delete(id);
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ABORT_ERR" || controller.signal.aborted) {
+        this.activeRequests.delete(id);
         return;
       }
+      const active = this.activeRequests.get(id);
+      if (code === "ECONNREFUSED" && canRetry && active?.bodyChunks) {
+        // Local service may be listening on the other loopback family
+        // (IPv6-only binds are common on Windows). Retry once, replaying
+        // any buffered request body.
+        this.loopbackHost.delete(port);
+        const retryReq = attempt(otherLoopback(hostname), false);
+        active.req = retryReq;
+        for (const chunk of active.bodyChunks) retryReq.write(chunk);
+        if (active.bodyEnded) retryReq.end();
+        return;
+      }
+      this.activeRequests.delete(id);
       this.send({
         type: "response-start",
         id,
@@ -403,17 +445,32 @@ export class TunnelClient extends EventEmitter {
       });
       this.send({ type: "response-data-end", id });
     });
+    return req;
+    };
+
+    const req = attempt(this.loopbackHost.get(port) ?? "127.0.0.1", true);
+    this.activeRequests.set(id, { controller, req, bodyChunks: [], bodyBytes: 0, bodyEnded: false });
   }
 
   private handleRequestData(msg: TunnelRequestDataMessage): void {
     const active = this.activeRequests.get(msg.id);
     if (!active) return;
-    active.req.write(Buffer.from(msg.data, "binary"));
+    const chunk = Buffer.from(msg.data, "binary");
+    if (active.bodyChunks) {
+      active.bodyBytes += chunk.length;
+      if (active.bodyBytes > RETRY_BODY_BUFFER_LIMIT) {
+        active.bodyChunks = null; // too big to replay — give up on retry, stop buffering
+      } else {
+        active.bodyChunks.push(chunk);
+      }
+    }
+    active.req.write(chunk);
   }
 
   private handleRequestDataEnd(msg: TunnelRequestDataEndMessage): void {
     const active = this.activeRequests.get(msg.id);
     if (!active) return;
+    active.bodyEnded = true;
     active.req.end();
   }
 
@@ -456,6 +513,7 @@ export class TunnelClient extends EventEmitter {
     }
     forwardHeaders.host = `127.0.0.1:${port}`;
 
+    const connect = (hostname: LoopbackHost, canRetry: boolean): void => {
     try {
       const WebSocketCtor = WebSocket as unknown as {
         new (
@@ -467,7 +525,10 @@ export class TunnelClient extends EventEmitter {
         ): WebSocket;
       };
 
-      const ws = new WebSocketCtor(parsed.toString(), {
+      const target = new URL(parsed.toString());
+      target.hostname = hostname;
+      let opened = false;
+      const ws = new WebSocketCtor(target.toString(), {
         headers: forwardHeaders,
         protocols,
       });
@@ -476,6 +537,8 @@ export class TunnelClient extends EventEmitter {
       ws.binaryType = "arraybuffer";
 
       ws.addEventListener("open", () => {
+        opened = true;
+        this.loopbackHost.set(port, hostname);
         this.send({ type: "ws-opened", id, protocol: ws.protocol || undefined });
       });
 
@@ -493,18 +556,33 @@ export class TunnelClient extends EventEmitter {
       });
 
       ws.addEventListener("close", (event: CloseEvent) => {
+        if (this.activeWs.get(id) !== ws) return; // superseded by loopback retry
         this.activeWs.delete(id);
+        if (!opened && canRetry) {
+          this.loopbackHost.delete(port);
+          connect(otherLoopback(hostname), false);
+          return;
+        }
         this.send({ type: "ws-close", id, code: event.code, reason: event.reason });
       });
 
       ws.addEventListener("error", () => {
+        if (this.activeWs.get(id) !== ws) return; // superseded by loopback retry
         this.activeWs.delete(id);
+        if (!opened && canRetry) {
+          this.loopbackHost.delete(port);
+          connect(otherLoopback(hostname), false);
+          return;
+        }
         this.send({ type: "ws-error", id, message: "WebSocket connection error" });
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.send({ type: "ws-error", id, message });
     }
+    };
+
+    connect(this.loopbackHost.get(port) ?? "127.0.0.1", true);
   }
 
   private handleWsData(msg: TunnelWsDataMessage): void {


### PR DESCRIPTION
## Windows fixes

**Tunnels: URL created but 502/unreachable**
`TunnelClient` only ever connected to `127.0.0.1`. On Windows, `localhost` commonly resolves to `::1` first, so dev servers bound to IPv6-only loopback refuse IPv4 connections → every proxied request returned 502 "Local service not available".

- Retry `[::1]` once on `ECONNREFUSED` for both HTTP and WebSocket proxying
- Request bodies are buffered (4 MB cap) so the retry can replay them
- Working loopback family is cached per port; cache resets if it starts refusing

**Usage: wrong project names**
`aggregator.ts` derived `projectShort` via `project.split("/").pop()` — Windows cwds use backslashes, so the usage dashboard showed full paths like `C:\Users\...`. Now splits on both separators.

## Tests
- New test: IPv6-only local server → request succeeds via fallback, body replayed, family cached (skips if no ::1)
- New test: Windows-style project paths → `projectShort` is the folder name
- `bun test packages/tunnel` 40 pass, `packages/cli/src/usage` 27 pass, tsc clean

Follow-up captured in Godmother (us9mtiE4): broader UI sweep for `cwd.split("/")` display helpers on Windows.