### PR TITLE
feat(runner): track and kill session-spawned processes

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -26,6 +26,7 @@ import { toolSearchExtension } from "./tool-search.js";
 import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
 import { providerRequestLogExtension } from "./provider-request-log.js";
+import { sessionProcessesExtension } from "./session-processes.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     providerRequestLogExtension,
@@ -37,6 +38,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     ollamaWebToolsExtension,
     goalExtension,
     restartExtension,
+    sessionProcessesExtension,
     setSessionNameExtension,
     updateTodoExtension,
     spawnSessionExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -5,6 +5,7 @@ import { initialPromptExtension } from "./initial-prompt.js";
 import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
 import { restartExtension } from "./restart.js";
+import { sessionProcessesExtension } from "./session-processes.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
@@ -74,6 +75,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     factories.push(
         named(goalExtension, "goal"),
         named(restartExtension, "restart"),
+        named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
         named(updateTodoExtension, "todo"),
         named(spawnSessionExtension, "spawn-session"),

--- a/packages/cli/src/extensions/session-processes.test.ts
+++ b/packages/cli/src/extensions/session-processes.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { formatWidgetLine, shortCommand, type GroupProcess } from "./session-processes.js";
+import { formatWidgetLine, sessionProcessesExtension, shortCommand, type GroupProcess } from "./session-processes.js";
 
 const proc = (pid: number, command: string): GroupProcess => ({ pid, etime: "01:00", rssKb: 1024, command });
 
@@ -9,6 +9,24 @@ describe("shortCommand", () => {
         expect(shortCommand("node /app/server.js")).toBe("node server.js");
         expect(shortCommand("sleep 30")).toBe("sleep 30");
         expect(shortCommand("pgrep -g 0")).toBe("pgrep");
+    });
+});
+
+describe("sessionProcessesExtension", () => {
+    test("session_start is a no-op outside TUI mode (runner workers stub ui.theme)", () => {
+        const handlers: Record<string, (event: unknown, ctx: unknown) => void> = {};
+        sessionProcessesExtension({ on: (name: string, fn: any) => { handlers[name] = fn; } } as any);
+
+        let widgetCalls = 0;
+        // Mirrors the runner worker's headless ui stub: hasUI true, theme undefined.
+        const ctx = {
+            mode: "rpc",
+            hasUI: true,
+            ui: { setWidget: () => { widgetCalls++; }, get theme() { return undefined; } },
+        };
+        expect(() => handlers.session_start({}, ctx)).not.toThrow();
+        expect(widgetCalls).toBe(0);
+        handlers.session_shutdown({}, ctx);
     });
 });
 

--- a/packages/cli/src/extensions/session-processes.test.ts
+++ b/packages/cli/src/extensions/session-processes.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "bun:test";
+import { formatWidgetLine, shortCommand, type GroupProcess } from "./session-processes.js";
+
+const proc = (pid: number, command: string): GroupProcess => ({ pid, etime: "01:00", rssKb: 1024, command });
+
+describe("shortCommand", () => {
+    test("basename + first non-flag arg", () => {
+        expect(shortCommand("/usr/local/bin/bun run dev")).toBe("bun run");
+        expect(shortCommand("node /app/server.js")).toBe("node server.js");
+        expect(shortCommand("sleep 30")).toBe("sleep 30");
+        expect(shortCommand("pgrep -g 0")).toBe("pgrep");
+    });
+});
+
+describe("formatWidgetLine", () => {
+    test("null when only self is in the group", () => {
+        expect(formatWidgetLine([proc(100, "pi")], 100)).toBeNull();
+        expect(formatWidgetLine([], 100)).toBeNull();
+    });
+
+    test("lists children excluding self, with overflow count", () => {
+        const procs = [proc(100, "pi"), proc(1, "bun run dev"), proc(2, "vite"), proc(3, "a"), proc(4, "b"), proc(5, "c"), proc(6, "d")];
+        const line = formatWidgetLine(procs, 100);
+        expect(line).toContain("6 procs");
+        expect(line).toContain("bun run:1");
+        expect(line).toContain("+2");
+        expect(line).not.toContain(":100");
+    });
+});

