### PR TITLE
fix(windows): native Windows robustness — tunnels, runner lifecycle, tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Files whose content is executed by POSIX shells must keep LF endings even
+# on Windows checkouts (core.autocrlf=true) — a trailing \r breaks sh parsing
+# (e.g. lefthook pre-commit hooks failing with "unexpected end of file").
+lefthook.yml text eol=lf
+*.sh text eol=lf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,21 +1,26 @@
+# NOTE: hook scripts must avoid double quotes. On Windows, lefthook's spawn
+# re-parses the script through MSVCRT command-line rules: embedded `"` chars
+# are stripped (so "$var" becomes bare $var) and double-quoted strings with
+# spaces split the script mid-line ("syntax error: unexpected end of file").
+# Single quotes pass through intact on both platforms — use those, and keep
+# test/[ operands single-word (e.g. grep -c counts, x-prefix comparisons).
 pre-commit:
   commands:
     no-direct-main:
       run: |
         branch=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$branch" = "main" ]; then
-          echo "❌ Direct commits to main are not allowed."
-          echo "Create a feature branch and open a pull request instead:"
-          echo "  git checkout -b my-branch"
+        if [ x$branch = xmain ]; then
+          echo 'Direct commits to main are not allowed.'
+          echo 'Create a feature branch and open a pull request instead:'
+          echo '  git checkout -b my-branch'
           exit 1
         fi
     no-root-images:
       run: |
-        staged=$(git diff --cached --name-only --diff-filter=ACR)
-        bad=$(echo "$staged" | grep -E '^[^/]+\.(png|jpg|jpeg|gif|webp)$' || true)
-        if [ -n "$bad" ]; then
-          echo "❌ Image files are not allowed at the repository root:"
-          echo "$bad"
-          echo "Move them into the appropriate package (e.g. packages/ui/public/)."
+        count=$(git diff --cached --name-only --diff-filter=ACR | grep -cE '^[^/]+\.(png|jpg|jpeg|gif|webp)$' || true)
+        if [ x0 != x$count ]; then
+          echo 'Image files are not allowed at the repository root:'
+          git diff --cached --name-only --diff-filter=ACR | grep -E '^[^/]+\.(png|jpg|jpeg|gif|webp)$'
+          echo 'Move them into the appropriate package (e.g. packages/ui/public/).'
           exit 1
         fi

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -493,11 +493,29 @@ export function getTrustedPlugins(): string[] {
 }
 
 /**
+ * Canonicalize a plugin root for comparison: resolve to an absolute path and
+ * strip trailing separators of either flavor.
+ */
+function canonicalPluginPath(p: string): string {
+    return resolve(p).replace(/[\\/]+$/, "");
+}
+
+/**
+ * Compare plugin roots. Case-insensitive on Windows (NTFS is case-insensitive,
+ * and the same directory can legally arrive as `C:\Users\…` or `c:\users\…`) —
+ * a trust decision must not silently flip on casing or separator differences.
+ */
+function pluginPathsEqual(a: string, b: string): boolean {
+    const ca = canonicalPluginPath(a);
+    const cb = canonicalPluginPath(b);
+    return process.platform === "win32" ? ca.toLowerCase() === cb.toLowerCase() : ca === cb;
+}
+
+/**
  * Check whether a plugin at the given root path is in the trust list.
  */
 export function isPluginTrusted(pluginRootPath: string): boolean {
-    const resolved = pluginRootPath.replace(/\/+$/, ""); // strip trailing slashes
-    return getTrustedPlugins().some((p) => p.replace(/\/+$/, "") === resolved);
+    return getTrustedPlugins().some((p) => pluginPathsEqual(p, pluginRootPath));
 }
 
 /**
@@ -505,10 +523,9 @@ export function isPluginTrusted(pluginRootPath: string): boolean {
  * Returns true if it was added (false if already present).
  */
 export function trustPlugin(pluginRootPath: string): boolean {
-    const resolved = pluginRootPath.replace(/\/+$/, "");
     const list = getTrustedPlugins();
-    if (list.some((p) => p.replace(/\/+$/, "") === resolved)) return false;
-    list.push(resolved);
+    if (list.some((p) => pluginPathsEqual(p, pluginRootPath))) return false;
+    list.push(canonicalPluginPath(pluginRootPath));
     saveGlobalConfig({ trustedPlugins: list });
     return true;
 }
