### PR TITLE
feat(time-service): schedule follow-ups instead of sleeping

### DIFF
--- a/packages/cli/src/runner/services/time-service.reconcile.test.ts
+++ b/packages/cli/src/runner/services/time-service.reconcile.test.ts
@@ -52,6 +52,25 @@ function entry(
     return { sessionId, triggerType, subscriptionId: subscriptionId ?? `${sessionId}-${triggerType}`, runnerId: "runner-test", params };
 }
 
+interface RecordedCall { method: string; url: string; body: string }
+
+/** Install a recording fetch mock. Returns the call log (fires are POSTs, one-shot cleanup are DELETEs). */
+function mockFetch(status = 200): RecordedCall[] {
+    const calls: RecordedCall[] = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        calls.push({
+            method: init?.method ?? "GET",
+            url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+            body: typeof init?.body === "string" ? init.body : "",
+        });
+        return new Response(null, { status });
+    }) as typeof fetch;
+    return calls;
+}
+
+const posts = (calls: RecordedCall[]) => calls.filter((c) => c.method === "POST");
+const deletes = (calls: RecordedCall[]) => calls.filter((c) => c.method === "DELETE");
+
 function setupBroadcastEnv(): void {
     const home = mkdtempSync(join(tmpdir(), "pizzapi-time-service-"));
     mkdirSync(join(home, ".pizzapi"), { recursive: true });
@@ -267,14 +286,7 @@ describe("TimeService.reconcileSubscriptions()", () => {
     describe("same-type multi-subscriptions", () => {
         test("snapshot keeps two same-session timer subscriptions distinct", async () => {
             setupBroadcastEnv();
-            const fetchCalls: Array<{ url: string; body: string }> = [];
-            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-                fetchCalls.push({
-                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
-                    body: typeof init?.body === "string" ? init.body : "",
-                });
-                return new Response(null, { status: 200 });
-            }) as typeof fetch;
+            const fetchCalls = mockFetch();
 
             service = new TimeService();
             const result = service.reconcileSubscriptions([
@@ -284,8 +296,9 @@ describe("TimeService.reconcileSubscriptions()", () => {
 
             expect(result.applied).toBe(2);
             await new Promise((resolve) => setTimeout(resolve, 90));
-            expect(fetchCalls).toHaveLength(2);
-            expect(fetchCalls.map((call) => call.body)).toEqual(expect.arrayContaining([
+            const fires = posts(fetchCalls);
+            expect(fires).toHaveLength(2);
+            expect(fires.map((call) => call.body)).toEqual(expect.arrayContaining([
                 expect.stringContaining('"label":"first"'),
                 expect.stringContaining('"label":"second"'),
             ]));
@@ -293,14 +306,7 @@ describe("TimeService.reconcileSubscriptions()", () => {
 
         test("targeted unsubscribe removes only the matching subscription id", async () => {
             setupBroadcastEnv();
-            const fetchCalls: Array<{ url: string; body: string }> = [];
-            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-                fetchCalls.push({
-                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
-                    body: typeof init?.body === "string" ? init.body : "",
-                });
-                return new Response(null, { status: 200 });
-            }) as typeof fetch;
+            const fetchCalls = mockFetch();
 
             service = new TimeService();
             service.reconcileSubscriptions([
@@ -314,22 +320,16 @@ describe("TimeService.reconcileSubscriptions()", () => {
 
             expect(result.applied).toBe(1);
             await new Promise((resolve) => setTimeout(resolve, 90));
-            expect(fetchCalls).toHaveLength(1);
-            expect(fetchCalls[0]?.body).toContain('"label":"second"');
+            const fires = posts(fetchCalls);
+            expect(fires).toHaveLength(1);
+            expect(fires[0]?.body).toContain('"label":"second"');
         });
     });
 
     describe("delta reconciliation", () => {
         test("unsubscribe delta removes an existing timer", async () => {
             setupBroadcastEnv();
-            const fetchCalls: Array<{ url: string; body: string }> = [];
-            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-                fetchCalls.push({
-                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
-                    body: typeof init?.body === "string" ? init.body : "",
-                });
-                return new Response(null, { status: 200 });
-            }) as typeof fetch;
+            const fetchCalls = mockFetch();
 
             service = new TimeService();
             service.reconcileSubscriptions([
@@ -347,14 +347,7 @@ describe("TimeService.reconcileSubscriptions()", () => {
 
         test("single-subscription delta does not remove unrelated timers", async () => {
             setupBroadcastEnv();
-            const fetchCalls: Array<{ url: string; body: string }> = [];
-            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-                fetchCalls.push({
-                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
-                    body: typeof init?.body === "string" ? init.body : "",
-                });
-                return new Response(null, { status: 200 });
-            }) as typeof fetch;
+            const fetchCalls = mockFetch();
 
             service = new TimeService();
             service.reconcileSubscriptions([
@@ -368,9 +361,79 @@ describe("TimeService.reconcileSubscriptions()", () => {
 
             expect(result.applied).toBe(1);
             await new Promise((resolve) => setTimeout(resolve, 70));
-            expect(fetchCalls).toHaveLength(1);
-            expect(fetchCalls[0]?.url).toBe("http://relay.test/api/runners/runner-test/trigger-broadcast");
-            expect(fetchCalls[0]?.body).toContain('"label":"short"');
+            const fires = posts(fetchCalls);
+            expect(fires).toHaveLength(1);
+            expect(fires[0]?.url).toBe("http://relay.test/api/sessions/sess-b/trigger");
+            expect(fires[0]?.body).toContain('"label":"short"');
+        });
+    });
+
+    describe("follow-up semantics", () => {
+        test("fire is delivered only to the owning session with the message in the payload", async () => {
+            setupBroadcastEnv();
+            const fetchCalls = mockFetch();
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "0.02s", message: "Check the build" }, "sub-1"),
+            ]);
+
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            const fires = posts(fetchCalls);
+            expect(fires).toHaveLength(1);
+            expect(fires[0]?.url).toBe("http://relay.test/api/sessions/sess-1/trigger");
+            const body = JSON.parse(fires[0]!.body);
+            expect(body.payload.message).toBe("Check the build");
+            expect(body.summary).toBe("Check the build");
+            expect(body.deliverAs).toBe("followUp");
+        });
+
+        test("one-shot subscription is removed server-side after successful delivery", async () => {
+            setupBroadcastEnv();
+            const fetchCalls = mockFetch();
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "0.02s" }, "sub-1"),
+            ]);
+
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            const cleanup = deletes(fetchCalls);
+            expect(cleanup).toHaveLength(1);
+            expect(cleanup[0]?.url).toBe(
+                "http://relay.test/api/sessions/sess-1/trigger-subscriptions/time%3Atimer_fired?subscriptionId=sub-1",
+            );
+        });
+
+        test("past time:at fires immediately and removes its subscription", async () => {
+            setupBroadcastEnv();
+            const fetchCalls = mockFetch();
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:at", { at: "2020-01-01T00:00:00Z", message: "Morning check-in" }, "sub-at"),
+            ]);
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const fires = posts(fetchCalls);
+            expect(fires).toHaveLength(1);
+            expect(fires[0]?.url).toBe("http://relay.test/api/sessions/sess-1/trigger");
+            expect(JSON.parse(fires[0]!.body).payload.message).toBe("Morning check-in");
+            expect(deletes(fetchCalls)).toHaveLength(1);
+        });
+
+        test("failed delivery keeps the subscription (no DELETE)", async () => {
+            setupBroadcastEnv();
+            const fetchCalls = mockFetch(503);
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "0.02s" }, "sub-1"),
+            ]);
+
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            expect(posts(fetchCalls)).toHaveLength(1);
+            expect(deletes(fetchCalls)).toHaveLength(0);
         });
     });
 

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -1,8 +1,13 @@
 /**
- * Built-in Time service — timer triggers and adaptive time sigils.
+ * Built-in Time service — scheduled follow-ups and adaptive time sigils.
+ *
+ * The trigger types let an agent schedule a follow-up and end its turn instead
+ * of blocking on something like `sleep`. Fires are delivered only to the
+ * session that owns the subscription, and one-shot subscriptions
+ * (time:timer_fired, time:at) are automatically removed after delivery.
  *
  * Triggers:
- *   time:timer_fired  — one-shot delay timer
+ *   time:timer_fired  — one-shot delay timer ("check back in 10m")
  *   time:at            — fire at a specific absolute time
  *   time:cron          — periodic on a cron schedule
  *
@@ -32,14 +37,6 @@ import {
 import { logInfo, logWarn, logError } from "../logger.js";
 
 // ── Relay helpers ────────────────────────────────────────────────────────────
-
-function readRunnerId(): string | null {
-    try {
-        const home = process.env.HOME || homedir();
-        const raw = JSON.parse(readFileSync(join(home, ".pizzapi", "runner.json"), "utf-8"));
-        return typeof raw?.runnerId === "string" ? raw.runnerId : null;
-    } catch { return null; }
-}
 
 function resolveRelayUrl(): string {
     const home = process.env.HOME || homedir();
@@ -98,8 +95,8 @@ interface CronEntry {
 export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
     {
         type: "time:timer_fired",
-        label: "Timer Fired",
-        description: "One-shot delay timer. Subscribe with a duration (e.g. \"10m\", \"1h30m\", \"30s\") and receive a trigger when it elapses.",
+        label: "Scheduled Follow-up",
+        description: "Schedule a follow-up instead of blocking with `sleep`. Subscribe with a duration (e.g. \"10m\", \"1h30m\", \"30s\") and a `message` describing what to do, then end your turn — the trigger wakes the session when the time elapses. Fires once and the subscription is removed automatically.",
         schema: {
             type: "object",
             properties: {
@@ -107,6 +104,7 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
                 durationMs: { type: "number", description: "Duration in milliseconds" },
                 firedAt: { type: "string", description: "ISO timestamp when the timer fired" },
                 label: { type: "string", description: "Optional label" },
+                message: { type: "string", description: "The follow-up note provided at subscribe time" },
             },
         },
         params: [
@@ -116,6 +114,13 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
                 type: "string",
                 description: "How long to wait (e.g. \"10m\", \"1h30m\", \"30s\")",
                 required: true,
+            },
+            {
+                name: "message",
+                label: "Message",
+                type: "string",
+                description: "Note to your future self — what to do when this fires (e.g. \"Check if the build finished and report results\")",
+                required: false,
             },
             {
                 name: "label",
@@ -128,14 +133,15 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
     },
     {
         type: "time:at",
-        label: "Fire At Time",
-        description: "Fire a trigger at a specific absolute time. Supports ISO 8601 (\"2026-03-30T08:00:00Z\") and HH:MMUTC (\"14:30UTC\").",
+        label: "Follow-up At Time",
+        description: "Schedule a follow-up at a specific absolute time instead of waiting/polling. Supports ISO 8601 (\"2026-03-30T08:00:00Z\") and HH:MMUTC (\"14:30UTC\"). Subscribe with a `message`, end your turn, and the trigger wakes the session at the target time. Fires once and the subscription is removed automatically.",
         schema: {
             type: "object",
             properties: {
                 at: { type: "string", description: "The target time (ISO 8601)" },
                 firedAt: { type: "string", description: "ISO timestamp when the trigger fired" },
                 label: { type: "string", description: "Optional label" },
+                message: { type: "string", description: "The follow-up note provided at subscribe time" },
             },
         },
         params: [
@@ -145,6 +151,13 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
                 type: "string",
                 description: "When to fire (ISO 8601 or HH:MMUTC)",
                 required: true,
+            },
+            {
+                name: "message",
+                label: "Message",
+                type: "string",
+                description: "Note to your future self — what to do when this fires",
+                required: false,
             },
             {
                 name: "label",
@@ -158,13 +171,14 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
     {
         type: "time:cron",
         label: "Cron Schedule",
-        description: "Periodic trigger on a cron schedule. Standard 5-field format: minute hour day-of-month month day-of-week.",
+        description: "Recurring follow-up on a cron schedule. Standard 5-field format: minute hour day-of-month month day-of-week. Delivered only to your session; unsubscribe when you no longer need it.",
         schema: {
             type: "object",
             properties: {
                 cron: { type: "string", description: "The cron expression" },
                 firedAt: { type: "string", description: "ISO timestamp when the trigger fired" },
                 label: { type: "string", description: "Optional label" },
+                message: { type: "string", description: "The follow-up note provided at subscribe time" },
                 iteration: { type: "number", description: "How many times this cron has fired" },
             },
         },
@@ -175,6 +189,13 @@ export const TIME_TRIGGER_DEFS: ServiceTriggerDef[] = [
                 type: "string",
                 description: "Standard 5-field cron (e.g. \"*/30 * * * *\" for every 30 minutes)",
                 required: true,
+            },
+            {
+                name: "message",
+                label: "Message",
+                type: "string",
+                description: "Note to your future self — what to do on each fire",
+                required: false,
             },
             {
                 name: "label",
@@ -463,18 +484,20 @@ export class TimeService implements ServiceHandler {
         }
 
         const label = typeof params?.label === "string" ? params.label : undefined;
+        const message = typeof params?.message === "string" ? params.message : undefined;
         const fireAt = Date.now() + durationMs;
 
         logInfo(`[time] starting timer for session ${sessionId}: ${durationStr} (${formatDuration(durationMs)})${label ? ` [${label}]` : ""}`);
 
         const handle = setTimeout(() => {
             this.#timers.delete(key);
-            void this.#broadcastTrigger("time:timer_fired", {
+            void this.#fireOneShot(sessionId, subscriptionId, "time:timer_fired", {
                 duration: durationStr,
                 durationMs,
                 firedAt: new Date().toISOString(),
                 label,
-            }, label ? `Timer "${label}" fired after ${formatDuration(durationMs)}` : `Timer fired after ${formatDuration(durationMs)}`);
+                message,
+            }, message ?? (label ? `Timer "${label}" fired after ${formatDuration(durationMs)}` : `Timer fired after ${formatDuration(durationMs)}`));
         }, durationMs);
 
         this.#timers.set(key, {
@@ -510,29 +533,32 @@ export class TimeService implements ServiceHandler {
             return;
         }
 
+        const label = typeof params?.label === "string" ? params.label : undefined;
+        const message = typeof params?.message === "string" ? params.message : undefined;
+
         const delayMs = targetMs - Date.now();
         if (delayMs <= 0) {
             // Already past — fire immediately
             logInfo(`[time] at target "${atStr}" already passed, firing immediately for session ${sessionId}`);
-            void this.#broadcastTrigger("time:at", {
+            void this.#fireOneShot(sessionId, subscriptionId, "time:at", {
                 at: new Date(targetMs).toISOString(),
                 firedAt: new Date().toISOString(),
-                label: typeof params?.label === "string" ? params.label : undefined,
-            }, `Scheduled trigger fired (target: ${atStr})`);
+                label,
+                message,
+            }, message ?? `Scheduled trigger fired (target: ${atStr})`);
             return;
         }
