### PR TITLE
Project memory and session recaps

### DIFF
--- a/docs/specs/project-memory-and-recaps.md
+++ b/docs/specs/project-memory-and-recaps.md
@@ -1,0 +1,121 @@
+# Spec: Project Memory + Session Recaps
+
+Godmother epic `Eo9M8M2Bm21jN7VnkmIU3`. Ideas `n431RaJV` (memory), `pkJVsyfs` (recaps).
+
+Two Claude Code–inspired features, built **into the PizzaPi source tree** (not `~/.pizzapi` add-ons). No new dependencies.
+
+## Status: implemented
+
+- `packages/cli/src/extensions/memory/storage.ts` — shared storage module (+ `storage.test.ts`)
+- `packages/cli/src/extensions/memory/index.ts` — built-in extension: `memory_*` + `recap` tools, `before_agent_start` context injection, `/memory` + `/recap` commands, resume auto-recap (+ `index.test.ts`)
+- registered in `packages/cli/src/extensions/factories.ts`
+- `packages/cli/src/runner/services/memory-service.ts` — Web UI backend (list/read/write), registered in `daemon.ts`
+- `packages/ui/src/components/MemoryPanel.tsx` — Web UI panel, registered in `service-panels/registry.tsx`
+
+Deferred: auto **idle-refocus** recap in the Web UI (away >3min → background draft). On-demand `/recap` and resume auto-recap ship now; idle-refocus needs App.tsx focus plumbing + background generation — add when wanted.
+
+Note: memory tools are **built-in pi tools** (via `pi.registerTool`), not a separate MCP server. Recaps render in both TUI and Web UI automatically because `pi.sendMessage({display:true})` renders in any attached client.
+
+## Goals
+
+1. **Auto-memory** — a per-project findings store the agent writes to (autonomously + on command) and that auto-loads into every future session. Human-browsable/editable in TUI *and* Web UI.
+2. **Recaps** — a one-line "where you left off" summary, on-demand (`/recap`) and automatically on session idle/resume, shown in TUI + Web UI and saved to memory.
+
+## Non-goals
+
+AGENTS.md/CLAUDE.md reimplementation (pi already loads these), `.claude/rules/` path-scoping, `@import` syntax, cross-machine sync, org/managed-policy scopes, full topic-file autoloading heuristics.
+
+---
+
+## Architecture (what we reuse)
+
+| Need | Existing mechanism |
+|------|--------------------|
+| Auto-inject memory each turn | `ExtensionProvider.onBeforeAgentStart` → `ContextContribution[]` (`type:"memory"` artifact already in the example) |
+| React to resume / turn end | `ExtensionProvider` lifecycle: `onSessionStart({reason:"resume"})`, `onTurnEnd`, `onSessionClose` |
+| Agent-writable tools | MCP server (mirrors godmother's MCP) |
+| Web UI panel | `ServiceHandler` panel (mirrors `~/.pizzapi/services/godmother-panel`) |
+| TUI command | Extension slash command (mirrors `packages/cli/src/extensions/*`) |
+| Trigger to UI on idle | `ProviderInitContext.fireTrigger` + service trigger def |
+
+`~/.pizzapi/providers/` is currently empty — this ships the first ExtensionProvider.
+
+---
+
+## Storage layout
+
+```
+~/.pizzapi/memory/<project-key>/
+├── MEMORY.md          # index, loaded every session (cap: 200 lines / 25KB)
+├── <topic>.md         # detail files, loaded on demand via memory_read
+└── recaps.md          # appended session recaps (session-log)
+```
+
+`<project-key>`: `git rev-parse --show-toplevel` basename + short hash (fallback: cwd basename + hash). One dir per repo, shared across worktrees — matches Claude Code semantics. Machine-local, never committed.
+
+---
+
+## Feature 1: Auto-memory
+
+### Injection (provider `memory`)
+- `onBeforeAgentStart`: read `MEMORY.md`, truncate to first 200 lines / 25KB, return as one `ContextContribution` (`placement:"prepend"`, `order:60`, `dedupeKey:"project-memory"`, artifact `{type:"memory"}`). Skip if file missing/empty.
+- If truncated, append a line noting more detail lives in topic files (agent can `memory_read`).
+
+### Tools (MCP server `memory`)
+| Tool | Behavior |
+|------|----------|
+| `memory_save(summary, detail?, topic?)` | Append a one-line entry to `MEMORY.md` index; if `detail` given, write/append to `<topic>.md` and link it. Enforces cap (warns + suggests trimming when near limit, mirroring Claude Code). |
+| `memory_append(topic, text)` | Append to a topic file. |
+| `memory_edit(topic, oldText, newText)` | Targeted edit (or `MEMORY.md`). |
+| `memory_read(topic)` | Read a topic/detail file on demand. |
+| `memory_list()` | List files + index. |
+
+### Autonomous saving
+Not a magic feature in Claude Code either — it's prompting + a tool. Ship a plugin rule (`~/.pizzapi/plugins/…/rules` or provider-injected note) instructing the agent to `memory_save` notable findings (build gotchas, corrections, architecture facts) and telling it memory auto-loads next session. `memory_save` is also the manual force-save. Autonomous-but-gated / opt-in variants deferred (YAGNI until asked).
+
+### Human editing surfaces
+- **Web UI**: `ServiceHandler` panel `memory-panel` — lists files, view/edit textarea, save via panel API writing to the store. Icon `brain` / `notebook`.
+- **TUI**: `/memory` slash command — lists files, opens one in `$EDITOR` (mirrors Claude Code `/memory`). Sub-args `/memory list`, `/memory edit <topic>`.
+
+### Config (`~/.pizzapi/config.json` → `providers.memory`)
+`enabled` (default true), `autoMemory` (default true), `memoryDir` (override path), `maxIndexLines`/`maxIndexBytes`.
+
+---
+
+## Feature 2: Recaps
+
+Depends on memory storage (persist target).
+
+### On-demand `/recap`
+- TUI slash command + MCP tool `recap`. Reads recent turns from the session JSONL and asks the model to emit one line: "you were <doing X>; <state / what's pending>". Prints it and appends to `recaps.md`.
+
+### Auto on resume
+- Provider `onSessionStart({reason:"resume"})`: inject a context contribution instructing the model to open its next response with a one-line recap of prior state; capture that line in `onTurnEnd` and append to `recaps.md`.
+
+### Auto on idle (Web UI)
+- Web UI detects tab focus/blur; on refocus after > threshold (default 3 min) with ≥3 turns, fires `memory:recap_requested` trigger → surfaces the latest recap (or requests generation). Mirrors Claude Code's away-summary; TUI keeps `/recap` on-demand (terminal focus isn't observable there).
+
+### Rules / guards
+- Skip in non-interactive (`claude -p` / headless) sessions.
+- Never twice in a row without fresh activity.
+- Toggle + threshold via `providers.memory.recap` config (`enabled`, `idleMinutes`, `minTurns`).
+
+---
+
+## Build order
+
+1. Storage module + project-key resolver + cap enforcement (+ self-check test).
+2. MCP `memory` server (tools) — testable headless.
+3. `memory` ExtensionProvider — injection + autonomous-save rule.
+4. TUI `/memory` command.
+5. Web UI `memory-panel` ServiceHandler.
+6. Recaps: `/recap` (on-demand) → resume auto → Web UI idle trigger.
+
+Each step lands independently; 1–3 deliver working agent-side memory before any UI.
+
+## Testing
+
+- Storage: unit test cap truncation + project-key derivation.
+- MCP tools: headless save/read/list round-trip.
+- Provider: injection returns capped contribution; resume triggers recap directive.
+- UI: panel edit round-trip via playwright-cli sandbox skill.

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -13,6 +13,7 @@ import { restartExtension } from "./restart.js";
 import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
