### PR TITLE
fix(subagent): claude-subscription provider support in subagents

### DIFF
--- a/packages/cli/scripts/e2e-claude-sub-subagent.ts
+++ b/packages/cli/scripts/e2e-claude-sub-subagent.ts
@@ -1,0 +1,68 @@
+/**
+ * E2E check: subagent engine works with the claude-subscription provider.
+ *
+ * Registers the provider directly on a real ModelRegistry (same call the
+ * minimalcc-pi extension makes), then runs a subagent with an anthropic/*
+ * model override — exercising the same-id provider fallback AND shared
+ * registry auth. Burns one tiny haiku request.
+ *
+ * Run: bun scripts/e2e-claude-sub-subagent.ts
+ */
+import { ModelRegistry, AuthStorage } from "@earendil-works/pi-coding-agent";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { runSingleAgent } from "../src/extensions/subagent/engine.js";
+import type { AgentConfig } from "../src/extensions/subagent-agents.js";
+
+const mcc = join(homedir(), ".pizzapi/git/github.com/5omeOtherGuy/minimalcc-pi");
+const { MODELS, CLAUDE_SUBSCRIPTION_NATIVE_API_ID } = await import(join(mcc, "src/models.ts"));
+const { streamNativeClaudeSubscription } = await import(join(mcc, "src/native-stream-simple.ts"));
+
+const agentDir = join(homedir(), ".pizzapi");
+const auth = AuthStorage.create(join(agentDir, "auth.json"));
+const registry = ModelRegistry.create(auth, join(agentDir, "models.json"));
+
+registry.unregisterProvider("anthropic");
+registry.registerProvider("claude-subscription", {
+    name: "Claude subscription (Claude Code OAuth)",
+    baseUrl: "https://api.anthropic.com",
+    apiKey: "claude-code-oauth-loaded-at-runtime",
+    api: CLAUDE_SUBSCRIPTION_NATIVE_API_ID,
+    models: [...MODELS],
+    streamSimple: streamNativeClaudeSubscription,
+});
+
+const agent: AgentConfig = {
+    name: "echo",
+    description: "test agent",
+    tools: ["read"],
+    systemPrompt: "You are a test agent. Follow instructions exactly.",
+    source: "user",
+} as AgentConfig;
+
+const result = await runSingleAgent(
+    process.cwd(),
+    [agent],
+    "echo",
+    "Reply with exactly the word: pong",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    (r) => ({ mode: "single", results: r }) as any,
+    { provider: "anthropic", id: "claude-haiku-4-5" }, // anthropic → same-id fallback
+    registry,
+);
+
+console.log("exitCode:", result.exitCode);
+console.log("model:", result.model);
+console.log("stderr:", result.stderr || "(none)");
+const last = result.messages.filter((m: any) => m.role === "assistant").at(-1) as any;
+const text = last?.content?.filter((c: any) => c.type === "text").map((c: any) => c.text).join("") ?? "";
+console.log("output:", JSON.stringify(text.trim()));
+
+if (result.exitCode !== 0 || !/pong/i.test(text)) {
+    console.error("E2E FAILED");
+    process.exit(1);
+}
+console.log("E2E PASSED");

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -12,6 +12,7 @@ import {
     summarizeResultForStreaming,
     summarizeResultsForStreaming,
     parseModelString,
+    resolveModelSpec,
     selectLightweightModel,
 } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
