### PR TITLE
chore: bump @earendil-works/* 0.80.6 → 0.82.0 and migrate off removed…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-updater": "^8",
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-tui": "^0.82.0",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -40,13 +40,13 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.80.6",
+        "@earendil-works/pi-coding-agent": "^0.82.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -83,8 +83,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -112,8 +112,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -200,10 +200,10 @@
     },
   },
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.80.6": "patches/@earendil-works%2Fpi-agent-core@0.80.6.patch",
-    "@earendil-works/pi-tui@0.80.6": "patches/@earendil-works%2Fpi-tui@0.80.6.patch",
-    "@earendil-works/pi-coding-agent@0.80.6": "patches/@earendil-works%2Fpi-coding-agent@0.80.6.patch",
-    "@earendil-works/pi-ai@0.80.6": "patches/@earendil-works%2Fpi-ai@0.80.6.patch",
+    "@earendil-works/pi-ai@0.82.0": "patches/@earendil-works%2Fpi-ai@0.82.0.patch",
+    "@earendil-works/pi-coding-agent@0.82.0": "patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch",
+    "@earendil-works/pi-agent-core@0.82.0": "patches/@earendil-works%2Fpi-agent-core@0.82.0.patch",
+    "@earendil-works/pi-tui@0.82.0": "patches/@earendil-works%2Fpi-tui@0.82.0.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -584,13 +584,13 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.6", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.6", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.6", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.6", "@earendil-works/pi-ai": "^0.80.6", "@earendil-works/pi-tui": "^0.80.6", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.6", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-updater": "^8",
-    "@earendil-works/pi-agent-core": "^0.80.6",
-    "@earendil-works/pi-ai": "^0.80.6",
-    "@earendil-works/pi-tui": "^0.80.6",
+    "@earendil-works/pi-agent-core": "^0.82.0",
+    "@earendil-works/pi-ai": "^0.82.0",
+    "@earendil-works/pi-tui": "^0.82.0",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -70,9 +70,9 @@
   },
   "version": "",
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.80.6": "patches/@earendil-works%2Fpi-agent-core@0.80.6.patch",
-    "@earendil-works/pi-tui@0.80.6": "patches/@earendil-works%2Fpi-tui@0.80.6.patch",
-    "@earendil-works/pi-ai@0.80.6": "patches/@earendil-works%2Fpi-ai@0.80.6.patch",
-    "@earendil-works/pi-coding-agent@0.80.6": "patches/@earendil-works%2Fpi-coding-agent@0.80.6.patch"
+    "@earendil-works/pi-agent-core@0.82.0": "patches/@earendil-works%2Fpi-agent-core@0.82.0.patch",
+    "@earendil-works/pi-tui@0.82.0": "patches/@earendil-works%2Fpi-tui@0.82.0.patch",
+    "@earendil-works/pi-ai@0.82.0": "patches/@earendil-works%2Fpi-ai@0.82.0.patch",
+    "@earendil-works/pi-coding-agent@0.82.0": "patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.6",
+    "@earendil-works/pi-coding-agent": "^0.82.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/cli/src/extensions/ollama-web-tools.ts
+++ b/packages/cli/src/extensions/ollama-web-tools.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { AuthStorage, type ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential, type ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { defaultAgentDir, expandHome, loadConfig } from "../config.js";
@@ -198,20 +198,29 @@ export function createOllamaWebTools(deps: OllamaWebToolDeps = {}): { webSearch:
   return { webSearch, webFetch };
 }
 
-function createOllamaAuthStorage(): AuthStorage {
+function getOllamaAuthPath(): string {
   const config = loadConfig(process.cwd());
   const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-  return AuthStorage.create(join(agentDir, "auth.json"));
+  return join(agentDir, "auth.json");
+}
+
+// ponytail: Ollama Cloud is api_key-only (no OAuth), so a stored-credential
+// read plus the OLLAMA_API_KEY env fallback covers it without spinning up a
+// full ModelRuntime just to read one key.
+function getOllamaApiKey(authPath: string): string | undefined {
+  const cred = readStoredCredential("ollama-cloud", authPath);
+  if (cred?.type === "api_key" && cred.key) return cred.key;
+  return process.env.OLLAMA_API_KEY;
 }
 
 export const ollamaWebToolsExtension: ExtensionFactory = (pi) => {
   if (!isOllamaWebSearchEnabled()) return;
-  const auth = createOllamaAuthStorage();
+  const authPath = getOllamaAuthPath();
   const tools = createOllamaWebTools({
     defaultMaxResults: envDefaultMaxResults(),
     maxContentChars: envMaxContentChars(),
     maxLinks: envMaxLinks(),
-    apiKeyProvider: () => auth.getApiKey("ollama-cloud"),
+    apiKeyProvider: () => getOllamaApiKey(authPath),
   });
   // Only skip registering web_search when the default provider is Anthropic
   // AND Anthropic server-side web search is enabled (PIZZAPI_WEB_SEARCH=1).

--- a/packages/cli/src/extensions/remote-auth-source.ts
+++ b/packages/cli/src/extensions/remote-auth-source.ts
@@ -10,19 +10,22 @@ import { getEnvApiKey } from "@earendil-works/pi-ai/compat";
 import type { AuthSource } from "./remote-types.js";
 
 /**
- * Mirrors AuthStorage.getApiKey() priority chain to determine WHERE the
+ * Mirrors the auth-resolution priority chain to determine WHERE the
  * active API key comes from, so we can relay that to the user.
  */
 export function getAuthSource(ctx: ExtensionContext | null): AuthSource {
     if (!ctx?.model) return "unknown";
     const provider = ctx.model.provider;
 
-    // 1. Check auth.json credentials (highest priority after runtime overrides)
-    const cred = ctx.modelRegistry.authStorage.get(provider);
-    if (cred?.type === "oauth") return "oauth";
-    if (cred?.type === "api_key") return "auth.json";
+    // 1. OAuth takes priority when active
+    if (ctx.modelRegistry.isUsingOAuth(ctx.model)) return "oauth";
 
-    // 2. Check environment variable
+    // 2. Stored auth.json credential vs. environment variable
+    const status = ctx.modelRegistry.getProviderAuthStatus(provider);
+    if (status.configured && status.source === "stored") return "auth.json";
+    if (status.configured && status.source === "environment") return "env";
+
+    // 3. Fallback: raw environment variable check
     if (getEnvApiKey(provider)) return "env";
 
     return "unknown";

--- a/packages/cli/src/extensions/remote-provider-usage.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
 import { getAnthropicKeychainToken } from "../runner/usage-auth.js";
 import type { UsageWindow, ProviderUsageData } from "./remote-types.js";
@@ -234,8 +234,8 @@ async function refreshGeminiUsage(opts: { force?: boolean } = {}): Promise<void>
     try {
         const config = loadConfig(process.cwd());
         const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-        const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
-        const raw = await authStorage.getApiKey("google-gemini-cli");
+        const cred = readStoredCredential("google-gemini-cli", join(agentDir, "auth.json"));
+        const raw = cred?.type === "api_key" ? cred.key : undefined;
         if (!raw) return;
         const parsed = JSON.parse(raw) as { token?: string; projectId?: string };
         if (!parsed.token || !parsed.projectId) return;

--- a/packages/cli/src/extensions/remote/model-selection.test.ts
+++ b/packages/cli/src/extensions/remote/model-selection.test.ts
@@ -50,7 +50,8 @@ function createRctx(modelFromRegistry?: any) {
             model: null,
             modelRegistry: {
                 find: () => modelFromRegistry,
-                authStorage: { get: () => ({ type: "api_key" }) },
+                isUsingOAuth: () => false,
+                getProviderAuthStatus: () => ({ configured: true, source: "stored" as const }),
             },
             sessionManager: {
                 getEntries: () => [],

--- a/packages/cli/src/extensions/spawn-session.test.ts
+++ b/packages/cli/src/extensions/spawn-session.test.ts
@@ -33,7 +33,7 @@ function fakeCtx(hasOllamaAuth: boolean) {
         modelRegistry: {
             getAll: () => [fakeDiskModel("claude-x")],
             getAvailable: () => [fakeDiskModel("claude-x")],
-            authStorage: { hasAuth: (provider: string) => hasOllamaAuth && provider === "ollama-cloud" },
+            getProviderAuthStatus: (provider: string) => ({ configured: hasOllamaAuth && provider === "ollama-cloud" }),
         },
     } as any;
 }

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -297,7 +297,7 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
             // Ollama Cloud models are discovered dynamically (fetched live from ollama.com,
             // not baked into the static registry) — merge in the runner's cached list, same
             // as the Web UI and `pizza models` do, so newly-pulled cloud models show up here.
-            const hasOllamaAuth = ctx.modelRegistry.authStorage.hasAuth("ollama-cloud") || !!process.env.OLLAMA_API_KEY;
+            const hasOllamaAuth = ctx.modelRegistry.getProviderAuthStatus("ollama-cloud").configured || !!process.env.OLLAMA_API_KEY;
             const ollamaModels = hasOllamaAuth
                 ? (getCachedOllamaCloudModels() ?? []).map(toOllamaCloudRuntimeModel).filter((m) => !isHidden(m))
                 : [];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 import {
-    AuthStorage,
     createAgentSession,
     createAgentSessionFromServices,
     createAgentSessionRuntime,
     createAgentSessionServices,
     DefaultResourceLoader,
     InteractiveMode,
+    readStoredCredential,
     SessionManager,
 } from "@earendil-works/pi-coding-agent";
 import { join } from "path";
@@ -92,7 +92,7 @@ async function main() {
     if (args[0] === "usage") {
         const config = loadConfig(cwd);
         const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-        const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+        const authPath = join(agentDir, "auth.json");
         const showJson = args.includes("--json");
 
         // Determine which provider(s) to show
@@ -107,7 +107,7 @@ async function main() {
             // auth.json first, then fall back to Claude Code's own OAuth token
             // (Keychain / ~/.claude/.credentials.json) for users who never ran
             // /login inside pizzapi — read-only, never refreshed.
-            const accessToken = getOAuthAccessToken(authStorage.get("anthropic")) ?? getAnthropicKeychainToken();
+            const accessToken = getOAuthAccessToken(readStoredCredential("anthropic", authPath)) ?? getAnthropicKeychainToken();
             if (!accessToken) {
                 if (providerArg === "anthropic") {
                     log.error("No Anthropic credentials found. Log in with /login inside pizzapi.");
@@ -196,7 +196,8 @@ async function main() {
 
         // ── Gemini (Google Cloud Code Assist, OAuth) ───────────────────────────
         if (showGemini) {
-            const rawCred = await authStorage.getApiKey("google-gemini-cli");
+            const geminiCred = readStoredCredential("google-gemini-cli", authPath);
+            const rawCred = geminiCred?.type === "api_key" ? geminiCred.key : undefined;
             if (!rawCred) {
                 if (providerArg === "gemini") {
                     log.error("No Gemini credentials found. Log in with /login inside pizzapi.");

--- a/packages/cli/src/models-command.ts
+++ b/packages/cli/src/models-command.ts
@@ -6,7 +6,7 @@
  * https://ollama.com/v1/models endpoint is fetched and enriched with /api/show
  * metadata. Results are cached for 24 hours in ~/.pizzapi.
  */
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { join } from "path";
 import { c } from "./cli-colors.js";
 import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
@@ -30,8 +30,11 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
 
-    const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
-    const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+    const runtime = await ModelRuntime.create({
+        authPath: join(agentDir, "auth.json"),
+        modelsPath: join(agentDir, "models.json"),
+    });
+    const modelRegistry = new ModelRegistry(runtime);
 
     const staticEntries = modelRegistry
         .getAvailable()
@@ -44,7 +47,7 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
         }));
 
     let ollamaEntries: ModelListEntry[] = [];
-    if (authStorage.hasAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
+    if (runtime.hasConfiguredAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
         try {
             const live = await fetchOllamaCloudModels();
             ollamaEntries = live.map(toModelListEntry);

--- a/packages/cli/src/ollama-provider.test.ts
+++ b/packages/cli/src/ollama-provider.test.ts
@@ -242,18 +242,18 @@ describe("Ollama built-in provider", () => {
 
   test("coding-agent treats Ollama Cloud as a built-in API-key login provider", async () => {
     const { defaultModelPerProvider } = await import(piCodingAgentPath("dist/core/model-resolver.js"));
-    const { BUILT_IN_PROVIDER_DISPLAY_NAMES } = await import(piCodingAgentPath("dist/core/provider-display-names.js"));
-    const { isApiKeyLoginProvider } = await import(
-      piCodingAgentPath("dist/modes/interactive/interactive-mode.js")
-    );
+    const { ollamaCloudProvider } = await import("@earendil-works/pi-ai/providers/all");
 
     expect(defaultModelPerProvider["ollama-cloud"]).toBe("glm-5.1");
-    expect(BUILT_IN_PROVIDER_DISPLAY_NAMES["ollama-cloud"]).toBe("Ollama Cloud");
-    expect(isApiKeyLoginProvider("ollama-cloud", new Set())).toBe(true);
+    const provider = ollamaCloudProvider();
+    expect(provider.name).toBe("Ollama Cloud");
+    // API-key auth only, no OAuth handler — login flows treat it as an API-key provider.
+    expect(provider.auth.apiKey).toBeDefined();
+    expect(provider.auth.oauth).toBeUndefined();
   });
 
   test("custom local ollama models remain separate from built-in cloud auth", async () => {
-    const { AuthStorage, ModelRegistry } = await import("@earendil-works/pi-coding-agent");
+    const { ModelRegistry, ModelRuntime } = await import("@earendil-works/pi-coding-agent");
 
     const dir = mkdtempSync(join(tmpdir(), "ollama-cloud-registry-"));
     const modelsPath = join(dir, "models.json");
@@ -270,11 +270,14 @@ describe("Ollama built-in provider", () => {
         },
       }),
     );
+    const authPath = join(dir, "auth.json");
+    writeFileSync(authPath, "{}");
 
     const prev = process.env.OLLAMA_API_KEY;
     process.env.OLLAMA_API_KEY = "test-ollama-key";
     try {
-      const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+      const runtime = await ModelRuntime.create({ authPath, modelsPath });
+      const registry = new ModelRegistry(runtime);
       const available = registry.getAvailable();
 
       expect(available.some((m: any) => m.provider === "ollama-cloud" && m.id === "glm-5.1")).toBe(true);

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -255,9 +255,14 @@ describe("pi-coding-agent API surface compatibility", () => {
         expect(typeof mod.SessionManager).toBe("function");
     });
 
-    test("AuthStorage is exported", async () => {
+    test("readStoredCredential is exported", async () => {
         const mod = await import("@earendil-works/pi-coding-agent");
-        expect(mod.AuthStorage).toBeDefined();
+        expect(typeof mod.readStoredCredential).toBe("function");
+    });
+
+    test("ModelRuntime is exported", async () => {
+        const mod = await import("@earendil-works/pi-coding-agent");
+        expect(typeof mod.ModelRuntime).toBe("function");
     });
 
     test("buildSessionContext is exported", async () => {
@@ -502,7 +507,7 @@ describe("pi-ai patch application — Anthropic web search", () => {
 describe("pi-ai patch application — Claude Code credentials fallback (Keychain-first)", () => {
     test("anthropic.js (oauth): tryReadClaudeCodeCredentials with Keychain + file fallback", async () => {
         const source = await Bun.file(
-            piAiPath("dist/utils/oauth/anthropic.js"),
+            piAiPath("dist/auth/oauth/anthropic.js"),
         ).text();
 
         expect(source).toContain("PATCH(pizzapi): read Claude Code credentials as a refresh fallback");
@@ -518,29 +523,28 @@ describe("pi-ai patch application — Claude Code credentials fallback (Keychain
 
     test("anthropic.js (oauth): refreshToken awaits Claude Code credentials first", async () => {
         const source = await Bun.file(
-            piAiPath("dist/utils/oauth/anthropic.js"),
+            piAiPath("dist/auth/oauth/anthropic.js"),
         ).text();
 
         expect(source).toContain("PATCH(pizzapi): try Claude Code credentials first");
         // Verify the fallback awaits tryReadClaudeCodeCredentials before refreshAnthropicToken
         const ccCredsIndex = source.indexOf("await tryReadClaudeCodeCredentials()");
-        const refreshIndex = source.indexOf("refreshAnthropicToken(credentials.refresh)");
+        const refreshIndex = source.indexOf("refreshAnthropicToken(credential.refresh)");
         expect(ccCredsIndex).toBeGreaterThan(-1);
         expect(refreshIndex).toBeGreaterThan(-1);
         expect(ccCredsIndex).toBeLessThan(refreshIndex);
     });
 
     test("anthropic.js (oauth): file is syntactically valid", async () => {
-        const mod = await import(piAiPath("dist/utils/oauth/anthropic.js"));
-        expect(typeof mod.anthropicOAuthProvider).toBe("object");
-        expect(typeof mod.anthropicOAuthProvider.refreshToken).toBe("function");
-        expect(typeof mod.loginAnthropic).toBe("function");
-        expect(typeof mod.refreshAnthropicToken).toBe("function");
+        const mod = await import(piAiPath("dist/auth/oauth/anthropic.js"));
+        expect(typeof mod.anthropicOAuth).toBe("object");
+        expect(typeof mod.anthropicOAuth.refresh).toBe("function");
+        expect(typeof mod.anthropicOAuth.login).toBe("function");
     });
 
     test("anthropic.js (oauth): 60s safety margin on credential expiry", async () => {
         const source = await Bun.file(
-            piAiPath("dist/utils/oauth/anthropic.js"),
+            piAiPath("dist/auth/oauth/anthropic.js"),
         ).text();
 
         // Ensures we don't use credentials that expire within 60 seconds

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -31,7 +31,7 @@ import type { PizzaPiConfig } from "../config.js";
 import { findSessionPathById } from "./session-list-cache.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { triggerSessionClose } from "../extensions/providers/extension.js";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
@@ -459,10 +459,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             const config = loadConfig(cwd);
             return config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
         };
-        const listConfiguredModels = (cwd = process.cwd()) => {
+        const listConfiguredModels = async (cwd = process.cwd()) => {
             const agentDir = resolveConfiguredAgentDir(cwd);
-            const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
-            const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+            const runtime = await ModelRuntime.create({
+                authPath: join(agentDir, "auth.json"),
+                modelsPath: join(agentDir, "models.json"),
+            });
+            const modelRegistry = new ModelRegistry(runtime);
             const diskModels = modelRegistry
                 .getAvailable()
                 .map((model: any) => ({
@@ -478,7 +481,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // the session snapshot yet. Gated on Ollama credentials so we don't
             // advertise models the runner can't actually use.
             let ollamaModels: SessionModelEntry[] = [];
-            if (authStorage.hasAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
+            if (runtime.hasConfiguredAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
                 ollamaModels = (getCachedOllamaCloudModels() ?? []).map((model) => ({
                     provider: model.provider,
                     id: model.id,
@@ -495,10 +498,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 readSessionModelsCache() ?? [],
             );
         };
-        const getContextWindowsForAnalysis = (cwd = process.cwd()): Map<string, number> => {
+        const getContextWindowsForAnalysis = async (cwd = process.cwd()): Promise<Map<string, number>> => {
             const windows = new Map<string, number>();
             try {
-                for (const model of listConfiguredModels(cwd)) {
+                for (const model of await listConfiguredModels(cwd)) {
                     if (typeof model.contextWindow !== "number") continue;
                     windows.set(`${model.provider}:${model.id}`, model.contextWindow);
                 }
@@ -1844,11 +1847,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         // ── Models ──────────────────────────────────────────────────────
 
-        socket.on("list_models", (data: any) => {
+        socket.on("list_models", async (data: any) => {
             if (isShuttingDown) return;
             const requestId = data?.requestId;
             try {
-                const models = listConfiguredModels(process.cwd());
+                const models = await listConfiguredModels(process.cwd());
                 socket.emit("models_list", { requestId, models });
             } catch (e: any) {
                 socket.emit("models_list", { requestId, models: [], error: e.message ?? "Failed to list models" });
@@ -1929,7 +1932,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 const analysis = reconstructContext(
                     entries,
                     leafId,
-                    getContextWindowsForAnalysis(sessionMetadata?.cwd),
+                    await getContextWindowsForAnalysis(sessionMetadata?.cwd),
                 );
                 socket.emit("analyze_session_data", { requestId, data: analysis });
             } catch (e: any) {

--- a/packages/cli/src/runner/runner-ollama-models-cache.ts
+++ b/packages/cli/src/runner/runner-ollama-models-cache.ts
@@ -8,7 +8,7 @@
  * runner itself, independent of session activity, refreshing every 12 hours.
  */
 import { join } from "node:path";
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
 import { fetchOllamaCloudModels } from "../ollama-cloud-models.js";
 import { logInfo, logWarn } from "./logger.js";
@@ -22,7 +22,7 @@ function hasOllamaCreds(): boolean {
     try {
         const config = loadConfig(process.cwd());
         const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-        return AuthStorage.create(join(agentDir, "auth.json")).hasAuth("ollama-cloud");
+        return readStoredCredential("ollama-cloud", join(agentDir, "auth.json"))?.type === "api_key";
     } catch {
         return false;
     }

--- a/packages/cli/src/runner/runner-usage-cache.test.ts
+++ b/packages/cli/src/runner/runner-usage-cache.test.ts
@@ -35,15 +35,9 @@ describe("runner-usage-cache child", () => {
         const projectAgentDirByCwd = new Map([[projectCwd, "~/custom-agent-dir"]]);
 
         mock.module("@earendil-works/pi-coding-agent", () => ({
-            AuthStorage: {
-                create: (authPath: string) => {
-                    authCreateCalls.push(authPath);
-                    return {
-                        authPath,
-                        get: () => ({ type: "oauth", access: authPath }),
-                        getApiKey: async () => undefined,
-                    };
-                },
+            readStoredCredential: (_providerId: string, authPath: string) => {
+                authCreateCalls.push(authPath);
+                return { type: "oauth", access: authPath };
             },
         }));
 

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -1,7 +1,7 @@
 import { renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
 import { getOAuthAccessToken, getAnthropicKeychainToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 import { logInfo, logWarn } from "./logger.js";
@@ -55,38 +55,32 @@ export function runnerUsageCacheFilePath(): string {
 }
 
 /**
- * Returns all unique AuthStorage instances known to the daemon:
+ * Returns all unique auth.json paths known to the daemon:
  * the daemon's own startup CWD first, followed by any CWD registered by active
  * worker sessions that maps to a different auth.json (e.g. a project-specific
- * agentDir override).  Results are deduplicated by resolved auth.json path so
- * the same file is never probed twice.
+ * agentDir override). Deduplicated so the same file is never probed twice.
  *
- * Usage fetch functions iterate this list and use the first storage that
+ * Usage fetch functions iterate this list and use the first path that
  * yields valid credentials, ensuring that sessions spawned in projects with
  * their own agentDir overrides are covered even when the daemon was started
  * from a different directory.
  */
-function getKnownAuthStorages(): AuthStorage[] {
+function getKnownAuthPaths(): string[] {
     const seen = new Set<string>();
-    const result: AuthStorage[] = [];
     const cwds = [process.cwd(), ..._activeSessionCwds.keys()];
     for (const cwd of cwds) {
         const config = loadConfig(cwd);
         const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-        const authPath = join(agentDir, "auth.json");
-        if (!seen.has(authPath)) {
-            seen.add(authPath);
-            result.push(AuthStorage.create(authPath));
-        }
+        seen.add(join(agentDir, "auth.json"));
     }
-    return result;
+    return [...seen];
 }
 
 async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
     let token: string | null = null;
     try {
-        for (const authStorage of getKnownAuthStorages()) {
-            const raw = authStorage.get("anthropic");
+        for (const authPath of getKnownAuthPaths()) {
+            const raw = readStoredCredential("anthropic", authPath);
             token = getOAuthAccessToken(raw);
             if (token) break;
         }
@@ -153,14 +147,14 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
     let token: string | undefined;
     let projectId: string | undefined;
     try {
-        for (const authStorage of getKnownAuthStorages()) {
-            // AuthStorage.getApiKey handles OAuth token refresh and returns
-            // JSON.stringify({ token, projectId }) via the provider's getApiKey().
+        for (const authPath of getKnownAuthPaths()) {
+            // The stored credential's `key` is JSON.stringify({ token, projectId }).
             // Use parseGeminiQuotaCredential to validate the result — API-key
-            // credentials return a plain string that fails JSON.parse, so we
+            // credentials with an unrelated shape fail JSON.parse, so we
             // must not short-circuit on the first truthy raw value; we need to
-            // confirm it is a valid OAuth Gemini credential before stopping.
-            const raw = await authStorage.getApiKey("google-gemini-cli");
+            // confirm it is a valid Gemini quota credential before stopping.
+            const stored = readStoredCredential("google-gemini-cli", authPath);
+            const raw = stored?.type === "api_key" ? stored.key : undefined;
             const cred = parseGeminiQuotaCredential(raw);
             if (cred) {
                 token = cred.token;
@@ -204,8 +198,8 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
     let token: string | null = null;
     try {
-        for (const authStorage of getKnownAuthStorages()) {
-            const raw = authStorage.get("openai-codex");
+        for (const authPath of getKnownAuthPaths()) {
+            const raw = readStoredCredential("openai-codex", authPath);
             token = getOAuthAccessToken(raw);
             if (token) break;
         }

--- a/packages/cli/src/runner/worker-auth.test.ts
+++ b/packages/cli/src/runner/worker-auth.test.ts
@@ -3,8 +3,8 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-// We can't easily unit-test the full createAuthStorageWithRetry because it
-// depends on the AuthStorage class from pi-coding-agent which uses lockfile.
+// We can't easily unit-test the full createModelRuntimeWithRetry because it
+// depends on pi-coding-agent's ModelRuntime, which uses lockfile internally.
 // Instead, we test the lockless fallback logic and the retry detection.
 
 describe("worker auth resilience", () => {
@@ -54,10 +54,10 @@ describe("worker auth resilience", () => {
         expect(Object.keys(parsed).length).toBe(0);
     });
 
-    test("AuthStorage.create reads from correct path", async () => {
+    test("readStoredCredential reads from correct path", async () => {
         // This test verifies that when we pass an explicit authPath,
-        // AuthStorage reads from that path, not from ~/.pi/agent/auth.json
-        const { AuthStorage } = await import("@earendil-works/pi-coding-agent");
+        // readStoredCredential reads from that path, not from ~/.pi/agent/auth.json
+        const { readStoredCredential } = await import("@earendil-works/pi-coding-agent");
 
         const authPath = join(tmpDir, "auth.json");
         const authData = {
@@ -68,44 +68,23 @@ describe("worker auth resilience", () => {
         };
         writeFileSync(authPath, JSON.stringify(authData, null, 2));
 
-        const storage = AuthStorage.create(authPath);
-        expect(storage.has("test-provider")).toBe(true);
-        expect(storage.list()).toContain("test-provider");
+        const cred = readStoredCredential("test-provider", authPath);
+        expect(cred?.type).toBe("api_key");
+        expect(cred?.type === "api_key" ? cred.key : undefined).toBe("test-key-12345");
 
         // Should NOT have providers from the real ~/.pi/agent/auth.json
-        // (unless they happen to match, which "test-provider" won't)
-        const key = await storage.getApiKey("test-provider");
-        expect(key).toBe("test-key-12345");
+        expect(readStoredCredential("anthropic", authPath)).toBeUndefined();
     });
 
-    test("AuthStorage.inMemory creates storage from pre-loaded data", async () => {
-        // This tests the lockless fallback path: read file without lock,
-        // create in-memory storage
-        const { AuthStorage } = await import("@earendil-works/pi-coding-agent");
-
-        const authData = {
-            anthropic: {
-                type: "oauth" as const,
-                access: "test-access",
-                refresh: "test-refresh",
-                expires: Date.now() + 3600000,
-            },
-        };
-
-        const storage = AuthStorage.inMemory(authData);
-        expect(storage.has("anthropic")).toBe(true);
-        expect(storage.list()).toContain("anthropic");
-    });
-
-    test("AuthStorage.create with nonexistent path creates empty storage", async () => {
-        const { AuthStorage } = await import("@earendil-works/pi-coding-agent");
+    test("ModelRuntime.create with nonexistent path creates empty auth.json", async () => {
+        const { ModelRuntime } = await import("@earendil-works/pi-coding-agent");
 
         const authPath = join(tmpDir, "nonexistent", "auth.json");
-        // Ensure parent dir exists (AuthStorage.create tries to create it)
+        // Ensure parent dir exists (the underlying storage tries to create it)
         mkdirSync(join(tmpDir, "nonexistent"), { recursive: true });
 
-        const storage = AuthStorage.create(authPath);
-        expect(storage.list().length).toBe(0);
+        const runtime = await ModelRuntime.create({ authPath, modelsPath: null });
+        expect((await runtime.listCredentials()).length).toBe(0);
         // Verify it created the file
         expect(existsSync(authPath)).toBe(true);
     });

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -1,4 +1,4 @@
-import { createAgentSession, DefaultResourceLoader, AuthStorage, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultResourceLoader, ModelRuntime, readStoredCredential, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { SHELL_PROC_CAPTURE_PREFIX } from "./session-procs.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -14,30 +14,56 @@ import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
 /**
- * Create an AuthStorage instance with retried file locking.
+ * Minimal in-memory credential store for the lockless fallback tier below.
+ * Structurally matches pi-ai's `CredentialStore` interface (read/list/modify/
+ * delete); that type isn't part of pi-ai's public export surface, so we
+ * match its shape rather than importing/implementing it by name.
+ */
+class InMemoryCredentialsFallback {
+    constructor(private data: Record<string, any>) {}
+    async read(providerId: string) {
+        return this.data[providerId];
+    }
+    async list() {
+        return Object.entries(this.data).map(([providerId, credential]) => ({
+            providerId,
+            type: (credential as { type: string }).type,
+        }));
+    }
+    async modify(providerId: string, fn: (current: any) => Promise<any>) {
+        const next = await fn(this.data[providerId]);
+        if (next !== undefined) this.data[providerId] = next;
+        return this.data[providerId];
+    }
+    async delete(providerId: string) {
+        delete this.data[providerId];
+    }
+}
+
+/**
+ * Create a ModelRuntime with retried file locking on auth.json.
  *
  * When many worker processes spawn simultaneously (e.g. 6 sub-sessions in
- * parallel), the upstream AuthStorage constructor acquires a synchronous
- * file lock on auth.json during its `reload()` call. The sync lock uses
- * only 10 retries × 20ms = ~200ms window, which is too short when another
- * process is doing an async OAuth token refresh (seconds). Workers that
- * lose the lock race silently start with empty credentials → "No API key
- * found" errors.
+ * parallel), the underlying auth-storage backend acquires a synchronous
+ * file lock on auth.json while loading. The sync lock uses only 10 retries
+ * × 20ms = ~200ms window, which is too short when another process is doing
+ * an async OAuth token refresh (seconds). Workers that lose the lock race
+ * silently start with empty credentials → "No API key found" errors.
  *
- * This helper retries AuthStorage creation with increasing delays,
+ * This helper retries ModelRuntime creation with increasing delays,
  * and if all retries fail, falls back to a lockless read so the worker
  * at least has stale-but-valid credentials rather than none.
  */
-async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Promise<AuthStorage> {
+async function createModelRuntimeWithRetry(authPath: string, modelsPath: string, maxAttempts = 5): Promise<ModelRuntime> {
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
-            const storage = AuthStorage.create(authPath);
+            const runtime = await ModelRuntime.create({ authPath, modelsPath });
             // Verify it actually loaded credentials (not silently empty due to lock failure)
-            const providers = storage.list();
+            const providers = await runtime.listCredentials();
             if (providers.length > 0) {
-                return storage;
+                return runtime;
             }
             // If the file exists but we got zero providers, it could be a lock failure
             // that was silently swallowed. Check if the file actually has data.
@@ -46,12 +72,12 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                     const raw = readFileSync(authPath, "utf-8");
                     const data = JSON.parse(raw);
                     if (Object.keys(data).length > 0) {
-                        // File has data but AuthStorage didn't load it — lock contention.
+                        // File has data but the runtime didn't load it — lock contention.
                         // Wait and retry.
                         logWarn(
-                            `pizzapi worker: auth.json has ${Object.keys(data).length} provider(s) but AuthStorage loaded 0 (attempt ${attempt}/${maxAttempts}, likely lock contention)`,
+                            `pizzapi worker: auth.json has ${Object.keys(data).length} provider(s) but ModelRuntime loaded 0 (attempt ${attempt}/${maxAttempts}, likely lock contention)`,
                         );
-                        lastError = new Error("Lock contention: auth.json has data but AuthStorage loaded empty");
+                        lastError = new Error("Lock contention: auth.json has data but ModelRuntime loaded empty");
                         if (attempt < maxAttempts) {
                             // Exponential backoff: 100ms, 200ms, 400ms, 800ms
                             await Bun.sleep(100 * Math.pow(2, attempt - 1));
@@ -59,12 +85,12 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                         }
                         // Final attempt still hit lock contention — break out of the
                         // loop so we fall through to the lockless fallback below
-                        // instead of returning the empty storage.
+                        // instead of returning the empty runtime.
                         break;
                     }
                 } catch {
                     // Partial/empty JSON during a concurrent token refresh —
-                    // retry instead of returning the empty storage (P1 fix).
+                    // retry instead of returning the empty runtime (P1 fix).
                     lastError = new Error("Lockless auth.json probe got unreadable/partial JSON");
                     if (attempt < maxAttempts) {
                         await Bun.sleep(100 * Math.pow(2, attempt - 1));
@@ -74,7 +100,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                 }
             }
             // File genuinely empty or doesn't exist — return as-is
-            return storage;
+            return runtime;
         } catch (err) {
             lastError = err;
             if (attempt < maxAttempts) {
@@ -88,7 +114,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
     // Retry the lockless read a few times with short delays because a
     // concurrent writeFileSync can produce empty/partial JSON momentarily.
     logWarn(
-        `pizzapi worker: AuthStorage lock retries exhausted (${maxAttempts} attempts), falling back to lockless read`,
+        `pizzapi worker: ModelRuntime lock retries exhausted (${maxAttempts} attempts), falling back to lockless read`,
     );
     const locklessRetries = 3;
     for (let lr = 1; lr <= locklessRetries; lr++) {
@@ -105,15 +131,16 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
             const data = JSON.parse(raw);
             if (Object.keys(data).length > 0) {
                 // The lock holder may have finished by now — try one final
-                // AuthStorage.create() so we get a file-backed instance that
+                // ModelRuntime.create() so we get a file-backed instance that
                 // can persist token refreshes and see future credential updates.
                 try {
-                    const fileStorage = AuthStorage.create(authPath);
-                    if (fileStorage.list().length > 0) {
+                    const fileRuntime = await ModelRuntime.create({ authPath, modelsPath });
+                    const fileCreds = await fileRuntime.listCredentials();
+                    if (fileCreds.length > 0) {
                         logInfo(
-                            `pizzapi worker: lock released — file-backed AuthStorage loaded ${fileStorage.list().length} provider(s) on final retry`,
+                            `pizzapi worker: lock released — file-backed ModelRuntime loaded ${fileCreds.length} provider(s) on final retry`,
                         );
-                        return fileStorage;
+                        return fileRuntime;
                     }
                 } catch {
                     // Still can't acquire lock — fall through to in-memory
@@ -121,11 +148,15 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                 // Use in-memory as last resort (read-only snapshot — token
                 // refreshes won't be persisted and credential updates won't
                 // be visible, but at least the worker can start).
-                const storage = AuthStorage.inMemory(data);
+                const runtime = await ModelRuntime.create({
+                    authPath,
+                    modelsPath,
+                    credentials: new InMemoryCredentialsFallback(data) as any,
+                });
                 logWarn(
                     `pizzapi worker: lockless fallback loaded ${Object.keys(data).length} provider(s) from ${authPath} (in-memory snapshot — token refreshes will not persist)`,
                 );
-                return storage;
+                return runtime;
             }
             // Parsed OK but empty object — file genuinely has no providers
             break;
@@ -148,7 +179,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
     logError(
         `pizzapi worker: failed to load auth credentials after ${maxAttempts} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
     );
-    return AuthStorage.create(authPath);
+    return ModelRuntime.create({ authPath, modelsPath });
 }
 
 // buildPromptPaths moved to ../skills.ts as buildPromptTemplatePaths
@@ -356,17 +387,18 @@ async function main(): Promise<void> {
     await loader.reload();
     bootTimer.end("[boot] resource-loader");
 
-    // Create AuthStorage with retry logic to handle lock contention when
+    // Create a ModelRuntime with retry logic to handle lock contention when
     // multiple workers spawn simultaneously (common with parallel sub-sessions).
     const authPath = join(agentDir, "auth.json");
-    const authStorage = await createAuthStorageWithRetry(authPath);
+    const modelsPath = join(agentDir, "models.json");
+    const modelRuntime = await createModelRuntimeWithRetry(authPath, modelsPath);
 
     // ── Auth diagnostics — log credential state before first API call ────
     // This helps diagnose intermittent "No API key found" failures in
     // concurrent worker sessions (see Godmother idea fIUvBDLZ).
     try {
         for (const provider of ["anthropic", "google-gemini-cli", "openai-codex"]) {
-            const raw = authStorage.get(provider);
+            const raw = readStoredCredential(provider, authPath);
             if (raw && typeof raw === "object" && "type" in raw) {
                 const cred = raw as { type: string; expires?: number };
                 if (cred.type === "oauth" && cred.expires) {
@@ -407,7 +439,7 @@ async function main(): Promise<void> {
     const { session } = await createAgentSession({
         cwd,
         agentDir,
-        authStorage,
+        modelRuntime,
         resourceLoader: loader,
         settingsManager,
     });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/server/tests/pi-compat.test.ts
+++ b/packages/server/tests/pi-compat.test.ts
@@ -98,6 +98,8 @@ describe("pi-agent-core API compatibility", () => {
                 model,
                 tools: [],
             },
+            // Never actually invoked in these construction-only tests.
+            streamFn: () => { throw new Error("streamFn not implemented in test"); },
             getApiKey: async () => undefined,
         });
 
@@ -126,6 +128,8 @@ describe("pi-agent-core API compatibility", () => {
                 model,
                 tools: [],
             },
+            // Never actually invoked in these construction-only tests.
+            streamFn: () => { throw new Error("streamFn not implemented in test"); },
             getApiKey: async () => undefined,
         });
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6"
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@earendil-works%2Fpi-agent-core@0.82.0.patch
+++ b/patches/@earendil-works%2Fpi-agent-core@0.82.0.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/agent-loop.js b/dist/agent-loop.js
+index 5b5da787a637df62dfd944f92a45fc9cb945eac3..e562421f188eb4193fa9de00ef1d4b5482b2ac76 100644
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -102,6 +102,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
+                 }
+                 pendingMessages = [];
+             }
++            // PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response
++            currentContext.systemPrompt = currentContext.__getLatestSystemPrompt?.() ?? currentContext.systemPrompt;
++            currentContext.tools = currentContext.__getLatestTools?.() ?? currentContext.tools;
+             // Stream assistant response
+             const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
+             newMessages.push(message);
+diff --git a/dist/agent.js b/dist/agent.js
+index e26aedf3192690e9ad2816d83092f6dd15f2b70e..673e4322ad32f376a4c878e7f5c70b427978bb5c 100644
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -275,6 +275,9 @@ export class Agent {
+     createContextSnapshot() {
+         return {
+             systemPrompt: this._state.systemPrompt,
++            // PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state
++            __getLatestSystemPrompt: () => this._state.systemPrompt,
++            __getLatestTools: () => this._state.tools.slice(),
+             messages: this._state.messages.slice(),
+             tools: this._state.tools.slice(),
+         };

--- a/patches/@earendil-works%2Fpi-ai@0.82.0.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.82.0.patch
@@ -1,0 +1,373 @@
+diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
+index 70ead54dbbbea64daff7350b70ce1c23352cd208..8de4f08523a6be84b90e36be42c5529ca6238d4a 100644
+--- a/dist/api/anthropic-messages.js
++++ b/dist/api/anthropic-messages.js
+@@ -438,6 +438,29 @@ export const stream = (model, context, options) => {
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    else if (event.content_block.type === "server_tool_use") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            partialJson: "",
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -479,6 +502,10 @@ export const stream = (model, context, options) => {
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -495,6 +522,16 @@ export const stream = (model, context, options) => {
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                }
++                                catch {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -750,6 +787,22 @@ function buildParams(model, context, isOAuthToken, options) {
+             ...convertTools(deferredTools, isOAuthToken, compat.supportsEagerToolInputStreaming, compat.supportsStrictTools, undefined, true),
+         ];
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
++        if (!params.tools)
++            params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0)
++            webSearchTool.max_uses = maxUses;
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive, budget-based, or explicitly disabled.
+     if (model.reasoning) {
+         if (options?.thinkingEnabled) {
+@@ -878,7 +931,23 @@ function convertMessages(transformedMessages, isOAuthToken, cacheControl, allowE
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -989,6 +1058,10 @@ function convertTools(tools, isOAuthToken, supportsEagerToolInputStreaming, supp
+     if (!tools)
+         return [];
+     return tools.map((tool, index) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const strict = resolveJsonSchemaStrictSampling(tool, supportsStrictTools);
+         const schema = tool.parameters;
+         const legacyInputSchema = {
+diff --git a/dist/auth/oauth/anthropic.js b/dist/auth/oauth/anthropic.js
+index 05ba3fc970f095bacc3f2b175186ceab68ff7f59..05b3ac2f79dbd8def484c7f857ff99ff873a3efb 100644
+--- a/dist/auth/oauth/anthropic.js
++++ b/dist/auth/oauth/anthropic.js
+@@ -291,10 +291,48 @@ async function refreshAnthropicToken(refreshToken) {
+         expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+     };
+ }
++// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
++async function tryReadClaudeCodeCredentials() {
++    try {
++        if (process.platform === "darwin") {
++            const { execSync } = await import("node:child_process");
++            const raw = execSync(`security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`, { encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
++            if (raw) {
++                const cc = JSON.parse(raw)?.claudeAiOauth;
++                if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++                    return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++                }
++            }
++        }
++    }
++    catch {
++    }
++    try {
++        const [{ readFileSync }, { join }, { homedir }] = await Promise.all([
++            import("node:fs"),
++            import("node:path"),
++            import("node:os"),
++        ]);
++        const cc = JSON.parse(readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"))?.claudeAiOauth;
++        if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++            return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++        }
++    }
++    catch {
++    }
++    return null;
++}
+ export const anthropicOAuth = {
+     name: "Anthropic (Claude Pro/Max)",
+     login: loginAnthropic,
+-    refresh: (credential) => refreshAnthropicToken(credential.refresh),
++    async refresh(credential) {
++        // PATCH(pizzapi): try Claude Code credentials first
++        const ccCreds = await tryReadClaudeCodeCredentials();
++        if (ccCreds) {
++            return ccCreds;
++        }
++        return refreshAnthropicToken(credential.refresh);
++    },
+     async toAuth(credential) {
+         return { apiKey: credential.access };
+     },
+diff --git a/dist/env-api-keys.js b/dist/env-api-keys.js
+index f8883cf0c1b503d7d31e612891a9ffc3ada0f1bb..4f3ac6b5031a05fc98f5373ab8034660ef281925 100644
+--- a/dist/env-api-keys.js
++++ b/dist/env-api-keys.js
+@@ -80,6 +80,7 @@ function getApiKeyEnvVars(provider) {
+         xai: "XAI_API_KEY",
+         radius: "RADIUS_API_KEY",
+         openrouter: "OPENROUTER_API_KEY",
++        "ollama-cloud": "OLLAMA_API_KEY",
+         "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+         zai: "ZAI_API_KEY",
+         "zai-coding-cn": "ZAI_CODING_CN_API_KEY",
+diff --git a/dist/models.generated.d.ts b/dist/models.generated.d.ts
+index 17a47cd197fe4d439788a8d5d57d60cfaf4b73c7..8640c1883d96824a9b6fb27b15b7cb8ecf8c44d3 100644
+--- a/dist/models.generated.d.ts
++++ b/dist/models.generated.d.ts
+@@ -62,6 +62,11 @@ export declare const MODELS: {
+     readonly "opencode": typeof OPENCODE_MODELS;
+     readonly "opencode-go": typeof OPENCODE_GO_MODELS;
+     readonly "openrouter": typeof OPENROUTER_MODELS;
++    // PATCH(pizzapi): Ollama Cloud provider models
++    readonly "ollama-cloud": Record<string, import("./types.ts").Model<"openai-completions"> & {
++        id: string;
++        provider: "ollama-cloud";
++    }>;
+     readonly "qwen-token-plan": typeof QWEN_TOKEN_PLAN_MODELS;
+     readonly "qwen-token-plan-cn": typeof QWEN_TOKEN_PLAN_CN_MODELS;
+     readonly "together": typeof TOGETHER_MODELS;
+diff --git a/dist/models.generated.js b/dist/models.generated.js
+index 2979df55ce4b0bc051bc116a2c3d4c7deddbb68a..ef16ae7727ebb330b6b7a357b9c74692b1ed23fa 100644
+--- a/dist/models.generated.js
++++ b/dist/models.generated.js
+@@ -37,6 +37,73 @@ import { XIAOMI_TOKEN_PLAN_CN_MODELS } from "./providers/xiaomi-token-plan-cn.mo
+ import { XIAOMI_TOKEN_PLAN_SGP_MODELS } from "./providers/xiaomi-token-plan-sgp.models.js";
+ import { ZAI_MODELS } from "./providers/zai.models.js";
+ import { ZAI_CODING_CN_MODELS } from "./providers/zai-coding-cn.models.js";
++// PATCH(pizzapi): Ollama Cloud provider models. Sourced from the OpenAI-compatible
++// Ollama Cloud list endpoint (https://ollama.com/v1/models) with context windows
++// and capabilities from https://ollama.com/api/show with the corresponding
++// :cloud/-cloud model name. Cost metadata is zero until Ollama publishes
++// machine-usable per-token pricing.
++const OLLAMA_BASE_URL = "https://ollama.com/v1";
++const OLLAMA_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
++const OLLAMA_COMPAT = { supportsStore: false, supportsDeveloperRole: false, supportsReasoningEffort: false, supportsUsageInStreaming: true, supportsLongCacheRetention: false, supportsStrictMode: false, maxTokensField: "max_tokens" };
++function createOllamaModel(id, name, { reasoning = false, input = ["text"], contextWindow = 128000, maxTokens = 16384 } = {}) {
++    return {
++        id,
++        name,
++        api: "openai-completions",
++        provider: "ollama-cloud",
++        baseUrl: OLLAMA_BASE_URL,
++        compat: OLLAMA_COMPAT,
++        reasoning,
++        input,
++        cost: OLLAMA_ZERO_COST,
++        contextWindow,
++        maxTokens,
++    };
++}
++export const OLLAMA_CLOUD_MODELS = {
++    "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
++    "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 524288, maxTokens: 32768 }),
++    "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "gemini-3-flash-preview": createOllamaModel("gemini-3-flash-preview", "Gemini 3 Flash Preview", { reasoning: true, input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536 }),
++    "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:27b": createOllamaModel("gemma3:27b", "Gemma 3 27B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma4:31b": createOllamaModel("gemma4:31b", "Gemma 4 31B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "glm-4.6": createOllamaModel("glm-4.6", "GLM 4.6", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-4.7": createOllamaModel("glm-4.7", "GLM 4.7", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-5": createOllamaModel("glm-5", "GLM 5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "glm-5.1": createOllamaModel("glm-5.1", "GLM 5.1", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "gpt-oss:120b": createOllamaModel("gpt-oss:120b", "GPT-OSS 120B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "gpt-oss:20b": createOllamaModel("gpt-oss:20b", "GPT-OSS 20B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.7-code": createOllamaModel("kimi-k2.7-code", "Kimi K2.7 Code", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: false, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m3": createOllamaModel("minimax-m3", "MiniMax M3", { reasoning: true, input: ["text", "image"], contextWindow: 524288, maxTokens: 32768 }),
++    "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-ultra": createOllamaModel("nemotron-3-ultra", "Nemotron 3 Ultra", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder-next": createOllamaModel("qwen3-coder-next", "Qwen 3 Coder Next", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder:480b": createOllamaModel("qwen3-coder:480b", "Qwen 3 Coder 480B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-next:80b": createOllamaModel("qwen3-next:80b", "Qwen 3 Next 80B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b": createOllamaModel("qwen3-vl:235b", "Qwen 3 VL 235B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b-instruct": createOllamaModel("qwen3-vl:235b-instruct", "Qwen 3 VL 235B Instruct", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3.5:397b": createOllamaModel("qwen3.5:397b", "Qwen 3.5 397B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 32768, maxTokens: 16384 }),
++};
+ export const MODELS = {
+     "amazon-bedrock": AMAZON_BEDROCK_MODELS,
+     "ant-ling": ANT_LING_MODELS,
+@@ -64,6 +131,7 @@ export const MODELS = {
+     "opencode": OPENCODE_MODELS,
+     "opencode-go": OPENCODE_GO_MODELS,
+     "openrouter": OPENROUTER_MODELS,
++    "ollama-cloud": OLLAMA_CLOUD_MODELS,
+     "qwen-token-plan": QWEN_TOKEN_PLAN_MODELS,
+     "qwen-token-plan-cn": QWEN_TOKEN_PLAN_CN_MODELS,
+     "together": TOGETHER_MODELS,
+diff --git a/dist/providers/all.d.ts b/dist/providers/all.d.ts
+index b92d9141961e3b53c2726ec9ec7197e4259030af..20aa3a0f22dbfd03ae28bd89c476df187f15b849 100644
+--- a/dist/providers/all.d.ts
++++ b/dist/providers/all.d.ts
+@@ -4,6 +4,9 @@ import { type CreateModelsOptions, type MutableModels, type Provider } from "../
+ import type { Api, Model } from "../types.ts";
+ import { radiusProvider } from "./radius.ts";
+ export { radiusProvider };
++// PATCH(pizzapi): Ollama Cloud provider factory (see all.js for why it's
++// inlined here instead of its own providers/ollama-cloud.ts file).
++export declare function ollamaCloudProvider(): Provider<"openai-completions">;
+ /** Providers present in the generated catalog. `KnownProvider` additionally
+  * includes purely dynamic providers (e.g. "radius") that have no static
+  * catalog entry. */
+diff --git a/dist/providers/all.js b/dist/providers/all.js
+index a9a3ce56cc3525ce136c9078fc335f81330132d6..aa366564e7c4d2f375ac0d543c6e9d818fb2b91a 100644
+--- a/dist/providers/all.js
++++ b/dist/providers/all.js
+@@ -1,6 +1,8 @@
+ import { createImagesModels } from "../images-models.js";
+-import { MODELS } from "../models.generated.js";
+-import { createModels } from "../models.js";
++import { MODELS, OLLAMA_CLOUD_MODELS } from "../models.generated.js";
++import { createModels, createProvider } from "../models.js";
++import { openAICompletionsApi } from "../api/openai-completions.lazy.js";
++import { envApiKeyAuth } from "../auth/helpers.js";
+ import { amazonBedrockProvider } from "./amazon-bedrock.js";
+ import { antLingProvider } from "./ant-ling.js";
+ import { anthropicProvider } from "./anthropic.js";
+@@ -42,6 +44,19 @@ import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp.js";
+ import { zaiProvider } from "./zai.js";
+ import { zaiCodingCnProvider } from "./zai-coding-cn.js";
+ export { radiusProvider };
++// PATCH(pizzapi): Ollama Cloud provider (inlined here rather than its own
++// providers/ollama-cloud.js file — `bun patch` cannot add new files in
++// nested directories, see oven-sh/bun#13330).
++export function ollamaCloudProvider() {
++    return createProvider({
++        id: "ollama-cloud",
++        name: "Ollama Cloud",
++        baseUrl: "https://ollama.com/v1",
++        auth: { apiKey: envApiKeyAuth("Ollama Cloud API key", ["OLLAMA_API_KEY"]) },
++        models: Object.values(OLLAMA_CLOUD_MODELS),
++        api: openAICompletionsApi(),
++    });
++}
+ /** Typed read of the generated built-in catalog. */
+ export function getBuiltinModel(provider, modelId) {
+     const models = MODELS[provider];
+@@ -90,6 +105,7 @@ export function builtinProviders() {
+         opencodeProvider(),
+         opencodeGoProvider(),
+         openrouterProvider(),
++        ollamaCloudProvider(),
+         qwenTokenPlanProvider(),
+         qwenTokenPlanCnProvider(),
+         radiusProvider(),
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index 0a1b76919766126f1c8c4a306b24e8096a5e02d0..e6f566e6154764158f714ea4f83a3a6f3819f2d2 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -15,7 +15,7 @@ export type KnownApi = "openai-completions" | "mistral-conversations" | "openai-
+ export type Api = KnownApi | (string & {});
+ export type KnownImagesApi = "openrouter-images";
+ export type ImagesApi = KnownImagesApi | (string & {});
+-export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
++export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "ollama-cloud" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
+ export type ProviderId = KnownProvider | string;
+ export type KnownImagesProvider = "openrouter";
+ export type ImagesProviderId = KnownImagesProvider | string;
+diff --git a/dist/utils/retry.js b/dist/utils/retry.js
+index ac5c157bb4a7b0e5599b6bf07d4022f8ed49aac4..556a686f7bec631e784b1d9392e3015c570f545e 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -63,6 +63,9 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+     "stream ended before message_stop",
+     "stream ended before a terminal response event",
+     "http2 request did not get a response",
++    // PATCH(pizzapi): retry transient JSON parse failures from truncated provider streams.
++    "json.?parse.?error",
++    "unexpected.?end.?of.?json",
+     // Provider-requested retry delay cap failures should flow through the outer
+     // retry policy so callers can surface/abort the backoff (#1123).
+     "retry delay",

--- a/patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch
@@ -1,0 +1,319 @@
+diff --git a/dist/config.js b/dist/config.js
+index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed05659f958 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -358,6 +358,10 @@ export function getExamplesPath() {
+ }
+ /** Get path to CHANGELOG.md */
+ export function getChangelogPath() {
++    // PATCH(pizzapi): allow PizzaPi to display its wrapper changelog.
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "CHANGELOG.md"));
+ }
+ /**
+@@ -391,7 +395,7 @@ const piConfigName = pkg.piConfig?.name;
+ export const PACKAGE_NAME = pkg.name || "@earendil-works/pi-coding-agent";
+ export const APP_NAME = piConfigName || "pi";
+ export const APP_TITLE = piConfigName ? APP_NAME : "π";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++export const CONFIG_DIR_NAME = ".pizzapi"; // PATCH(pizzapi): force PizzaPi's config namespace instead of upstream .pi.
+ export const VERSION = pkg.version || "0.0.0";
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+@@ -414,7 +418,8 @@ export function getAgentDir() {
+     if (envDir) {
+         return expandTildePath(envDir);
+     }
+-    return join(homedir(), CONFIG_DIR_NAME, "agent");
++    // PATCH(pizzapi): flat directory structure, no nested agent/ segment.
++    return join(homedir(), CONFIG_DIR_NAME);
+ }
+ /** Get path to user's custom themes directory */
+ export function getCustomThemesDir() {
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index 64f82bf289064c50554a71c0dae4f1c4b2796149..fd900e486bddd7c143ba0f14d5be0f426a055fec 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1122,9 +1122,10 @@ export class AgentSession {
+             if (images.length === 0)
+                 images = undefined;
+         }
+-        // Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
++        // Use prompt() with expandPromptTemplates: false by default to skip command handling and template expansion.
++        // PATCH(pizzapi): allow callers to opt into command/template expansion (e.g. web UI input).
+         await this.prompt(text, {
+-            expandPromptTemplates: false,
++            expandPromptTemplates: options?.expandPromptTemplates ?? false,
+             streamingBehavior: options?.deliverAs,
+             images,
+             source: "extension",
+@@ -1895,6 +1896,17 @@ export class AgentSession {
+             },
+             getThinkingLevel: () => this.thinkingLevel,
+             setThinkingLevel: (level) => this.setThinkingLevel(level),
++            // PATCH(pizzapi): expose the pending queues so the remote extension can sync them to the web UI.
++            getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] }),
++            // PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals).
++            // ponytail: text-only — queued image attachments are dropped on replace; the queue mirrors only store text.
++            replaceQueuedMessages: (followUp) => {
++                const { steering } = this.clearQueue();
++                for (const text of steering)
++                    void this._queueSteer(text);
++                for (const text of followUp)
++                    void this._queueFollowUp(text);
++            },
+         }, {
+             getModel: () => this.model,
+             isIdle: () => this.isIdle,
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+index 099e74e87220ed9c57990771d0466416184d4304..7291108e826c39fddeabf06e49687012e33096b7 100644
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -143,6 +143,10 @@ export function createExtensionRuntime() {
+         sendUserMessage: notInitialized,
+         appendEntry: notInitialized,
+         setSessionName: notInitialized,
++        // PATCH(pizzapi): expose session-control actions on ExtensionAPI, not only command contexts.
++        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        fork: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getSessionName: notInitialized,
+         setLabel: notInitialized,
+         getActiveTools: notInitialized,
+@@ -154,6 +158,9 @@ export function createExtensionRuntime() {
+         setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getThinkingLevel: notInitialized,
+         setThinkingLevel: notInitialized,
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync.
++        getQueuedMessages: notInitialized,
++        replaceQueuedMessages: notInitialized,
+         flagValues: new Map(),
+         pendingProviderRegistrations: [],
+         pendingNativeProviderRegistrations: [],
+@@ -252,6 +259,28 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+             runtime.assertActive();
+             runtime.setSessionName(name);
+         },
++        // PATCH(pizzapi): remote exec handlers need /new and /resume from lifecycle/event handlers.
++        newSession(options) {
++            runtime.assertActive();
++            return runtime.newSession(options);
++        },
++        switchSession(sessionPath, options) {
++            runtime.assertActive();
++            return runtime.switchSession(sessionPath, options);
++        },
++        fork(entryId, options) {
++            runtime.assertActive();
++            return runtime.fork(entryId, options);
++        },
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync (web UI queue edits).
++        getQueuedMessages() {
++            runtime.assertActive();
++            return runtime.getQueuedMessages();
++        },
++        replaceQueuedMessages(followUp) {
++            runtime.assertActive();
++            runtime.replaceQueuedMessages(followUp);
++        },
+         getSessionName() {
+             runtime.assertActive();
+             return runtime.getSessionName();
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+index 686ff326fd6adc6fc1ddcb89e46f6d790621a197..a5ee2cd7902d8f36d98ed21bc1f8843a156f0cb1 100644
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -170,6 +170,9 @@ export class ExtensionRunner {
+         this.runtime.setModel = actions.setModel;
+         this.runtime.getThinkingLevel = actions.getThinkingLevel;
+         this.runtime.setThinkingLevel = actions.setThinkingLevel;
++        // PATCH(pizzapi): expose pending-queue read/replace to extensions (remote queue sync).
++        this.runtime.getQueuedMessages = actions.getQueuedMessages;
++        this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages;
+         // Context actions (required)
+         this.getModel = contextActions.getModel;
+         this.isIdleFn = contextActions.isIdle;
+@@ -249,17 +252,24 @@ export class ExtensionRunner {
+         if (actions) {
+             this.waitForIdleFn = actions.waitForIdle;
+             this.newSessionHandler = actions.newSession;
++            // PATCH(pizzapi): make session controls available to ExtensionAPI callers.
++            this.runtime.newSession = (options) => this.newSessionHandler(options);
+             this.forkHandler = actions.fork;
++            this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+             this.navigateTreeHandler = actions.navigateTree;
+             this.switchSessionHandler = actions.switchSession;
++            this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+             this.reloadHandler = actions.reload;
+             return;
+         }
+         this.waitForIdleFn = async () => { };
+         this.newSessionHandler = async () => ({ cancelled: false });
++        this.runtime.newSession = (options) => this.newSessionHandler(options);
+         this.forkHandler = async () => ({ cancelled: false });
++        this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+         this.navigateTreeHandler = async () => ({ cancelled: false });
+         this.switchSessionHandler = async () => ({ cancelled: false });
++        this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+         this.reloadHandler = async () => { };
+     }
+     setUIContext(uiContext, mode = "print") {
+diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
+index 8ae1e52b8efa6c23ab1999b90b90dca85ed3f314..7941e67c47542fda8629c36ac03c495be17bbf9c 100644
+--- a/dist/core/extensions/types.d.ts
++++ b/dist/core/extensions/types.d.ts
+@@ -910,11 +910,32 @@ export interface ExtensionAPI {
+      */
+     sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
+         deliverAs?: "steer" | "followUp";
++        /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++        expandPromptTemplates?: boolean;
+     }): void;
+     /** Append a custom entry to the session for state persistence (not sent to LLM). */
+     appendEntry<T = unknown>(customType: string, data?: T): void;
+     /** Set the session display name (shown in session selector). */
+     setSessionName(name: string): void;
++    /** Start a new session. Available to PizzaPi remote event handlers. */
++    newSession(options?: {
++        parentSession?: string;
++        setup?: (sessionManager: SessionManager) => Promise<void>;
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Switch to a different session file. Available to PizzaPi remote event handlers. */
++    switchSession(sessionPath: string, options?: {
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Fork from a specific entry, creating a new session file. Available to PizzaPi remote event handlers. */
++    fork(entryId: string, options?: {
++        position?: "before" | "at";
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
++    /** PATCH(pizzapi): read the pending steering/follow-up queues (remote queue sync). */
++    getQueuedMessages(): { steering: string[]; followUp: string[]; };
++    /** PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals). */
++    replaceQueuedMessages(followUp: string[]): void;
+     /** Get the current session name, if set. */
+     getSessionName(): string | undefined;
+     /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
+@@ -1105,6 +1126,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+ }) => void;
+ export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
+     deliverAs?: "steer" | "followUp";
++    /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++    expandPromptTemplates?: boolean;
+ }) => void;
+ export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
+ export type SetSessionNameHandler = (name: string) => void;
+@@ -1162,6 +1185,9 @@ export interface ExtensionActions {
+     sendUserMessage: SendUserMessageHandler;
+     appendEntry: AppendEntryHandler;
+     setSessionName: SetSessionNameHandler;
++    newSession: ExtensionCommandContextActions["newSession"];
++    switchSession: ExtensionCommandContextActions["switchSession"];
++    fork: ExtensionCommandContextActions["fork"];
+     getSessionName: GetSessionNameHandler;
+     setLabel: SetLabelHandler;
+     getActiveTools: GetActiveToolsHandler;
+@@ -1172,6 +1198,9 @@ export interface ExtensionActions {
+     setModel: SetModelHandler;
+     getThinkingLevel: GetThinkingLevelHandler;
+     setThinkingLevel: SetThinkingLevelHandler;
++    /** PATCH(pizzapi): pending-queue read/replace for remote queue sync. */
++    getQueuedMessages: () => { steering: string[]; followUp: string[]; };
++    replaceQueuedMessages: (followUp: string[]) => void;
+ }
+ /**
+  * Actions for ExtensionContext (ctx.* in event handlers).
+diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
+index 720f0a354ca9d4125fffbee7866855d0ac9b101f..c544197f808d8a3d2ebbe81960db1122dedf2204 100644
+--- a/dist/core/model-resolver.js
++++ b/dist/core/model-resolver.js
+@@ -21,6 +21,7 @@ export const defaultModelPerProvider = {
+     "google-vertex": "gemini-3.1-pro-preview",
+     "github-copilot": "gpt-5.4",
+     openrouter: "moonshotai/kimi-k2.6",
++    "ollama-cloud": "glm-5.1",
+     "vercel-ai-gateway": "zai/glm-5.1",
+     xai: "grok-4.5",
+     groq: "openai/gpt-oss-120b",
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index e91e38f8bedfabb6e67305f9739277d1ebacde22..8ee1013bedc3895457115c714122c40b65871ed8 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -13,6 +13,7 @@ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveMode
+ export { type CreateModelRuntimeOptions, ModelRuntime, type ModelRuntimeAuthOverrides, } from "./core/model-runtime.ts";
+ export type { PackageManager, PathMetadata, ProgressCallback, ProgressEvent, ResolvedPaths, ResolvedResource, } from "./core/package-manager.ts";
+ export { DefaultPackageManager } from "./core/package-manager.ts";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
+ export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.ts";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
+ export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
+diff --git a/dist/index.js b/dist/index.js
+index a2ee19264ac2c192d67bb4a601aa32b63a508562..730bc336253592faacd434918c20a0c4969951db 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -13,6 +13,7 @@ export { ModelRegistry } from "./core/model-registry.js";
+ export { resolveCliModel, resolveModelScopeWithDiagnostics, } from "./core/model-resolver.js";
+ export { ModelRuntime, } from "./core/model-runtime.js";
+ export { DefaultPackageManager } from "./core/package-manager.js";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.js";
+ // SDK for programmatic usage
+ export { AgentSessionRuntime, 
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index 2fbfb484612c47b8653dc1459c6c3631ad1eb59a..58a55904d232c0d29eef2bf7683c81ef0d3d3f18 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -33,7 +33,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";
+ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
+ import { killTrackedDetachedChildren } from "../../utils/shell.js";
+ import { ensureTool } from "../../utils/tools-manager.js";
+-import { checkForNewPiVersion } from "../../utils/version-check.js";
+ import { ArminComponent } from "./components/armin.js";
+ import { AssistantMessageComponent } from "./components/assistant-message.js";
+ import { BashExecutionComponent } from "./components/bash-execution.js";
+@@ -587,12 +586,6 @@ export class InteractiveMode {
+                 .then(() => this.updateAvailableProviderCount())
+                 .catch(() => { });
+         }
+-        // Start version check asynchronously
+-        checkForNewPiVersion(this.version).then((newRelease) => {
+-            if (newRelease) {
+-                this.showNewVersionNotification(newRelease);
+-            }
+-        });
+         // Start package update check asynchronously
+         this.checkForPackageUpdates()
+             .then((updates) => {
+@@ -3169,29 +3162,6 @@ export class InteractiveMode {
+         this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+         this.ui.requestRender();
+     }
+-    showNewVersionNotification(release) {
+-        const action = theme.fg("accent", `${APP_NAME} update`);
+-        const updateInstruction = theme.fg("muted", `New version ${release.version} is available. Run `) + action;
+-        const changelogUrl = "https://pi.dev/changelog";
+-        const changelogLink = getCapabilities().hyperlinks
+-            ? hyperlink(theme.fg("accent", changelogUrl), changelogUrl)
+-            : theme.fg("accent", changelogUrl);
+-        const changelogLine = theme.fg("muted", "Changelog: ") + changelogLink;
+-        const note = release.note?.trim();
+-        this.chatContainer.addChild(new Spacer(1));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.chatContainer.addChild(new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}`, 1, 0));
+-        if (note) {
+-            this.chatContainer.addChild(new Spacer(1));
+-            this.chatContainer.addChild(new Markdown(note, 1, 0, this.getMarkdownThemeWithSettings(), {
+-                color: (text) => theme.fg("muted", text),
+-            }));
+-            this.chatContainer.addChild(new Spacer(1));
+-        }
+-        this.chatContainer.addChild(new Text(changelogLine, 1, 0));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.ui.requestRender();
+-    }
+     showPackageUpdateNotification(packages) {
+         const action = theme.fg("accent", `${APP_NAME} update --extensions`);
+         const updateInstruction = theme.fg("muted", "Package updates are available. Run ") + action;

--- a/patches/@earendil-works%2Fpi-tui@0.82.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.82.0.patch
@@ -1,0 +1,161 @@
+diff --git a/dist/terminal.js b/dist/terminal.js
+index 71db088cfd658bde7ecbd91c9842da248f7573a7..2cb9fe5dc35c16fdd1ff35b6c1fcb5101601be93 100644
+--- a/dist/terminal.js
++++ b/dist/terminal.js
+@@ -6,6 +6,100 @@ import { setKittyProtocolActive } from "./keys.js";
+ import { isNativeModifierPressed } from "./native-modifiers.js";
+ import { StdinBuffer } from "./stdin-buffer.js";
+ const cjsRequire = createRequire(import.meta.url);
++// PATCH(pizzapi): Windows console output lifecycle helpers
++function safeWindowsCall(fn) {
++    try {
++        return fn();
++    }
++    catch {
++        return undefined;
++    }
++}
++/**
++ * Create a Windows console lifecycle helper that enables VT output and UTF-8
++ * code pages on activation, and restores the original state on teardown.
++ */
++export function createWindowsConsoleLifecycle() {
++    let state = undefined;
++    return {
++        activate() {
++            if (process.platform !== "win32") {
++                return { stdoutMode: "unknown", stderrMode: "unknown", source: "pi-tui" };
++            }
++            const result = safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const GetConsoleCP = k32.func("uint32_t __stdcall GetConsoleCP()");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const GetConsoleOutputCP = k32.func("uint32_t __stdcall GetConsoleOutputCP()");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
++                const handleModes = { stdout: undefined, stderr: undefined };
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = new Uint32Array(1);
++                    if (GetConsoleMode(handle, mode)) {
++                        handleModes[key] = mode[0];
++                        SetConsoleMode(handle, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
++                    }
++                }
++                const inputCP = GetConsoleCP();
++                const outputCP = GetConsoleOutputCP();
++                SetConsoleCP(65001);
++                SetConsoleOutputCP(65001);
++                return { handleModes, inputCP, outputCP };
++            });
++            const stdoutOk = result?.handleModes?.stdout !== undefined;
++            const stderrOk = result?.handleModes?.stderr !== undefined;
++            const caps = {
++                stdoutMode: stdoutOk ? "unicode" : "ascii",
++                stderrMode: stderrOk ? "unicode" : "ascii",
++                source: "pi-tui",
++            };
++            state = result ?? undefined;
++            return caps;
++        },
++        restore() {
++            if (!state || process.platform !== "win32")
++                return;
++            safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = state.handleModes[key];
++                    if (mode !== undefined) {
++                        SetConsoleMode(handle, mode);
++                    }
++                }
++                if (state.inputCP !== undefined) {
++                    SetConsoleCP(state.inputCP);
++                }
++                if (state.outputCP !== undefined) {
++                    SetConsoleOutputCP(state.outputCP);
++                }
++            });
++            state = undefined;
++        },
++    };
++}
+ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
+ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
+ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
+@@ -49,6 +143,7 @@ export class ProcessTerminal {
+     stdinBuffer;
+     stdinDataHandler;
+     progressInterval;
++    windowsConsoleLifecycle;
+     writeLogPath = (() => {
+         const env = process.env.PI_TUI_WRITE_LOG || "";
+         if (!env)
+@@ -95,10 +190,29 @@ export class ProcessTerminal {
+         // events that lose modifier information. Must run AFTER setRawMode(true)
+         // since that resets console mode flags.
+         this.enableWindowsVTInput();
++        // PATCH(pizzapi): Windows console output lifecycle
++        this.setupWindowsConsole();
+         // Query Kitty keyboard protocol and fall back to modifyOtherKeys when DA confirms no Kitty response.
+         // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+         this.queryAndEnableKittyProtocol();
+     }
++    /**
++     * On Windows, set up VT output and UTF-8 code page for Unicode rendering,
++     * and publish a capability signal for downstream renderers.
++     */
++    setupWindowsConsole() {
++        if (process.platform !== "win32")
++            return;
++        try {
++            this.windowsConsoleLifecycle = createWindowsConsoleLifecycle();
++            const result = this.windowsConsoleLifecycle.activate();
++            const globalObj = globalThis;
++            globalObj.__PI_WINDOWS_CONSOLE_CAPS__ = result;
++        }
++        catch {
++            // Best-effort: if console API setup fails, leave it alone
++        }
++    }
+     /**
+      * Set up StdinBuffer to split batched input into individual sequences.
+      * This ensures components receive single events, making matchesKey/isKeyRelease work correctly.
+@@ -350,6 +464,17 @@ export class ProcessTerminal {
+             process.stdout.removeListener("resize", this.resizeHandler);
+             this.resizeHandler = undefined;
+         }
++        // PATCH(pizzapi): restore Windows console state
++        if (this.windowsConsoleLifecycle) {
++            try {
++                this.windowsConsoleLifecycle.restore();
++            }
++            catch {
++                // Best-effort restore
++            }
++            this.windowsConsoleLifecycle = undefined;
++            delete globalThis.__PI_WINDOWS_CONSOLE_CAPS__;
++        }
+         // Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
+         // re-interpreted after raw mode is disabled. This fixes a race condition
+         // where Ctrl+D could close the parent shell over SSH.

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,116 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @earendil-works/pi-agent-core@0.80.6
+## @earendil-works/pi-agent-core@0.82.0
+
+Same runtime fix as 0.80.6, ported forward unchanged — neither patched file
+(`dist/agent.js`, `dist/agent-loop.js`) changed upstream between 0.80.6 and
+0.82.0.
+
+## @earendil-works/pi-tui@0.82.0
+
+Same Windows console lifecycle patch as 0.80.6, ported forward unchanged —
+`dist/terminal.js` didn't change upstream between 0.80.6 and 0.82.0.
+
+## @earendil-works/pi-ai@0.82.0
+
+Same intent as 0.80.6 (Anthropic web-search passthrough, Claude Code
+credentials fallback, Ollama Cloud support, retryable-JSON-parse patterns),
+ported to upstream's restructured 0.82.0 layout:
+
+- The Anthropic OAuth module moved from `dist/utils/oauth/anthropic.js` to
+  `dist/auth/oauth/anthropic.js`, and its shape changed: the old
+  `anthropicOAuthProvider.refreshToken(credentials)` object is gone, replaced
+  by `anthropicOAuth.refresh(credential)` on the same `anthropicOAuth` object
+  used for login. The Claude Code Keychain/file fallback now lives inside
+  that `refresh()` method.
+- `dist/models.generated.js`'s `OLLAMA_CLOUD_MODELS` constant is now exported
+  (it was module-private in 0.80.6) so the new provider factory below can
+  import it.
+- **New in 0.82.0:** upstream restructured how built-in providers register —
+  `dist/providers/all.js`'s `builtinProviders()` now assembles one `Provider`
+  object (id, name, baseUrl, auth, models, api) per provider, rather than
+  coding-agent statically listing provider display names
+  (`provider-display-names.js`, removed upstream — see the pi-coding-agent
+  entry below). This patch adds an `ollamaCloudProvider()` factory function to
+  `dist/providers/all.js` (and its `.d.ts`) following the same pattern as
+  `openrouterProvider()`/`togetherProvider()`, registers it in
+  `builtinProviders()`, and exports `OLLAMA_CLOUD_MODELS`/adds an
+  `ollama-cloud` entry to `models.generated.d.ts` so the factory type-checks.
+  It's inlined into the existing `all.js` file rather than a new
+  `providers/ollama-cloud.js` file for the same `bun patch`-can't-add-nested-
+  files reason as `OLLAMA_CLOUD_MODELS` itself (see the 0.80.6 note below).
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/api/anthropic-messages.js` | Same Anthropic web-search patch as 0.80.6 (unchanged file) |
+| `dist/auth/oauth/anthropic.js` | Claude Code Keychain/file credentials fallback, now inside `anthropicOAuth.refresh()` |
+| `dist/env-api-keys.js` | Same `OLLAMA_API_KEY` recognition as 0.80.6 (unchanged file) |
+| `dist/models.generated.js` | Same `OLLAMA_CLOUD_MODELS` catalog as 0.80.6, now exported |
+| `dist/models.generated.d.ts` | Same `ollama-cloud` typing as 0.80.6 (unchanged file) |
+| `dist/providers/all.js` / `.d.ts` | **New**: `ollamaCloudProvider()` factory, registered in `builtinProviders()` |
+| `dist/types.d.ts` | Same `ollama-cloud` `KnownProvider` addition as 0.80.6 (unchanged file) |
+| `dist/utils/retry.js` | Same retryable-JSON-parse patterns as 0.80.6 (unchanged file) |
+
+## @earendil-works/pi-coding-agent@0.82.0
+
+Same PizzaPi integration changes as 0.80.6, ported forward, with two upstream
+removals absorbed elsewhere rather than restored:
+
+- **`dist/core/provider-display-names.js` was deleted upstream.** Provider
+  display names now come from each provider's own `name` field (set at
+  registration in pi-ai's `builtinProviders()`) via
+  `ModelRegistry.getProviderDisplayName()` → `runtime.getProvider(id)?.name`.
+  The `Ollama Cloud` display name patch moved to the pi-ai `all.js` patch
+  above (`ollamaCloudProvider()`'s `name` field) instead of living here.
+- **`AuthStorage` (and its associated types) is no longer exported from the
+  package root**, and the class itself was rewritten to a plain
+  `CredentialStore` (read/list/modify/delete) with all OAuth-refresh/env-
+  fallback/runtime-override orchestration moved into `ModelRuntime`. Only
+  `readStoredCredential(providerId, authPath)` (a stateless raw JSON read,
+  unchanged in shape) remains exported. This patch does **not** try to
+  restore the old export — the class it pointed to doesn't exist in the old
+  shape anymore. Instead, `packages/cli` callers were migrated to
+  `ModelRuntime`/`ModelRegistry`/`readStoredCredential` (see below).
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/config.js` | Same `.pizzapi` config-dir / flat-directory / `PIZZAPI_CHANGELOG_PATH` overrides as 0.80.6 |
+| `dist/core/agent-session.js` | Same `expandPromptTemplates` opt-in as 0.80.6 |
+| `dist/core/extensions/loader.js` / `dist/core/extensions/runner.js` | Same `newSession()`/`switchSession()`/`fork()` general-API exposure as 0.80.6 |
+| `dist/core/extensions/types.d.ts` | Same `ExtensionAPI`/`ExtensionActions` typings as 0.80.6 |
+| `dist/core/model-resolver.js` | Same `ollama-cloud` default model (`glm-5.1`) as 0.80.6 |
+| `dist/modes/interactive/interactive-mode.js` | Same version-notification-UI removal as 0.80.6 (upstream shifted a few lines; hunk re-applied manually) |
+| `dist/index.js` / `dist/index.d.ts` | Same `handlePackageCommand`/`handleConfigCommand` re-export as 0.80.6 |
+
+**No longer present (see above for why):** `dist/core/provider-display-names.js`.
+
+### packages/cli auth call-site migration (not a patch — our own source)
+
+Because `AuthStorage` and `ModelRegistry.create()`/`.authStorage` are gone,
+every `packages/cli` call site that constructed or read through them was
+updated to the new API:
+
+| Old | New |
+|-----|-----|
+| `AuthStorage.create(authPath)` + `ModelRegistry.create(authStorage, modelsPath)` | `await ModelRuntime.create({ authPath, modelsPath })` + `new ModelRegistry(runtime)` |
+| `authStorage.get(provider)` (raw credential read) | `readStoredCredential(provider, authPath)` (same shape, now a plain exported function) |
+| `authStorage.hasAuth(provider)` | `modelRegistry.getProviderAuthStatus(provider).configured` (or `runtime.hasConfiguredAuth(provider)` where only the runtime is in scope) |
+| `ctx.modelRegistry.authStorage.get(provider)` (extension auth-source detection) | `ctx.modelRegistry.isUsingOAuth(ctx.model)` + `ctx.modelRegistry.getProviderAuthStatus(provider)` |
+| `authStorage.getApiKey("google-gemini-cli")` (a synthetic, non-model-registry credential slot used only for usage reporting) | `readStoredCredential("google-gemini-cli", authPath)` — this slot is api_key-only in practice (no real OAuth provider registered for it), so the raw `.key` read is behavior-preserving |
+| `worker.ts`'s `createAuthStorageWithRetry()` (lock-contention retry wrapper around `AuthStorage.create()`, feeding `createAgentSession({ authStorage })`) | `createModelRuntimeWithRetry()`, same retry/backoff/lockless-fallback structure around `ModelRuntime.create()` + `runtime.listCredentials()`, feeding `createAgentSession({ modelRuntime })`. The last-resort in-memory snapshot tier uses a small local class structurally matching pi-ai's (unexported) `CredentialStore` interface, since there's no public in-memory credential store constructor anymore. |
+
+Affected files: `models-command.ts`, `index.ts`, `runner/daemon.ts`,
+`runner/runner-ollama-models-cache.ts`, `runner/runner-usage-cache.ts`,
+`runner/worker.ts`, `extensions/ollama-web-tools.ts`,
+`extensions/remote-auth-source.ts`, `extensions/remote-provider-usage.ts`,
+`extensions/spawn-session.ts`, plus their tests.
+
+## @earendil-works/pi-coding-agent@0.80.6
 
 Adds one PizzaPi-specific runtime fix:
 
@@ -302,6 +411,17 @@ syntactic validity. Run with `bun test packages/cli/src/patches.test.ts`.
 this patch can be deleted.
 
 ## Previously patched (no longer needed)
+
+### @earendil-works/*@0.80.6 (replaced by 0.82.0 patches)
+
+The 0.80.6 patch files are retained in this directory for history but are no
+longer referenced by `patchedDependencies`. See the 0.82.0 entries above for
+what changed in the port: `pi-agent-core` and `pi-tui` carried over unchanged;
+`pi-ai` needed a new `ollamaCloudProvider()` registration (upstream moved from
+static display-name/model-catalog data to per-provider factory objects) and an
+Anthropic OAuth module path/shape change; `pi-coding-agent` lost the
+`provider-display-names.js` file and the top-level `AuthStorage` export
+entirely, requiring `packages/cli` call-site migrations to `ModelRuntime`.
 
 ### @earendil-works/*@0.80.5 (replaced by 0.80.6 patches)
 


### PR DESCRIPTION
… AuthStorage API

- pi-agent-core, pi-tui: no upstream changes to patched files; patches carry over verbatim.
- pi-ai: same intent as 0.80.6 (Anthropic web-search passthrough, Claude Code credentials fallback, Ollama Cloud support, retryable-JSON-parse patterns). Anthropic OAuth module moved to dist/auth/oauth/anthropic.js with a reshaped anthropicOAuth.refresh() API. Upstream restructured built-in provider registration into per-provider factory objects in dist/providers/all.js, so this patch adds an ollamaCloudProvider() factory there instead of a static display-name entry.
- pi-coding-agent: dist/core/provider-display-names.js was deleted upstream (display names now come from each provider's own .name); the top-level AuthStorage export (and the class's OAuth-refresh/hasAuth/getApiKey API) was removed entirely, replaced by ModelRuntime for auth orchestration and a stateless readStoredCredential() for raw reads.
- Migrated every packages/cli call site off AuthStorage/ModelRegistry.create to ModelRuntime.create()/new ModelRegistry(runtime)/readStoredCredential(), including worker.ts's lock-contention retry wrapper (now wraps ModelRuntime.create() + listCredentials(), with a small local CredentialStore-shaped class for the lockless in-memory fallback tier, since pi-ai doesn't export an in-memory credential store publicly). Updated the affected tests' mocks to match.

Verified: full bun install from scratch, bun run typecheck, bun run test (all green except a pre-existing macOS-only /tmp-vs-os.tmpdir() sandbox test flake unrelated to this change, confirmed present on main too).