--- a/packages/cli/src/extensions/session-processes.ts
+++ b/packages/cli/src/extensions/session-processes.ts
@@ -61,7 +61,9 @@ export const sessionProcessesExtension: ExtensionFactory = (pi) => {
     let lastLine: string | null | undefined;
 
     pi.on("session_start", (_event, ctx: any) => {
-        if (!ctx.hasUI || timer) return;
+        // TUI only: hasUI is also true in RPC mode (runner workers), where
+        // ctx.ui is a headless stub whose theme is undefined.
+        if (ctx.mode !== "tui" || timer) return;
 
         const update = async () => {
             let line: string | null;

--- a/packages/cli/src/extensions/session-processes.ts
+++ b/packages/cli/src/extensions/session-processes.ts
@@ -1,0 +1,86 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+
+const execFileAsync = promisify(execFile);
+
+const POLL_MS = 5000;
+
+export interface GroupProcess {
+    pid: number;
+    etime: string;
+    rssKb: number;
+    command: string;
+}
+
+/**
+ * OS processes in this session's process group.
+ * Runner workers are spawned detached (PGID = worker PID); local TUI sessions
+ * get their own group from shell job control. Either way, everything this
+ * session spawned (bash children, MCP stdio servers, dev servers) is here.
+ */
+export async function listOwnGroupProcesses(): Promise<GroupProcess[]> {
+    // pgrep translates group 0 into the caller's own process group and
+    // never reports itself; ps runs after pgrep exits so neither shows up.
+    const { stdout: pidsOut } = await execFileAsync("pgrep", ["-g", "0"]);
+    const pids = pidsOut.split("\n").map((l) => l.trim()).filter(Boolean);
+    if (pids.length === 0) return [];
+    const { stdout } = await execFileAsync("ps", ["-o", "pid=,etime=,rss=,command=", "-p", pids.join(",")]);
+    const procs: GroupProcess[] = [];
+    for (const line of stdout.split("\n")) {
+        const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+(.*)$/);
+        if (!m) continue;
+        procs.push({ pid: parseInt(m[1], 10), etime: m[2], rssKb: parseInt(m[3], 10), command: m[4] });
+    }
+    return procs;
+}
+
+/** Short display name for a process (basename of argv[0] + first arg). */
+export function shortCommand(command: string): string {
+    const parts = command.trim().split(/\s+/);
+    const bin = parts[0]?.split("/").pop() ?? "?";
+    const arg = parts[1] && !parts[1].startsWith("-") ? ` ${parts[1].split("/").pop()}` : "";
+    return `${bin}${arg}`;
+}
+
+/** One-line widget summary, or null when the session has no child processes. */
+export function formatWidgetLine(procs: GroupProcess[], selfPid: number, maxShown = 4): string | null {
+    const children = procs.filter((p) => p.pid !== selfPid);
+    if (children.length === 0) return null;
+    const shown = children.slice(0, maxShown).map((p) => `${shortCommand(p.command)}:${p.pid}`);
+    const more = children.length > maxShown ? ` +${children.length - maxShown}` : "";
+    return `⚙ ${children.length} proc${children.length === 1 ? "" : "s"} ${shown.join(" · ")}${more}`;
+}
+
+/**
+ * Live widget above the editor showing every process spawned by this session.
+ * Hidden when the session has no child processes.
+ */
+export const sessionProcessesExtension: ExtensionFactory = (pi) => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let lastLine: string | null | undefined;
+
+    pi.on("session_start", (_event, ctx: any) => {
+        if (!ctx.hasUI || timer) return;
+
+        const update = async () => {
+            let line: string | null;
+            try {
+                line = formatWidgetLine(await listOwnGroupProcesses(), process.pid);
+            } catch {
+                line = null; // no pgrep/ps (e.g. Windows) — stay hidden
+            }
+            if (line === lastLine) return;
+            lastLine = line;
+            ctx.ui.setWidget("session-processes", line === null ? undefined : [ctx.ui.theme.fg("dim", line)]);
+        };
+
+        void update();
+        timer = setInterval(() => void update(), POLL_MS);
+    });
+
+    pi.on("session_shutdown", () => {
+        if (timer) clearInterval(timer);
+        timer = null;
+    });
+};

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -15,6 +15,7 @@ import { resolvePizzaPiVar } from "../config/io.js";
 import { mergeModelLists, readSessionModelsCache, type SessionModelEntry } from "../session-models-cache.js";
 import { getCachedOllamaCloudModels } from "../ollama-cloud-models.js";
 import { TunnelService } from "./services/tunnel-service.js";
+import { ProcessService } from "./services/process-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
 import { globalPluginDirs } from "../plugins/discover.js";
@@ -40,7 +41,7 @@ import { normalizeLoopbackHost } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
-import { type RunnerSession, spawnSession } from "./session-spawner.js";
+import { type RunnerSession, spawnSession, killSessionProcessGroup } from "./session-spawner.js";
 import { pruneSessionCloseMetadata, type SessionCloseMetadata } from "./session-close-metadata.js";
 
 import {
@@ -173,7 +174,9 @@ function escalateToSigkill(child: ChildProcess, label: string, timeoutMs = 5_000
         try {
             if (!child.killed && child.exitCode === null) {
                 logWarn(`[daemon] ${label} did not exit after ${timeoutMs}ms; force-killing`);
-                forceKillTree(child);
+                // Kill the whole process group (worker + descendants); fall back
+                // to tree-kill (Windows) / plain kill if group signaling isn't possible.
+                if (!killSessionProcessGroup(child.pid, "SIGKILL")) forceKillTree(child);
             }
         } catch {
             // Process already exited; ignore.
@@ -432,6 +435,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             logInfo('[services] built-in service "git" disabled by config');
         } else {
             registry.register(new GitService());
+        }
+        if (isServiceDisabled("process")) {
+            logInfo('[services] built-in service "process" disabled by config');
+        } else {
+            registry.register(new ProcessService((sessionId) => runningSessions.get(sessionId)?.child?.pid ?? null));
         }
         const cleanupGitSessionState = (sessionId: string) => {
             const gitService = registry.get("git");
@@ -1348,12 +1356,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         // exit handler sees it even if exit code 43 (restart-in-place)
                         // arrives before the shutdown request is delivered.
                         killedSessions.add(sessionId);
-                        // SIGTERM on POSIX; IPC shutdown message on Windows (where
-                        // kill() would TerminateProcess and skip worker cleanup).
+                        // Signal the whole process group so background processes
+                        // spawned by the session die too. Falls back to the
+                        // standard graceful path (IPC shutdown message on Windows,
+                        // where kill() would TerminateProcess and skip cleanup;
+                        // plain SIGTERM elsewhere) if group signaling fails.
                         const child = entry.child;
-                        requestChildShutdown(child, (timeoutMs) =>
-                            logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
-                        );
+                        if (!killSessionProcessGroup(child.pid)) {
+                            requestChildShutdown(child, (timeoutMs) =>
+                                logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
+                            );
+                        } else {
+                            escalateToSigkill(child, `session ${sessionId}`);
+                        }
                     } catch {}
                 } else if (entry.adopted) {
                     // No child handle — ask the relay to disconnect the worker's

--- a/packages/cli/src/runner/services/process-service.test.ts
+++ b/packages/cli/src/runner/services/process-service.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parsePsLine, ProcessService } from "./process-service.js";
 import { killSessionProcessGroup } from "../session-spawner.js";
 
@@ -71,5 +74,35 @@ describe("ProcessService", () => {
         expect(sent[2].type).toBe("process_error");
 
         killSessionProcessGroup(pid, "SIGKILL");
+    });
+
+    test("lists a recorded background group even with no worker pid", async () => {
+        // Simulate a backgrounded command whose bash wrapper exited: the group
+        // leader PID was recorded to the pid file, and a detached grandchild is
+        // still alive in that group.
+        const child = spawn("sh", ["-c", "sleep 30"], { detached: true, stdio: "ignore" });
+        const groupPid = child.pid!;
+        await new Promise((r) => setTimeout(r, 100));
+
+        const dir = mkdtempSync(join(tmpdir(), "procsvc-"));
+        const procFile = join(dir, "s2.pids");
+        writeFileSync(procFile, `${groupPid}\n`);
+
+        // No worker pid (adopted/ended session) — only the recorded group.
+        const service = new ProcessService(() => null, () => procFile);
+        const sent: Array<{ type: string; payload: any }> = [];
+        (service as any).socket = { on() {}, off() {}, emit: (_e: string, env: any) => sent.push(env) };
+
+        await (service as any).handleList({ serviceId: "process", type: "process_list", sessionId: "s2", payload: {} });
+        expect(sent[0].type).toBe("process_list_result");
+        expect(sent[0].payload.workerPid).toBeNull();
+        expect(sent[0].payload.processes.some((p: any) => p.pid === groupPid)).toBe(true);
+
+        // A member of the recorded group can be killed (authorized).
+        await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s2", payload: { pid: groupPid } });
+        expect(sent[1].type).toBe("process_list_result");
+
+        killSessionProcessGroup(groupPid, "SIGKILL");
+        rmSync(dir, { recursive: true, force: true });
     });
 });

--- a/packages/cli/src/runner/services/process-service.test.ts
+++ b/packages/cli/src/runner/services/process-service.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { parsePsLine, ProcessService } from "./process-service.js";
+import { killSessionProcessGroup } from "../session-spawner.js";
+
+describe("parsePsLine", () => {
+    test("parses a normal ps line", () => {
+        expect(parsePsLine("  1234 02:13  51200 bun run dev --port 3000")).toEqual({
+            pid: 1234,
+            etime: "02:13",
+            rssKb: 51200,
+            command: "bun run dev --port 3000",
+        });
+    });
+
+    test("parses day-form etime", () => {
+        expect(parsePsLine("99999 1-04:00:00 8 node server.js")?.etime).toBe("1-04:00:00");
+    });
+
+    test("rejects garbage", () => {
+        expect(parsePsLine("")).toBeNull();
+        expect(parsePsLine("not a ps line")).toBeNull();
+    });
+});
+
+describe("killSessionProcessGroup", () => {
+    test("returns false for undefined or dead pid", () => {
+        expect(killSessionProcessGroup(undefined)).toBe(false);
+        // PID unlikely to be a live process group
+        expect(killSessionProcessGroup(2 ** 21)).toBe(false);
+    });
+
+    test("kills a detached process group including grandchildren", async () => {
+        // sh spawns a background sleep (grandchild), then sleeps itself
+        const child = spawn("sh", ["-c", "sleep 30 & sleep 30"], { detached: true, stdio: "ignore" });
+        const pid = child.pid!;
+        await new Promise((r) => setTimeout(r, 100));
+        expect(killSessionProcessGroup(pid, "SIGKILL")).toBe(true);
+        await new Promise((r) => setTimeout(r, 100));
+        // Signaling again should fail — the whole group is gone
+        expect(killSessionProcessGroup(pid, "SIGKILL")).toBe(false);
+    });
+});
+
+describe("ProcessService", () => {
+    test("lists processes for a live group and refuses foreign pids", async () => {
+        const child = spawn("sh", ["-c", "sleep 30"], { detached: true, stdio: "ignore" });
+        const pid = child.pid!;
+        await new Promise((r) => setTimeout(r, 100));
+
+        const service = new ProcessService((sessionId) => (sessionId === "s1" ? pid : null));
+        const sent: Array<{ type: string; payload: any }> = [];
+        const socket = {
+            on: () => {},
+            off: () => {},
+            emit: (_event: string, envelope: any) => sent.push(envelope),
+        };
+        (service as any).socket = socket;
+
+        await (service as any).handleList({ serviceId: "process", type: "process_list", sessionId: "s1", payload: {} });
+        expect(sent[0].type).toBe("process_list_result");
+        expect(sent[0].payload.workerPid).toBe(pid);
+        expect(sent[0].payload.processes.some((p: any) => p.pid === pid)).toBe(true);
+
+        // Kill request for a pid outside the group is rejected
+        await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s1", payload: { pid: process.pid } });
+        expect(sent[1].type).toBe("process_error");
+
+        // Killing the worker pid itself is refused
+        await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s1", payload: { pid } });
+        expect(sent[2].type).toBe("process_error");
+
+        killSessionProcessGroup(pid, "SIGKILL");
+    });
+});

--- a/packages/cli/src/runner/services/process-service.ts
+++ b/packages/cli/src/runner/services/process-service.ts
@@ -1,0 +1,146 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
+import { logInfo } from "../logger.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface SessionProcess {
+    pid: number;
+    /** Elapsed time as reported by ps (e.g. "02:13" or "1-04:00:00"). */
+    etime: string;
+    /** Resident set size in KB. */
+    rssKb: number;
+    command: string;
+}
+
+/** Parse one `ps -o pid=,etime=,rss=,command=` output line. */
+export function parsePsLine(line: string): SessionProcess | null {
+    const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+(.*)$/);
+    if (!m) return null;
+    return { pid: parseInt(m[1], 10), etime: m[2], rssKb: parseInt(m[3], 10), command: m[4] };
+}
+
+/**
+ * Lists and kills OS processes belonging to a session's process group.
+ * Workers are spawned detached, so PGID = worker PID and every descendant
+ * (bash children, MCP stdio servers, dev servers) is enumerable via `pgrep -g`.
+ */
+export class ProcessService implements ServiceHandler {
+    readonly id = "process";
+
+    private socket: Socket | null = null;
+    private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
+
+    constructor(private getWorkerPid: (sessionId: string) => number | null) {}
+
+    init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        this.socket = socket;
+
+        this._onServiceMessage = (envelope: ServiceEnvelope) => {
+            if (isShuttingDown()) return;
+            if (envelope.serviceId !== "process") return;
+
+            switch (envelope.type) {
+                case "process_list":
+                    void this.handleList(envelope);
+                    break;
+                case "process_kill":
+                    void this.handleKill(envelope);
+                    break;
+            }
+        };
+
+        (socket as any).on("service_message", this._onServiceMessage);
+    }
+
+    dispose(): void {
+        if (this.socket && this._onServiceMessage) {
+            (this.socket as any).off("service_message", this._onServiceMessage);
+        }
+        this.socket = null;
+        this._onServiceMessage = null;
+    }
+
+    /** PIDs in the session's process group. Empty when the group is gone. */
+    private async groupPids(workerPid: number): Promise<number[]> {
+        try {
+            const { stdout } = await execFileAsync("pgrep", ["-g", String(workerPid)]);
+            return stdout.split("\n").map((l) => parseInt(l, 10)).filter((n) => Number.isFinite(n));
+        } catch {
+            // pgrep exits 1 when no processes match
+            return [];
+        }
+    }
+
+    private async listProcesses(workerPid: number): Promise<SessionProcess[]> {
+        const pids = await this.groupPids(workerPid);
+        if (pids.length === 0) return [];
+        try {
+            const { stdout } = await execFileAsync("ps", ["-o", "pid=,etime=,rss=,command=", "-p", pids.join(",")]);
+            return stdout.split("\n").map(parsePsLine).filter((p): p is SessionProcess => p !== null);
+        } catch {
+            return [];
+        }
+    }
+
+    private emit(type: string, payload: unknown, requestId?: string): void {
+        if (!this.socket) return;
+        (this.socket as any).emit("service_message", {
+            serviceId: "process",
+            type,
+            ...(requestId ? { requestId } : {}),
+            payload,
+        } satisfies ServiceEnvelope);
+    }
+
+    private resolveSessionId(envelope: ServiceEnvelope): string | null {
+        if (typeof envelope.sessionId === "string" && envelope.sessionId) return envelope.sessionId;
+        const payload = envelope.payload as Record<string, unknown> | undefined;
+        return typeof payload?.sessionId === "string" ? payload.sessionId : null;
+    }
+
+    private async handleList(envelope: ServiceEnvelope): Promise<void> {
+        const sessionId = this.resolveSessionId(envelope);
+        const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
+        // workerPid is null for adopted sessions (worker survived a daemon
+        // restart — no child handle) and ended sessions. Report an empty list.
+        const processes = workerPid ? await this.listProcesses(workerPid) : [];
+        this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
+    }
+
+    private async handleKill(envelope: ServiceEnvelope): Promise<void> {
+        const sessionId = this.resolveSessionId(envelope);
+        const payload = envelope.payload as { pid?: number } | undefined;
+        const pid = typeof payload?.pid === "number" ? payload.pid : NaN;
+        const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
+
+        if (!workerPid || !Number.isInteger(pid) || pid <= 0) {
+            this.emit("process_error", { error: `Invalid kill request (pid=${payload?.pid})` }, envelope.requestId);
+            return;
+        }
+
+        // Trust boundary: only allow killing PIDs that are actually members of
+        // this session's process group — never arbitrary system PIDs.
+        const pids = await this.groupPids(workerPid);
+        if (!pids.includes(pid)) {
+            this.emit("process_error", { error: `PID ${pid} is not part of session ${sessionId}` }, envelope.requestId);
+            return;
+        }
+        if (pid === workerPid) {
+            this.emit("process_error", { error: "Refusing to kill the session worker — use Kill Session instead" }, envelope.requestId);
+            return;
+        }
+
+        try {
+            process.kill(pid, "SIGTERM");
+            logInfo(`[process] killed pid ${pid} in session ${sessionId} group ${workerPid}`);
+        } catch {
+            // Already exited — fall through to refreshed list
+        }
+        // Respond with a fresh list so the panel updates immediately.
+        const processes = await this.listProcesses(workerPid);
+        this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
+    }
+}