+import { memoryExtension } from "./memory/index.js";
 import { subagentExtension } from "./subagent.js";
 import { tunnelToolsExtension } from "./tunnel-tools.js";
 import { planModeToggleExtension } from "./plan-mode/index.js";
@@ -41,6 +42,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     sessionProcessesExtension,
     setSessionNameExtension,
     updateTodoExtension,
+    memoryExtension,
     spawnSessionExtension,
     subagentExtension,
     planModeToggleExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -10,6 +10,7 @@ import { sessionProcessesExtension } from "./session-processes.js";
 import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
+import { memoryExtension } from "./memory/index.js";
 import { goalExtension } from "./goal/index.js";
 import { createClaudePluginExtension } from "./claude-plugins.js";
 import { subagentExtension } from "./subagent.js";
@@ -78,6 +79,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
         named(updateTodoExtension, "todo"),
+        named(memoryExtension, "memory"),
         named(spawnSessionExtension, "spawn-session"),
         named(subagentExtension, "subagent"),
         named(planModeToggleExtension, "plan-mode"),

--- a/packages/cli/src/extensions/memory/index.test.ts
+++ b/packages/cli/src/extensions/memory/index.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpHome = mkdtempSync(join(tmpdir(), "memext-home-"));
+const projDir = mkdtempSync(join(tmpdir(), "memext-proj-"));
+process.env.HOME = tmpHome;
+process.env.PIZZAPI_PROJECT_DIR = projDir;
+
+const { memoryExtension } = await import("./index.js");
+
+// Minimal fake `pi` capturing registrations.
+function makeFakePi() {
+  const tools = new Map<string, any>();
+  const commands = new Map<string, any>();
+  const handlers = new Map<string, Function[]>();
+  const sent: any[] = [];
+  const userMessages: string[] = [];
+  const pi: any = {
+    registerTool: (t: any) => tools.set(t.name, t),
+    registerCommand: (name: string, opts: any) => commands.set(name, opts),
+    on: (evt: string, h: Function) => {
+      const list = handlers.get(evt) ?? [];
+      list.push(h);
+      handlers.set(evt, list);
+    },
+    sendMessage: (m: any) => sent.push(m),
+    sendUserMessage: (c: string) => userMessages.push(c),
+    getSessionName: () => undefined,
+    setSessionName: () => {},
+  };
+  return { pi, tools, commands, handlers, sent, userMessages };
+}
+
+let fake: ReturnType<typeof makeFakePi>;
+beforeAll(() => {
+  fake = makeFakePi();
+  memoryExtension(fake.pi);
+});
+afterAll(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(projDir, { recursive: true, force: true });
+});
+
+test("registers all memory tools + recap", () => {
+  for (const n of ["memory_save", "memory_append", "memory_edit", "memory_read", "memory_list", "recap"]) {
+    expect(fake.tools.has(n)).toBe(true);
+  }
+});
+
+test("registers /memory and /recap commands", () => {
+  expect(fake.commands.has("memory")).toBe(true);
+  expect(fake.commands.has("recap")).toBe(true);
+});
+
+test("memory_save persists and memory_list reads it back", async () => {
+  await fake.tools.get("memory_save").execute("id1", { summary: "use bun not npm" });
+  const res = await fake.tools.get("memory_list").execute("id2", {});
+  const payload = JSON.parse(res.content[0].text);
+  expect(payload.index).toContain("use bun not npm");
+});
+
+test("before_agent_start injects the memory block + save instruction", async () => {
+  const handler = fake.handlers.get("before_agent_start")![0];
+  const result = await handler({ systemPrompt: "BASE" });
+  expect(result.systemPrompt).toContain("BASE");
+  expect(result.systemPrompt).toContain("<project-memory>");
+  expect(result.systemPrompt).toContain("use bun not npm");
+  expect(result.systemPrompt).toContain("memory_save");
+});
+
+test("resume surfaces the latest recap once", async () => {
+  await fake.tools.get("recap").execute("id3", { summary: "you were wiring the memory extension" });
+  const startHandlers = fake.handlers.get("session_start")!;
+  for (const h of startHandlers) await h({ reason: "resume" });
+  const recap = fake.sent.find((m) => m.customType === "memory_recap");
+  expect(recap).toBeTruthy();
+  expect(recap.content).toContain("you were wiring the memory extension");
+});
+
+test("/recap (no args) requests a fresh summary from the model", async () => {
+  await fake.commands.get("recap").handler("", {});
+  expect(fake.userMessages.some((m) => m.includes("recap"))).toBe(true);
+});

