### PR TITLE
fix(runner): flush extension providers into ModelRuntime before session creation

### DIFF
--- a/packages/cli/src/runner/apply-default-model.test.ts
+++ b/packages/cli/src/runner/apply-default-model.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applySettingsDefaultModel, type DefaultModelSession } from "./apply-default-model.js";
+import { applySettingsDefaultModel, flushPendingExtensionProviders, type DefaultModelSession } from "./apply-default-model.js";
 
 function makeSession(overrides: Partial<{
     current: { provider: string; id: string } | undefined;
@@ -124,5 +124,67 @@ describe("applySettingsDefaultModel", () => {
         const { session, setCalls } = makeSession({ messages: [{ role: "user" }] });
         expect(await applySettingsDefaultModel(session)).toBe(false);
         expect(setCalls).toEqual([]);
+    });
+});
+
+describe("flushPendingExtensionProviders", () => {
+    function makeTargets(pending: { name: string; config: unknown; extensionPath: string }[], nativePending: { provider: unknown; extensionPath: string }[] = [], failFor: string[] = []) {
+        const runtime = {
+            pendingProviderRegistrations: pending,
+            pendingNativeProviderRegistrations: nativePending,
+        };
+        const registered: string[] = [];
+        const warnings: string[] = [];
+        return {
+            runtime,
+            registered,
+            warnings,
+            targets: {
+                loader: { getExtensions: () => ({ runtime }) },
+                modelRuntime: {
+                    registerProvider(name: string) {
+                        if (failFor.includes(name)) throw new Error(`boom ${name}`);
+                        registered.push(name);
+                    },
+                    registerNativeProvider(provider: unknown) {
+                        registered.push(`native:${(provider as { name: string }).name}`);
+                    },
+                },
+                warn: (m: string) => { warnings.push(m); },
+            },
+        };
+    }
+
+    test("registers queued providers into the runtime and clears the queues", () => {
+        const { targets, runtime, registered } = makeTargets(
+            [{ name: "claude-subscription", config: {}, extensionPath: "/ext/a" }],
+            [{ provider: { name: "native-x" }, extensionPath: "/ext/b" }],
+        );
+        const count = flushPendingExtensionProviders(targets);
+        expect(count).toBe(2);
+        expect(registered).toEqual(["claude-subscription", "native:native-x"]);
+        expect(runtime.pendingProviderRegistrations).toEqual([]);
+        expect(runtime.pendingNativeProviderRegistrations).toEqual([]);
+    });
+
+    test("a failing registration warns but does not block the rest", () => {
+        const { targets, registered, warnings } = makeTargets(
+            [
+                { name: "bad", config: {}, extensionPath: "/ext/bad" },
+                { name: "good", config: {}, extensionPath: "/ext/good" },
+            ],
+            [],
+            ["bad"],
+        );
+        const count = flushPendingExtensionProviders(targets);
+        expect(count).toBe(1);
+        expect(registered).toEqual(["good"]);
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain("/ext/bad");
+    });
+
+    test("no-op when queues are empty", () => {
+        const { targets } = makeTargets([]);
+        expect(flushPendingExtensionProviders(targets)).toBe(0);
     });
 });

--- a/packages/cli/src/runner/apply-default-model.ts
+++ b/packages/cli/src/runner/apply-default-model.ts
@@ -15,6 +15,52 @@
  */
 import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 
