### PR TITLE
Fix duplicate terminal spawn race

### DIFF
--- a/packages/server/src/ws/namespaces/terminal.ts
+++ b/packages/server/src/ws/namespaces/terminal.ts
@@ -19,7 +19,7 @@ import { bindSocketHandlersToAuthContext } from "./context.js";
 import {
     getTerminalEntry,
     setTerminalViewer,
-    markTerminalSpawned,
+    claimTerminalSpawn,
     removeTerminalViewer,
     getLocalRunnerSocket,
 } from "../sio-registry.js";
@@ -137,7 +137,7 @@ export function registerTerminalNamespace(io: SocketIOServer, context: AuthConte
 
             // Deferred spawn: if the PTY hasn't been spawned yet and we receive
             // the first terminal_resize from the viewer, use those dimensions to spawn.
-            if (!te.spawned) {
+            if (!te.spawned && await claimTerminalSpawn(tid)) {
                 const spawnOpts = JSON.parse(te.spawnOpts) as {
                     cwd?: string;
                     shell?: string;
@@ -157,8 +157,6 @@ export function registerTerminalNamespace(io: SocketIOServer, context: AuthConte
                     `deferred spawn: viewer sent resize → spawning PTY ` +
                         `terminalId=${tid} ${cols}x${rows} cwd=${spawnOpts.cwd ?? "(default)"}`,
                 );
-
-                await markTerminalSpawned(tid);
 
                 try {
                     runnerSocket.emit("new_terminal" as string, {

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -62,7 +62,7 @@ export type { TerminalSpawnOpts } from "./terminals.js";
 export {
     registerTerminal,
     setTerminalViewer,
-    markTerminalSpawned,
+    claimTerminalSpawn,
     removeTerminalViewer,
     getTerminalEntry,
     removeTerminal,

--- a/packages/server/src/ws/sio-registry/terminals.ts
+++ b/packages/server/src/ws/sio-registry/terminals.ts
@@ -14,6 +14,7 @@ import {
     setTerminal,
     getTerminal as getTerminalState,
     updateTerminalFields,
+    claimTerminalSpawn as claimTerminalSpawnState,
     deleteTerminal as deleteTerminalState,
     getTerminalsForRunner as getTerminalsForRunnerState,
 } from "../sio-state/index.js";
@@ -127,9 +128,9 @@ export async function setTerminalViewer(terminalId: string, socket: Socket): Pro
     return true;
 }
 
-/** Mark terminal as spawned in Redis. */
-export async function markTerminalSpawned(terminalId: string): Promise<void> {
-    await updateTerminalFields(terminalId, { spawned: true });
+/** Atomically claim the right to spawn a terminal exactly once. */
+export async function claimTerminalSpawn(terminalId: string): Promise<boolean> {
+    return claimTerminalSpawnState(terminalId);
 }
 
 /** Remove a terminal viewer socket. */

--- a/packages/server/src/ws/sio-state-summary.test.ts
+++ b/packages/server/src/ws/sio-state-summary.test.ts
@@ -54,11 +54,50 @@ const mockRedis = {
         for (const member of members) current.delete(member);
     }),
     incr: mock(async () => 1),
-    eval: mock(async () => 0),
+    eval: mock(async (_script: string, options: { keys: string[] }) => {
+        const hash = hashStore.get(options.keys[0]);
+        if (!hash || hash.spawned !== "0") return 0;
+        hash.spawned = "1";
+        return 1;
+    }),
 };
 
 // No mock.module needed — mock Redis client is injected directly via initStateRedis().
-import { initStateRedis, setSession, getSessionSummary } from "./sio-state.js";
+import {
+    claimTerminalSpawn,
+    getSessionSummary,
+    initStateRedis,
+    setSession,
+    setTerminal,
+} from "./sio-state.js";
+
+describe("claimTerminalSpawn", () => {
+    beforeEach(async () => {
+        hashStore.clear();
+        setStore.clear();
+        mockRedis.eval.mockClear();
+        await initStateRedis(mockRedis as never);
+    });
+
+    it("allows only one concurrent spawn claim", async () => {
+        const terminalId = "terminal-race";
+        await setTerminal(terminalId, {
+            terminalId,
+            runnerId: "runner-1",
+            userId: "user-1",
+            spawned: false,
+            exited: false,
+            spawnOpts: "{}",
+        });
+
+        const claims = await Promise.all([
+            claimTerminalSpawn(terminalId),
+            claimTerminalSpawn(terminalId),
+        ]);
+
+        expect(claims.filter(Boolean)).toHaveLength(1);
+    });
+});
 
 describe("getSessionSummary", () => {
     beforeEach(async () => {

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -749,6 +749,23 @@ export async function getTerminal(terminalId: string): Promise<RedisTerminalData
     return parseTerminalFromHash(hash);
 }
 
+/** Atomically claim the right to spawn a terminal exactly once. */
+export async function claimTerminalSpawn(terminalId: string): Promise<boolean> {
+    const r = requireRedis();
+    const result = await r.eval(`
+        if redis.call('HGET', KEYS[1], 'spawned') ~= '0' then
+            return 0
+        end
+        redis.call('HSET', KEYS[1], 'spawned', '1')
+        redis.call('EXPIRE', KEYS[1], ARGV[1])
+        return 1
+    `, {
+        keys: [terminalKey(terminalId)],
+        arguments: [String(TERMINAL_TTL_SECONDS)],
+    });
+    return result === 1;
+}
+
 export async function updateTerminalFields(
     terminalId: string,
     fields: Partial<RedisTerminalData>,


### PR DESCRIPTION
## Summary
- atomically claim deferred terminal spawning in Redis
- only send `new_terminal` from the viewer that wins the claim
- add a regression test proving concurrent claims have one winner

## Testing
- `bun test packages/server/src/ws/sio-state-summary.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run test` *(one unrelated existing macOS failure: sandbox test expects literal `/tmp` instead of `os.tmpdir()`; tracked separately)*