--- a/packages/cli/src/extensions/memory/index.ts
+++ b/packages/cli/src/extensions/memory/index.ts
@@ -1,0 +1,219 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import * as S from "./storage.js";
+
+/**
+ * Memory + Recaps extension (Claude Code parity, built into PizzaPi).
+ *
+ * Memory: a per-project findings store the agent writes to (autonomously via the
+ * memory_* tools, or on command) and that auto-loads into every session's system
+ * prompt. Machine-local under ~/.pizzapi/memory/<project-key>/, keyed by git root.
+ *
+ * Recaps: `/recap` asks the model for a one-line "where you left off" summary and
+ * saves it; on session resume the last saved recap is surfaced automatically.
+ */
+export const memoryExtension: ExtensionFactory = (pi) => {
+  const cwd = () => process.env.PIZZAPI_PROJECT_DIR || process.cwd();
+  // Tools throw on failure (per the pi tool contract); the agent loop encodes
+  // the thrown message as an error tool result.
+  const ok = (obj: unknown) => ({
+    content: [{ type: "text" as const, text: JSON.stringify(obj) }],
+    details: undefined,
+  });
+
+  // ── Tools ──────────────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: "memory_save",
+    label: "Save Memory",
+    description:
+      "Persist a notable finding to project memory so it auto-loads in future sessions. " +
+      "Use for build gotchas, corrections you had to make, conventions, and architecture facts — " +
+      "anything you'd otherwise rediscover next session. Give a one-line `summary` for the always-loaded " +
+      "index; add `detail`+`topic` for longer notes stored in a topic file.",
+    parameters: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line fact for the always-loaded index" },
+        detail: { type: "string", description: "Optional longer note, stored in the topic file" },
+        topic: { type: "string", description: "Optional topic file name (e.g. 'auth', 'build')" },
+      },
+      required: ["summary"],
+    } as any,
+    execute: async (_id, params) => {
+      const a = params as { summary: string; detail?: string; topic?: string };
+      const r = S.saveMemory(a, cwd());
+      const warn = r.indexCap.overLimit
+        ? "WARNING: memory index is over the 200-line/25KB load limit — content past the limit will NOT load next session. Trim it (memory_edit) or move detail into topic files."
+        : r.indexCap.nearLimit
+          ? "Note: memory index is near the load limit — keep entries to one line."
+          : undefined;
+      return ok({ saved: true, wroteTopic: r.wroteTopic, cap: r.indexCap, warn });
+    },
+  });
+
+  pi.registerTool({
+    name: "memory_append",
+    label: "Append Memory",
+    description: "Append text to a topic file (detail notes, not the always-loaded index).",
+    parameters: {
+      type: "object",
+      properties: { topic: { type: "string" }, text: { type: "string" } },
+      required: ["topic", "text"],
+    } as any,
+    execute: async (_id, params) => {
+      const a = params as { topic: string; text: string };
+      return ok({ appended: S.appendTopic(a.topic, a.text, cwd()) });
+    },
+  });
+
+  pi.registerTool({
+    name: "memory_edit",
+    label: "Edit Memory",
+    description: "Replace a unique snippet in a memory file. `file` is a topic name or 'MEMORY.md'.",
+    parameters: {
+      type: "object",
+      properties: {
+        file: { type: "string" },
+        oldText: { type: "string" },
+        newText: { type: "string" },
+      },
+      required: ["file", "oldText", "newText"],
+    } as any,
+    execute: async (_id, params) => {
+      const a = params as { file: string; oldText: string; newText: string };
+      S.editFile(a.file, a.oldText, a.newText, cwd());
+      return ok({ edited: a.file });
+    },
+  });
+
+  pi.registerTool({
+    name: "memory_read",
+    label: "Read Memory",
+    description: "Read a memory file in full. `file` is a topic name or 'MEMORY.md'.",
+    parameters: {
+      type: "object",
+      properties: { file: { type: "string" } },
+      required: ["file"],
+    } as any,
+    execute: async (_id, params) => {
+      const a = params as { file: string };
+      return ok({ file: a.file, content: S.readMemoryFile(a.file, cwd()) });
+    },
+  });
+
+  pi.registerTool({
+    name: "memory_list",
+    label: "List Memory",
+    description: "List this project's memory files with sizes, plus the loaded index.",
+    parameters: { type: "object", properties: {} } as any,
+    execute: async () =>
+      ok({
+        dir: S.memoryDir(cwd()),
+        files: S.listFiles(cwd()),
+        index: S.readIndexTruncated(cwd()).text,
+      }),
+  });
+
+  pi.registerTool({
+    name: "recap",
+    label: "Save Recap",
+    description:
+      "Save a one-line 'where you left off' recap of the current session to project memory. " +
+      "Call this when asked to recap, or before a long pause, with a concise summary of what you " +
+      "were doing and what's still pending.",
+    parameters: {
+      type: "object",
+      properties: { summary: { type: "string", description: "One-line recap of current state and next step" } },
+      required: ["summary"],
+    } as any,
+    execute: async (_id, params) => {
+      const a = params as { summary: string };
+      S.appendRecap(a.summary, cwd());
+      return ok({ saved: true });
+    },
+  });
+
+  // ── Context injection: auto-load the memory index every turn ────────────────
+
+  pi.on("before_agent_start", (event) => {
+    const { text, truncated } = S.readIndexTruncated(cwd());
+    let block = "";
+    if (text.trim()) {
+      block =
+        `\n\n<project-memory>\n${text.trim()}\n</project-memory>\n` +
+        (truncated ? "(memory index truncated to the load limit; use memory_read for topic files)\n" : "");
+    }
+    return {
+      systemPrompt:
+        event.systemPrompt +
+        block +
+        "\n\nWhen you learn a durable fact about this project (a build gotcha, a correction, a " +
+        "convention, an architecture detail), call the `memory_save` tool so it persists to future sessions.",
+    };
+  });
+
+  // ── Recap on resume: surface the last saved recap ───────────────────────────
+
+  let recapShown = false;
+  pi.on("session_start", (event) => {
+    if (event.reason === "new" || event.reason === "startup") recapShown = false;
+    if (event.reason !== "resume" || recapShown) return;
+    const r = S.latestRecap(cwd());
+    if (r) {
+      recapShown = true;
+      pi.sendMessage({ customType: "memory_recap", content: `⏺ Recap: ${r}`, display: true });
+    }
+  });
+
+  // ── /recap command: on-demand summary ───────────────────────────────────────
+
+  pi.registerCommand("recap", {
+    description: "Summarize where you left off (one line) and save it to project memory",
+    handler: async (args) => {
+      const showLast = args.trim() === "last" || args.trim() === "show";
+      if (showLast) {
+        const r = S.latestRecap(cwd());
+        pi.sendMessage({
+          customType: "memory_recap",
+          content: r ? `⏺ Recap: ${r}` : "No saved recap yet.",
+          display: true,
+        });
+        return;
+      }
+      // Ask the model to produce + save a fresh recap.
+      pi.sendUserMessage(
+        "Give a one-line recap of where we left off — what you were doing and what's still pending — " +
+          "then save it by calling the `recap` tool with that same one line. Keep it to a single sentence.",
+      );
+    },
+  });
+
+  // ── /memory command: browse the store ───────────────────────────────────────
+
+  pi.registerCommand("memory", {
+    description: "Show this project's memory files (browse/edit in the Memory panel or ask me to edit)",
+    handler: async () => {
+      try {
+        const dir = S.memoryDir(cwd());
+        const files = S.listFiles(cwd());
+        const lines = files.length
+          ? files.map((f) => `  ${f.file} — ${f.lines} lines, ${f.bytes} B`).join("\n")
+          : "  (empty)";
+        const { text } = S.readIndexTruncated(cwd());
+        pi.sendMessage({
+          customType: "memory_list",
+          content:
+            `Project memory: ${dir}\n${lines}` +
+            (text.trim() ? `\n\nLoaded index:\n${text.trim()}` : ""),
+          display: true,
+        });
+      } catch (e) {
+        pi.sendMessage({
+          customType: "memory_list",
+          content: `Error reading memory: ${e instanceof Error ? e.message : String(e)}`,
+          display: true,
+        });
+      }
+    },
+  });
+};