-
-        const label = typeof params?.label === "string" ? params.label : undefined;
 
         logInfo(`[time] scheduling at-timer for session ${sessionId}: ${atStr} (in ${formatDuration(delayMs)})${label ? ` [${label}]` : ""}`);
 
         const handle = setTimeout(() => {
             this.#timers.delete(key);
-            void this.#broadcastTrigger("time:at", {
+            void this.#fireOneShot(sessionId, subscriptionId, "time:at", {
                 at: new Date(targetMs).toISOString(),
                 firedAt: new Date().toISOString(),
                 label,
-            }, label ? `Scheduled "${label}" fired` : `Scheduled trigger fired (target: ${atStr})`);
+                message,
+            }, message ?? (label ? `Scheduled "${label}" fired` : `Scheduled trigger fired (target: ${atStr})`));
         }, delayMs);
 
         this.#timers.set(key, {
@@ -570,6 +596,7 @@ export class TimeService implements ServiceHandler {
         }
 
         const label = typeof params?.label === "string" ? params.label : undefined;
+        const message = typeof params?.message === "string" ? params.message : undefined;
         const nextFire = nextCronTime(cron);
         if (!nextFire) {
             logWarn(`[time] cron "${cronStr}" has no next fire time`);
@@ -590,12 +617,13 @@ export class TimeService implements ServiceHandler {
                 const iteration = (this.#cronIterations.get(key) ?? 0) + 1;
                 this.#cronIterations.set(key, iteration);
 
-                void this.#broadcastTrigger("time:cron", {
+                void this.#deliverToSession(sessionId, "time:cron", {
                     cron: cronStr,
                     firedAt: new Date().toISOString(),
                     label,
+                    message,
                     iteration,
-                }, label ? `Cron "${label}" fired (#${iteration})` : `Cron "${cronStr}" fired (#${iteration})`);
+                }, message ?? (label ? `Cron "${label}" fired (#${iteration})` : `Cron "${cronStr}" fired (#${iteration})`));
 
                 // Schedule next
                 const nextTime = nextCronTime(cron, now);
