### PR TITLE
fix(ui-tests): TunnelPanel test owns its localStorage (unblocks CI)

### DIFF
--- a/packages/ui/src/components/TunnelPanel.test.tsx
+++ b/packages/ui/src/components/TunnelPanel.test.tsx
@@ -21,6 +21,9 @@ const win = new Window({ url: "http://localhost/" });
 (globalThis as any).Node = win.Node;
 (globalThis as any).SVGElement = win.SVGElement;
 (globalThis as any).MutationObserver = win.MutationObserver;
+// Own localStorage: without this the panel inherits another file's storage and
+// a stray pizzapi.serverUrl flips useTunnelSrc into mobile (token-fetch) mode.
+(globalThis as any).localStorage = win.localStorage;
 (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
 // ResizeObserver stub — guards against transitive deps that use it
 (globalThis as any).ResizeObserver = class {

--- a/packages/ui/src/lib/mobile-fetch.test.ts
+++ b/packages/ui/src/lib/mobile-fetch.test.ts
@@ -5,7 +5,7 @@
  *  - Request inputs are rebuilt against the resolved URL, preserving method,
  *    headers, and body (spreading a Request drops all of these).
  */
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
 import { Window } from "happy-dom";
 
 const SERVER_URL = "https://relay.example.com";
@@ -71,6 +71,13 @@ beforeEach(() => {
     localStorage.clear();
     _resetMobileRuntimeCache();
     seedMobile();
+});
+
+// ponytail: bun shares globalThis across test files, so leaving
+// pizzapi.serverUrl set puts every later file into "mobile bundled" mode.
+afterAll(() => {
+    localStorage.clear();
+    _resetMobileRuntimeCache();
 });
 
 describe("patchedFetch — api key gating", () => {


### PR DESCRIPTION
`TunnelPanel.test.tsx` never set `globalThis.localStorage`, so it inherited whatever happy-dom window an earlier test file installed. `mobile-fetch.test.ts` seeds `pizzapi.serverUrl` and never clears it, which flips `useTunnelSrc` into mobile token-fetch mode — no iframe renders and `clears previewPort on disconnect` fails.

Test file order is filesystem-dependent, hence green on macOS and red on Linux CI. Blocks #620 and #622.

- `TunnelPanel.test.tsx`: install its own `win.localStorage`
- `mobile-fetch.test.ts`: `afterAll` clears the seeded serverUrl

Repro: a scratch test that sets `pizzapi.serverUrl` before TunnelPanel reproduces the exact CI failure; with the fix it passes.