@@ -382,6 +383,58 @@ describe("parseModelString", () => {
 
     test("trims whitespace", () => {
         expect(parseModelString("  haiku  ")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+    });
+});
+
+describe("resolveModelSpec", () => {
+    const makeRegistry = (models: Array<{ provider: string; id: string; available?: boolean }>) => ({
+        find: (provider: string, modelId: string) => models.find(m => m.provider === provider && m.id === modelId) as any,
+        getAvailable: () => models.filter(m => m.available !== false) as any[],
+    });
+
+    test("resolves an exact provider/id match", () => {
+        const registry = makeRegistry([
+            { provider: "anthropic", id: "claude-haiku-4-5" },
+            { provider: "claude-subscription", id: "claude-haiku-4-5" },
+        ]);
+        const model = resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry);
+        expect(model!.provider).toBe("anthropic");
+    });
+
+    test("prefers a same-id available provider over a credential-less exact match", () => {
+        // Built-in anthropic catalog remains registered but has no API key when
+        // the claude-subscription extension is the only configured provider.
+        const registry = makeRegistry([
+            { provider: "anthropic", id: "claude-haiku-4-5", available: false },
+            { provider: "claude-subscription", id: "claude-haiku-4-5" },
+        ]);
+        const model = resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry);
+        expect(model!.provider).toBe("claude-subscription");
+    });
+
+    test("returns the credential-less exact match when no same-id fallback exists", () => {
+        const registry = makeRegistry([
+            { provider: "anthropic", id: "claude-haiku-4-5", available: false },
+        ]);
+        const model = resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry);
+        expect(model!.provider).toBe("anthropic");
+    });
+
+    test("falls back to same id under another provider when the requested provider is missing", () => {
+        // claude-subscription unregisters "anthropic" and re-registers the same ids
+        const registry = makeRegistry([
+            { provider: "claude-subscription", id: "claude-haiku-4-5" },
+        ]);
+        const model = resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry);
+        expect(model).toBeDefined();
+        expect(model!.provider).toBe("claude-subscription");
+    });
+
+    test("returns undefined when no provider has the id", () => {
+        const registry = makeRegistry([
+            { provider: "claude-subscription", id: "claude-haiku-4-5" },
+        ]);
+        expect(resolveModelSpec({ provider: "anthropic", id: "claude-opus-4-5" }, registry)).toBeUndefined();
     });
 });
 

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -124,6 +124,14 @@ export interface ModelRegistryLike {
 }
 
 /**
+ * True when the registry is a real ModelRegistry (safe to hand to
+ * createAgentSession for API-key resolution), not a narrow test mock.
+ */
+function isFullModelRegistry(registry: ModelRegistryLike): registry is ModelRegistryLike & import("@earendil-works/pi-coding-agent").ModelRegistry {
+    return typeof (registry as { getApiKeyForProvider?: unknown }).getApiKeyForProvider === "function";
+}
+
+/**
  * Select the cheapest available model from the registry.
  *
  * When no model is explicitly specified (neither by the caller nor the agent
@@ -142,6 +150,32 @@ export function selectLightweightModel(registry: ModelRegistryLike): Model<any> 
     // Sort by output token cost ascending — cheapest first
     const sorted = [...available].sort((a, b) => a.cost.output - b.cost.output);
     return sorted[0];
+}
+
+/**
+ * Resolve an explicit model spec against the registry.
+ *
+ * Falls back through:
+ *   1. Exact provider/id match — but only if it has credentials configured
+ *   2. Cached Ollama Cloud catalog (dynamic models not in the static registry)
+ *   3. Same model id under a different available provider — e.g. the
+ *      claude-subscription extension registers the same model ids under its
+ *      own provider while the built-in "anthropic" catalog has no API key, so
+ *      "anthropic/claude-haiku-4-5" resolves to
+ *      "claude-subscription/claude-haiku-4-5".
+ *   4. The credential-less exact match, so the downstream auth error names
+ *      the provider the caller actually asked for.
+ */
+export function resolveModelSpec(spec: ModelOverride, registry: ModelRegistryLike): Model<any> | undefined {
+    const exact = registry.find(spec.provider, spec.id);
+    const available = registry.getAvailable();
+    if (exact && available.includes(exact)) return exact;
+    return (
+        findCachedOllamaCloudModel(spec.provider, spec.id) ??
+        // ponytail: same-id fallback only, no fuzzy matching
+        available.find((m) => m.id === spec.id) ??
+        exact
+    );
 }
 
 export async function runSingleAgent(
@@ -262,12 +296,9 @@ export async function runSingleAgent(
         let resolvedModel: Model<any> | undefined;
         const modelSpec = modelOverride ?? (agent.model ? parseModelString(agent.model) : undefined);
         if (modelSpec && modelRegistry) {
-            // Explicit model specified — look it up. Ollama Cloud models are
-            // discovered dynamically and aren't in the static registry, so fall
-            // back to the cached catalog before giving up.
-            resolvedModel =
-                modelRegistry.find(modelSpec.provider, modelSpec.id) ??
-                findCachedOllamaCloudModel(modelSpec.provider, modelSpec.id);
+            // Explicit model specified — look it up (with same-id provider
+            // fallback for cases like claude-subscription replacing anthropic).
+            resolvedModel = resolveModelSpec(modelSpec, modelRegistry);
             if (!resolvedModel) {
                 currentResult.exitCode = 1;
                 currentResult.stderr = `Model not found: ${modelSpec.provider}/${modelSpec.id}. Use the \`models\` command to see available models.`;
@@ -286,6 +317,11 @@ export async function runSingleAgent(
             tools,
             resourceLoader: loader,
             ...(resolvedModel && { model: resolvedModel }),
+            // Share the parent's model registry so extension-registered
+            // providers (e.g. claude-subscription, ollama-cloud) resolve with
+            // their API keys — the subagent session skips extensions, so a
+            // fresh registry would fail with "No API key found".
+            ...(modelRegistry && isFullModelRegistry(modelRegistry) && { modelRegistry }),
         });
 
         // Subscribe to events to track messages and usage

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -387,5 +387,5 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
 export * from "./types.js";
 export * from "./format.js";
-export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS, parseModelString, selectLightweightModel, type ModelOverride, type ModelRegistryLike } from "./engine.js";
+export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS, parseModelString, resolveModelSpec, selectLightweightModel, type ModelOverride, type ModelRegistryLike } from "./engine.js";
 export { renderSubagentCall, renderSubagentResult } from "./render.js";


### PR DESCRIPTION
## Problem
With the claude-subscription provider (minimalcc-pi) as the only configured Claude provider, the `subagent` tool fails:

1. `model: { provider: "anthropic", id: "claude-haiku-4-5" }` (the form nightshift rules mandate, and what the `haiku`/`sonnet`/`opus` frontmatter aliases parse to) resolves to the credential-less built-in anthropic catalog → **"No API key found for anthropic"**.
2. Even with an explicit `claude-subscription/...` override, the subagent session builds a fresh ModelRegistry (extensions are skipped via `noExtensions: true`), so the extension-registered provider config/key is missing → **"No API key found for claude-subscription"**. (Reproduced live before the fix.)

## Fix
- New `resolveModelSpec` in `engine.ts`: exact match only wins if the provider has credentials; otherwise falls back to Ollama Cloud cache → same-id model under an available provider → the credential-less exact match (so auth errors still name the requested provider).
- `runSingleAgent` now passes the parent session's `ModelRegistry` into `createAgentSession` (guarded so narrow test mocks are not passed), giving subagent sessions access to extension-registered providers and their keys.

## Verification
- `bun test src/extensions/subagent.test.ts src/extensions/subagent-agents.test.ts` — 78 pass, 0 fail (5 new resolveModelSpec tests)
- `tsc --noEmit` clean
- **Live e2e** (`packages/cli/scripts/e2e-claude-sub-subagent.ts`): registers the claude-subscription provider exactly like the extension does, runs a subagent with an `anthropic/claude-haiku-4-5` override → resolves to `claude-subscription/claude-haiku-4-5`, streams a real request, returns `pong`, exit 0.