+interface PendingProviderRuntime {
+    pendingProviderRegistrations: Array<{ name: string; config: unknown; extensionPath: string }>;
+    pendingNativeProviderRegistrations: Array<{ provider: unknown; extensionPath: string }>;
+}
+
+export interface ProviderFlushTargets {
+    loader: { getExtensions(): { runtime: PendingProviderRuntime } };
+    modelRuntime: {
+        registerProvider(name: string, config: unknown): void;
+        registerNativeProvider(provider: unknown): void;
+    };
+    warn: (message: string) => void;
+}
+
+/**
+ * Flush provider registrations queued by extension factories into the
+ * ModelRuntime — mirrors pi 0.82's createAgentSessionServices(), which the
+ * worker bypasses by building its own loader + ModelRuntime. Without this,
+ * extension providers (e.g. claude-subscription) are invisible to
+ * findInitialModel and new sessions fall back to the first built-in provider
+ * default (openai-codex/gpt-5.5). Returns the number of providers registered.
+ */
+export function flushPendingExtensionProviders({ loader, modelRuntime, warn }: ProviderFlushTargets): number {
+    const runtime = loader.getExtensions().runtime;
+    let registered = 0;
+    for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
+        try {
+            modelRuntime.registerProvider(name, config);
+            registered++;
+        } catch (e) {
+            warn(`extension "${extensionPath}" provider registration failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+    runtime.pendingProviderRegistrations = [];
+    for (const { provider, extensionPath } of runtime.pendingNativeProviderRegistrations) {
+        try {
+            modelRuntime.registerNativeProvider(provider);
+            registered++;
+        } catch (e) {
+            warn(`extension "${extensionPath}" native provider registration failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+    runtime.pendingNativeProviderRegistrations = [];
+    return registered;
+}
+
 interface ModelRef {
     provider: string;
     id: string;

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -9,7 +9,7 @@ import { setRegisteredCommandsProvider } from "../extensions/command-introspecti
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
 import { headlessFork } from "./worker-fork.js";
-import { applySettingsDefaultModel } from "./apply-default-model.js";
+import { applySettingsDefaultModel, flushPendingExtensionProviders } from "./apply-default-model.js";
 import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
@@ -392,6 +392,14 @@ async function main(): Promise<void> {
     const authPath = join(agentDir, "auth.json");
     const modelsPath = join(agentDir, "models.json");
     const modelRuntime = await createModelRuntimeWithRetry(authPath, modelsPath);
+
+    // pi 0.82 moved the extension-provider flush out of the AgentSession
+    // constructor into createAgentSessionServices(), which this worker bypasses
+    // (it builds its own loader + ModelRuntime). Flush here so findInitialModel
+    // inside createAgentSession can resolve extension providers (e.g.
+    // claude-subscription) instead of falling back to openai-codex/gpt-5.5.
+    const flushed = flushPendingExtensionProviders({ loader, modelRuntime, warn: logWarn });
+    if (flushed > 0) logInfo(`registered ${flushed} extension provider(s) before session creation`);
 
     // ── Auth diagnostics — log credential state before first API call ────
     // This helps diagnose intermittent "No API key found" failures in


### PR DESCRIPTION
## Problem

Since the pi 0.80.6 → 0.82.0 bump (fb533549, Jul 24), every new web-UI session started on `openai-codex/gpt-5.5` instead of the settings default (`claude-subscription/claude-opus-5`).

## Root cause

pi 0.82 moved the `pendingProviderRegistrations` flush out of the `AgentSession` constructor into `createAgentSessionServices()` / `ExtensionRunner.bindActions`. The worker bypasses that path — it builds its own `DefaultResourceLoader` + `ModelRuntime` and passes them to `createAgentSession()`, which never flushes. So:

1. `findInitialModel` couldn't see extension-registered providers (e.g. minimalcc-pi's `claude-subscription`) → silent fallback to the first built-in provider default (`gpt-5.5`)
2. The existing `applySettingsDefaultModel` safety net ran right after `createAgentSession` — also before the flush (which now happens during `bindExtensions`) — so it silently declined too

Evidence: "applied settings default model" runner-log entries stop dead at the daemon restart on the new version (Jul 24 17:39).

## Fix

`flushPendingExtensionProviders()` in `apply-default-model.ts`, called in worker boot right after `loader.reload()` and before `createAgentSession()` — mirrors exactly what upstream's `createAgentSessionServices()` does (register queued provider + native-provider registrations into the `ModelRuntime`, clear the queues, warn on per-provider failure).

`applySettingsDefaultModel` stays as belt-and-suspenders.

## Verification

- `bun test packages/cli/src/runner/apply-default-model.test.ts` — 10 pass (3 new tests for the flush helper)
- `tsc --noEmit` clean in packages/cli
- End-to-end: spawned a fresh session with no explicit model — log shows `registered 1 extension provider(s) before session creation` and the session boots directly on `claude-subscription/claude-opus-5`, confirmed by its Anthropic request bodies. Pre-fix control session fell back to gpt-5.5.

New sessions pick the fix up immediately (workers run repo source); no daemon restart required.