--- a/packages/cli/src/extensions/memory/storage.test.ts
+++ b/packages/cli/src/extensions/memory/storage.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// isolate storage under a temp HOME
+const tmpHome = mkdtempSync(join(tmpdir(), "memtest-"));
+process.env.HOME = tmpHome;
+const cwd = mkdtempSync(join(tmpdir(), "memproj-"));
+
+const S = await import("./storage.js");
+
+afterAll(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+test("projectKey is stable and sanitized", () => {
+  const a = S.projectKey(cwd);
+  const b = S.projectKey(cwd);
+  expect(a).toBe(b);
+  expect(a).toMatch(/^[A-Za-z0-9._-]+-[0-9a-f]{8}$/);
+});
+
+test("save appends to index and reads back", () => {
+  S.saveMemory({ summary: "use bun, not npm" }, cwd);
+  S.saveMemory({ summary: "api handlers in src/api" }, cwd);
+  const { text } = S.readIndexTruncated(cwd);
+  expect(text).toContain("use bun, not npm");
+  expect(text).toContain("api handlers in src/api");
+});
+
+test("detail writes a topic file and links it", () => {
+  const r = S.saveMemory({ summary: "auth flow", detail: "JWT expiry is 15m", topic: "auth" }, cwd);
+  expect(r.wroteTopic).toBe("auth.md");
+  expect(S.readMemoryFile("auth", cwd)).toContain("JWT expiry is 15m");
+  expect(S.readIndexRaw(cwd)).toContain("(see auth.md)");
+});
+
+test("index truncates at 200 lines", () => {
+  const big = mkdtempSync(join(tmpdir(), "membig-"));
+  for (let i = 0; i < 250; i++) S.saveMemory({ summary: `entry ${i}` }, big);
+  const { text, truncated } = S.readIndexTruncated(big);
+  expect(truncated).toBe(true);
+  expect(text.split("\n").length).toBeLessThanOrEqual(S.MAX_INDEX_LINES);
+  expect(S.capInfo(S.readIndexRaw(big)).overLimit).toBe(true);
+  rmSync(big, { recursive: true, force: true });
+});
+
+test("edit requires unique match", () => {
+  const e = mkdtempSync(join(tmpdir(), "memedit-"));
+  S.saveMemory({ summary: "old fact" }, e);
+  S.editFile("MEMORY.md", "old fact", "new fact", e);
+  expect(S.readIndexRaw(e)).toContain("new fact");
+  expect(() => S.editFile("MEMORY.md", "nope", "x", e)).toThrow();
+  rmSync(e, { recursive: true, force: true });
+});
+
+test("topic name traversal is blocked", () => {
+  S.appendTopic("../../evil", "x", cwd);
+  const files = S.listFiles(cwd).map((f) => f.file);
+  expect(files).toContain("evil.md");
+  expect(files.every((f) => !f.includes("/"))).toBe(true);
+});
+
+test("recaps append and latest reads back", () => {
+  S.appendRecap("you were building the storage module", cwd);
+  S.appendRecap("you were wiring the MCP server", cwd);
+  expect(S.latestRecap(cwd)).toBe("you were wiring the MCP server");
+});

--- a/packages/cli/src/extensions/memory/storage.ts
+++ b/packages/cli/src/extensions/memory/storage.ts
@@ -1,0 +1,171 @@
+// Per-project memory storage. Machine-local, keyed by git root (fallback cwd).
+// Layout: ~/.pizzapi/memory/<project-key>/{MEMORY.md, <topic>.md, recaps.md}
+//
+// Shared by the memory extension (context injection + tools + /memory command)
+// and the recap flow (/recap, resume auto-recap). The agent writes here via the
+// memory_* tools; the index auto-loads into every session's system prompt.
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+export const MAX_INDEX_LINES = 200;
+export const MAX_INDEX_BYTES = 25 * 1024;
+
+const INDEX = "MEMORY.md";
+const RECAPS = "recaps.md";
+
+function root(): string {
+  return join(process.env.HOME || homedir(), ".pizzapi", "memory");
+}
+
+/** Stable per-repo key: <basename>-<8-char hash of abs path>. Shared across worktrees of one repo. */
+export function projectKey(cwd = process.cwd()): string {
+  let base = cwd;
+  try {
+    base =
+      execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        cwd,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() || cwd;
+  } catch {
+    // not a git repo — use cwd
+  }
+  const hash = createHash("sha256").update(base).digest("hex").slice(0, 8);
+  const name = basename(base).replace(/[^A-Za-z0-9._-]/g, "_") || "project";
+  return `${name}-${hash}`;
+}
+
+export function memoryDir(cwd?: string): string {
+  const dir = join(root(), projectKey(cwd));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+function safeTopic(topic: string): string {
+  const name = basename(topic).replace(/[^A-Za-z0-9._-]/g, "_").replace(/\.md$/i, "");
+  if (!name) throw new Error("invalid topic name");
+  return `${name}.md`;
+}
+
+function filePath(cwd: string | undefined, file: string): string {
+  return join(memoryDir(cwd), file);
+}
+
+export interface CapInfo {
+  lines: number;
+  bytes: number;
+  overLimit: boolean;
+  nearLimit: boolean;
+}
+
+export function capInfo(text: string): CapInfo {
+  const lines = text.length === 0 ? 0 : text.split("\n").length;
+  const bytes = Buffer.byteLength(text, "utf-8");
+  return {
+    lines,
+    bytes,
+    overLimit: lines > MAX_INDEX_LINES || bytes > MAX_INDEX_BYTES,
+    nearLimit: lines > MAX_INDEX_LINES * 0.9 || bytes > MAX_INDEX_BYTES * 0.9,
+  };
+}
+
+/** Read the index, truncated to what actually loads into context. Returns "" if none. */
+export function readIndexTruncated(cwd?: string): { text: string; truncated: boolean } {
+  const p = filePath(cwd, INDEX);
+  if (!existsSync(p)) return { text: "", truncated: false };
+  const raw = readFileSync(p, "utf-8");
+  const lines = raw.split("\n");
+  let truncated = false;
+  let out = raw;
+  if (lines.length > MAX_INDEX_LINES) {
+    out = lines.slice(0, MAX_INDEX_LINES).join("\n");
+    truncated = true;
+  }
+  if (Buffer.byteLength(out, "utf-8") > MAX_INDEX_BYTES) {
+    out = Buffer.from(out, "utf-8").subarray(0, MAX_INDEX_BYTES).toString("utf-8");
+    truncated = true;
+  }
+  return { text: out, truncated };
+}
+
+export function readIndexRaw(cwd?: string): string {
+  const p = filePath(cwd, INDEX);
+  return existsSync(p) ? readFileSync(p, "utf-8") : "";
+}
+
+/** Append a one-line entry to the index. If detail+topic given, write detail to a topic file and link it. */
+export function saveMemory(
+  args: { summary: string; detail?: string; topic?: string },
+  cwd?: string,
+): { indexCap: CapInfo; wroteTopic?: string } {
+  const summary = args.summary.trim().replace(/\n+/g, " ");
+  if (!summary) throw new Error("summary required");
+  let line = `- ${summary}`;
+  let wroteTopic: string | undefined;
+  if (args.detail && args.topic) {
+    const file = safeTopic(args.topic);
+    appendFileSync(filePath(cwd, file), `\n${args.detail.trim()}\n`, { mode: 0o600 });
+    wroteTopic = file;
+    line += ` (see ${file})`;
+  }
+  const p = filePath(cwd, INDEX);
+  const prefix = existsSync(p) && readFileSync(p, "utf-8").length > 0 ? "" : "# Project Memory\n\n";
+  appendFileSync(p, `${prefix}${line}\n`, { mode: 0o600 });
+  return { indexCap: capInfo(readIndexRaw(cwd)), wroteTopic };
+}
+
+export function appendTopic(topic: string, text: string, cwd?: string): string {
+  const file = safeTopic(topic);
+  appendFileSync(filePath(cwd, file), `\n${text.trim()}\n`, { mode: 0o600 });
+  return file;
+}
+
+export function editFile(file: string, oldText: string, newText: string, cwd?: string): void {
+  const name = file === INDEX ? INDEX : safeTopic(file);
+  const p = filePath(cwd, name);
+  if (!existsSync(p)) throw new Error(`no such memory file: ${name}`);
+  const cur = readFileSync(p, "utf-8");
+  if (!cur.includes(oldText)) throw new Error(`oldText not found in ${name}`);
+  if (cur.split(oldText).length > 2) throw new Error(`oldText is not unique in ${name}`);
+  writeFileSync(p, cur.replace(oldText, newText), { mode: 0o600 });
+}
+
+export function writeMemoryFile(file: string, content: string, cwd?: string): void {
+  const name = file === INDEX ? INDEX : safeTopic(file);
+  writeFileSync(filePath(cwd, name), content, { mode: 0o600 });
+}
+
+export function readMemoryFile(file: string, cwd?: string): string {
+  const name = file === INDEX ? INDEX : safeTopic(file);
+  const p = filePath(cwd, name);
+  if (!existsSync(p)) throw new Error(`no such memory file: ${name}`);
+  return readFileSync(p, "utf-8");
+}
+
+export function listFiles(cwd?: string): Array<{ file: string; bytes: number; lines: number }> {
+  const dir = memoryDir(cwd);
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const t = readFileSync(join(dir, f), "utf-8");
+      return { file: f, bytes: Buffer.byteLength(t, "utf-8"), lines: t.split("\n").length };
+    });
+}
+
+export function appendRecap(text: string, cwd?: string): void {
+  const stamp = new Date().toISOString();
+  appendFileSync(filePath(cwd, RECAPS), `\n## ${stamp}\n${text.trim()}\n`, { mode: 0o600 });
+}
+
+export function latestRecap(cwd?: string): string | null {
+  const p = filePath(cwd, RECAPS);
+  if (!existsSync(p)) return null;
+  const blocks = readFileSync(p, "utf-8").split(/\n## /).filter(Boolean);
+  const last = blocks[blocks.length - 1];
+  if (!last) return null;
+  const nl = last.indexOf("\n");
+  return nl === -1 ? "" : last.slice(nl + 1).trim();
+}

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -16,6 +16,7 @@ import { mergeModelLists, readSessionModelsCache, type SessionModelEntry } from 
 import { getCachedOllamaCloudModels } from "../ollama-cloud-models.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { ProcessService } from "./services/process-service.js";
+import { MemoryService } from "./services/memory-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
 import { globalPluginDirs } from "../plugins/discover.js";
@@ -455,6 +456,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const sessionCloseMetadataSweep = setInterval(() => {
             pruneSessionCloseMetadata(sessionCloseMetadata, runningSessions);
         }, 5 * 60_000);
+        if (isServiceDisabled("memory")) {
+            logInfo('[services] built-in service "memory" disabled by config');
+        } else {
+            registry.register(new MemoryService((sessionId) => sessionCloseMetadata.get(sessionId)?.cwd ?? null));
+        }
         const resolveConfiguredAgentDir = (cwd = process.cwd()) => {
             const config = loadConfig(cwd);
             return config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();

--- a/packages/cli/src/runner/services/memory-service.ts
+++ b/packages/cli/src/runner/services/memory-service.ts
@@ -1,0 +1,99 @@
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
+import { isCwdAllowed } from "../workspace.js";
+import {
+  listFiles,
+  readMemoryFile,
+  writeMemoryFile,
+  memoryDir,
+  readIndexTruncated,
+} from "../../extensions/memory/storage.js";
+
+/**
+ * Web UI backend for per-project memory. Lets the Memory panel browse and edit
+ * the machine-local memory store the agent writes to via the memory_* tools.
+ *
+ * The project directory is resolved server-side from the session (never trusted
+ * from the client) and validated against workspace roots, so the panel can only
+ * touch memory for directories the runner already allows.
+ */
+export class MemoryService implements ServiceHandler {
+  readonly id = "memory";
+
+  private socket: Socket | null = null;
+  private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
+
+  constructor(private getSessionCwd: (sessionId: string) => string | null) {}
+
+  init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+    this.socket = socket;
+    this._onServiceMessage = (envelope: ServiceEnvelope) => {
+      if (isShuttingDown()) return;
+      if (envelope.serviceId !== "memory") return;
+      switch (envelope.type) {
+        case "memory_list":
+          this.handle(envelope, (cwd) => ({
+            dir: memoryDir(cwd),
+            files: listFiles(cwd),
+            index: readIndexTruncated(cwd).text,
+          }));
+          break;
+        case "memory_read":
+          this.handle(envelope, (cwd) => {
+            const file = (envelope.payload as { file?: string })?.file;
+            if (!file) throw new Error("Missing file");
+            return { file, content: readMemoryFile(file, cwd) };
+          });
+          break;
+        case "memory_write":
+          this.handle(envelope, (cwd) => {
+            const p = envelope.payload as { file?: string; content?: string };
+            if (!p?.file) throw new Error("Missing file");
+            writeMemoryFile(p.file, p.content ?? "", cwd);
+            return { file: p.file, saved: true };
+          });
+          break;
+      }
+    };
+    (socket as any).on("service_message", this._onServiceMessage);
+  }
+
+  dispose(): void {
+    if (this.socket && this._onServiceMessage) {
+      (this.socket as any).off("service_message", this._onServiceMessage);
+    }
+    this.socket = null;
+    this._onServiceMessage = null;
+  }
+
+  private resolveCwd(envelope: ServiceEnvelope): string | null {
+    const sessionId =
+      (typeof envelope.sessionId === "string" && envelope.sessionId) ||
+      (envelope.payload as { sessionId?: string })?.sessionId ||
+      null;
+    return sessionId ? this.getSessionCwd(sessionId) : null;
+  }
+
+  private handle(envelope: ServiceEnvelope, fn: (cwd: string) => unknown): void {
+    const cwd = this.resolveCwd(envelope);
+    if (!cwd || !isCwdAllowed(cwd)) {
+      this.emit("memory_error", { error: "No accessible project for this session" }, envelope.requestId);
+      return;
+    }
+    try {
+      this.emit(`${envelope.type}_result`, fn(cwd), envelope.requestId);
+    } catch (err) {
+      this.emit("memory_error", { error: err instanceof Error ? err.message : String(err) }, envelope.requestId);
+    }
+  }
+
+  private emit(type: string, payload: unknown, requestId?: string): void {
+    if (!this.socket) return;
+    (this.socket as any).emit("service_message", {
+      serviceId: "memory",
+      type,
+      ...(requestId ? { requestId } : {}),
+      payload,
+    } satisfies ServiceEnvelope);
+  }
+}

--- a/packages/ui/src/components/MemoryPanel.tsx
+++ b/packages/ui/src/components/MemoryPanel.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from "react";
+import { useServiceChannel } from "@/hooks/useServiceChannel";
+import { reportError } from "@/lib/frontend-log";
+import { RefreshCw, Save, FileText } from "lucide-react";
+
+interface MemoryFile {
+    file: string;
+    bytes: number;
+    lines: number;
+}
+
+interface MemoryPanelProps {
+    sessionId: string;
+    runnerId?: string;
+}
+
+export function MemoryPanel({ sessionId }: MemoryPanelProps) {
+    const [files, setFiles] = useState<MemoryFile[]>([]);
+    const [dir, setDir] = useState<string>("");
+    const [active, setActive] = useState<string | null>(null);
+    const [content, setContent] = useState("");
+    const [dirty, setDirty] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+
+    const { send, available } = useServiceChannel<unknown, unknown>("memory", {
+        onMessage: (type, payload) => {
+            const p = payload as Record<string, unknown>;
+            if (type === "memory_list_result") {
+                setFiles((p.files as MemoryFile[]) ?? []);
+                setDir((p.dir as string) ?? "");
+                setLoaded(true);
+            } else if (type === "memory_read_result") {
+                setActive((p.file as string) ?? null);
+                setContent((p.content as string) ?? "");
+                setDirty(false);
+            } else if (type === "memory_write_result") {
+                setDirty(false);
+                send("memory_list", { sessionId });
+            } else if (type === "memory_error") {
+                reportError("memory", (p.error as string) || "Memory operation failed");
+            }
+        },
+    });
+
+    const refresh = useCallback(() => send("memory_list", { sessionId }), [send, sessionId]);
+
+    useEffect(() => {
+        if (!available) {
+            setFiles([]);
+            setLoaded(false);
+            return;
+        }
+        refresh();
+    }, [available, refresh]);
+
+    if (!available) return null;
+
+    const openFile = (file: string) => {
+        if (dirty && !confirm("Discard unsaved changes?")) return;
+        send("memory_read", { sessionId, file });
+    };
+    const save = () => {
+        if (active) send("memory_write", { sessionId, file: active, content });
+    };
+
+    return (
+        <div className="flex h-full overflow-hidden">
+            {/* File list */}
+            <div className="w-48 shrink-0 border-r border-border flex flex-col overflow-hidden">
+                <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0">
+                    <span className="text-xs text-muted-foreground">
+                        {files.length} file{files.length === 1 ? "" : "s"}
+                    </span>
+                    <div className="flex-1" />
+                    <button
+                        type="button"
+                        onClick={refresh}
+                        className="p-1 text-muted-foreground hover:text-foreground rounded"
+                        title="Refresh"
+                    >
+                        <RefreshCw size={12} />
+                    </button>
+                </div>
+                <div className="flex-1 overflow-y-auto">
+                    {files.length === 0 ? (
+                        <div className="flex items-center justify-center h-full text-xs text-muted-foreground px-3 text-center">
+                            {loaded ? "No memory yet. The agent saves findings here as it works." : "Loading…"}
+                        </div>
+                    ) : (
+                        files.map((f) => (
+                            <button
+                                key={f.file}
+                                type="button"
+                                onClick={() => openFile(f.file)}
+                                className={`w-full flex items-center gap-1.5 px-3 py-1.5 text-left text-xs hover:bg-accent/30 ${
+                                    active === f.file ? "bg-accent/50" : ""
+                                }`}
+                                title={`${f.lines} lines · ${f.bytes} B`}
+                            >
+                                <FileText size={12} className="shrink-0 text-muted-foreground" />
+                                <span className="truncate font-mono">{f.file}</span>
+                            </button>
+                        ))
+                    )}
+                </div>
+            </div>
+
+            {/* Editor */}
+            <div className="flex-1 flex flex-col overflow-hidden">
+                {active ? (
+                    <>
+                        <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0">
+                            <span className="text-xs font-mono truncate" title={dir ? `${dir}/${active}` : active}>
+                                {active}
+                                {dirty && <span className="ml-1 text-primary/80">•</span>}
+                            </span>
+                            <div className="flex-1" />
+                            <button
+                                type="button"
+                                onClick={save}
+                                disabled={!dirty}
+                                className="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-border text-muted-foreground hover:text-foreground disabled:opacity-40"
+                                title="Save"
+                            >
+                                <Save size={12} /> Save
+                            </button>
+                        </div>
+                        <textarea
+                            value={content}
+                            onChange={(e) => {
+                                setContent(e.target.value);
+                                setDirty(true);
+                            }}
+                            spellCheck={false}
+                            className="flex-1 w-full resize-none bg-background text-xs font-mono p-3 outline-none"
+                        />
+                    </>
+                ) : (
+                    <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
+                        Select a memory file to view or edit
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -21,9 +21,10 @@
  * 3. Start an HTTP server in init() and call announcePanel(port)
  */
 import React from "react";
-import { Network, Cpu } from "lucide-react";
+import { Network, Cpu, Brain } from "lucide-react";
 import { TunnelPanel } from "@/components/TunnelPanel";
 import { ProcessPanel } from "@/components/ProcessPanel";
+import { MemoryPanel } from "@/components/MemoryPanel";
 
 export interface ServicePanelDef {
     /** Must match the runner service's `id` */
@@ -52,5 +53,11 @@ export const SERVICE_PANELS: ServicePanelDef[] = [
         label: "Processes",
         icon: <Cpu className="size-3.5" />,
         component: ProcessPanel,
+    },
+    {
+        serviceId: "memory",
+        label: "Memory",
+        icon: <Brain className="size-3.5" />,
+        component: MemoryPanel,
     },
 ];


### PR DESCRIPTION
Godmother epic `Eo9M8M2Bm21jN7VnkmIU3` — ideas `n431RaJV` (memory), `pkJVsyfs` (recaps). Spec: `docs/specs/project-memory-and-recaps.md`.

Two Claude Code–inspired features built into the source tree, no new dependencies:

## Project memory
- `packages/cli/src/extensions/memory/` — built-in extension with `memory_save` / `memory_append` / `memory_edit` / `memory_read` / `memory_list` tools, `before_agent_start` context injection (always-loaded index + topic files), and a `/memory` command
- `packages/cli/src/runner/services/memory-service.ts` — runner service backing the web UI (list/read/write), registered in `daemon.ts` (respects service-disable config)
- `packages/ui/src/components/MemoryPanel.tsx` — web UI service panel, registered in `service-panels/registry.tsx`

## Session recaps
- `recap` tool + `/recap` command — one-line 'where you left off' summaries persisted to project memory
- Auto-recap on session resume

## Deferred
Idle-refocus auto-recap in the web UI (away >3min → background draft) — needs App.tsx focus plumbing and background generation.

## Tests
`bun test packages/cli/src/extensions/memory/` — 13 pass. `tsc --noEmit` clean for both `packages/cli` and `packages/ui`.