@@ -518,9 +535,8 @@ export function trustPlugin(pluginRootPath: string): boolean {
  * Returns true if it was removed (false if not found).
  */
 export function untrustPlugin(pluginRootPath: string): boolean {
-    const resolved = pluginRootPath.replace(/\/+$/, "");
     const list = getTrustedPlugins();
-    const filtered = list.filter((p) => p.replace(/\/+$/, "") !== resolved);
+    const filtered = list.filter((p) => !pluginPathsEqual(p, pluginRootPath));
     if (filtered.length === list.length) return false;
     saveGlobalConfig({ trustedPlugins: filtered });
     return true;

--- a/packages/cli/src/config/sandbox.ts
+++ b/packages/cli/src/config/sandbox.ts
@@ -1,5 +1,5 @@
-import { homedir } from "os";
-import { join, resolve } from "path";
+import { homedir, tmpdir } from "os";
+import { isAbsolute, join, resolve } from "path";
 
 import {
     type PizzaPiConfig,
@@ -29,6 +29,10 @@ const SENSITIVE_DENY_READ: string[] = [
     "~/.mozilla/firefox",
     "~/.config/google-chrome",
     "~/.config/chromium",
+    // Windows equivalents (harmless elsewhere — the paths simply don't exist)
+    "~/AppData/Local/Google/Chrome/User Data",
+    "~/AppData/Roaming/Mozilla/Firefox",
+    "~/AppData/Roaming/gcloud",
 ];
 
 const SENSITIVE_DENY_WRITE: string[] = [
@@ -43,10 +47,14 @@ const SENSITIVE_DENY_WRITE: string[] = [
  * `basic` preset: filesystem protection, unrestricted network.
  * No `network` key → srt does not activate network sandboxing.
  */
+// os.tmpdir() instead of a hardcoded "/tmp": on Windows the temp dir lives
+// under %LOCALAPPDATA%, and a literal "/tmp" resolves to a nonexistent C:\tmp.
+const TMP_DIR = tmpdir();
+
 const PRESET_BASIC: Omit<SrtConfig, "network"> = {
     filesystem: {
         denyRead: SENSITIVE_DENY_READ,
-        allowWrite: [".", "/tmp"],
+        allowWrite: [".", TMP_DIR],
         denyWrite: SENSITIVE_DENY_WRITE,
     },
 };
@@ -64,7 +72,7 @@ const PRESET_FULL: SrtConfig = {
     },
     filesystem: {
         denyRead: SENSITIVE_DENY_READ,
-        allowWrite: [".", "/tmp"],
+        allowWrite: [".", TMP_DIR],
         denyWrite: SENSITIVE_DENY_WRITE,
     },
 };
@@ -139,8 +147,9 @@ function sanitizeSandboxConfig(raw: SandboxConfig): SandboxConfig {
 function resolveSandboxPath(p: string, cwd: string): string {
     const expanded = p.startsWith("~") ? join(homedir(), p.slice(1)) : p;
     if (expanded === ".") return resolve(cwd);
-    // Relative paths (not starting with /) are resolved against cwd
-    if (!expanded.startsWith("/")) return resolve(cwd, expanded);
+    // isAbsolute (not startsWith("/")) so Windows paths like C:\data and
+    // \\server\share are recognized as absolute instead of joined onto cwd.
+    if (!isAbsolute(expanded)) return resolve(cwd, expanded);
     return expanded;
 }
 

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -26,6 +26,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { createLogger } from "@pizzapi/tools";
+import { resolveShell } from "./hooks/index.js";
 
 const log = createLogger("claude-plugins");
 
@@ -38,11 +39,10 @@ interface HookExecResult {
 }
 
 /**
- * Execute a hook command via /bin/sh.
+ * Execute a hook command via the resolved POSIX shell.
  *
  * Platform note: Claude Code plugins assume a POSIX shell environment.
- * This adapter targets macOS and Linux only (matching pi's supported
- * platforms). Windows support would require a different shell strategy.
+ * On Windows this uses Git for Windows' bundled bash (see resolveShell).
  */
 async function execHookCommand(
     command: string,
@@ -52,10 +52,11 @@ async function execHookCommand(
 ): Promise<HookExecResult> {
     const resolved = resolvePluginRoot(command, pluginRoot);
 
+    const { shell, flag } = resolveShell();
     return new Promise((resolveP) => {
         const child = execFile(
-            "/bin/sh",
-            ["-c", resolved],
+            shell,
+            [flag, resolved],
             {
                 timeout: timeoutMs,
                 maxBuffer: 1024 * 256,
@@ -142,8 +143,9 @@ function registerPluginCommand(
             for (const match of inlineMatches) {
                 const shellCmd = match[1];
                 try {
+                    const { shell, flag } = resolveShell();
                     const result = await new Promise<string>((res) => {
-                        execFile("/bin/sh", ["-c", shellCmd], {
+                        execFile(shell, [flag, shellCmd], {
                             timeout: 5000,
                             maxBuffer: 64 * 1024,
                             cwd: ctx.cwd,

--- a/packages/cli/src/extensions/hooks/runner.ts
+++ b/packages/cli/src/extensions/hooks/runner.ts
@@ -1,6 +1,4 @@
-import { execSync } from "child_process";
-import { existsSync } from "fs";
-import { join } from "path";
+import { resolvePosixShell } from "@pizzapi/tools";
 import type { HookEntry } from "../../config.js";
 import { expandVars } from "../../config.js";
 import type { HookOutput, HookResult } from "./types.js";
@@ -25,43 +23,6 @@ export type SpawnLike = (
 // Hook runner
 // ---------------------------------------------------------------------------
 
-/**
- * Find Git for Windows' bundled bash.exe by checking well-known install
- * paths and falling back to `git --exec-path` to derive the Git root.
- * Returns the absolute path to bash.exe, or null if not found.
- */
-function findGitBashOnWindows(): string | null {
-    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
-    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
-    const localAppData = process.env.LOCALAPPDATA || "";
-
-    const candidates = [
-        join(programFiles, "Git", "bin", "bash.exe"),
-        join(programFilesX86, "Git", "bin", "bash.exe"),
-        ...(localAppData ? [join(localAppData, "Programs", "Git", "bin", "bash.exe")] : []),
-    ];
-
-    for (const candidate of candidates) {
-        if (existsSync(candidate)) return candidate;
-    }
-
-    // Try to derive from `git --exec-path` (e.g. C:\Program Files\Git\mingw64\libexec\git-core)
-    try {
-        const execPath = execSync("git --exec-path", {
-            encoding: "utf-8",
-            stdio: ["ignore", "pipe", "ignore"],
-        }).trim();
-        // Walk up to the Git root: <root>/mingw64/libexec/git-core → <root>
-        const gitRoot = join(execPath, "..", "..", "..");
-        const bashFromGit = join(gitRoot, "bin", "bash.exe");
-        if (existsSync(bashFromGit)) return bashFromGit;
-    } catch {
-        // git not in PATH or other error — fall through
-    }
-
-    return null;
-}
-
 /** Cached result so we only probe the filesystem once per process. */
 let _cachedShell: { shell: string; flag: string } | undefined;
 
@@ -81,14 +42,10 @@ let _cachedShell: { shell: string; flag: string } | undefined;
 export function resolveShell(): { shell: string; flag: string } {
     if (_cachedShell) return _cachedShell;
 
-    if (process.platform !== "win32") {
-        _cachedShell = { shell: "/bin/sh", flag: "-c" };
-        return _cachedShell;
-    }
-
-    // Windows: prefer Git for Windows bash, fall back to bare `bash`
-    const gitBash = findGitBashOnWindows();
-    _cachedShell = { shell: gitBash ?? "bash", flag: "-c" };
+    // Windows: prefer Git for Windows bash, fall back to bare `bash` so the
+    // error message is clear ("bash not found") rather than an opaque cmd.exe
+    // syntax failure.
+    _cachedShell = resolvePosixShell() ?? { shell: "bash", flag: "-c" };
     return _cachedShell;
 }
 

--- a/packages/cli/src/extensions/mcp/transport-stdio.ts
+++ b/packages/cli/src/extensions/mcp/transport-stdio.ts
@@ -7,6 +7,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
 import { expandHome, expandVars, expandVarsDeep } from "../../config.js";
+import { buildSpawnInvocation } from "./windows-command.js";
 import {
   MCP_PROTOCOL_VERSION,
   MCP_SUPPORTED_VERSIONS,
@@ -41,9 +42,13 @@ export async function createStdioMcpClient(opts: {
   // expansion doesn't occur.
 
 
-  const child: ChildProcessWithoutNullStreams = spawn(command, args, {
+  // On Windows, `.cmd`/`.bat` shims (npx, npm-installed servers) cannot be
+  // spawned directly — reroute through cmd.exe with PATHEXT resolution.
+  const invocation = buildSpawnInvocation(command, args);
+  const child: ChildProcessWithoutNullStreams = spawn(invocation.command, invocation.args, {
     stdio: "pipe",
     env: mergedEnv,
+    ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     ...(cwd ? { cwd } : {}),
   });
 

--- a/packages/cli/src/extensions/mcp/windows-command.test.ts
+++ b/packages/cli/src/extensions/mcp/windows-command.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { buildSpawnInvocation, quoteForCmd, resolveWindowsExecutable } from "./windows-command.js";
+
+describe("quoteForCmd", () => {
+    test("passes plain args through", () => {
+        expect(quoteForCmd("plain")).toBe("plain");
+        expect(quoteForCmd("-y")).toBe("-y");
+        expect(quoteForCmd("@modelcontextprotocol/server-filesystem")).toBe("@modelcontextprotocol/server-filesystem");
+    });
+
+    test("quotes whitespace and cmd metacharacters", () => {
+        expect(quoteForCmd("hello world")).toBe('"hello world"');
+        expect(quoteForCmd("a&b")).toBe('"a&b"');
+        expect(quoteForCmd("")).toBe('""');
+    });
+
+    test("escapes embedded quotes", () => {
+        expect(quoteForCmd('say "hi"')).toBe('"say \\"hi\\""');
+    });
+});
+
+describe("buildSpawnInvocation", () => {
+    test("is the identity on POSIX or for unresolvable commands", () => {
+        const inv = buildSpawnInvocation("definitely-not-a-real-command-xyz", ["a", "b"]);
+        expect(inv.command).toBe("definitely-not-a-real-command-xyz");
+        expect(inv.args).toEqual(["a", "b"]);
+        expect(inv.windowsVerbatimArguments).toBeUndefined();
+    });
+
+    test.if(process.platform === "win32")("routes .cmd shims through cmd.exe", () => {
+        // npx.cmd ships with Node — present on any dev machine with npm.
+        const resolved = resolveWindowsExecutable("npx");
+        if (!resolved) return; // no Node install — nothing to assert
+        expect(resolved.toLowerCase().endsWith(".cmd")).toBe(true);
+
+        const inv = buildSpawnInvocation("npx", ["-y", "some-pkg"]);
+        expect(inv.command.toLowerCase()).toContain("cmd.exe");
+        expect(inv.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+        expect(inv.args[3]).toContain("npx.cmd");
+        expect(inv.windowsVerbatimArguments).toBe(true);
+    });
+
+    test.if(process.platform === "win32")("spawns real executables directly by resolved path", () => {
+        const inv = buildSpawnInvocation("cmd", ["/c", "echo hi"]);
+        expect(inv.command.toLowerCase().endsWith("cmd.exe")).toBe(true);
+        expect(inv.windowsVerbatimArguments).toBeUndefined();
+    });
+});

--- a/packages/cli/src/extensions/mcp/windows-command.ts
+++ b/packages/cli/src/extensions/mcp/windows-command.ts
@@ -1,0 +1,94 @@
+/**
+ * Windows command resolution for stdio MCP servers.
+ *
+ * Node/Bun cannot spawn `.cmd`/`.bat` files directly (CreateProcess only
+ * understands real executables, and recent Node versions hard-error with
+ * EINVAL). The overwhelmingly common MCP config (`command: "npx"`) resolves to
+ * `npx.cmd` on Windows, so a bare spawn fails. This module resolves a command
+ * through PATH + PATHEXT the way the shell would, and rewrites `.cmd`/`.bat`
+ * invocations to run through `cmd.exe /d /s /c` with explicit quoting.
+ */
+
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, resolve as pathResolve } from "node:path";
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+export interface SpawnInvocation {
+    command: string;
+    args: string[];
+    /** Set when args are pre-quoted for cmd.exe and must not be re-escaped. */
+    windowsVerbatimArguments?: boolean;
+}
+
+/**
+ * Resolve a command name to the on-disk file it would execute, following
+ * PATH (for bare names) and PATHEXT (for extension-less names).
+ * Returns null when nothing matches — the caller falls back to spawning the
+ * original command and surfacing the OS error.
+ */
+export function resolveWindowsExecutable(command: string): string | null {
+    const exts = (process.env.PATHEXT ?? DEFAULT_PATHEXT)
+        .split(";")
+        .filter(Boolean);
+
+    // For extension-less names, PATHEXT candidates come first: an extension-less
+    // file on disk (e.g. the POSIX `npx` shell script next to `npx.cmd`) is not
+    // something CreateProcess can execute.
+    const candidatesFor = (base: string): string[] => {
+        const lower = base.toLowerCase();
+        const withExts = exts.map((e) => base + e.toLowerCase());
+        const hasExecExt = exts.some((e) => lower.endsWith(e.toLowerCase()));
+        return hasExecExt ? [base, ...withExts] : [...withExts, base];
+    };
+
+    const hasPathPart = command.includes("/") || command.includes("\\") || isAbsolute(command);
+    if (hasPathPart) {
+        for (const candidate of candidatesFor(pathResolve(command))) {
+            if (existsSync(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+    for (const dir of pathDirs) {
+        for (const candidate of candidatesFor(pathResolve(dir, command))) {
+            if (existsSync(candidate)) return candidate;
+        }
+    }
+    return null;
+}
+
+/** Quote a single argument for a cmd.exe command line. */
+export function quoteForCmd(s: string): string {
+    if (s === "") return '""';
+    if (!/[\s"&|<>^%()!]/.test(s)) return s;
+    // Double preceding backslashes and escape embedded quotes (MSVCRT rules).
+    return '"' + s.replace(/(\\*)"/g, '$1$1\\"') + '"';
+}
+
+/**
+ * Build the spawn invocation for a configured command + args.
+ * On non-Windows platforms (or for real executables) this is the identity.
+ */
+export function buildSpawnInvocation(command: string, args: string[]): SpawnInvocation {
+    if (process.platform !== "win32") return { command, args };
+
+    const resolved = resolveWindowsExecutable(command);
+    if (!resolved) return { command, args };
+
+    if (!/\.(cmd|bat)$/i.test(resolved)) {
+        // A real executable — spawn the resolved path directly so PATHEXT
+        // resolution isn't left to CreateProcess (which only tries .exe).
+        return { command: resolved, args };
+    }
+
+    // .cmd/.bat: run through cmd.exe. /d skips AutoRun, /s preserves the
+    // outer quotes around the full command line.
+    const commandLine = [resolved, ...args].map(quoteForCmd).join(" ");
+    return {
+        command: process.env.ComSpec ?? "cmd.exe",
+        args: ["/d", "/s", "/c", `"${commandLine}"`],
+        windowsVerbatimArguments: true,
+    };
+}

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -528,8 +528,11 @@ export async function handleExecFromWeb(
                     process.exit(43);
                     return;
                 }
+                // detached:true on Windows allocates a new console for the child,
+                // popping a window — the inherited stdio is enough to keep the
+                // replacement attached to the current console there.
                 const child = spawn(process.execPath, process.argv.slice(1), {
-                    detached: true,
+                    detached: process.platform !== "win32",
                     stdio: "inherit",
                     env: process.env,
                 });

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "node:crypto";
 import { buildSessionContext } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "../../config.js";
+import { normalizeLoopbackHost } from "../../relay-url.js";
 import { buildHeartbeat } from "../remote-heartbeat.js";
 import { getCurrentTodoList } from "../update-todo.js";
 import { isDisabled, toWebSocketBaseUrl } from "./connection.js";
@@ -98,7 +99,7 @@ export function createRelayContext(
                 process.env.PIZZAPI_RELAY_URL ??
                 loadConfig(process.cwd()).relayUrl ??
                 RELAY_DEFAULT;
-            return configured.replace(/\/$/, "");
+            return normalizeLoopbackHost(configured.replace(/\/$/, ""));
         },
 
         relayHttpBaseUrl(): string {

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { loadConfig } from "../config.js";
+import { normalizeLoopbackHost } from "../relay-url.js";
 import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../ollama-cloud-models.js";
 import { mergeModelLists } from "../session-models-cache.js";
 import { getRelaySessionId } from "./remote.js";
@@ -31,7 +32,9 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
 
         if (configured.toLowerCase() === "off") return null;
 
-        const trimmed = configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, "");
+        const trimmed = normalizeLoopbackHost(
+            configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, ""),
+        );
         // Normalize to HTTP(S) base URL
         if (trimmed.startsWith("ws://")) return `http://${trimmed.slice("ws://".length)}`;
         if (trimmed.startsWith("wss://")) return `https://${trimmed.slice("wss://".length)}`;

--- a/packages/cli/src/extensions/trigger-client.ts
+++ b/packages/cli/src/extensions/trigger-client.ts
@@ -31,6 +31,7 @@ import type { JsonValue } from "@pizzapi/protocol";
 import type { ServiceSigilDef } from "@pizzapi/protocol";
 import { getRelaySocket as getRelaySocketDefault } from "./remote.js";
 import { loadConfig } from "../config.js";
+import { normalizeLoopbackHost } from "../relay-url.js";
 
 const log = createLogger("trigger-client");
 
@@ -76,7 +77,9 @@ function defaultGetRelayHttpBaseUrl(): string | null {
 
     if (configured.toLowerCase() === "off") return null;
 
-    const trimmed = configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, "");
+    const trimmed = normalizeLoopbackHost(
+        configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, ""),
+    );
     if (trimmed.startsWith("ws://")) return `http://${trimmed.slice("ws://".length)}`;
     if (trimmed.startsWith("wss://")) return `https://${trimmed.slice("wss://".length)}`;
     if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed;

--- a/packages/cli/src/extensions/tunnel-tools.test.ts
+++ b/packages/cli/src/extensions/tunnel-tools.test.ts
@@ -298,7 +298,7 @@ describe("buildPublicTunnelUrl", () => {
         const tool = pi.tools.get("create_tunnel")!;
         const result = await tool.execute("call-1", { port: 8080 });
 
-        expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/runner/runner-abc/8080/");
+        expect(result.details.publicUrl).toBe("http://127.0.0.1:7492/api/tunnel/runner/runner-abc/8080/");
 
         if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
         else delete process.env.PIZZAPI_RELAY_URL;
@@ -333,7 +333,7 @@ describe("buildPublicTunnelUrl", () => {
         const result = await tool.execute("call-1", { port: 8080 });
 
         // No runner ID mocked, falls back to session-based URL
-        expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/abc-def-123/8080/");
+        expect(result.details.publicUrl).toBe("http://127.0.0.1:7492/api/tunnel/abc-def-123/8080/");
 
         // Restore
         if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;

--- a/packages/cli/src/extensions/tunnel-tools.ts
+++ b/packages/cli/src/extensions/tunnel-tools.ts
@@ -21,6 +21,7 @@ import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { getRelaySocket as getRelaySocketDefault, getRelaySessionId as getRelaySessionIdDefault } from "./remote.js";
 import { loadConfig as loadConfigDefault } from "../config.js";
+import { normalizeLoopbackHost } from "../relay-url.js";
 
 /** Timeout for service_message request/response round-trips. */
 const SERVICE_TIMEOUT_MS = 10_000;
@@ -115,7 +116,9 @@ function getRelayHttpBaseUrl(deps: TunnelToolsDeps): string | null {
 
     if (configured.toLowerCase() === "off") return null;
 
-    const trimmed = configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, "");
+    const trimmed = normalizeLoopbackHost(
+        configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, ""),
+    );
     if (trimmed.startsWith("ws://")) return `http://${trimmed.slice("ws://".length)}`;
     if (trimmed.startsWith("wss://")) return `https://${trimmed.slice("wss://".length)}`;
     if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed;

--- a/packages/cli/src/local.test.ts
+++ b/packages/cli/src/local.test.ts
@@ -86,8 +86,8 @@ describe("parseLocalArgs", () => {
 
 describe("URL builders", () => {
     test("build local relay, ws, and browser URLs", () => {
-        expect(buildLocalRelayUrl(7492)).toBe("http://localhost:7492");
-        expect(buildLocalWsRelayUrl(7492)).toBe("ws://localhost:7492");
+        expect(buildLocalRelayUrl(7492)).toBe("http://127.0.0.1:7492");
+        expect(buildLocalWsRelayUrl(7492)).toBe("ws://127.0.0.1:7492");
         expect(buildLocalBrowserUrl(7492)).toBe("http://localhost:7492");
         expect(buildLocalBrowserUrl(8080)).toBe("http://localhost:8080");
     });
@@ -367,7 +367,7 @@ describe("runLocal orchestration", () => {
         await expect(runLocal([], deps as any)).rejects.toThrow("exit:0");
         expect(calls.runWeb).toHaveLength(0);
         expect(setupCalled).toBe(true);
-        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://localhost:7492" }]);
+        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://127.0.0.1:7492" }]);
         expect(calls.runSupervisor).toBe(1);
         expect(calls.openBrowser).toEqual(["http://localhost:7492"]);
     });
@@ -501,7 +501,7 @@ describe("runLocal orchestration", () => {
             },
         });
         await expect(runLocal(["--port", "8080", "--no-browser"], deps as any)).rejects.toThrow("exit:0");
-        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://localhost:8080" }]);
+        expect(calls.runSetup).toEqual([{ force: false, relayDefault: "http://127.0.0.1:8080" }]);
         expect(calls.runSupervisor).toBe(1);
     });
 });

--- a/packages/cli/src/local.ts
+++ b/packages/cli/src/local.ts
@@ -103,12 +103,16 @@ export function printLocalHelp(): void {
     log.info("");
 }
 
+// The relay/ws URLs pin 127.0.0.1: Docker's short-form port publish binds the
+// IPv4 wildcard only, while `localhost` can resolve to `::1` first (notably on
+// native Windows), making health checks and runner connects fail. The browser
+// URL keeps `localhost` — browsers fall back across address families themselves.
 export function buildLocalRelayUrl(port: number): string {
-    return `http://localhost:${port}`;
+    return `http://127.0.0.1:${port}`;
 }
 
 export function buildLocalWsRelayUrl(port: number): string {
-    return `ws://localhost:${port}`;
+    return `ws://127.0.0.1:${port}`;
 }
 
 export function buildLocalBrowserUrl(port: number): string {

--- a/packages/cli/src/plugins-cli.test.ts
+++ b/packages/cli/src/plugins-cli.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterAll } from "bun:test";
+import { resolve } from "path";
 import {
     getTrustedPlugins,
     isPluginTrusted,
@@ -44,7 +45,8 @@ describe("plugin trust config helpers", () => {
         const added = trustPlugin(p);
         expect(added).toBe(true);
         expect(isPluginTrusted(p)).toBe(true);
-        expect(getTrustedPlugins()).toContain(p);
+        // Stored form is the canonical (resolved) path.
+        expect(getTrustedPlugins()).toContain(resolve(p));
     });
 
     test("trustPlugin is idempotent", () => {
@@ -53,7 +55,7 @@ describe("plugin trust config helpers", () => {
         const added = trustPlugin(p);
         expect(added).toBe(false);
         // Should only appear once
-        expect(getTrustedPlugins().filter(x => x === p)).toHaveLength(1);
+        expect(getTrustedPlugins().filter(x => x === resolve(p))).toHaveLength(1);
     });
 
     test("isPluginTrusted handles trailing slashes", () => {
@@ -85,7 +87,7 @@ describe("plugin trust config helpers", () => {
         trustPlugin(p);
         // getTrustedPlugins reads from disk each time
         const list = getTrustedPlugins();
-        expect(list).toContain(p);
+        expect(list).toContain(resolve(p));
     });
 
     test("multiple plugins can be trusted independently", () => {

--- a/packages/cli/src/relay-url.test.ts
+++ b/packages/cli/src/relay-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeLoopbackHost } from "./relay-url.js";
+
+describe("normalizeLoopbackHost", () => {
+    test("rewrites localhost hosts to 127.0.0.1 across schemes", () => {
+        expect(normalizeLoopbackHost("ws://localhost:7492")).toBe("ws://127.0.0.1:7492");
+        expect(normalizeLoopbackHost("wss://localhost:7492")).toBe("wss://127.0.0.1:7492");
+        expect(normalizeLoopbackHost("http://localhost:7492")).toBe("http://127.0.0.1:7492");
+        expect(normalizeLoopbackHost("https://localhost:7492/path")).toBe("https://127.0.0.1:7492/path");
+        expect(normalizeLoopbackHost("LOCALHOST:7492")).toBe("127.0.0.1:7492");
+    });
+
+    test("handles bare hosts and missing ports", () => {
+        expect(normalizeLoopbackHost("localhost:7492")).toBe("127.0.0.1:7492");
+        expect(normalizeLoopbackHost("localhost")).toBe("127.0.0.1");
+        expect(normalizeLoopbackHost("ws://localhost")).toBe("ws://127.0.0.1");
+        expect(normalizeLoopbackHost("ws://localhost/path")).toBe("ws://127.0.0.1/path");
+    });
+
+    test("preserves userinfo", () => {
+        expect(normalizeLoopbackHost("http://user:pw@localhost:7492")).toBe("http://user:pw@127.0.0.1:7492");
+    });
+
+    test("leaves non-localhost hosts untouched", () => {
+        expect(normalizeLoopbackHost("wss://relay.example.com")).toBe("wss://relay.example.com");
+        expect(normalizeLoopbackHost("http://mylocalhost.com")).toBe("http://mylocalhost.com");
+        expect(normalizeLoopbackHost("http://localhost.example.com")).toBe("http://localhost.example.com");
+        expect(normalizeLoopbackHost("http://127.0.0.1:7492")).toBe("http://127.0.0.1:7492");
+        expect(normalizeLoopbackHost("http://[::1]:7492")).toBe("http://[::1]:7492");
+        expect(normalizeLoopbackHost("off")).toBe("off");
+        expect(normalizeLoopbackHost("")).toBe("");
+    });
+});

--- a/packages/cli/src/relay-url.ts
+++ b/packages/cli/src/relay-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Relay URL helpers shared across the CLI.
+ *
+ * `localhost` may resolve to `::1` before `127.0.0.1` (notably on native
+ * Windows), while the local relay is only reachable over IPv4 — Docker's
+ * short-form port publish (`7492:7492`) binds the IPv4 wildcard only. A
+ * loopback relay URL must therefore pin the IPv4 literal instead of relying
+ * on resolver order. See #609 for the same bug class on the tunnel client.
+ */
+
+/**
+ * Rewrite a `localhost` host to `127.0.0.1`, preserving scheme, userinfo,
+ * port and path. Non-loopback hosts (including `[::1]`, which expresses
+ * explicit IPv6 intent) are returned unchanged.
+ */
+export function normalizeLoopbackHost(url: string): string {
+    return url.replace(
+        /^((?:[a-z][a-z0-9+.-]*:\/\/)?(?:[^/@]*@)?)localhost(?=[:/]|$)/i,
+        "$1127.0.0.1",
+    );
+}

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -3,7 +3,9 @@ import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
 import { hostname, homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { existsSync, rmSync } from "node:fs";
+import { forceKillTree, isShutdownMessage, requestChildShutdown, STOP_FILE_NAME } from "./process-kill.js";
 import { ServiceRegistry, type ServiceHandler, type ServiceInitOptions } from "./service-handler.js";
 import { TerminalService } from "./services/terminal-service.js";
 import { FileExplorerService } from "./services/file-explorer-service.js";
@@ -34,6 +36,7 @@ import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { sanitizeConfigForUI, restoreMaskedServerEntry, findRenamedServerMatch, MASK_SENTINEL, validateProviderOverridesSection, mergeProviderOverridesSection } from "./daemon-config-sanitize.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
+import { normalizeLoopbackHost } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
@@ -169,8 +172,8 @@ function escalateToSigkill(child: ChildProcess, label: string, timeoutMs = 5_000
     const timer = setTimeout(() => {
         try {
             if (!child.killed && child.exitCode === null) {
-                logWarn(`[daemon] ${label} did not exit after ${timeoutMs}ms; force-killing with SIGKILL`);
-                child.kill("SIGKILL");
+                logWarn(`[daemon] ${label} did not exit after ${timeoutMs}ms; force-killing`);
+                forceKillTree(child);
             }
         } catch {
             // Process already exited; ignore.
@@ -343,9 +346,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         // ── Socket.IO connection setup ────────────────────────────────────
         // Priority: env var > config.json > default
-        const relayRaw = (process.env.PIZZAPI_RELAY_URL ?? resolveConfigRelayUrl() ?? "ws://localhost:7492")
-            .trim()
-            .replace(/\/$/, "");
+        const relayRaw = normalizeLoopbackHost(
+            (process.env.PIZZAPI_RELAY_URL ?? resolveConfigRelayUrl() ?? "ws://localhost:7492")
+                .trim()
+                .replace(/\/$/, ""),
+        );
 
         // Normalise the relay URL for socket.io-client (needs http(s)://).
         // If the user supplies a bare hostname (no scheme), default to https://.
@@ -773,9 +778,23 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             triggerScan();
         }, 5 * 60 * 1000);
 
+        // Windows `runner stop` cannot deliver a catchable signal — it drops a
+        // stop file next to the state file instead; poll for it. A stale file
+        // from an earlier unclean exit is cleared before polling starts.
+        const stopFilePath = join(dirname(statePath), STOP_FILE_NAME);
+        try { rmSync(stopFilePath, { force: true }); } catch {}
+        const stopFilePoll = setInterval(() => {
+            if (existsSync(stopFilePath)) {
+                try { rmSync(stopFilePath, { force: true }); } catch {}
+                logInfo("stop requested via stop file — shutting down");
+                void shutdown(0);
+            }
+        }, 1_000);
+
         const shutdown = async (code: number) => {
             if (isShuttingDown) return;
             isShuttingDown = true;
+            clearInterval(stopFilePoll);
             clearInterval(endedSessionSweep);
             clearInterval(sessionCloseMetadataSweep);
             clearInterval(usageScanInterval);
@@ -793,6 +812,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         process.on("SIGINT", () => shutdown(0));
         process.on("SIGTERM", () => shutdown(0));
+        // Windows: the supervisor requests shutdown over IPC because a signal
+        // would TerminateProcess us before any of the cleanup above could run.
+        process.on("message", (msg: unknown) => {
+            if (isShutdownMessage(msg)) void shutdown(0);
+        });
 
         // ── Helper: emit registration ─────────────────────────────────────
         const emitRegister = () => {
@@ -1320,12 +1344,16 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (entry) {
                 if (entry.child) {
                     try {
-                        // Mark as killed BEFORE sending SIGTERM so the child's
+                        // Mark as killed BEFORE requesting shutdown so the child's
                         // exit handler sees it even if exit code 43 (restart-in-place)
-                        // arrives before SIGTERM is delivered.
+                        // arrives before the shutdown request is delivered.
                         killedSessions.add(sessionId);
-                        entry.child.kill("SIGTERM");
-                        escalateToSigkill(entry.child, `session ${sessionId}`);
+                        // SIGTERM on POSIX; IPC shutdown message on Windows (where
+                        // kill() would TerminateProcess and skip worker cleanup).
+                        const child = entry.child;
+                        requestChildShutdown(child, (timeoutMs) =>
+                            logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
+                        );
                     } catch {}
                 } else if (entry.adopted) {
                     // No child handle — ask the relay to disconnect the worker's

--- a/packages/cli/src/runner/process-kill.ts
+++ b/packages/cli/src/runner/process-kill.ts
@@ -1,0 +1,91 @@
+/**
+ * Cross-platform child-process shutdown helpers.
+ *
+ * Windows has no deliverable signals: `child.kill("SIGTERM")` is an immediate
+ * TerminateProcess, so the target's `process.on("SIGTERM")` cleanup never runs
+ * and its own children (MCP servers, shells) are orphaned. Graceful shutdown
+ * on Windows therefore goes over the IPC channel, and hard kills go through
+ * `taskkill /T` so the whole process tree dies together.
+ */
+
+import { execFile, type ChildProcess } from "node:child_process";
+
+export const STOP_FILE_NAME = "runner.stop";
+
+/** IPC message understood by daemon and workers as a graceful-shutdown request. */
+export const SHUTDOWN_MESSAGE = { type: "shutdown" } as const;
+
+export function isShutdownMessage(msg: unknown): boolean {
+    return typeof msg === "object" && msg !== null && (msg as Record<string, unknown>).type === "shutdown";
+}
+
+/**
+ * Hard-kill a child and, on Windows, its entire process tree.
+ * `taskkill /T` reaches grandchildren that a plain kill() would orphan —
+ * Windows has no process groups to signal.
+ */
+export function forceKillTree(child: ChildProcess): void {
+    if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
+        try {
+            execFile("taskkill", ["/PID", String(child.pid), "/T", "/F"], () => {
+                // taskkill missing or failed — fall back to a plain kill.
+                try {
+                    if (child.exitCode === null && !child.killed) child.kill("SIGKILL");
+                } catch {}
+            });
+            return;
+        } catch {
+            // fall through to plain kill
+        }
+    }
+    try {
+        child.kill("SIGKILL");
+    } catch {}
+}
+
+/**
+ * Ask a child to shut down gracefully, then hard-kill (tree kill on Windows)
+ * if it hasn't exited after `timeoutMs`.
+ *
+ * - POSIX: SIGTERM → catchable, child runs its shutdown handler.
+ * - Windows with an IPC channel: `{ type: "shutdown" }` message — the only
+ *   catchable cross-process shutdown request that exists there.
+ * - Windows without IPC: immediate hard kill (nothing gentler is possible).
+ */
+export function requestChildShutdown(
+    child: ChildProcess,
+    onEscalate?: (timeoutMs: number) => void,
+    timeoutMs = 5_000,
+): void {
+    let requested = false;
+    if (process.platform === "win32") {
+        if (child.connected && typeof child.send === "function") {
+            try {
+                child.send(SHUTDOWN_MESSAGE);
+                requested = true;
+            } catch {
+                // channel already closed — fall through
+            }
+        }
+    } else {
+        try {
+            child.kill("SIGTERM");
+            requested = true;
+        } catch {}
+    }
+
+    if (!requested) {
+        forceKillTree(child);
+        return;
+    }
+
+    const timer = setTimeout(() => {
+        try {
+            if (child.exitCode === null && !child.killed) {
+                onEscalate?.(timeoutMs);
+                forceKillTree(child);
+            }
+        } catch {}
+    }, timeoutMs);
+    child.once("exit", () => clearTimeout(timer));
+}

--- a/packages/cli/src/runner/runner-state.ts
+++ b/packages/cli/src/runner/runner-state.ts
@@ -124,7 +124,7 @@ export function releaseStateLock(statePath: string) {
 }
 
 export function isPidRunning(pid: number): boolean {
-    if (!Number.isFinite(pid) || pid <= 0) return false;
+    if (!Number.isInteger(pid) || pid <= 0) return false;
     try {
         process.kill(pid, 0);
     } catch (err: any) {
@@ -140,13 +140,21 @@ export function isPidRunning(pid: number): boolean {
     try {
         let cmd: string;
         if (process.platform === "win32") {
-            // On Windows, use WMIC to inspect the process command line.
-            // wmic is available on Windows 7+ and returns the full command line.
+            // wmic is removed from Windows 11 24H2+, so query CIM via PowerShell.
             cmd = execFileSync(
-                "wmic",
-                ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/format:list"],
-                { encoding: "utf-8", timeout: 5000 },
+                "powershell.exe",
+                [
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine`,
+                ],
+                { encoding: "utf-8", timeout: 10000, windowsHide: true },
             ).trim();
+            // Empty output: the process is gone, or its command line is not ours
+            // to read (another user's / a system process). The runner always runs
+            // as the current user, so either way this PID is not the runner.
+            if (cmd.length === 0) return false;
         } else {
             cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8", timeout: 3000 }).trim();
         }

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
@@ -289,11 +289,38 @@ async function refreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean 
 
     const cache: RunnerUsageCacheFile = { fetchedAt: Date.now(), providers };
     try {
-        writeFileSync(runnerUsageCacheFilePath(), JSON.stringify(cache, null, 2), { encoding: "utf-8", mode: 0o600 });
+        await writeUsageCacheAtomic(runnerUsageCacheFilePath(), JSON.stringify(cache, null, 2));
         logInfo(`usage cache refreshed (${Object.keys(providers).join(", ")})`);
     } catch (err: any) {
         logWarn(`failed to write usage cache: ${err?.message ?? String(err)}`);
     }
+}
+
+/**
+ * Write the cache via temp-file + rename so workers never observe a
+ * truncated/partial JSON file mid-write. On Windows the rename can fail
+ * transiently (EPERM/EACCES/EBUSY) while a worker holds the destination open
+ * for reading — retry briefly, then fall back to a direct write rather than
+ * dropping the refresh entirely.
+ */
+async function writeUsageCacheAtomic(path: string, contents: string): Promise<void> {
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, contents, { encoding: "utf-8", mode: 0o600 });
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            renameSync(tmp, path);
+            return;
+        } catch (err: any) {
+            const code = err?.code;
+            if (code !== "EPERM" && code !== "EACCES" && code !== "EBUSY") {
+                rmSync(tmp, { force: true });
+                throw err;
+            }
+            await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+        }
+    }
+    writeFileSync(path, contents, { encoding: "utf-8", mode: 0o600 });
+    rmSync(tmp, { force: true });
 }
 
 export function startUsageRefreshLoop(): void {

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -35,6 +35,10 @@ import {
     nextCronTime,
 } from "./time-utils.js";
 import { logInfo, logWarn, logError } from "../logger.js";
+import { normalizeLoopbackHost } from "../../relay-url.js";
+
+/** Largest delay setTimeout honors; anything above overflows and fires immediately. */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 // ── Relay helpers ────────────────────────────────────────────────────────────
 
@@ -47,7 +51,7 @@ function resolveRelayUrl(): string {
             if (typeof cfg?.relayUrl === "string" && cfg.relayUrl !== "off") raw = cfg.relayUrl.trim();
         } catch { /* ignore */ }
     }
-    raw = raw || "http://localhost:7492";
+    raw = normalizeLoopbackHost(raw || "http://localhost:7492");
     if (raw.startsWith("ws://")) return raw.replace(/^ws:/, "http:").replace(/\/$/, "");
     if (raw.startsWith("wss://")) return raw.replace(/^wss:/, "https:").replace(/\/$/, "");
     return raw.replace(/\/$/, "");
@@ -489,7 +493,7 @@ export class TimeService implements ServiceHandler {
 
         logInfo(`[time] starting timer for session ${sessionId}: ${durationStr} (${formatDuration(durationMs)})${label ? ` [${label}]` : ""}`);
 
-        const handle = setTimeout(() => {
+        const handle = this.#setTimeoutUntil(key, fireAt, () => {
             this.#timers.delete(key);
             void this.#fireOneShot(sessionId, subscriptionId, "time:timer_fired", {
                 duration: durationStr,
@@ -498,7 +502,7 @@ export class TimeService implements ServiceHandler {
                 label,
                 message,
             }, message ?? (label ? `Timer "${label}" fired after ${formatDuration(durationMs)}` : `Timer fired after ${formatDuration(durationMs)}`));
-        }, durationMs);
+        });
 
         this.#timers.set(key, {
             subscriptionId,
@@ -508,6 +512,22 @@ export class TimeService implements ServiceHandler {
             triggerType: "time:timer_fired",
             label,
         });
+    }
+
+    /**
+     * setTimeout against an absolute deadline. Delays beyond 2^31-1 ms overflow
+     * setTimeout and fire immediately, so longer waits are chained in max-size
+     * hops; each hop refreshes the handle stored in #timers under `key` so
+     * clearTimeout on unsubscribe still cancels the live hop.
+     */
+    #setTimeoutUntil(key: string, fireAt: number, cb: () => void): ReturnType<typeof setTimeout> {
+        const remaining = fireAt - Date.now();
+        if (remaining <= MAX_TIMEOUT_MS) return setTimeout(cb, Math.max(0, remaining));
+        return setTimeout(() => {
+            const entry = this.#timers.get(key);
+            if (!entry) return; // unsubscribed while waiting
+            entry.handle = this.#setTimeoutUntil(key, fireAt, cb);
+        }, MAX_TIMEOUT_MS);
     }
 
     #handleAtSubscription(subscriptionId: string, sessionId: string, params: any, action: string): void {
@@ -551,7 +571,7 @@ export class TimeService implements ServiceHandler {
 
         logInfo(`[time] scheduling at-timer for session ${sessionId}: ${atStr} (in ${formatDuration(delayMs)})${label ? ` [${label}]` : ""}`);
 
-        const handle = setTimeout(() => {
+        const handle = this.#setTimeoutUntil(key, targetMs, () => {
             this.#timers.delete(key);
             void this.#fireOneShot(sessionId, subscriptionId, "time:at", {
                 at: new Date(targetMs).toISOString(),
@@ -559,7 +579,7 @@ export class TimeService implements ServiceHandler {
                 label,
                 message,
             }, message ?? (label ? `Scheduled "${label}" fired` : `Scheduled trigger fired (target: ${atStr})`));
-        }, delayMs);
+        });
 
         this.#timers.set(key, {
             subscriptionId,

--- a/packages/cli/src/runner/stop.ts
+++ b/packages/cli/src/runner/stop.ts
@@ -9,9 +9,71 @@
  * SIGTERM to the daemon PID directly.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { logError, logInfo, logWarn, setLogComponent } from "./logger.js";
 import { defaultStatePath, isPidRunning } from "./runner-state.js";
+import { STOP_FILE_NAME } from "./process-kill.js";
+
+/** Cheap liveness probe for wait loops (no command-line verification). */
+function pidAlive(pid: number): boolean {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err: any) {
+        return err?.code !== "ESRCH";
+    }
+}
+
+/** Hard-kill a PID and its process tree on Windows. */
+function taskkillTree(pid: number): void {
+    try {
+        execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", timeout: 10_000 });
+    } catch {
+        try { process.kill(pid, "SIGTERM"); } catch {}
+    }
+}
+
+/**
+ * Windows stop flow. Signals are undeliverable (TerminateProcess only), so a
+ * stop file is dropped next to the state file; the daemon polls for it, shuts
+ * down cleanly (releasing its lock and closing the tunnel), and the supervisor
+ * observes the clean exit and follows. Falls back to a tree force-kill.
+ */
+async function runStopWindows(statePath: string, supervisorPid: number, daemonPid: number): Promise<number> {
+    const stopFile = join(dirname(statePath), STOP_FILE_NAME);
+    let stopFileWritten = false;
+    try {
+        writeFileSync(stopFile, new Date().toISOString(), "utf-8");
+        stopFileWritten = true;
+        logInfo("Requested graceful shutdown (stop file)…");
+    } catch (err: any) {
+        logWarn(`Could not write stop file: ${err?.message ?? String(err)}`);
+    }
+
+    if (stopFileWritten) {
+        // Daemon polls every 1 s; give it time to clean up sessions + tunnel.
+        const deadline = Date.now() + 12_000;
+        while (Date.now() < deadline) {
+            if (!pidAlive(daemonPid) && !pidAlive(supervisorPid)) {
+                try { rmSync(stopFile, { force: true }); } catch {}
+                logInfo("Runner stopped.");
+                return 0;
+            }
+            await new Promise((r) => setTimeout(r, 250));
+        }
+        logWarn("Runner did not exit in time. Force-killing…");
+    }
+
+    try { rmSync(stopFile, { force: true }); } catch {}
+    for (const pid of [supervisorPid, daemonPid]) {
+        if (pid > 0 && pidAlive(pid)) taskkillTree(pid);
+    }
+    logInfo("Runner force-stopped.");
+    return 0;
+}
 
 export async function runStop(): Promise<number> {
     setLogComponent("supervisor");
@@ -53,6 +115,12 @@ export async function runStop(): Promise<number> {
     const label = targetPid === supervisorPid ? "supervisor" : "daemon";
     logInfo(`Stopping runner ${label} (pid ${targetPid})…`);
 
+    if (process.platform === "win32") {
+        // SIGTERM here would TerminateProcess the supervisor and orphan the
+        // daemon (no signal forwarding exists on Windows) — use the stop file.
+        return runStopWindows(statePath, supervisorPid, daemonPid);
+    }
+
     try {
         process.kill(targetPid, "SIGTERM");
     } catch (err: any) {
@@ -74,10 +142,8 @@ export async function runStop(): Promise<number> {
         await new Promise((r) => setTimeout(r, 250));
     }
 
-    // Still alive — force kill.
-    // On Windows, SIGKILL is not supported; use SIGTERM which unconditionally
-    // terminates the process on Windows (equivalent to SIGKILL on Unix).
-    const forceSignal = process.platform === "win32" ? "SIGTERM" : "SIGKILL";
+    // Still alive — force kill. (Windows exits above via runStopWindows.)
+    const forceSignal = "SIGKILL";
     logWarn("Runner did not exit in time. Force-killing…");
     try {
         process.kill(targetPid, forceSignal);

--- a/packages/cli/src/runner/supervisor.ts
+++ b/packages/cli/src/runner/supervisor.ts
@@ -28,6 +28,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { defaultStatePath } from "./runner-state.js";
 import { setLogComponent, logInfo, logError } from "./logger.js";
+import { forceKillTree, SHUTDOWN_MESSAGE } from "./process-kill.js";
 
 const RESTART_DELAY_BASE = 2_000;  // 2 s
 const RESTART_DELAY_MAX  = 60_000; // 60 s
@@ -68,12 +69,28 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
     let child: ChildProcess | null = null;
 
     // Forward SIGINT / SIGTERM to the child so it can release its lock file
-    // and close its WebSocket before we restart or exit.
+    // and close its WebSocket before we restart or exit. On Windows a signal
+    // would TerminateProcess the daemon before its cleanup runs, so the
+    // request goes over the IPC channel instead, with a delayed hard kill in
+    // case the daemon hangs.
     const forwardSignal = (sig: NodeJS.Signals) => {
         isShuttingDown = true;
-        if (child && !child.killed) {
-            try { child.kill(sig); } catch {}
+        if (!child || child.killed) return;
+        if (process.platform === "win32" && child.connected) {
+            const c = child;
+            try {
+                c.send(SHUTDOWN_MESSAGE);
+                const timer = setTimeout(() => {
+                    try { if (c.exitCode === null) forceKillTree(c); } catch {}
+                }, 10_000);
+                timer.unref?.();
+                c.once("exit", () => clearTimeout(timer));
+                return;
+            } catch {
+                // IPC channel already gone — fall through to kill
+            }
         }
+        try { child.kill(sig); } catch {}
     };
     process.on("SIGINT",  () => forwardSignal("SIGINT"));
     process.on("SIGTERM", () => forwardSignal("SIGTERM"));
@@ -99,7 +116,11 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
         const exitCode = await new Promise<number>((resolve) => {
             child = spawn(process.execPath, spawnArgs, {
                 env:   process.env as Record<string, string>,
-                stdio: ["ignore", "inherit", "inherit"],
+                // The IPC channel (Windows) carries graceful-shutdown requests,
+                // since signals there are an uncatchable TerminateProcess.
+                stdio: process.platform === "win32"
+                    ? ["ignore", "inherit", "inherit", "ipc"]
+                    : ["ignore", "inherit", "inherit"],
             });
 
             child.on("exit", (code, signal) => {

--- a/packages/cli/src/runner/terminal.ts
+++ b/packages/cli/src/runner/terminal.ts
@@ -27,6 +27,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveDefaultShell } from "./terminal-utils.js";
 import { logInfo, logWarn, logError } from "./logger.js";
+import { forceKillTree } from "./process-kill.js";
 
 export interface TerminalEntry {
     terminalId: string;
@@ -46,12 +47,31 @@ function escalateTerminalKill(worker: ChildProcess, terminalId: string, timeoutM
     const timer = setTimeout(() => {
         try {
             if (!worker.killed && worker.exitCode === null) {
-                logWarn(`[terminal] terminal ${terminalId} did not exit after ${timeoutMs}ms; force-killing with SIGKILL`);
-                worker.kill("SIGKILL");
+                logWarn(`[terminal] terminal ${terminalId} did not exit after ${timeoutMs}ms; force-killing`);
+                forceKillTree(worker);
             }
         } catch {}
     }, timeoutMs);
     worker.once("exit", () => clearTimeout(timer));
+}
+
+/**
+ * Stop a terminal worker: IPC "kill" first so it can dispose its PTY, then a
+ * SIGTERM on POSIX. On Windows the SIGTERM would TerminateProcess the worker
+ * before it reads the IPC message, so only the escalation timer backs it up.
+ */
+function stopTerminalWorker(worker: ChildProcess, terminalId: string): void {
+    try { worker.send({ type: "kill" }); } catch {}
+    if (process.platform === "win32" && worker.connected) {
+        escalateTerminalKill(worker, terminalId);
+        return;
+    }
+    try {
+        worker.kill("SIGTERM");
+        escalateTerminalKill(worker, terminalId);
+    } catch (err) {
+        logWarn(`[terminal] stopTerminalWorker: worker.kill() failed for terminalId=${terminalId}: ${err}`);
+    }
 }
 
 /** Is this process running inside a compiled Bun single-file binary? */
@@ -300,15 +320,7 @@ export function killTerminal(terminalId: string): boolean {
         return false;
     }
     runningTerminals.delete(terminalId);
-    try {
-        entry.worker.send({ type: "kill" });
-    } catch {}
-    try {
-        entry.worker.kill("SIGTERM");
-        escalateTerminalKill(entry.worker, terminalId);
-    } catch (err) {
-        logWarn(`[terminal] killTerminal: worker.kill() failed for terminalId=${terminalId}: ${err}`);
-    }
+    stopTerminalWorker(entry.worker, terminalId);
     return true;
 }
 
@@ -320,11 +332,7 @@ export function listTerminals(): string[] {
 /** Kill all running terminals (used on daemon shutdown). */
 export function killAllTerminals(): void {
     for (const [id, entry] of runningTerminals) {
-        try { entry.worker.send({ type: "kill" }); } catch {}
-        try {
-            entry.worker.kill("SIGTERM");
-            escalateTerminalKill(entry.worker, id);
-        } catch {}
+        stopTerminalWorker(entry.worker, id);
         runningTerminals.delete(id);
     }
 }

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -710,6 +710,13 @@ async function main(): Promise<void> {
 
     process.on("SIGTERM", shutdown);
     process.on("SIGINT", shutdown);
+    // Windows: the daemon can't deliver a catchable SIGTERM (kill() there is an
+    // immediate TerminateProcess) — it sends a shutdown request over IPC instead.
+    process.on("message", (msg: unknown) => {
+        if (typeof msg === "object" && msg !== null && (msg as Record<string, unknown>).type === "shutdown") {
+            void shutdown();
+        }
+    });
 
     // Keep the process alive; work happens via relay/websocket events.
     await new Promise<void>(() => {});

--- a/packages/tools/src/bash.ts
+++ b/packages/tools/src/bash.ts
@@ -3,6 +3,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { wrapCommand, getSandboxEnv, isSandboxActive } from "./sandbox.js";
+import { resolvePosixShell } from "./posix-shell.js";
 
 // ── Internal types for dependency injection (used in tests) ───────────────────
 
@@ -61,8 +62,14 @@ export function createBashTool(deps?: Partial<BashDeps>): AgentTool {
                 }
             }
 
+            // The tool contract is bash semantics. On Windows exec() defaults to
+            // cmd.exe, which breaks POSIX command strings — route through Git for
+            // Windows' bash.exe when available (cmd.exe remains the last resort).
+            const posixShell = process.platform === "win32" ? resolvePosixShell() : null;
+            const shellOpt = posixShell ? { shell: posixShell.shell } : {};
+
             try {
-                const { stdout, stderr } = await execAsync(command, { timeout, env, maxBuffer });
+                const { stdout, stderr } = await execAsync(command, { timeout, env, maxBuffer, ...shellOpt });
                 return {
                     content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
                     details: { command: params.command, stdout, stderr },

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -5,6 +5,7 @@ export { readFileTool } from "./read-file.js";
 export { writeFileTool } from "./write-file.js";
 export { searchTool } from "./search.js";
 export { createToolkit } from "./toolkit.js";
+export { findGitBashOnWindows, resolvePosixShell } from "./posix-shell.js";
 export {
     initSandbox,
     wrapCommand,

--- a/packages/tools/src/posix-shell.ts
+++ b/packages/tools/src/posix-shell.ts
@@ -1,0 +1,78 @@
+/**
+ * POSIX shell resolution.
+ *
+ * The bash tool (and hook/plugin runners in the CLI) execute agent- and
+ * user-authored command strings that assume POSIX semantics. On Windows the
+ * default `exec()` shell is cmd.exe, which breaks most of those commands —
+ * Git for Windows' bundled bash.exe is the standard non-WSL substitute.
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Find Git for Windows' bundled bash.exe by checking well-known install
+ * paths and falling back to `git --exec-path` to derive the Git root.
+ * Returns the absolute path to bash.exe, or null if not found.
+ */
+export function findGitBashOnWindows(): string | null {
+    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    const localAppData = process.env.LOCALAPPDATA || "";
+
+    const candidates = [
+        join(programFiles, "Git", "bin", "bash.exe"),
+        join(programFilesX86, "Git", "bin", "bash.exe"),
+        ...(localAppData ? [join(localAppData, "Programs", "Git", "bin", "bash.exe")] : []),
+    ];
+
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate;
+    }
+
+    // Try to derive from `git --exec-path` (e.g. C:\Program Files\Git\mingw64\libexec\git-core)
+    try {
+        const execPath = execSync("git --exec-path", {
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        // Walk up to the Git root: <root>/mingw64/libexec/git-core → <root>
+        const gitRoot = join(execPath, "..", "..", "..");
+        const bashFromGit = join(gitRoot, "bin", "bash.exe");
+        if (existsSync(bashFromGit)) return bashFromGit;
+    } catch {
+        // git not in PATH or other error — fall through
+    }
+
+    return null;
+}
+
+/** Cached result so the filesystem is only probed once per process. */
+let _cachedShell: { shell: string; flag: string } | null | undefined;
+
+/**
+ * Resolve a POSIX-compatible shell for running command strings.
+ *
+ * - **Unix / macOS**: `/bin/sh -c` (POSIX-guaranteed to exist).
+ * - **Windows**: Git for Windows' bundled `bash.exe`, or null when no
+ *   git-bash could be found — callers decide their own fallback (cmd.exe
+ *   default, bare `bash`, or a clear error).
+ */
+export function resolvePosixShell(): { shell: string; flag: string } | null {
+    if (_cachedShell !== undefined) return _cachedShell;
+
+    if (process.platform !== "win32") {
+        _cachedShell = { shell: "/bin/sh", flag: "-c" };
+        return _cachedShell;
+    }
+
+    const gitBash = findGitBashOnWindows();
+    _cachedShell = gitBash ? { shell: gitBash, flag: "-c" } : null;
+    return _cachedShell;
+}
+
+/** Test hook: clear the cached shell resolution. */
+export function _resetPosixShellCache(): void {
+    _cachedShell = undefined;
+}

--- a/packages/tools/src/sandbox.test.ts
+++ b/packages/tools/src/sandbox.test.ts
@@ -295,7 +295,9 @@ describe("sandbox", () => {
                 const tmpDir = mktmp(join(td(), "symlink-test-"));
                 const targetDir = mktmp(join(td(), "symlink-target-"));
                 const linkPath = join(tmpDir, "escape");
-                symlinkSync(targetDir, linkPath);
+                // "junction" so the test doesn't require symlink privileges on
+                // Windows; ignored on POSIX.
+                symlinkSync(targetDir, linkPath, "junction");
 
                 await initSandbox(makeConfig({
                     denyRead: [targetDir],
@@ -332,7 +334,7 @@ describe("sandbox", () => {
                 validatePath("/etc/secrets/key.pem", "read");
                 expect(getViolations().length).toBe(1);
                 expect(getViolations()[0].operation).toBe("read");
-                expect(getViolations()[0].target).toContain("etc/secrets/key.pem");
+                expect(getViolations()[0].target.replace(/\\/g, "/")).toContain("etc/secrets/key.pem");
             });
 
             test("records violations on denied writes", async () => {
@@ -457,7 +459,7 @@ describe("sandbox", () => {
 
             validatePath("/etc/secrets/test", "read");
             expect(received.length).toBe(1);
-            expect(received[0].target).toContain("etc/secrets/test");
+            expect(received[0].target.replace(/\\/g, "/")).toContain("etc/secrets/test");
             unsub();
         });
 

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -413,8 +413,9 @@ function _normalizePath(filePath: string): string {
         }
         let parent = dirname(resolved);
         const tail: string[] = [resolved.slice(parent.length)];
-        while (parent !== "/" && !existsSync(parent)) {
+        while (!existsSync(parent)) {
             const next = dirname(parent);
+            if (next === parent) break; // filesystem root ("/", "C:\", or a UNC root)
             tail.unshift(parent.slice(next.length));
             parent = next;
         }
@@ -444,8 +445,9 @@ function _normalizeRulePath(rulePath: string): string {
         }
         let parent = dirname(resolved);
         const tail: string[] = [resolved.slice(parent.length)];
-        while (parent !== "/" && !existsSync(parent)) {
+        while (!existsSync(parent)) {
             const next = dirname(parent);
+            if (next === parent) break; // filesystem root ("/", "C:\", or a UNC root)
             tail.unshift(parent.slice(next.length));
             parent = next;
         }
@@ -512,18 +514,30 @@ function _pathStartsWith(path: string, prefix: string): boolean {
         : path.startsWith(prefix);
 }
 
+/**
+ * Canonicalize separators for comparison: resolved paths use backslashes on
+ * Windows, and comparing them against a "/"-joined rule prefix would make
+ * every allow-check fail (and every deny-check under-match).
+ */
+function _toComparable(p: string): string {
+    return p.replace(/\\/g, "/");
+}
+
+function _pathIsUnderRule(normalizedPath: string, rulePath: string): boolean {
+    const rule = _toComparable(_normalizeRulePath(rulePath));
+    const path = _toComparable(normalizedPath);
+    // A rule already ending in "/" ("/" itself, or a drive root like "C:/") is
+    // a ready-made prefix; appending another "/" would never match.
+    const prefix = rule.endsWith("/") ? rule : rule + "/";
+    return _pathsEqual(path, rule) || _pathStartsWith(path, prefix);
+}
+
 function _pathMatchesDeny(normalizedPath: string, deniedPath: string): boolean {
-    const rule = _normalizeRulePath(deniedPath);
-    // When the rule is "/" (filesystem root), every absolute path is a child.
-    // Appending "/" naively would produce "//" which never matches.
-    const prefix = rule === "/" ? "/" : rule + "/";
-    return _pathsEqual(normalizedPath, rule) || _pathStartsWith(normalizedPath, prefix);
+    return _pathIsUnderRule(normalizedPath, deniedPath);
 }
 
 function _pathWithinAllow(normalizedPath: string, allowedPath: string): boolean {
-    const rule = _normalizeRulePath(allowedPath);
-    const prefix = rule === "/" ? "/" : rule + "/";
-    return _pathsEqual(normalizedPath, rule) || _pathStartsWith(normalizedPath, prefix);
+    return _pathIsUnderRule(normalizedPath, allowedPath);
 }
 
 /** Record a violation. Caps at MAX_VIOLATIONS entries. */

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -306,9 +306,14 @@ export const searchTool: AgentTool = {
         // rg handles its own relative path matching via --glob patterns.
         let absSafePath: string;
         try { absSafePath = realpathSync(pathResolve(safePath)); } catch { absSafePath = pathResolve(safePath); }
+        // On Windows, `find` resolves to System32's string-search tool (no
+        // -name/-type support), so file listing goes through ripgrep instead —
+        // its gitignore-style globs match basenames at any depth like -name.
         const [cmd, args, maxLines] =
             type === "files"
-                ? (["find", [absSafePath, ...denyExclusions.find, "-name", pattern, "-type", "f", "-print"], 50] as const)
+                ? process.platform === "win32"
+                    ? (["rg", ["--files", ...denyExclusions.rg, "--glob", pattern, "--", safePath], 50] as const)
+                    : (["find", [absSafePath, ...denyExclusions.find, "-name", pattern, "-type", "f", "-print"], 50] as const)
                 : (["rg", ["--no-heading", "-n", ...denyExclusions.rg, "-e", pattern, "--", safePath], 100] as const);
 
         let result: SpawnResult;
@@ -324,18 +329,21 @@ export const searchTool: AgentTool = {
         // Normalize type for isFailure — unknown values fall through to "content"
         // (rg branch) in command selection, so must match here too.
         const normalizedType = type === "files" ? "files" : "content";
+        // Exit-code semantics follow the binary actually used, not the search
+        // mode: rg exits 1 for "no matches" even in --files mode.
+        const exitSemantics = cmd === "rg" ? "content" : "files";
 
         let output: string;
         if (result.lines.length > 0) {
             output = result.lines.join("\n");
             // Surface partial errors (e.g. permission denied on some subdirs,
             // timeout with partial output) so the caller knows results may be incomplete.
-            if (isFailure(result, normalizedType)) {
+            if (isFailure(result, exitSemantics)) {
                 const reason = result.error?.split("\n")[0]
                     || (result.exitCode === null ? "process terminated unexpectedly" : `exit code ${result.exitCode}`);
                 output += `\n\n[warning: some results may be missing — ${reason}]`;
             }
-        } else if (isFailure(result, normalizedType)) {
+        } else if (isFailure(result, exitSemantics)) {
             const reason = result.error?.split("\n")[0];
             if (result.exitCode === null && !result.truncated) {
                 output = `Search failed: ${reason || "timed out or command not found"}`;

--- a/packages/ui/src/components/TriggersPanel.logic.test.ts
+++ b/packages/ui/src/components/TriggersPanel.logic.test.ts
@@ -7,9 +7,25 @@
 import { describe, test, expect, mock } from "bun:test";
 
 // ── Minimal mocks for TriggersPanel's UI imports ─────────────────────────────
+// IMPORTANT: bun's mock.module is process-global and is NOT undone by
+// mock.restore(), so these leak into every test file that runs after this one.
+// The stubs must therefore render their children (a `() => null` Button here
+// blanked out buttons in unrelated component tests, e.g. DeviceSetupScanner's
+// "Allow Camera & Scan" — which tests failed depended on file order).
 /* eslint-disable @typescript-eslint/no-explicit-any */
-mock.module("@/components/ui/button", () => ({ Button: () => null }));
-mock.module("@/components/ui/badge", () => ({ Badge: () => null }));
+const R = await import("react");
+const childStub = (tag: string) => {
+  const Stub = R.forwardRef(({ children, ...props }: any, ref: any) =>
+    R.createElement(tag, { ...props, ref }, children),
+  );
+  Stub.displayName = `Stub(${tag})`;
+  return Stub;
+};
+mock.module("@/components/ui/button", () => ({ Button: childStub("button") }));
+mock.module("@/components/ui/badge", () => ({ Badge: childStub("span") }));
+// Dialog stubs stay null: real dialogs hide content until opened, so a
+// children-rendering stub would leak inline dialog text into later files
+// and break their single-match queries the same way.
 mock.module("@/components/ui/dialog", () => ({
   Dialog: () => null, DialogContent: () => null, DialogHeader: () => null,
   DialogTitle: () => null, DialogFooter: () => null, DialogDescription: () => null,

--- a/packages/ui/src/components/session-viewer/goal-status-badge.test.tsx
+++ b/packages/ui/src/components/session-viewer/goal-status-badge.test.tsx
@@ -1,7 +1,19 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { Window } from "happy-dom";
 import { cleanup, render } from "@testing-library/react";
 import * as React from "react";
+
+// Register our own tooltip mock so this file is immune to module mocks leaked
+// by earlier test files (bun's mock.module is process-global and mocks are
+// resolved-path-keyed, so importing "the actual" back is impossible once a
+// mock is registered). Trigger renders inline, content renders nothing —
+// matching real (closed) tooltip behavior so text queries stay single-match.
+mock.module("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
 
 const win = new Window({ url: "http://localhost/" });
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/ui/src/components/ui/error-boundary.render.test.tsx
+++ b/packages/ui/src/components/ui/error-boundary.render.test.tsx
@@ -164,8 +164,10 @@ describe("ErrorBoundary render: custom fallback prop", () => {
 
 describe("ErrorBoundary render: dev vs prod message display", () => {
 	test("prod mode (DEV=false): shows generic 'Render error' for widget level", () => {
-		// Ensure DEV is falsy (default in bun test environment)
-		(import.meta.env as Record<string, unknown>).DEV = false;
+		// Ensure DEV is falsy. Must delete rather than assign false: on Windows
+		// bun's import.meta.env IS process.env, which coerces false to the
+		// truthy string "false".
+		delete (import.meta.env as Record<string, unknown>).DEV;
 		const { container } = renderCrashed("Secret internal message", { level: "widget" });
 		expect(container.innerHTML).toContain("Render error");
 		expect(container.innerHTML).not.toContain("Secret internal message");
@@ -181,7 +183,8 @@ describe("ErrorBoundary render: dev vs prod message display", () => {
 	});
 
 	test("prod mode: section/root level does NOT show error message", () => {
-		(import.meta.env as Record<string, unknown>).DEV = false;
+		// delete, not `= false` — see the widget-level prod test above.
+		delete (import.meta.env as Record<string, unknown>).DEV;
 		const { container } = renderCrashed("Hidden error text", { level: "section" });
 		expect(container.innerHTML).not.toContain("Hidden error text");
 		delete (import.meta.env as Record<string, unknown>).DEV;

--- a/scripts/link-workspaces.ts
+++ b/scripts/link-workspaces.ts
@@ -18,7 +18,8 @@ for (const pkg of packages) {
 
   // Check if the link already points to the correct target
   try {
-    const existing = readlinkSync(link);
+    // Junction targets on Windows may come back with a \\?\ prefix.
+    const existing = readlinkSync(link).replace(/^\\\\\?\\/, "");
     if (resolve(scope, existing) === target) continue;
     // Symlink exists but points to the wrong target — remove it
     rmSync(link, { recursive: true, force: true });
@@ -34,7 +35,8 @@ for (const pkg of packages) {
   }
 
   try {
-    symlinkSync(target, link);
+    // Junctions on Windows work without Developer Mode/admin, unlike symlinks.
+    symlinkSync(target, link, process.platform === "win32" ? "junction" : null);
   } catch (err) {
     console.error(
       `[link-workspaces] Failed to symlink @pizzapi/${pkg} → ${target}: ${(err as Error).message}\n` +


### PR DESCRIPTION
## Summary

Broad native-Windows (non-WSL) hardening pass, driven by a four-track audit of the codebase (tunnels/networking, usage refresh + runner daemon, process/shell/signals, filesystem/paths). Every fix below was verified live on Windows 11 Pro 24H2+ (build 26200).

### Tunnels / relay connectivity
- **Loopback relay URLs normalize to `127.0.0.1`** via new `packages/cli/src/relay-url.ts`, applied at every resolution site (daemon socket, `pizza local` health poll, tunnel-tools public URLs, trigger-client, spawn-session, time-service, relay-context-factory). `localhost` resolves to `::1` first on Windows while Docker's short-form port publish binds IPv4 only — the same bug class as #609, which only covered the runner→dev-server hop. This was the remaining cause of tunnel 502s/timeouts.

### Runner lifecycle / usage refresh
- **`wmic` → PowerShell CIM** for PID liveness verification (`runner-state.ts`). wmic is removed on Windows 11 24H2+, so the check silently fell back to "assume it's the runner": stale locks blocked daemon startup and `runner stop` could kill an unrelated reused PID. Unreadable command lines now count as "not the runner".
- **Graceful shutdown actually works on Windows** (new `runner/process-kill.ts`). Windows signals are an uncatchable `TerminateProcess`; `runner stop` previously hard-killed the supervisor and *orphaned the daemon* with a stale lock. Now: the daemon polls a `runner.stop` file, supervisor⇄daemon and daemon⇄workers exchange IPC `{type:"shutdown"}` messages, and escalation uses `taskkill /T` so MCP/shell grandchildren die with the tree. Verified live: clean stop in ~1 s with the lock released.
- **Atomic usage-cache writes** (tmp + rename with EPERM retry) so workers never parse a half-written `usage-cache.json`.
- **Timer overflow clamp** in time-service: delays past 2³¹−1 ms overflow `setTimeout` and fire immediately; now chained against the absolute deadline.
- Self-restart no longer allocates a new console window (`detached:false` on win32).

### Agent tools (were broken outright on Windows)
- **Sandbox path matching** built `/`-joined rule prefixes and compared them against backslash paths — every `write_file` was blocked in the default config, and denyRead/denyWrite silently under-matched (e.g. `~/.ssh` unprotected). Fixed with canonical-separator comparison, root-terminating parent walks (drive/UNC roots hung the old `parent !== "/"` loop), `path.isAbsolute`, `os.tmpdir()` presets, and Windows-specific sensitive paths in denyRead.
- **File search** spawned Unix `find` — which on Windows is System32's string-search tool. Files mode now uses `rg --files` on win32.
- **stdio MCP servers via `npx` couldn't spawn** (`.cmd` shims are not executables). New PATHEXT-aware resolver (`extensions/mcp/windows-command.ts`) routes them through `cmd.exe /d /s /c` with explicit quoting.
- **bash tool** ran agent commands through cmd.exe and **Claude-plugin hooks** hardcoded `/bin/sh`. Both now resolve Git for Windows bash via shared `tools/posix-shell.ts` (the hooks runner delegates to it).
- **Plugin trust comparisons** normalize separators and compare case-insensitively on win32 — the same plugin trusted as `C:\Users\…`, `c:\users\…` etc. no longer re-prompts.

### Tooling / repo health
- **postinstall workspace links use junctions** — directory symlinks need Developer Mode/admin, which made `bun install` exit 1 mid-install (this machine's node_modules was silently missing ~500 packages).
- **lefthook pre-commit scripts rewritten without double quotes**: lefthook's Windows spawn re-parses scripts via MSVCRT command-line rules — embedded `"` are stripped (`[ -n "$bad" ]` → always-true `[ -n ]`) and quoted strings with spaces split the script (`syntax error: unexpected end of file`). Every commit on Windows failed the hooks before this. `.gitattributes` also pins LF for `lefthook.yml`/`*.sh`.

## Testing
- `bun run typecheck` clean.
- Targeted suites pass: relay-url (new), local, tunnel-tools, sandbox (50), search (35), bash+hooks (190), plugins-cli, windows-command (new).
- Full `packages/cli/src` isolated suite: identical pass/fail counts before vs. after the change (the 29 remaining failures are pre-existing native-Windows test issues in unrelated suites — CRLF/path assumptions — left for a follow-up).
- Live end-to-end on Windows: runner start → `runner stop` graceful cycle (lock released, ~1 s); `isPidRunning` against live/dead/unrelated PIDs; bash tool POSIX pipelines; `npx.cmd` spawn chain; sandbox allow/deny on real Windows paths; `bun install` completing with junctions; lefthook guards firing correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)