### PR TITLE
feat(cli): add get_current_time tool for the model

### DIFF
--- a/packages/cli/src/extensions/current-time.test.ts
+++ b/packages/cli/src/extensions/current-time.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { formatCurrentTime } from "./current-time.js";
+
+describe("formatCurrentTime", () => {
+    test("includes local time, ISO UTC, and timezone", () => {
+        const now = new Date("2026-07-20T15:30:45Z");
+        const text = formatCurrentTime(now);
+        expect(text).toContain("Local: ");
+        expect(text).toContain("ISO (UTC): 2026-07-20T15:30:45.000Z");
+        expect(text).toContain(`Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
+        expect(text).toContain("2026");
+    });
+});

--- a/packages/cli/src/extensions/current-time.ts
+++ b/packages/cli/src/extensions/current-time.ts
@@ -1,0 +1,42 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Current-time extension — a tool the model can call to get the current date
+ * and time. The system prompt's timestamp is frozen at session start, so
+ * long-running sessions need this to know the actual current time.
+ */
+/** Format a Date as the tool's response text: local time, ISO UTC, and timezone. */
+export function formatCurrentTime(now: Date): string {
+    const local = now.toLocaleString("en-US", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+        timeZoneName: "short",
+    });
+    return [
+        `Local: ${local}`,
+        `ISO (UTC): ${now.toISOString()}`,
+        `Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`,
+    ].join("\n");
+}
+
+export const currentTimeExtension: ExtensionFactory = (pi) => {
+    pi.registerTool({
+        name: "get_current_time",
+        label: "Get Current Time",
+        description:
+            "Get the current date and time. Returns the local time, ISO 8601 UTC timestamp, and timezone. Use this when you need the actual current time — the timestamp in the system prompt is from session start and may be stale.",
+        parameters: {
+            type: "object",
+            properties: {},
+        } as any,
+        execute: async () => ({
+            content: [{ type: "text" as const, text: formatCurrentTime(new Date()) }],
+            details: undefined,
+        }),
+    });
+};

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -11,6 +11,7 @@ import { providerExtension } from "./providers/extension.js";
 import { restartExtension } from "./restart.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
+import { currentTimeExtension } from "./current-time.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { subagentExtension } from "./subagent.js";
@@ -40,6 +41,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     restartExtension,
     sessionProcessesExtension,
     setSessionNameExtension,
+    currentTimeExtension,
     updateTodoExtension,
     spawnSessionExtension,
     subagentExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -8,6 +8,7 @@ import { restartExtension } from "./restart.js";
 import { sessionProcessesExtension } from "./session-processes.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
+import { currentTimeExtension } from "./current-time.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { goalExtension } from "./goal/index.js";
@@ -77,6 +78,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(restartExtension, "restart"),
         named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
+        named(currentTimeExtension, "current-time"),
         named(updateTodoExtension, "todo"),
         named(spawnSessionExtension, "spawn-session"),
         named(subagentExtension, "subagent"),


### PR DESCRIPTION
## Summary
- Adds a `get_current_time` tool the model can call to get the current date and time (local time, ISO 8601 UTC, and timezone).
- The system prompt's timestamp is frozen at session start, so long-running sessions previously had no reliable way to know the actual current time.

## Changes
- New `packages/cli/src/extensions/current-time.ts` extension registering the parameterless tool.
- Registered in `buildPizzaPiExtensionFactories` (`factories.ts`) and the core-extension list in `factories.test.ts`.
- Unit test for the response formatting.

## Testing
- `bun test src/extensions/current-time.test.ts src/extensions/factories.test.ts` — 12 pass, 0 fail
- `tsc --noEmit` clean