### PR TITLE
fix(ui): queue input sent while session is hydrating instead of rejecting it

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -69,7 +69,7 @@ import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { HubSocketContext } from "@/lib/hub-socket-context";
 import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
 import { mapUserError } from "@/lib/user-error-message";
-import { canSubmitSessionInput, isSessionHydrating } from "@/lib/session-empty-state";
+import { classifySessionInput } from "@/lib/session-empty-state";
 import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
 import { evaluateVersionNegotiation } from "@/lib/version-negotiation";
 import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, setViewerSwitchGeneration } from "@/hooks/useRunnerServices";
@@ -3551,6 +3551,12 @@ export function App() {
   const inputDedupeRef = React.useRef<InputDedupeState | null>(null);
   const inputAttemptIdRef = React.useRef(0);
 
+  type SessionInputMessage = { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string;
+
+  // Messages submitted while the session was still hydrating (e.g. the runner
+  // was loading MCP servers). Flushed once the snapshot completes.
+  const pendingHydrationInputsRef = React.useRef<Array<{ sessionId: string; message: SessionInputMessage }>>([]);
+
   const requestOlderMessages = React.useCallback(() => {
     const socket = viewerWsRef.current;
     const sessionId = lifecycleRefs.activeSessionId.current;
@@ -3564,7 +3570,7 @@ export function App() {
     });
   }, [loadingOlderMessages]);
 
-  const sendSessionInput = React.useCallback(async (message: { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string) => {
+  const sendSessionInput = React.useCallback(async (message: SessionInputMessage) => {
     const socket = viewerWsRef.current;
     const sessionId = lifecycleRefs.activeSessionId.current;
     if (!sessionId) {
@@ -3575,12 +3581,15 @@ export function App() {
       setLifecycleStatus("Compacting…");
       return false;
     }
-    if (lifecycleRefs.awaitingSnapshot.current || !canSubmitSessionInput(sessionId, viewerStatus, isCompacting)) {
-      if (isSessionHydrating(viewerStatus) || lifecycleRefs.awaitingSnapshot.current) {
-        setLifecycleStatus("Connecting…");
-      }
-      return false;
+    const gate = classifySessionInput(sessionId, viewerStatus, isCompacting, lifecycleRefs.awaitingSnapshot.current);
+    if (gate === "queue") {
+      // Session is still hydrating (usually MCP servers loading on the
+      // runner). Queue the message and flush it once the snapshot completes
+      // instead of rejecting and forcing the user to retry.
+      pendingHydrationInputsRef.current.push({ sessionId, message });
+      return true;
     }
+    if (gate === "reject") return false;
     if (!socket || !socket.connected) {
       setLifecycleStatus("Not connected to a live session");
       return false;
@@ -3746,6 +3755,23 @@ export function App() {
       return false;
     }
   }, [isCompacting, patchSessionCache, viewerStatus]);
+
+  const sendSessionInputRef = React.useRef(sendSessionInput);
+  React.useEffect(() => { sendSessionInputRef.current = sendSessionInput; });
+
+  // Flush input queued during hydration once the session goes live. Entries
+  // for a session the user has since switched away from are dropped.
+  React.useEffect(() => {
+    if (!lifecycle.isLive) return;
+    const pending = pendingHydrationInputsRef.current;
+    if (pending.length === 0) return;
+    pendingHydrationInputsRef.current = [];
+    const activeId = lifecycleRefs.activeSessionId.current;
+    for (const item of pending) {
+      if (item.sessionId !== activeId) continue;
+      void sendSessionInputRef.current(item.message);
+    }
+  }, [lifecycle.isLive, lifecycleRefs]);
 
   const sendRemoteExec = React.useCallback((payload: any) => {
     const socket = viewerWsRef.current;

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -492,7 +492,14 @@ export function SessionViewer({
     ignoreTargetSelector: "[data-pp-prompt]",
   });
 
-  const composerReady = canSubmitSessionInput(sessionId, viewerStatus, !!isCompacting);
+  // Allow composing while the session is still hydrating (e.g. MCP servers
+  // loading on the runner) — input submitted then is queued and flushed once
+  // the snapshot completes. Only lock the composer when hydration is stuck
+  // (runner likely offline) so drafts aren't queued into the void.
+  const hydrating = isSessionHydrating(viewerStatus);
+  const composerReady =
+    canSubmitSessionInput(sessionId, viewerStatus, !!isCompacting) ||
+    (!!sessionId && !isCompacting && hydrating && !hydrationStuck);
 
   React.useEffect(() => {
     if (!sessionId || !isSessionHydrating(viewerStatus)) {
@@ -508,7 +515,7 @@ export function SessionViewer({
     (message: PromptInputMessage) => {
       if (!composerReady) {
         if (isSessionHydrating(viewerStatus)) {
-          setComposerError("Session is still connecting — wait a moment and try again.");
+          setComposerError("Session is still connecting — your draft is preserved, try again shortly.");
         }
         return;
       }

--- a/packages/ui/src/lib/session-empty-state.test.ts
+++ b/packages/ui/src/lib/session-empty-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   canSubmitSessionInput,
+  classifySessionInput,
   getSessionEmptyStateUi,
   isSessionHydrating,
   shouldShowSessionTranscript,
@@ -56,6 +57,24 @@ describe("canSubmitSessionInput", () => {
   test("allows submission once the session is connected and interactive", () => {
     expect(canSubmitSessionInput("sess-1", "Connected", false)).toBe(true);
     expect(canSubmitSessionInput("sess-1", "Waiting for session events", false)).toBe(true);
+  });
+});
+
+describe("classifySessionInput", () => {
+  test("rejects without a session or during compaction", () => {
+    expect(classifySessionInput(null, "Connected", false, false)).toBe("reject");
+    expect(classifySessionInput("sess-1", "Connected", true, false)).toBe("reject");
+  });
+
+  test("queues while hydrating or awaiting the snapshot", () => {
+    expect(classifySessionInput("sess-1", "Connecting…", false, false)).toBe("queue");
+    expect(classifySessionInput("sess-1", "Loading session (0 of 10 messages)…", false, false)).toBe("queue");
+    // Status says Connected but the snapshot hasn't arrived yet (slow MCP startup).
+    expect(classifySessionInput("sess-1", "Connected", false, true)).toBe("queue");
+  });
+
+  test("sends once live", () => {
+    expect(classifySessionInput("sess-1", "Connected", false, false)).toBe("send");
   });
 });
 

--- a/packages/ui/src/lib/session-empty-state.ts
+++ b/packages/ui/src/lib/session-empty-state.ts
@@ -41,6 +41,26 @@ export function canSubmitSessionInput(
 }
 
 /**
+ * Decides what to do with input submitted to a session.
+ *
+ * "queue" means the session is still hydrating (e.g. the runner is loading
+ * MCP servers) — the message should be buffered and flushed once the
+ * snapshot completes, instead of being rejected and forcing a manual retry.
+ */
+export type SessionInputGate = "send" | "queue" | "reject";
+
+export function classifySessionInput(
+  sessionId: string | null | undefined,
+  viewerStatus: string | null | undefined,
+  isCompacting: boolean,
+  awaitingSnapshot: boolean,
+): SessionInputGate {
+  if (!sessionId || isCompacting) return "reject";
+  if (awaitingSnapshot || isSessionHydrating(viewerStatus)) return "queue";
+  return "send";
+}
+
+/**
  * Copy + animation state for session-specific empty states.
  */
 export function getSessionEmptyStateUi(viewerStatus: string | null | undefined): SessionEmptyStateUi {


### PR DESCRIPTION
Sending a message right after opening a session (while the runner is still loading MCP servers) was hard-rejected: the composer was disabled during 'Connecting…', and sends during `awaitingSnapshot` returned 'Failed to send message' — forcing users to click another session and back.<br /><br />**Changes**<br />- `classifySessionInput()` (new, tested): decides send / queue / reject based on session, compaction, hydration, and snapshot state<br />- `App.tsx`: input submitted during hydration is queued and flushed once the lifecycle goes live; entries for a since-switched session are dropped<br />- `SessionViewer.tsx`: composer stays enabled during normal hydration; still locks when hydration is stuck (>10s) so drafts aren't queued into the void<br /><br />Runner side already buffers input behind `waitForWorkerStartupComplete`, so queued messages deliver correctly once MCP finishes loading.