--- a/packages/cli/src/runner/services/process-service.ts
+++ b/packages/cli/src/runner/services/process-service.ts
@@ -3,19 +3,20 @@ import { promisify } from "node:util";
 import type { Socket } from "socket.io-client";
 import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
 import { logInfo } from "../logger.js";
+import {
+    sessionProcFilePath,
+    readRecordedGroupPids,
+    pruneProcFile,
+    selectGroupProcesses,
+    parsePsFullLine,
+    type SessionProcess,
+} from "../session-procs.js";
 
 const execFileAsync = promisify(execFile);
 
-export interface SessionProcess {
-    pid: number;
-    /** Elapsed time as reported by ps (e.g. "02:13" or "1-04:00:00"). */
-    etime: string;
-    /** Resident set size in KB. */
-    rssKb: number;
-    command: string;
-}
+export type { SessionProcess };
 
-/** Parse one `ps -o pid=,etime=,rss=,command=` output line. */
+/** Parse one `ps -o pid=,etime=,rss=,command=` output line (legacy helper). */
 export function parsePsLine(line: string): SessionProcess | null {
     const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+(.*)$/);
     if (!m) return null;
@@ -23,9 +24,14 @@ export function parsePsLine(line: string): SessionProcess | null {
 }
 
 /**
- * Lists and kills OS processes belonging to a session's process group.
- * Workers are spawned detached, so PGID = worker PID and every descendant
- * (bash children, MCP stdio servers, dev servers) is enumerable via `pgrep -g`.
+ * Lists and kills OS processes belonging to a session.
+ *
+ * A session's processes span multiple process groups: the worker's own group
+ * (PGID = worker PID, holds inline children like MCP stdio servers) plus one
+ * group per bash command (the pi bash tool spawns each command detached, so it
+ * becomes its own group leader). Command group-leader PIDs are recorded at
+ * spawn time into a per-session pid file (see session-procs.ts), which lets us
+ * also enumerate — and kill — background processes that reparented to init.
  */
 export class ProcessService implements ServiceHandler {
     readonly id = "process";
@@ -33,7 +39,10 @@ export class ProcessService implements ServiceHandler {
     private socket: Socket | null = null;
     private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
 
-    constructor(private getWorkerPid: (sessionId: string) => number | null) {}
+    constructor(
+        private getWorkerPid: (sessionId: string) => number | null,
+        private getProcFilePath: (sessionId: string) => string = sessionProcFilePath,
+    ) {}
 
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this.socket = socket;
@@ -63,26 +72,58 @@ export class ProcessService implements ServiceHandler {
         this._onServiceMessage = null;
     }
 
-    /** PIDs in the session's process group. Empty when the group is gone. */
-    private async groupPids(workerPid: number): Promise<number[]> {
-        try {
-            const { stdout } = await execFileAsync("pgrep", ["-g", String(workerPid)]);
-            return stdout.split("\n").map((l) => parseInt(l, 10)).filter((n) => Number.isFinite(n));
-        } catch {
-            // pgrep exits 1 when no processes match
-            return [];
-        }
+    /**
+     * Process groups belonging to this session: the worker's own group plus
+     * every recorded bash-command group. `workerPid` is null for adopted
+     * sessions (no child handle after a daemon restart) — recorded groups from
+     * the still-running worker's pid file still apply.
+     */
+    private sessionGroups(sessionId: string, workerPid: number | null): { groups: Set<number>; filePath: string } {
+        const filePath = this.getProcFilePath(sessionId);
+        const groups = new Set<number>(readRecordedGroupPids(filePath));
+        if (workerPid) groups.add(workerPid);
+        return { groups, filePath };
     }
 
-    private async listProcesses(workerPid: number): Promise<SessionProcess[]> {
-        const pids = await this.groupPids(workerPid);
-        if (pids.length === 0) return [];
+    /** Full `ps` snapshot of every process (pid, pgid, etime, rss, command). */
+    private async psSnapshot(): Promise<string> {
+        const { stdout } = await execFileAsync("ps", ["-A", "-ww", "-o", "pid=,pgid=,etime=,rss=,command="]);
+        return stdout;
+    }
+
+    private async listProcesses(sessionId: string, workerPid: number | null): Promise<SessionProcess[]> {
+        const { groups, filePath } = this.sessionGroups(sessionId, workerPid);
+        if (groups.size === 0) return [];
+        let snapshot: string;
         try {
-            const { stdout } = await execFileAsync("ps", ["-o", "pid=,etime=,rss=,command=", "-p", pids.join(",")]);
-            return stdout.split("\n").map(parsePsLine).filter((p): p is SessionProcess => p !== null);
+            snapshot = await this.psSnapshot();
         } catch {
-            return [];
+            return []; // no ps (e.g. Windows) — process tracking unavailable
         }
+        const { processes, liveGroups } = selectGroupProcesses(snapshot, groups);
+        // Prune the recorded pid file to groups that still have live members
+        // (never drop the worker's own group — it isn't recorded there).
+        const liveRecorded = [...liveGroups].filter((g) => g !== workerPid);
+        pruneProcFile(filePath, liveRecorded);
+        return processes;
+    }
+
+    /** All PIDs that belong to this session (members of any session group). */
+    private async sessionMemberPids(sessionId: string, workerPid: number | null): Promise<Set<number>> {
+        const { groups } = this.sessionGroups(sessionId, workerPid);
+        const members = new Set<number>();
+        if (groups.size === 0) return members;
+        let snapshot: string;
+        try {
+            snapshot = await this.psSnapshot();
+        } catch {
+            return members;
+        }
+        for (const line of snapshot.split("\n")) {
+            const p = parsePsFullLine(line);
+            if (p && groups.has(p.pgid)) members.add(p.pid);
+        }
+        return members;
     }
 
     private emit(type: string, payload: unknown, requestId?: string): void {
@@ -104,9 +145,7 @@ export class ProcessService implements ServiceHandler {
     private async handleList(envelope: ServiceEnvelope): Promise<void> {
         const sessionId = this.resolveSessionId(envelope);
         const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
-        // workerPid is null for adopted sessions (worker survived a daemon
-        // restart — no child handle) and ended sessions. Report an empty list.
-        const processes = workerPid ? await this.listProcesses(workerPid) : [];
+        const processes = sessionId ? await this.listProcesses(sessionId, workerPid) : [];
         this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
     }
 
@@ -116,15 +155,15 @@ export class ProcessService implements ServiceHandler {
         const pid = typeof payload?.pid === "number" ? payload.pid : NaN;
         const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
 
-        if (!workerPid || !Number.isInteger(pid) || pid <= 0) {
+        if (!sessionId || !Number.isInteger(pid) || pid <= 0) {
             this.emit("process_error", { error: `Invalid kill request (pid=${payload?.pid})` }, envelope.requestId);
             return;
         }
 
         // Trust boundary: only allow killing PIDs that are actually members of
-        // this session's process group — never arbitrary system PIDs.
-        const pids = await this.groupPids(workerPid);
-        if (!pids.includes(pid)) {
+        // one of this session's process groups — never arbitrary system PIDs.
+        const members = await this.sessionMemberPids(sessionId, workerPid);
+        if (!members.has(pid)) {
             this.emit("process_error", { error: `PID ${pid} is not part of session ${sessionId}` }, envelope.requestId);
             return;
         }
@@ -135,12 +174,12 @@ export class ProcessService implements ServiceHandler {
 
         try {
             process.kill(pid, "SIGTERM");
-            logInfo(`[process] killed pid ${pid} in session ${sessionId} group ${workerPid}`);
+            logInfo(`[process] killed pid ${pid} in session ${sessionId}`);
         } catch {
             // Already exited — fall through to refreshed list
         }
         // Respond with a fresh list so the panel updates immediately.
-        const processes = await this.listProcesses(workerPid);
+        const processes = await this.listProcesses(sessionId, workerPid);
         this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
     }
 }

--- a/packages/cli/src/runner/session-procs.test.ts
+++ b/packages/cli/src/runner/session-procs.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "bun:test";
+import {
+    parseRecordedGroupPids,
+    parsePsFullLine,
+    selectGroupProcesses,
+    stripCapturePrefix,
+    sessionProcFilePath,
+    SHELL_PROC_CAPTURE_PREFIX,
+} from "./session-procs.js";
+
+describe("parseRecordedGroupPids", () => {
+    test("dedupes and drops garbage", () => {
+        expect(parseRecordedGroupPids("100\n200\n100\n\n-3\nabc\n0\n300\n")).toEqual([100, 200, 300]);
+    });
+    test("empty content", () => {
+        expect(parseRecordedGroupPids("")).toEqual([]);
+    });
+});
+
+describe("parsePsFullLine", () => {
+    test("parses pid pgid etime rss command", () => {
+        expect(parsePsFullLine("  1234  1200 02:13 51200 bun run dev --port 3000")).toEqual({
+            pid: 1234,
+            pgid: 1200,
+            etime: "02:13",
+            rssKb: 51200,
+            command: "bun run dev --port 3000",
+        });
+    });
+    test("parses day-form etime", () => {
+        expect(parsePsFullLine("99999 99999 1-04:00:00 8 node server.js")?.etime).toBe("1-04:00:00");
+    });
+    test("rejects garbage", () => {
+        expect(parsePsFullLine("")).toBeNull();
+        expect(parsePsFullLine("not a ps line")).toBeNull();
+    });
+});
+
+describe("stripCapturePrefix", () => {
+    test("removes the capture prefix (ps octal-escaped newline)", () => {
+        const line = `/bin/bash -c ${SHELL_PROC_CAPTURE_PREFIX}\\012sleep 3600`;
+        // ps shows the whole -c arg; the real command should survive
+        expect(stripCapturePrefix(line)).toBe("sleep 3600");
+    });
+    test("removes the capture prefix (real newline)", () => {
+        const line = `${SHELL_PROC_CAPTURE_PREFIX}\nnpm run build`;
+        expect(stripCapturePrefix(line)).toBe("npm run build");
+    });
+    test("leaves ordinary commands untouched", () => {
+        expect(stripCapturePrefix("/usr/bin/node server.js")).toBe("/usr/bin/node server.js");
+    });
+});
+
+describe("selectGroupProcesses", () => {
+    const snapshot = [
+        "  1     1 13-00:00:00 20000 /sbin/launchd",
+        "100   100 05:00 4000 /worker",
+        "200   100 04:59 8000 gm serve", // worker group inline child
+        "555   555 03:00 3000 /bin/bash -c sleep 3600", // recorded bash group leader
+        "556   555 03:00 1000 sleep 3600", // orphaned background child in recorded group
+        "900   900 01:00 500 unrelated",
+    ].join("\n");
+
+    test("selects worker group + recorded groups, reports live groups", () => {
+        const { processes, liveGroups } = selectGroupProcesses(snapshot, new Set([100, 555]));
+        expect(processes.map((p) => p.pid).sort((a, b) => a - b)).toEqual([100, 200, 555, 556]);
+        expect([...liveGroups].sort((a, b) => a - b)).toEqual([100, 555]);
+        // unrelated system processes are excluded
+        expect(processes.some((p) => p.pid === 1 || p.pid === 900)).toBe(false);
+    });
+
+    test("catches an orphaned background process via its recorded group", () => {
+        // Only the recorded bash group (555) is known — worker group absent.
+        const { processes } = selectGroupProcesses(snapshot, new Set([555]));
+        expect(processes.map((p) => p.pid).sort((a, b) => a - b)).toEqual([555, 556]);
+        expect(processes.find((p) => p.pid === 556)?.command).toBe("sleep 3600");
+    });
+});
+
+describe("sessionProcFilePath", () => {
+    test("sanitizes session ids into a safe filename", () => {
+        // Path separators are stripped (no traversal); dots are harmless once
+        // slashes are gone.
+        const p = sessionProcFilePath("abc/../etc");
+        expect(p.endsWith("abc_.._etc.pids")).toBe(true);
+        expect(p.includes("/../")).toBe(false);
+    });
+});

--- a/packages/cli/src/runner/session-procs.ts
+++ b/packages/cli/src/runner/session-procs.ts
@@ -1,0 +1,162 @@
+/**
+ * Session process tracking helpers.
+ *
+ * Problem: the pi bash tool spawns every command `detached: true`, so each
+ * command becomes its own process-group leader (PGID = command PID) in a new
+ * session — NOT the worker's group. Anything a command backgrounds (`foo &`)
+ * reparents to init when the wrapper exits but keeps that command's PGID. Such
+ * processes are therefore invisible to `pgrep -g <workerPid>` and un-killable
+ * via the worker's group, so they never showed in the Processes panel and
+ * outlived their session.
+ *
+ * Fix: capture each command's group-leader PID at spawn time. A shell command
+ * prefix (installed on the worker's SettingsManager) appends `$$` — the PID of
+ * the `bash -c` process, i.e. the detached group leader — to a per-session pid
+ * file every time a command runs. The daemon then enumerates every process
+ * whose PGID is the worker's group OR any recorded group, which catches
+ * orphaned background processes because they inherit their command's PGID.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+
+/** Directory holding per-session recorded-group pid files. */
+export function sessionProcDir(): string {
+    return join(homedir(), ".pizzapi", "session-procs");
+}
+
+/** Per-session pid file recording spawned command group-leader PIDs. */
+export function sessionProcFilePath(sessionId: string): string {
+    // Session IDs are relay-supplied — sanitize to a safe filename.
+    const safe = sessionId.replace(/[^A-Za-z0-9_.-]/g, "_");
+    return join(sessionProcDir(), `${safe}.pids`);
+}
+
+/** Ensure the proc-file directory exists (best-effort). */
+export function ensureSessionProcDir(): void {
+    try {
+        mkdirSync(sessionProcDir(), { recursive: true });
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Shell command prefix that records the running shell's PID (its detached
+ * process-group leader) into $PIZZAPI_SESSION_PROC_FILE. Guarded so it is a
+ * no-op when the env var is unset and never fails the user's command.
+ * `#pp-proc#` is a sentinel used to strip this line from displayed commands.
+ */
+export const SHELL_PROC_CAPTURE_PREFIX =
+    `{ [ -n "$PIZZAPI_SESSION_PROC_FILE" ] && printf '%s\\n' "$$" >>"$PIZZAPI_SESSION_PROC_FILE"; } 2>/dev/null || true #pp-proc#`;
+
+/** Sentinel marking the end of the capture prefix in a `bash -c` command line. */
+const CAPTURE_SENTINEL = "#pp-proc#";
+
+/**
+ * Remove the capture prefix from a command line for display. ps renders the
+ * embedded newline as an actual newline or `\012`; strip up to and including
+ * the sentinel plus any following separator.
+ */
+export function stripCapturePrefix(command: string): string {
+    const idx = command.indexOf(CAPTURE_SENTINEL);
+    if (idx === -1) return command;
+    let rest = command.slice(idx + CAPTURE_SENTINEL.length);
+    // Drop the separator between prefix and the real command (real newline,
+    // octal-escaped \012 as ps prints, or a space).
+    rest = rest.replace(/^(?:\r?\n|\\012|\s)+/, "");
+    return rest.length > 0 ? rest : command.slice(0, idx).trimEnd();
+}
+
+/** Read recorded group-leader PIDs from a session's pid file (deduped). */
+export function readRecordedGroupPids(filePath: string): number[] {
+    let content: string;
+    try {
+        content = readFileSync(filePath, "utf8");
+    } catch {
+        return []; // missing file — nothing recorded yet
+    }
+    return parseRecordedGroupPids(content);
+}
+
+/** Parse pid-file contents into a deduped list of positive integers. */
+export function parseRecordedGroupPids(content: string): number[] {
+    const seen = new Set<number>();
+    for (const line of content.split("\n")) {
+        const n = parseInt(line.trim(), 10);
+        if (Number.isInteger(n) && n > 0) seen.add(n);
+    }
+    return [...seen];
+}
+
+/** Delete a session's pid file (best-effort). */
+export function removeSessionProcFile(sessionId: string): void {
+    try {
+        rmSync(sessionProcFilePath(sessionId), { force: true });
+    } catch {
+        // best-effort
+    }
+}
+
+/** Rewrite a pid file with only the still-live group PIDs, bounding growth. */
+export function pruneProcFile(filePath: string, livePids: number[]): void {
+    try {
+        if (livePids.length === 0) {
+            rmSync(filePath, { force: true });
+            return;
+        }
+        writeFileSync(filePath, livePids.join("\n") + "\n");
+    } catch {
+        // best-effort
+    }
+}
+
+export interface GroupProc {
+    pid: number;
+    pgid: number;
+    etime: string;
+    rssKb: number;
+    command: string;
+}
+
+export interface SessionProcess {
+    pid: number;
+    etime: string;
+    rssKb: number;
+    command: string;
+}
+
+/** Parse one `ps -Ao pid=,pgid=,etime=,rss=,command=` line. */
+export function parsePsFullLine(line: string): GroupProc | null {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\d+)\s+(.*)$/);
+    if (!m) return null;
+    return {
+        pid: parseInt(m[1], 10),
+        pgid: parseInt(m[2], 10),
+        etime: m[3],
+        rssKb: parseInt(m[4], 10),
+        command: stripCapturePrefix(m[5]),
+    };
+}
+
+/**
+ * From a full `ps` snapshot, select processes whose PGID is one of `groups`.
+ * Returns the panel shape (pid/etime/rssKb/command) plus the set of PGIDs that
+ * still have live members (for pruning the recorded pid file).
+ */
+export function selectGroupProcesses(
+    psOutput: string,
+    groups: Set<number>,
+): { processes: SessionProcess[]; liveGroups: Set<number> } {
+    const processes: SessionProcess[] = [];
+    const liveGroups = new Set<number>();
+    for (const line of psOutput.split("\n")) {
+        const p = parsePsFullLine(line);
+        if (!p) continue;
+        if (!groups.has(p.pgid)) continue;
+        liveGroups.add(p.pgid);
+        processes.push({ pid: p.pid, etime: p.etime, rssKb: p.rssKb, command: p.command });
+    }
+    return { processes, liveGroups };
+}

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -3,6 +3,12 @@ import { existsSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { cleanupSessionAttachments } from "../extensions/session-attachments.js";
 import { logInfo } from "./logger.js";
+import {
+    sessionProcFilePath,
+    ensureSessionProcDir,
+    readRecordedGroupPids,
+    removeSessionProcFile,
+} from "./session-procs.js";
 import { runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd } from "./runner-usage-cache.js";
 import { isCwdAllowed } from "./workspace.js";
 import { loadConfig } from "../config.js";
@@ -95,6 +101,10 @@ export function spawnSession(
         throw new Error(`Session already running: ${sessionId}`);
     }
 
+    // Ensure the recorded-group pid file directory exists before the worker
+    // starts appending to it.
+    ensureSessionProcDir();
+
     // Resolve the effective cwd for this session now so we can register it for
     // usage auth lookups and clean it up on exit without re-deriving it.
     const effectiveCwd = requestedCwd ?? process.cwd();
@@ -168,6 +178,10 @@ export function spawnSession(
         // Tell the worker where the runner-managed usage cache lives so it can
         // read quota data without making its own provider API calls.
         PIZZAPI_RUNNER_USAGE_CACHE_PATH: runnerUsageCacheFilePath(),
+        // Per-session file where the worker's bash command prefix records each
+        // command's detached group-leader PID, so the daemon can enumerate and
+        // kill background processes that escaped the worker's own process group.
+        PIZZAPI_SESSION_PROC_FILE: sessionProcFilePath(sessionId),
         ...(requestedCwd ? { PIZZAPI_WORKER_CWD: requestedCwd } : {}),
         // Initial prompt and model for the new session (set by spawn_session tool).
         ...(options?.prompt ? { PIZZAPI_WORKER_INITIAL_PROMPT: options.prompt } : {}),
@@ -253,10 +267,16 @@ export function spawnSession(
             // Also remove from killedSessions if this was an explicit kill to prevent leaks.
             killedSessions.delete(sessionId);
             // Reap any stragglers the session left behind (background dev
-            // servers etc.) — the worker is gone, so signal its whole group.
+            // servers etc.) — the worker is gone, so signal its whole group
+            // plus every recorded bash-command group (which is where detached
+            // background processes actually live), then drop the pid file.
             if (killSessionProcessGroup(child.pid)) {
                 logInfo(`session ${sessionId} process group ${child.pid} signaled for cleanup`);
             }
+            for (const groupPid of readRecordedGroupPids(sessionProcFilePath(sessionId))) {
+                if (groupPid !== child.pid) killSessionProcessGroup(groupPid);
+            }
+            removeSessionProcFile(sessionId);
             void cleanupSessionAttachments(sessionId).catch(() => {});
         }
     });

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -23,6 +23,23 @@ export interface RunnerSession {
     sessionFile?: string;
 }
 
+/**
+ * Kill an entire session process group (worker + everything it spawned:
+ * bash children, MCP stdio servers, dev servers).  Workers are spawned with
+ * `detached: true`, making the worker PID the process-group ID.
+ * Returns false if the group signal could not be sent (already dead, or
+ * platform without process groups).
+ */
+export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): boolean {
+    if (!pid) return false;
+    try {
+        process.kill(-pid, signal);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 /** Is this process running inside a compiled Bun single-file binary? */
 // Detect compiled Bun single-file binary.
 // - Unix: import.meta.url contains "$bunfs"
@@ -176,6 +193,10 @@ export function spawnSession(
 
     const child = spawn(process.execPath, workerArgs, {
         env,
+        // New process group (PGID = worker PID).  Everything the session spawns
+        // (bash commands, MCP stdio servers, dev servers) inherits the group, so
+        // we can enumerate it (pgrep -g) and kill it wholesale on session end.
+        detached: true,
         // Include an IPC channel (fd[3]) so the worker can send a "pre_restart"
         // message to the daemon before calling process.exit(43).  This lets us
         // add the sessionId to restartingSessions *before* the process exits and
@@ -219,6 +240,10 @@ export function spawnSession(
             // message above; this add is a belt-and-suspenders fallback for the
             // (unlikely) case where the IPC message was not sent or was lost.
             restartingSessions.add(sessionId);
+            // ponytail: background processes from the old worker's group survive a
+            // restart-in-place (intentional — session continues) but land in a
+            // different pgid than the new worker. Track historical pgids per
+            // session if orphans from restarted workers become a problem.
             logInfo(`re-spawning session ${sessionId} (worker restart requested)`);
             onRestartRequested();
         } else {
@@ -227,6 +252,11 @@ export function spawnSession(
             // by then, so this is the reliable cleanup point for spawned sessions.
             // Also remove from killedSessions if this was an explicit kill to prevent leaks.
             killedSessions.delete(sessionId);
+            // Reap any stragglers the session left behind (background dev
+            // servers etc.) — the worker is gone, so signal its whole group.
+            if (killSessionProcessGroup(child.pid)) {
+                logInfo(`session ${sessionId} process group ${child.pid} signaled for cleanup`);
+            }
             void cleanupSessionAttachments(sessionId).catch(() => {});
         }
     });

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -1,4 +1,5 @@
-import { createAgentSession, DefaultResourceLoader, AuthStorage } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultResourceLoader, AuthStorage, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { SHELL_PROC_CAPTURE_PREFIX } from "./session-procs.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
@@ -388,12 +389,27 @@ async function main(): Promise<void> {
         // Non-fatal — diagnostic only
     }
 
+    // Install a shell command prefix that records each bash command's detached
+    // group-leader PID into $PIZZAPI_SESSION_PROC_FILE, so the daemon's process
+    // service can enumerate and kill background processes that escape the
+    // worker's own process group. Wrapping getShellCommandPrefix (rather than
+    // applyOverrides, which settingsManager.reload() would wipe) survives
+    // reloads and is baked into the bash tool at build time. Unix-only: the
+    // prefix uses POSIX shell + $$ and group tracking needs pgrep/ps.
+    const settingsManager = SettingsManager.create(cwd, agentDir);
+    if (process.platform !== "win32") {
+        const origGetPrefix = settingsManager.getShellCommandPrefix.bind(settingsManager);
+        settingsManager.getShellCommandPrefix = () =>
+            [origGetPrefix(), SHELL_PROC_CAPTURE_PREFIX].filter(Boolean).join("\n");
+    }
+
     bootTimer.start("[boot] create-session");
     const { session } = await createAgentSession({
         cwd,
         agentDir,
         authStorage,
         resourceLoader: loader,
+        settingsManager,
     });
     bootTimer.end("[boot] create-session");
 

--- a/packages/ui/src/components/ProcessPanel.tsx
+++ b/packages/ui/src/components/ProcessPanel.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from "react";
+import { useServiceChannel } from "@/hooks/useServiceChannel";
+import { reportError } from "@/lib/frontend-log";
+import { RefreshCw, X } from "lucide-react";
+
+interface SessionProcess {
+    pid: number;
+    etime: string;
+    rssKb: number;
+    command: string;
+}
+
+interface ProcessPanelProps {
+    sessionId: string;
+    runnerId?: string;
+}
+
+function formatRss(rssKb: number): string {
+    if (rssKb >= 1024 * 1024) return `${(rssKb / (1024 * 1024)).toFixed(1)} GB`;
+    if (rssKb >= 1024) return `${Math.round(rssKb / 1024)} MB`;
+    return `${rssKb} KB`;
+}
+
+const POLL_MS = 3000;
+
+export function ProcessPanel({ sessionId }: ProcessPanelProps) {
+    const [processes, setProcesses] = useState<SessionProcess[]>([]);
+    const [workerPid, setWorkerPid] = useState<number | null>(null);
+    const [loaded, setLoaded] = useState(false);
+
+    const { send, available } = useServiceChannel<unknown, unknown>("process", {
+        onMessage: (type, payload) => {
+            const p = payload as Record<string, unknown>;
+            if (type === "process_list_result") {
+                setProcesses((p.processes as SessionProcess[]) ?? []);
+                setWorkerPid((p.workerPid as number | null) ?? null);
+                setLoaded(true);
+            } else if (type === "process_error") {
+                reportError("process", (p.error as string) || "Process operation failed");
+            }
+        },
+    });
+
+    const refresh = useCallback(() => {
+        send("process_list", { sessionId });
+    }, [send, sessionId]);
+
+    useEffect(() => {
+        if (!available) {
+            setProcesses([]);
+            setLoaded(false);
+            return;
+        }
+        refresh();
+        const interval = setInterval(refresh, POLL_MS);
+        return () => clearInterval(interval);
+    }, [available, refresh]);
+
+    if (!available) return null;
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0">
+                <span className="text-xs text-muted-foreground">
+                    {processes.length} process{processes.length === 1 ? "" : "es"}
+                    {workerPid ? ` · group ${workerPid}` : ""}
+                </span>
+                <div className="flex-1" />
+                <button
+                    type="button"
+                    onClick={refresh}
+                    className="p-1 text-muted-foreground hover:text-foreground rounded"
+                    title="Refresh"
+                >
+                    <RefreshCw size={12} />
+                </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+                {processes.length === 0 ? (
+                    <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
+                        {loaded
+                            ? workerPid
+                                ? "No processes"
+                                : "Process tracking unavailable for this session"
+                            : "Loading…"}
+                    </div>
+                ) : (
+                    <table className="w-full text-xs">
+                        <thead className="sticky top-0 bg-background">
+                            <tr className="text-left text-muted-foreground border-b border-border">
+                                <th className="px-3 py-1 font-medium">PID</th>
+                                <th className="px-2 py-1 font-medium">Uptime</th>
+                                <th className="px-2 py-1 font-medium">Mem</th>
+                                <th className="px-2 py-1 font-medium">Command</th>
+                                <th className="px-2 py-1" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {processes.map((proc) => (
+                                <tr key={proc.pid} className="border-b border-border/50 hover:bg-accent/30">
+                                    <td className="px-3 py-1 font-mono">{proc.pid}</td>
+                                    <td className="px-2 py-1 font-mono whitespace-nowrap">{proc.etime}</td>
+                                    <td className="px-2 py-1 font-mono whitespace-nowrap">{formatRss(proc.rssKb)}</td>
+                                    <td className="px-2 py-1 font-mono truncate max-w-0 w-full" title={proc.command}>
+                                        {proc.command}
+                                        {proc.pid === workerPid && (
+                                            <span className="ml-1.5 text-[10px] text-primary/80">worker</span>
+                                        )}
+                                    </td>
+                                    <td className="px-2 py-1">
+                                        {proc.pid !== workerPid && (
+                                            <button
+                                                type="button"
+                                                onClick={() => send("process_kill", { sessionId, pid: proc.pid })}
+                                                className="text-muted-foreground hover:text-destructive"
+                                                title={`Kill ${proc.pid}`}
+                                                aria-label={`Kill process ${proc.pid}`}
+                                            >
+                                                <X size={11} />
+                                            </button>
+                                        )}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -21,8 +21,9 @@
  * 3. Start an HTTP server in init() and call announcePanel(port)
  */
 import React from "react";
-import { Network } from "lucide-react";
+import { Network, Cpu } from "lucide-react";
 import { TunnelPanel } from "@/components/TunnelPanel";
+import { ProcessPanel } from "@/components/ProcessPanel";
 
 export interface ServicePanelDef {
     /** Must match the runner service's `id` */
@@ -45,5 +46,11 @@ export const SERVICE_PANELS: ServicePanelDef[] = [
         label: "Tunnels",
         icon: <Network className="size-3.5" />,
         component: TunnelPanel,
+    },
+    {
+        serviceId: "process",
+        label: "Processes",
+        icon: <Cpu className="size-3.5" />,
+        component: ProcessPanel,
     },
 ];

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -67,6 +67,7 @@ export { tryRenderServerToolBlock } from "@/components/session-viewer/server-too
 
 import { CommandResultCard, type CommandResultData } from "@/components/session-viewer/cards/CommandResultCard";
 import { TriggerCard } from "@/components/session-viewer/cards/TriggerCard";
+import { resolveMobileMediaUrl } from "@/lib/mobile-runtime";
 import { tryRenderServerToolBlock } from "@/components/session-viewer/server-tools";
 
 /** Type guard: is the content a structured command result? */
@@ -342,7 +343,7 @@ export function renderContent(
                 return (
                   <img
                     key={i}
-                    src={url}
+                    src={resolveMobileMediaUrl(url)}
                     alt="Message attachment"
                     className="max-h-80 max-w-full rounded border border-border object-contain"
                     loading="lazy"

--- a/packages/ui/src/lib/mobile-runtime.test.ts
+++ b/packages/ui/src/lib/mobile-runtime.test.ts
@@ -11,7 +11,9 @@ import {
     setMobileApiKey,
     clearMobileApiKey,
     initMobileRuntime,
+    resolveMobileMediaUrl,
     _resetMobileRuntimeCache,
+    _setMobileRuntimeCache,
 } from "./mobile-runtime";
 
 const origLocalStorage = (globalThis as any).localStorage;
@@ -74,5 +76,45 @@ describe("mobile-runtime (web no-op path)", () => {
     test("initMobileRuntime is a no-op on web", async () => {
         await expect(initMobileRuntime()).resolves.toBeUndefined();
         expect(getMobileRuntimeConfig().apiKey).toBeNull();
+    });
+
+    test("resolveMobileMediaUrl leaves relative paths untouched on web", () => {
+        expect(resolveMobileMediaUrl("/api/attachments/abc")).toBe("/api/attachments/abc");
+    });
+});
+
+describe("resolveMobileMediaUrl (mobile-bundled path)", () => {
+    beforeEach(() => {
+        _resetMobileRuntimeCache();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: makeLocalStorage("https://relay.example.com"),
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        _resetMobileRuntimeCache();
+        (globalThis as any).localStorage = origLocalStorage;
+    });
+
+    test("prepends server URL and appends API key for relative media paths", () => {
+        _setMobileRuntimeCache("secret-key");
+        expect(resolveMobileMediaUrl("/api/attachments/abc")).toBe(
+            "https://relay.example.com/api/attachments/abc?apiKey=secret-key",
+        );
+    });
+
+    test("prepends server URL without key when none is cached", () => {
+        expect(resolveMobileMediaUrl("/api/attachments/abc")).toBe(
+            "https://relay.example.com/api/attachments/abc",
+        );
+    });
+
+    test("leaves absolute URLs untouched", () => {
+        _setMobileRuntimeCache("secret-key");
+        expect(resolveMobileMediaUrl("https://cdn.example.com/x.png")).toBe(
+            "https://cdn.example.com/x.png",
+        );
     });
 });

--- a/packages/ui/src/lib/mobile-runtime.ts
+++ b/packages/ui/src/lib/mobile-runtime.ts
@@ -81,6 +81,22 @@ export function resolveMobileUrl(path: string): string {
 }
 
 /**
+ * Resolve a relative media path (e.g. /api/attachments/…) for use as an
+ * <img>/<video> src in the bundled mobile app. Unlike resolveMobileUrl, this
+ * also appends the API key as a query param: element loads can't carry the
+ * x-api-key header the fetch patch injects, and the download endpoint accepts
+ * ?apiKey= for exactly this case. No-op on web (relative src stays same-origin).
+ */
+export function resolveMobileMediaUrl(path: string): string {
+    if (!path.startsWith("/")) return path;
+    const { serverUrl, apiKey, isMobileBundled } = getMobileRuntimeConfig();
+    if (!isMobileBundled || !serverUrl) return path;
+    const url = new URL(`${serverUrl.replace(/\/+$/, "")}${path}`);
+    if (apiKey && !url.searchParams.has("apiKey")) url.searchParams.set("apiKey", apiKey);
+    return url.toString();
+}
+
+/**
  * Dynamically import the native secure-storage plugin. No-op on web.
  *
  * IMPORTANT: the returned Capacitor plugin proxy (registerPlugin()'s Proxy)


### PR DESCRIPTION
## What

Sessions spawn OS processes (bash children, MCP stdio servers, dev servers) that were previously untracked — killing a session orphaned anything it started in the background.

- **Process groups**: workers spawn `detached: true` so PGID = worker PID; every descendant inherits the group
- **Kill on exit**: `kill_session`, the SIGKILL escalation, and natural worker exit now signal the whole group (`kill(-pid)`) with fallback to the lone worker
- **Web UI**: new `process` runner service + Processes service panel — lists PID/uptime/mem/command per session with per-process kill (3s polling)
- **TUI**: live dim widget above the editor (`⚙ 2 procs bun run:4123 · vite:4188`), hidden when the session has no children

## Safety

- Panel kill requests are validated against `pgrep -g` group membership — arbitrary system PIDs are rejected, and the worker itself is refused (use Kill Session)
- Restart-in-place (exit 43) intentionally does **not** kill the group, so session background processes survive worker restarts

## Known ceilings (marked with ponytail comments)

- Adopted sessions (worker survived a daemon restart) have no PID handle — panel shows "unavailable"
- Background procs from a pre-restart worker land in an old pgid and aren't reaped on final exit

## Testing

- 10 new tests: ps-line parsing, group kill incl. grandchildren, service list/kill guards, widget formatting
- Full `runner/` suite (368), UI panel suites (141), and repo typecheck pass