### PR TITLE
Defer child-session error reporting until auto-retries are exhausted

### DIFF
--- a/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
@@ -87,19 +87,21 @@ function setup(lastRetryableError: { errorMessage: string; detectedAt: number } 
     });
 
     const agentEnd = handlers.get("agent_end")!;
-    return { agentEnd, emitted };
+    const agentSettled = handlers.get("agent_settled")!;
+    return { agentEnd, agentSettled, emitted, rctx };
 }
 
 const agentEndCtx = { hasPendingMessages: () => false, shutdown: () => {} };
 
 describe("agent_end — session_error / session_complete ordering", () => {
     test("emits session_error before session_complete for a child session usage-limit error", () => {
-        const { agentEnd, emitted } = setup({
+        const { agentEnd, agentSettled, emitted } = setup({
             errorMessage: "You have exceeded your usage limit",
             detectedAt: Date.now(),
         });
 
         agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
 
         // Both are emitted synchronously within the handler call (before any
         // await/microtask), so capturing immediately after invocation is safe.
@@ -107,9 +109,37 @@ describe("agent_end — session_error / session_complete ordering", () => {
     });
 
     test("emits only session_complete when there is no usage-limit error", () => {
-        const { agentEnd, emitted } = setup(null);
+        const { agentEnd, agentSettled, emitted } = setup(null);
 
         agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+
+        expect(emitted).toEqual(["session_complete"]);
+    });
+
+    test("agent_end alone emits nothing — reporting waits for agent_settled (auto-retry pending)", () => {
+        const { agentEnd, emitted } = setup({
+            errorMessage: "You have exceeded your usage limit",
+            detectedAt: Date.now(),
+        });
+
+        agentEnd({ messages: [] }, agentEndCtx);
+
+        expect(emitted).toEqual([]);
+    });
+
+    test("no session_error when a retry recovers before settling", () => {
+        const { agentEnd, agentSettled, emitted, rctx } = setup({
+            errorMessage: "You have exceeded your usage limit",
+            detectedAt: Date.now(),
+        });
+
+        // Attempt 1 errors, pi auto-retries.
+        agentEnd({ messages: [] }, agentEndCtx);
+        // Retry succeeds: message_end (non-error) clears the latch.
+        (rctx as any).lastRetryableError = null;
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
 
         expect(emitted).toEqual(["session_complete"]);
     });

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -149,6 +149,10 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     // Session-local error-fired flag (not shared — only used inside agent_end/turn_start).
     let sessionErrorFired = false;
+    // Messages from the last agent_end, consumed by agent_settled. agent_end
+    // fires after every attempt (including ones pi will auto-retry); completion
+    // and error reporting must wait for agent_settled.
+    let settledMessages: any[] | null = null;
 
     // ── Register tools ────────────────────────────────────────────────────────
     registerAskUserTool(rctx);
@@ -364,16 +368,25 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     pi.on("agent_end", (event: any, ctx: any) => {
         rctx.isAgentActive = false;
+        rctx.forwardEvent(event);
+        rctx.forwardEvent(rctx.buildHeartbeat());
+        // Defer completion/error reporting to agent_settled: pi fires agent_end
+        // after every attempt, including ones it will auto-retry. agent_settled
+        // fires once, only after retries/compaction/continuations are exhausted.
+        settledMessages = (event as any).messages ?? [];
+    });
+
+    pi.on("agent_settled", (_event: any, ctx: any) => {
+        const messages = settledMessages;
+        settledMessages = null;
         const lastError = rctx.lastRetryableError;
         rctx.lastRetryableError = null;
         emitRetryStateChanged(rctx, null);
-        rctx.forwardEvent(event);
-        rctx.forwardEvent(rctx.buildHeartbeat());
+        if (messages === null) return; // settled without a preceding agent_end
 
         if (!ctx.hasPendingMessages()) {
             let summary = "Session completed";
             let fullOutputPath: string | undefined;
-            const messages = (event as any).messages;
             if (Array.isArray(messages)) {
                 for (let i = messages.length - 1; i >= 0; i--) {
                     const msg = messages[i];


### PR DESCRIPTION
## Problem
The remote extension fired `session_error` / `session_complete` to the parent from the `agent_end` handler — but pi fires extension `agent_end` after **every** attempt, including ones its auto-retry is about to redo. Parents saw transient retryable errors immediately, before retries had a chance to recover.

## Fix
Move the completion/error reporting block to pi's `agent_settled` event, which fires exactly once — only after retries, compaction, and queued continuations are exhausted. `agent_end` now just stashes the run's messages. If a retry recovers, the non-error `message_end` clears the error latch before settle, so the parent never sees the transient error.

## Tests
- Updated the session_error/session_complete ordering tests to drive `agent_end` + `agent_settled`
- New: `agent_end` alone emits nothing (retry pending)
- New: recovered retry emits only `session_complete`

`bun test` 24 pass, `tsc --noEmit` clean.