### PR TITLE
fix(ui): keep bottom icon strip below side rails

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5259,27 +5259,6 @@ export function App() {
                 />
               )}
 
-              {/* ── BOTTOM ICON STRIP ────────────────────────────────────── */}
-              {/* ponytail: strip lives outside the docked panel so it stays pinned to the bottom edge; the panel slides out above it */}
-              <ButtonStrip
-                position="center-bottom"
-                buttonIds={buttonPositions.slots["center-bottom"]}
-                onDragStart={handleButtonDragStart}
-                servicePanels={railServicePanels}
-                onToggleServicePanel={handleToggleServicePanelFromDock}
-                onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
-                onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}
-                onToggleGit={() => openPanelFromDockedButton("git", showGit, setShowGit, handleGitPositionChange)}
-                onToggleTriggers={() => openPanelFromDockedButton("triggers", showTriggers, setShowTriggers, handleTriggersPositionChange)}
-                onToggleAnalyzer={() => openPanelFromDockedButton("analyzer", showAnalyzer, setShowAnalyzer, handleAnalyzerPositionChange)}
-                onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
-                onExport={handleExport}
-                onExec={sendRemoteExec}
-                sessionId={activeSessionId}
-                effortLevel={effortLevel}
-                planModeEnabled={planModeEnabled}
-                tokenUsage={tokenUsage}
-              />
             </div>{/* end center column */}
 
             {/* ── RIGHT COLUMN ────────────────────────────────────────────── */}
@@ -5379,6 +5358,28 @@ export function App() {
               />
             </div>
           )}
+
+          {/* ── BOTTOM ICON STRIP ────────────────────────────────────── */}
+          {/* ponytail: render after the side rails so the strip owns the true bottom-left/right corners */}
+          <ButtonStrip
+            position="center-bottom"
+            buttonIds={buttonPositions.slots["center-bottom"]}
+            onDragStart={handleButtonDragStart}
+            servicePanels={railServicePanels}
+            onToggleServicePanel={handleToggleServicePanelFromDock}
+            onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
+            onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}
+            onToggleGit={() => openPanelFromDockedButton("git", showGit, setShowGit, handleGitPositionChange)}
+            onToggleTriggers={() => openPanelFromDockedButton("triggers", showTriggers, setShowTriggers, handleTriggersPositionChange)}
+            onToggleAnalyzer={() => openPanelFromDockedButton("analyzer", showAnalyzer, setShowAnalyzer, handleAnalyzerPositionChange)}
+            onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
+            onExport={handleExport}
+            onExec={sendRemoteExec}
+            sessionId={activeSessionId}
+            effortLevel={effortLevel}
+            planModeEnabled={planModeEnabled}
+            tokenUsage={tokenUsage}
+          />
 
           {/* ── MOBILE OVERLAY ──────────────────────────────────────────── */}
           {mobilePanelTabs.length > 0 && (


### PR DESCRIPTION
## Summary
- render the bottom icon strip after the left and right side rails
- keep bottom-row actions at the true bottom edge of the workspace
- preserve docked left/right actions directly above the bottom row

## Verification
- `bun test src` in `packages/ui` — 1212 passed, 1 existing skip
- `bunx tsc -p packages/ui/tsconfig.json --noEmit`
- `bun run build` in `packages/ui`
- sandbox browser check with icons docked on both left and right rails