@@ -620,22 +648,42 @@ export class TimeService implements ServiceHandler {
         });
     }
 
-    // ── Trigger broadcasting ─────────────────────────────────────────────
+    // ── Trigger delivery ─────────────────────────────────────────────
 
-    async #broadcastTrigger(
+    /**
+     * Fire a one-shot follow-up: deliver to the owning session, then remove
+     * the subscription so it doesn't re-arm and re-fire on runner restart.
+     * If delivery fails (e.g. session offline), the subscription is kept so
+     * the next reconcile retries it.
+     */
+    async #fireOneShot(
+        sessionId: string,
+        subscriptionId: string,
         type: string,
         payload: Record<string, unknown>,
         summary?: string,
     ): Promise<void> {
-        const runnerId = readRunnerId();
+        const delivered = await this.#deliverToSession(sessionId, type, payload, summary);
+        if (delivered) {
+            await this.#removeSubscription(sessionId, type, subscriptionId);
+        }
+    }
+
+    /** Deliver a trigger to the session that owns the subscription (not a broadcast). */
+    async #deliverToSession(
+        sessionId: string,
+        type: string,
+        payload: Record<string, unknown>,
+        summary?: string,
+    ): Promise<boolean> {
         const apiKey = getApiKey();
-        if (!runnerId || !apiKey) {
-            logWarn(`[time] cannot broadcast trigger — missing runnerId or apiKey`);
-            return;
+        if (!apiKey) {
+            logWarn(`[time] cannot deliver trigger — missing apiKey`);
+            return false;
         }
 
         try {
-            const res = await fetch(`${resolveRelayUrl()}/api/runners/${runnerId}/trigger-broadcast`, {
+            const res = await fetch(`${resolveRelayUrl()}/api/sessions/${encodeURIComponent(sessionId)}/trigger`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json", "x-api-key": apiKey },
                 body: JSON.stringify({
@@ -648,12 +696,36 @@ export class TimeService implements ServiceHandler {
             });
 
             if (!res.ok) {
-                logWarn(`[time] trigger broadcast failed: ${res.status} ${res.statusText}`);
-            } else {
-                logInfo(`[time] broadcast ${type}: ${summary ?? "(no summary)"}`);
+                logWarn(`[time] trigger delivery to ${sessionId} failed: ${res.status} ${res.statusText}`);
+                return false;
+            }
+            logInfo(`[time] delivered ${type} to ${sessionId}: ${summary ?? "(no summary)"}`);
+            return true;
+        } catch (err) {
+            logError(`[time] trigger delivery error: ${err}`);
+            return false;
+        }
+    }
+
+    /** Remove a fired one-shot subscription server-side. */
+    async #removeSubscription(sessionId: string, triggerType: string, subscriptionId: string): Promise<void> {
+        // Legacy entries without a real subscriptionId use a fabricated
+        // "<sessionId>\0<triggerType>" key — skip targeted deletion for those.
+        if (subscriptionId.includes("\0")) return;
+
+        const apiKey = getApiKey();
+        if (!apiKey) return;
+
+        try {
+            const res = await fetch(
+                `${resolveRelayUrl()}/api/sessions/${encodeURIComponent(sessionId)}/trigger-subscriptions/${encodeURIComponent(triggerType)}?subscriptionId=${encodeURIComponent(subscriptionId)}`,
+                { method: "DELETE", headers: { "x-api-key": apiKey } },
+            );
+            if (!res.ok) {
+                logWarn(`[time] failed to remove fired subscription ${subscriptionId}: ${res.status} ${res.statusText}`);
             }
         } catch (err) {
-            logError(`[time] trigger broadcast error: ${err}`);
+            logWarn(`[time] error removing fired subscription ${subscriptionId}: ${err}`);
         }
     }
 }

--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { cronFromSchedule, scheduleFromCron, type RecurringSchedule } from "@/lib/cron-schedule";
 import type { JsonValue, ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
 
 // ── Shared trigger utilities (re-exported for backward compat) ─────────────
@@ -1484,6 +1485,16 @@ function ServiceCatalogAccordion({
                               <option value="false">false</option>
                             </select>
 
+                          /* Cron expression: friendly recurring-schedule builder */
+                          ) : p.name === "cron" ? (
+                            <CronScheduleBuilder
+                              value={typeof currentVal === "string" ? currentVal : ""}
+                              onChange={(v) => onParamValuesChange((prev) => ({
+                                ...prev,
+                                [def.type]: { ...prev[def.type], [p.name]: v },
+                              }))}
+                            />
+
                           /* Default: text/number input */
                           ) : (
                             <input
@@ -2223,6 +2234,116 @@ export function TriggersPanel({ sessionId, triggerDefs = [], viewerSocket }: Tri
         triggerDefs={triggerDefs}
         onSent={() => { void fetchTriggers(true); }}
       />
+    </div>
+  );
+}
+
+// ── Cron schedule builder ───────────────────────────────────────────────────
+
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const DEFAULT_SCHEDULE: RecurringSchedule = { freq: "daily", hour: 9, minute: 0, day: 1 };
+
+const cronInputCls = "rounded border border-border bg-background px-1.5 py-0.5 text-[10px] focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * Friendly Daily/Weekly/Monthly builder for cron params. The user picks a
+ * local time; the stored param value is the equivalent UTC cron expression
+ * (the runner evaluates cron in UTC). Unrepresentable expressions (steps,
+ * ranges, lists) fall back to a raw "Custom" input.
+ */
+function CronScheduleBuilder({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  const parsed = React.useMemo(() => scheduleFromCron(value), [value]);
+  const [customMode, setCustomMode] = React.useState(() => value.trim() !== "" && !parsed);
+
+  // Seed the default schedule so subscribing without touching the form works.
+  React.useEffect(() => {
+    if (!customMode && value.trim() === "") onChange(cronFromSchedule(DEFAULT_SCHEDULE));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const sched = parsed ?? DEFAULT_SCHEDULE;
+  const set = (patch: Partial<RecurringSchedule>) => onChange(cronFromSchedule({ ...sched, ...patch }));
+
+  return (
+    <div className="flex-1 space-y-1">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <select
+          value={customMode ? "custom" : sched.freq}
+          onChange={(e) => {
+            const freq = e.target.value;
+            if (freq === "custom") {
+              setCustomMode(true);
+            } else {
+              setCustomMode(false);
+              set({ freq: freq as RecurringSchedule["freq"], day: 1 });
+            }
+          }}
+          className={cronInputCls}
+        >
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+          <option value="custom">Custom (cron)</option>
+        </select>
+
+        {!customMode && sched.freq === "weekly" && (
+          <select
+            value={String(sched.day)}
+            onChange={(e) => set({ day: Number(e.target.value) })}
+            className={cronInputCls}
+          >
+            {WEEKDAYS.map((name, i) => (
+              <option key={name} value={String(i)}>{name}</option>
+            ))}
+          </select>
+        )}
+
+        {!customMode && sched.freq === "monthly" && (
+          <label className="flex items-center gap-1 text-[10px] text-muted-foreground/70">
+            day
+            <input
+              type="number"
+              min={1}
+              max={31}
+              value={sched.day}
+              onChange={(e) => {
+                const n = Number(e.target.value);
+                if (Number.isInteger(n) && n >= 1 && n <= 31) set({ day: n });
+              }}
+              className={cn(cronInputCls, "w-12")}
+            />
+          </label>
+        )}
+
+        {!customMode && (
+          <label className="flex items-center gap-1 text-[10px] text-muted-foreground/70">
+            at
+            <input
+              type="time"
+              value={`${String(sched.hour).padStart(2, "0")}:${String(sched.minute).padStart(2, "0")}`}
+              onChange={(e) => {
+                const [h, m] = e.target.value.split(":").map(Number);
+                if (Number.isInteger(h) && Number.isInteger(m)) set({ hour: h, minute: m });
+              }}
+              className={cronInputCls}
+            />
+          </label>
+        )}
+      </div>
+
+      {customMode ? (
+        <input
+          type="text"
+          placeholder="*/30 * * * * (UTC)"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(cronInputCls, "w-full font-mono")}
+        />
+      ) : (
+        <p className="text-[9px] text-muted-foreground/60">
+          <span className="font-mono">{value || cronFromSchedule(sched)}</span> — local time, stored as UTC cron
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/lib/cron-schedule.test.ts
+++ b/packages/ui/src/lib/cron-schedule.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import { cronFromSchedule, scheduleFromCron, type RecurringSchedule } from "./cron-schedule.js";
+
+// Tests run in whatever timezone the machine has — assertions are round-trip
+// based so they hold in any timezone, plus a few structural checks.
+
+describe("cronFromSchedule", () => {
+    test("daily produces '* *' dom/dow", () => {
+        const cron = cronFromSchedule({ freq: "daily", hour: 9, minute: 30, day: 0 });
+        expect(cron).toMatch(/^\d{1,2} \d{1,2} \* \* \*$/);
+    });
+
+    test("weekly produces a single dow 0-6", () => {
+        const cron = cronFromSchedule({ freq: "weekly", hour: 9, minute: 0, day: 1 });
+        expect(cron).toMatch(/^\d{1,2} \d{1,2} \* \* [0-6]$/);
+    });
+
+    test("monthly produces a dom 1-31", () => {
+        const cron = cronFromSchedule({ freq: "monthly", hour: 8, minute: 15, day: 14 });
+        expect(cron).toMatch(/^\d{1,2} \d{1,2} ([1-9]|[12]\d|3[01]) \* \*$/);
+    });
+
+    test("monthly clamps day into 1-31", () => {
+        expect(scheduleFromCron(cronFromSchedule({ freq: "monthly", hour: 12, minute: 0, day: 99 }))?.day).toBe(31);
+        expect(scheduleFromCron(cronFromSchedule({ freq: "monthly", hour: 12, minute: 0, day: 0 }))?.day).toBe(1);
+    });
+});
+
+describe("round-trips (local ↔ UTC)", () => {
+    const cases: RecurringSchedule[] = [
+        { freq: "daily", hour: 0, minute: 0, day: 0 },
+        { freq: "daily", hour: 23, minute: 59, day: 0 },
+        { freq: "daily", hour: 9, minute: 30, day: 0 },
+        { freq: "weekly", hour: 0, minute: 5, day: 0 },   // Sunday just after local midnight
+        { freq: "weekly", hour: 23, minute: 55, day: 6 }, // Saturday just before local midnight
+        { freq: "weekly", hour: 12, minute: 0, day: 3 },
+        { freq: "monthly", hour: 1, minute: 0, day: 1 },
+        { freq: "monthly", hour: 22, minute: 0, day: 15 },
+    ];
+
+    for (const s of cases) {
+        test(`${s.freq} ${s.hour}:${s.minute} day=${s.day} survives schedule→cron→schedule`, () => {
+            const back = scheduleFromCron(cronFromSchedule(s));
+            expect(back).toEqual({ ...s, day: s.freq === "daily" ? 0 : s.day });
+        });
+    }
+
+    test("cron→schedule→cron is stable for representable crons", () => {
+        for (const cron of ["0 9 * * *", "30 14 * * 1", "0 0 15 * *", "59 23 * * 6", "0 6 1 * *"]) {
+            const sched = scheduleFromCron(cron);
+            expect(sched).not.toBeNull();
+            expect(cronFromSchedule(sched!)).toBe(cron);
+        }
+    });
+});
+
+describe("scheduleFromCron rejects what the builder can't represent", () => {
+    const unrepresentable = [
+        "*/30 * * * *",     // step
+        "0 9 * * 1-5",      // range
+        "0 9 * * 1,3",      // list
+        "0 9 1 6 *",        // month restriction
+        "0 9 1 * 1",        // both dom and dow
+        "0 9 * *",          // 4 fields
+        "x 9 * * *",        // junk
+        "0 25 * * *",       // hour out of range
+        "60 9 * * *",       // minute out of range
+    ];
+    for (const cron of unrepresentable) {
+        test(`"${cron}" → null`, () => {
+            expect(scheduleFromCron(cron)).toBeNull();
+        });
+    }
+});

--- a/packages/ui/src/lib/cron-schedule.ts
+++ b/packages/ui/src/lib/cron-schedule.ts
@@ -1,0 +1,73 @@
+/**
+ * Local-time recurring schedules ↔ UTC cron expressions.
+ *
+ * The runner evaluates cron in UTC, but users think in local time. These
+ * helpers convert a simple daily/weekly/monthly schedule (in the browser's
+ * timezone) to a 5-field UTC cron string and back, handling day-of-week /
+ * day-of-month shifts when the local↔UTC conversion crosses midnight.
+ */
+
+export interface RecurringSchedule {
+    freq: "daily" | "weekly" | "monthly";
+    /** Local hour 0-23 */
+    hour: number;
+    /** Local minute 0-59 */
+    minute: number;
+    /** Local weekday 0-6 (weekly) or day-of-month 1-31 (monthly). Ignored for daily. */
+    day: number;
+}
+
+// Reference dates in January (31 days) so day-of-month arithmetic is safe.
+// ponytail: "monthly on the 31st" near a local↔UTC midnight boundary is not
+// representable as a single UTC cron — the converted dom is only exact for
+// 31-day months. Fine for the common 1st-28th + daytime cases.
+const REF_YEAR = 2026;
+
+/** Convert a local-time schedule to a 5-field UTC cron expression. */
+export function cronFromSchedule(s: RecurringSchedule): string {
+    if (s.freq === "daily") {
+        const d = new Date(REF_YEAR, 0, 15, s.hour, s.minute);
+        return `${d.getUTCMinutes()} ${d.getUTCHours()} * * *`;
+    }
+    if (s.freq === "weekly") {
+        // Walk to a reference date whose *local* weekday matches, then read UTC fields.
+        const d = new Date(REF_YEAR, 0, 10, s.hour, s.minute);
+        while (d.getDay() !== ((s.day % 7) + 7) % 7) d.setDate(d.getDate() + 1);
+        return `${d.getUTCMinutes()} ${d.getUTCHours()} * * ${d.getUTCDay()}`;
+    }
+    // monthly
+    const dom = Math.min(31, Math.max(1, Math.round(s.day)));
+    const d = new Date(REF_YEAR, 0, dom, s.hour, s.minute);
+    return `${d.getUTCMinutes()} ${d.getUTCHours()} ${d.getUTCDate()} * *`;
+}
+
+/**
+ * Parse a 5-field UTC cron back into a local-time schedule.
+ * Returns null for anything the simple builder can't represent
+ * (steps, ranges, lists, month restrictions, non-integer fields).
+ */
+export function scheduleFromCron(cron: string): RecurringSchedule | null {
+    const parts = cron.trim().split(/\s+/);
+    if (parts.length !== 5) return null;
+    const [m, h, dom, mon, dow] = parts;
+    if (mon !== "*") return null;
+    if (!/^\d{1,2}$/.test(m) || !/^\d{1,2}$/.test(h)) return null;
+    const minute = Number(m);
+    const hour = Number(h);
+    if (minute > 59 || hour > 23) return null;
+
+    if (dom === "*" && dow === "*") {
+        const d = new Date(Date.UTC(REF_YEAR, 0, 15, hour, minute));
+        return { freq: "daily", hour: d.getHours(), minute: d.getMinutes(), day: 0 };
+    }
+    if (dom === "*" && /^[0-6]$/.test(dow)) {
+        const d = new Date(Date.UTC(REF_YEAR, 0, 10, hour, minute));
+        while (d.getUTCDay() !== Number(dow)) d.setUTCDate(d.getUTCDate() + 1);
+        return { freq: "weekly", hour: d.getHours(), minute: d.getMinutes(), day: d.getDay() };
+    }
+    if (dow === "*" && /^([1-9]|[12]\d|3[01])$/.test(dom)) {
+        const d = new Date(Date.UTC(REF_YEAR, 0, Number(dom), hour, minute));
+        return { freq: "monthly", hour: d.getHours(), minute: d.getMinutes(), day: d.getDate() };
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary

Makes the built-in time service a proper **follow-up scheduler** for agents: instead of blocking with `sleep`, an agent subscribes with a duration and a `message`, ends its turn, and the trigger wakes the session with the note-to-self.

### Changes

- **`message` param** on `time:timer_fired`, `time:at`, and `time:cron` — carried in the fired payload and used as the trigger summary, so the agent wakes up knowing exactly what to do.
- **Targeted delivery** — fires now go only to the session that owns the subscription (`POST /api/sessions/:id/trigger`) instead of `trigger-broadcast` fan-out. Previously any unfiltered subscriber of the same trigger type received everyone else's timer fires.
- **One-shot auto-cleanup** — `time:timer_fired` and `time:at` subscriptions are deleted server-side after successful delivery, so a runner restart no longer re-arms and re-fires already-fired timers. If delivery fails (session offline), the subscription is kept so the next reconcile retries it.
- **Trigger descriptions** rewritten to steer agents: subscribe + end your turn instead of sleeping/polling.

### Notes

- `time:cron` stays recurring but is now also delivered only to its owning session.
- Legacy subscriptions without a real `subscriptionId` skip targeted deletion (fabricated key path).
- Removes the now-unused `readRunnerId()` helper.

## Testing

- `bun test time-service.reconcile.test.ts` — 26 pass, including new coverage: message in payload, DELETE after fire, past `time:at` immediate fire + cleanup, failed delivery keeps subscription.
- `bunx tsc --noEmit` clean.