### PR TITLE
chore(deps): bump pi-* to 0.82.1 + fix Anthropic OAuth in standalone binaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-updater": "^8",
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
-        "@earendil-works/pi-tui": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -40,13 +40,14 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-coding-agent": "^0.82.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -83,8 +84,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -112,8 +113,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -200,10 +201,10 @@
     },
   },
   "patchedDependencies": {
-    "@earendil-works/pi-ai@0.82.0": "patches/@earendil-works%2Fpi-ai@0.82.0.patch",
-    "@earendil-works/pi-coding-agent@0.82.0": "patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch",
-    "@earendil-works/pi-agent-core@0.82.0": "patches/@earendil-works%2Fpi-agent-core@0.82.0.patch",
-    "@earendil-works/pi-tui@0.82.0": "patches/@earendil-works%2Fpi-tui@0.82.0.patch",
+    "@earendil-works/pi-agent-core@0.82.1": "patches/@earendil-works%2Fpi-agent-core@0.82.1.patch",
+    "@earendil-works/pi-ai@0.82.1": "patches/@earendil-works%2Fpi-ai@0.82.1.patch",
+    "@earendil-works/pi-tui@0.82.1": "patches/@earendil-works%2Fpi-tui@0.82.1.patch",
+    "@earendil-works/pi-coding-agent@0.82.1": "patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -584,13 +585,13 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.1", "@earendil-works/pi-ai": "^0.82.1", "@earendil-works/pi-tui": "^0.82.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-updater": "^8",
-    "@earendil-works/pi-agent-core": "^0.82.0",
-    "@earendil-works/pi-ai": "^0.82.0",
-    "@earendil-works/pi-tui": "^0.82.0",
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-tui": "^0.82.1",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -70,9 +70,9 @@
   },
   "version": "",
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.82.0": "patches/@earendil-works%2Fpi-agent-core@0.82.0.patch",
-    "@earendil-works/pi-tui@0.82.0": "patches/@earendil-works%2Fpi-tui@0.82.0.patch",
-    "@earendil-works/pi-ai@0.82.0": "patches/@earendil-works%2Fpi-ai@0.82.0.patch",
-    "@earendil-works/pi-coding-agent@0.82.0": "patches/@earendil-works%2Fpi-coding-agent@0.82.0.patch"
+    "@earendil-works/pi-agent-core@0.82.1": "patches/@earendil-works%2Fpi-agent-core@0.82.1.patch",
+    "@earendil-works/pi-tui@0.82.1": "patches/@earendil-works%2Fpi-tui@0.82.1.patch",
+    "@earendil-works/pi-ai@0.82.1": "patches/@earendil-works%2Fpi-ai@0.82.1.patch",
+    "@earendil-works/pi-coding-agent@0.82.1": "patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,8 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.82.0",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import {
     readStoredCredential,
     SessionManager,
 } from "@earendil-works/pi-coding-agent";
+import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
 import { join } from "path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
@@ -22,6 +23,9 @@ import { runSetup } from "./setup.js";
 import { createLogger, initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 
 const log = createLogger("cli");
+
+// ponytail: standalone binaries can't resolve pi-ai's dynamic OAuth imports; register the statically bundled flows.
+registerBunOAuthFlows();
 
 async function main() {
     const args = process.argv.slice(2);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0"
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@earendil-works%2Fpi-agent-core@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-agent-core@0.82.1.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/agent-loop.js b/dist/agent-loop.js
+index 5b5da78..e562421 100644
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -102,6 +102,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
+                 }
+                 pendingMessages = [];
+             }
++            // PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response
++            currentContext.systemPrompt = currentContext.__getLatestSystemPrompt?.() ?? currentContext.systemPrompt;
++            currentContext.tools = currentContext.__getLatestTools?.() ?? currentContext.tools;
+             // Stream assistant response
+             const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
+             newMessages.push(message);
+diff --git a/dist/agent.js b/dist/agent.js
+index e26aedf..673e432 100644
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -275,6 +275,9 @@ export class Agent {
+     createContextSnapshot() {
+         return {
+             systemPrompt: this._state.systemPrompt,
++            // PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state
++            __getLatestSystemPrompt: () => this._state.systemPrompt,
++            __getLatestTools: () => this._state.tools.slice(),
+             messages: this._state.messages.slice(),
+             tools: this._state.tools.slice(),
+         };

--- a/patches/@earendil-works%2Fpi-ai@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.82.1.patch
@@ -1,0 +1,373 @@
+diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
+index 70ead54..8de4f08 100644
+--- a/dist/api/anthropic-messages.js
++++ b/dist/api/anthropic-messages.js
+@@ -438,6 +438,29 @@ export const stream = (model, context, options) => {
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    else if (event.content_block.type === "server_tool_use") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            partialJson: "",
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -479,6 +502,10 @@ export const stream = (model, context, options) => {
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -495,6 +522,16 @@ export const stream = (model, context, options) => {
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                }
++                                catch {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -750,6 +787,22 @@ function buildParams(model, context, isOAuthToken, options) {
+             ...convertTools(deferredTools, isOAuthToken, compat.supportsEagerToolInputStreaming, compat.supportsStrictTools, undefined, true),
+         ];
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
++        if (!params.tools)
++            params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0)
++            webSearchTool.max_uses = maxUses;
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive, budget-based, or explicitly disabled.
+     if (model.reasoning) {
+         if (options?.thinkingEnabled) {
+@@ -878,7 +931,23 @@ function convertMessages(transformedMessages, isOAuthToken, cacheControl, allowE
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -989,6 +1058,10 @@ function convertTools(tools, isOAuthToken, supportsEagerToolInputStreaming, supp
+     if (!tools)
+         return [];
+     return tools.map((tool, index) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const strict = resolveJsonSchemaStrictSampling(tool, supportsStrictTools);
+         const schema = tool.parameters;
+         const legacyInputSchema = {
+diff --git a/dist/auth/oauth/anthropic.js b/dist/auth/oauth/anthropic.js
+index 05ba3fc..05b3ac2 100644
+--- a/dist/auth/oauth/anthropic.js
++++ b/dist/auth/oauth/anthropic.js
+@@ -291,10 +291,48 @@ async function refreshAnthropicToken(refreshToken) {
+         expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+     };
+ }
++// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
++async function tryReadClaudeCodeCredentials() {
++    try {
++        if (process.platform === "darwin") {
++            const { execSync } = await import("node:child_process");
++            const raw = execSync(`security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`, { encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
++            if (raw) {
++                const cc = JSON.parse(raw)?.claudeAiOauth;
++                if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++                    return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++                }
++            }
++        }
++    }
++    catch {
++    }
++    try {
++        const [{ readFileSync }, { join }, { homedir }] = await Promise.all([
++            import("node:fs"),
++            import("node:path"),
++            import("node:os"),
++        ]);
++        const cc = JSON.parse(readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"))?.claudeAiOauth;
++        if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++            return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++        }
++    }
++    catch {
++    }
++    return null;
++}
+ export const anthropicOAuth = {
+     name: "Anthropic (Claude Pro/Max)",
+     login: loginAnthropic,
+-    refresh: (credential) => refreshAnthropicToken(credential.refresh),
++    async refresh(credential) {
++        // PATCH(pizzapi): try Claude Code credentials first
++        const ccCreds = await tryReadClaudeCodeCredentials();
++        if (ccCreds) {
++            return ccCreds;
++        }
++        return refreshAnthropicToken(credential.refresh);
++    },
+     async toAuth(credential) {
+         return { apiKey: credential.access };
+     },
+diff --git a/dist/env-api-keys.js b/dist/env-api-keys.js
+index 942d630..9c57263 100644
+--- a/dist/env-api-keys.js
++++ b/dist/env-api-keys.js
+@@ -84,6 +84,7 @@ function getApiKeyEnvVars(provider) {
+         xai: "XAI_API_KEY",
+         radius: "RADIUS_API_KEY",
+         openrouter: "OPENROUTER_API_KEY",
++        "ollama-cloud": "OLLAMA_API_KEY",
+         "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+         zai: "ZAI_API_KEY",
+         "zai-coding-cn": "ZAI_CODING_CN_API_KEY",
+diff --git a/dist/models.generated.d.ts b/dist/models.generated.d.ts
+index 17a47cd..8640c18 100644
+--- a/dist/models.generated.d.ts
++++ b/dist/models.generated.d.ts
+@@ -62,6 +62,11 @@ export declare const MODELS: {
+     readonly "opencode": typeof OPENCODE_MODELS;
+     readonly "opencode-go": typeof OPENCODE_GO_MODELS;
+     readonly "openrouter": typeof OPENROUTER_MODELS;
++    // PATCH(pizzapi): Ollama Cloud provider models
++    readonly "ollama-cloud": Record<string, import("./types.ts").Model<"openai-completions"> & {
++        id: string;
++        provider: "ollama-cloud";
++    }>;
+     readonly "qwen-token-plan": typeof QWEN_TOKEN_PLAN_MODELS;
+     readonly "qwen-token-plan-cn": typeof QWEN_TOKEN_PLAN_CN_MODELS;
+     readonly "together": typeof TOGETHER_MODELS;
+diff --git a/dist/models.generated.js b/dist/models.generated.js
+index 2979df5..ef16ae7 100644
+--- a/dist/models.generated.js
++++ b/dist/models.generated.js
+@@ -37,6 +37,73 @@ import { XIAOMI_TOKEN_PLAN_CN_MODELS } from "./providers/xiaomi-token-plan-cn.mo
+ import { XIAOMI_TOKEN_PLAN_SGP_MODELS } from "./providers/xiaomi-token-plan-sgp.models.js";
+ import { ZAI_MODELS } from "./providers/zai.models.js";
+ import { ZAI_CODING_CN_MODELS } from "./providers/zai-coding-cn.models.js";
++// PATCH(pizzapi): Ollama Cloud provider models. Sourced from the OpenAI-compatible
++// Ollama Cloud list endpoint (https://ollama.com/v1/models) with context windows
++// and capabilities from https://ollama.com/api/show with the corresponding
++// :cloud/-cloud model name. Cost metadata is zero until Ollama publishes
++// machine-usable per-token pricing.
++const OLLAMA_BASE_URL = "https://ollama.com/v1";
++const OLLAMA_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
++const OLLAMA_COMPAT = { supportsStore: false, supportsDeveloperRole: false, supportsReasoningEffort: false, supportsUsageInStreaming: true, supportsLongCacheRetention: false, supportsStrictMode: false, maxTokensField: "max_tokens" };
++function createOllamaModel(id, name, { reasoning = false, input = ["text"], contextWindow = 128000, maxTokens = 16384 } = {}) {
++    return {
++        id,
++        name,
++        api: "openai-completions",
++        provider: "ollama-cloud",
++        baseUrl: OLLAMA_BASE_URL,
++        compat: OLLAMA_COMPAT,
++        reasoning,
++        input,
++        cost: OLLAMA_ZERO_COST,
++        contextWindow,
++        maxTokens,
++    };
++}
++export const OLLAMA_CLOUD_MODELS = {
++    "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
++    "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 524288, maxTokens: 32768 }),
++    "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "gemini-3-flash-preview": createOllamaModel("gemini-3-flash-preview", "Gemini 3 Flash Preview", { reasoning: true, input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536 }),
++    "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:27b": createOllamaModel("gemma3:27b", "Gemma 3 27B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma4:31b": createOllamaModel("gemma4:31b", "Gemma 4 31B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "glm-4.6": createOllamaModel("glm-4.6", "GLM 4.6", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-4.7": createOllamaModel("glm-4.7", "GLM 4.7", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-5": createOllamaModel("glm-5", "GLM 5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "glm-5.1": createOllamaModel("glm-5.1", "GLM 5.1", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "gpt-oss:120b": createOllamaModel("gpt-oss:120b", "GPT-OSS 120B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "gpt-oss:20b": createOllamaModel("gpt-oss:20b", "GPT-OSS 20B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.7-code": createOllamaModel("kimi-k2.7-code", "Kimi K2.7 Code", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: false, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m3": createOllamaModel("minimax-m3", "MiniMax M3", { reasoning: true, input: ["text", "image"], contextWindow: 524288, maxTokens: 32768 }),
++    "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-ultra": createOllamaModel("nemotron-3-ultra", "Nemotron 3 Ultra", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder-next": createOllamaModel("qwen3-coder-next", "Qwen 3 Coder Next", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder:480b": createOllamaModel("qwen3-coder:480b", "Qwen 3 Coder 480B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-next:80b": createOllamaModel("qwen3-next:80b", "Qwen 3 Next 80B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b": createOllamaModel("qwen3-vl:235b", "Qwen 3 VL 235B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b-instruct": createOllamaModel("qwen3-vl:235b-instruct", "Qwen 3 VL 235B Instruct", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3.5:397b": createOllamaModel("qwen3.5:397b", "Qwen 3.5 397B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 32768, maxTokens: 16384 }),
++};
+ export const MODELS = {
+     "amazon-bedrock": AMAZON_BEDROCK_MODELS,
+     "ant-ling": ANT_LING_MODELS,
+@@ -64,6 +131,7 @@ export const MODELS = {
+     "opencode": OPENCODE_MODELS,
+     "opencode-go": OPENCODE_GO_MODELS,
+     "openrouter": OPENROUTER_MODELS,
++    "ollama-cloud": OLLAMA_CLOUD_MODELS,
+     "qwen-token-plan": QWEN_TOKEN_PLAN_MODELS,
+     "qwen-token-plan-cn": QWEN_TOKEN_PLAN_CN_MODELS,
+     "together": TOGETHER_MODELS,
+diff --git a/dist/providers/all.d.ts b/dist/providers/all.d.ts
+index b92d914..20aa3a0 100644
+--- a/dist/providers/all.d.ts
++++ b/dist/providers/all.d.ts
+@@ -4,6 +4,9 @@ import { type CreateModelsOptions, type MutableModels, type Provider } from "../
+ import type { Api, Model } from "../types.ts";
+ import { radiusProvider } from "./radius.ts";
+ export { radiusProvider };
++// PATCH(pizzapi): Ollama Cloud provider factory (see all.js for why it's
++// inlined here instead of its own providers/ollama-cloud.ts file).
++export declare function ollamaCloudProvider(): Provider<"openai-completions">;
+ /** Providers present in the generated catalog. `KnownProvider` additionally
+  * includes purely dynamic providers (e.g. "radius") that have no static
+  * catalog entry. */
+diff --git a/dist/providers/all.js b/dist/providers/all.js
+index a9a3ce5..aa36656 100644
+--- a/dist/providers/all.js
++++ b/dist/providers/all.js
+@@ -1,6 +1,8 @@
+ import { createImagesModels } from "../images-models.js";
+-import { MODELS } from "../models.generated.js";
+-import { createModels } from "../models.js";
++import { MODELS, OLLAMA_CLOUD_MODELS } from "../models.generated.js";
++import { createModels, createProvider } from "../models.js";
++import { openAICompletionsApi } from "../api/openai-completions.lazy.js";
++import { envApiKeyAuth } from "../auth/helpers.js";
+ import { amazonBedrockProvider } from "./amazon-bedrock.js";
+ import { antLingProvider } from "./ant-ling.js";
+ import { anthropicProvider } from "./anthropic.js";
+@@ -42,6 +44,19 @@ import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp.js";
+ import { zaiProvider } from "./zai.js";
+ import { zaiCodingCnProvider } from "./zai-coding-cn.js";
+ export { radiusProvider };
++// PATCH(pizzapi): Ollama Cloud provider (inlined here rather than its own
++// providers/ollama-cloud.js file — `bun patch` cannot add new files in
++// nested directories, see oven-sh/bun#13330).
++export function ollamaCloudProvider() {
++    return createProvider({
++        id: "ollama-cloud",
++        name: "Ollama Cloud",
++        baseUrl: "https://ollama.com/v1",
++        auth: { apiKey: envApiKeyAuth("Ollama Cloud API key", ["OLLAMA_API_KEY"]) },
++        models: Object.values(OLLAMA_CLOUD_MODELS),
++        api: openAICompletionsApi(),
++    });
++}
+ /** Typed read of the generated built-in catalog. */
+ export function getBuiltinModel(provider, modelId) {
+     const models = MODELS[provider];
+@@ -90,6 +105,7 @@ export function builtinProviders() {
+         opencodeProvider(),
+         opencodeGoProvider(),
+         openrouterProvider(),
++        ollamaCloudProvider(),
+         qwenTokenPlanProvider(),
+         qwenTokenPlanCnProvider(),
+         radiusProvider(),
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index 0a1b769..e6f566e 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -15,7 +15,7 @@ export type KnownApi = "openai-completions" | "mistral-conversations" | "openai-
+ export type Api = KnownApi | (string & {});
+ export type KnownImagesApi = "openrouter-images";
+ export type ImagesApi = KnownImagesApi | (string & {});
+-export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
++export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "ollama-cloud" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
+ export type ProviderId = KnownProvider | string;
+ export type KnownImagesProvider = "openrouter";
+ export type ImagesProviderId = KnownImagesProvider | string;
+diff --git a/dist/utils/retry.js b/dist/utils/retry.js
+index ac5c157..556a686 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -63,6 +63,9 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+     "stream ended before message_stop",
+     "stream ended before a terminal response event",
+     "http2 request did not get a response",
++    // PATCH(pizzapi): retry transient JSON parse failures from truncated provider streams.
++    "json.?parse.?error",
++    "unexpected.?end.?of.?json",
+     // Provider-requested retry delay cap failures should flow through the outer
+     // retry policy so callers can surface/abort the backoff (#1123).
+     "retry delay",

--- a/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
@@ -1,0 +1,319 @@
+diff --git a/dist/config.js b/dist/config.js
+index 4600b23..85bd9b0 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -358,6 +358,10 @@ export function getExamplesPath() {
+ }
+ /** Get path to CHANGELOG.md */
+ export function getChangelogPath() {
++    // PATCH(pizzapi): allow PizzaPi to display its wrapper changelog.
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "CHANGELOG.md"));
+ }
+ /**
+@@ -391,7 +395,7 @@ const piConfigName = pkg.piConfig?.name;
+ export const PACKAGE_NAME = pkg.name || "@earendil-works/pi-coding-agent";
+ export const APP_NAME = piConfigName || "pi";
+ export const APP_TITLE = piConfigName ? APP_NAME : "π";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++export const CONFIG_DIR_NAME = ".pizzapi"; // PATCH(pizzapi): force PizzaPi's config namespace instead of upstream .pi.
+ export const VERSION = pkg.version || "0.0.0";
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+@@ -414,7 +418,8 @@ export function getAgentDir() {
+     if (envDir) {
+         return expandTildePath(envDir);
+     }
+-    return join(homedir(), CONFIG_DIR_NAME, "agent");
++    // PATCH(pizzapi): flat directory structure, no nested agent/ segment.
++    return join(homedir(), CONFIG_DIR_NAME);
+ }
+ /** Get path to user's custom themes directory */
+ export function getCustomThemesDir() {
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index c99a78f..7133b32 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1122,9 +1122,10 @@ export class AgentSession {
+             if (images.length === 0)
+                 images = undefined;
+         }
+-        // Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
++        // Use prompt() with expandPromptTemplates: false by default to skip command handling and template expansion.
++        // PATCH(pizzapi): allow callers to opt into command/template expansion (e.g. web UI input).
+         await this.prompt(text, {
+-            expandPromptTemplates: false,
++            expandPromptTemplates: options?.expandPromptTemplates ?? false,
+             streamingBehavior: options?.deliverAs,
+             images,
+             source: "extension",
+@@ -1890,6 +1891,17 @@ export class AgentSession {
+             },
+             getThinkingLevel: () => this.thinkingLevel,
+             setThinkingLevel: (level) => this.setThinkingLevel(level),
++            // PATCH(pizzapi): expose the pending queues so the remote extension can sync them to the web UI.
++            getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] }),
++            // PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals).
++            // ponytail: text-only — queued image attachments are dropped on replace; the queue mirrors only store text.
++            replaceQueuedMessages: (followUp) => {
++                const { steering } = this.clearQueue();
++                for (const text of steering)
++                    void this._queueSteer(text);
++                for (const text of followUp)
++                    void this._queueFollowUp(text);
++            },
+         }, {
+             getModel: () => this.model,
+             isIdle: () => this.isIdle,
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+index 099e74e..7291108 100644
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -143,6 +143,10 @@ export function createExtensionRuntime() {
+         sendUserMessage: notInitialized,
+         appendEntry: notInitialized,
+         setSessionName: notInitialized,
++        // PATCH(pizzapi): expose session-control actions on ExtensionAPI, not only command contexts.
++        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        fork: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getSessionName: notInitialized,
+         setLabel: notInitialized,
+         getActiveTools: notInitialized,
+@@ -154,6 +158,9 @@ export function createExtensionRuntime() {
+         setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getThinkingLevel: notInitialized,
+         setThinkingLevel: notInitialized,
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync.
++        getQueuedMessages: notInitialized,
++        replaceQueuedMessages: notInitialized,
+         flagValues: new Map(),
+         pendingProviderRegistrations: [],
+         pendingNativeProviderRegistrations: [],
+@@ -252,6 +259,28 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+             runtime.assertActive();
+             runtime.setSessionName(name);
+         },
++        // PATCH(pizzapi): remote exec handlers need /new and /resume from lifecycle/event handlers.
++        newSession(options) {
++            runtime.assertActive();
++            return runtime.newSession(options);
++        },
++        switchSession(sessionPath, options) {
++            runtime.assertActive();
++            return runtime.switchSession(sessionPath, options);
++        },
++        fork(entryId, options) {
++            runtime.assertActive();
++            return runtime.fork(entryId, options);
++        },
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync (web UI queue edits).
++        getQueuedMessages() {
++            runtime.assertActive();
++            return runtime.getQueuedMessages();
++        },
++        replaceQueuedMessages(followUp) {
++            runtime.assertActive();
++            runtime.replaceQueuedMessages(followUp);
++        },
+         getSessionName() {
+             runtime.assertActive();
+             return runtime.getSessionName();
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+index 686ff32..a5ee2cd 100644
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -170,6 +170,9 @@ export class ExtensionRunner {
+         this.runtime.setModel = actions.setModel;
+         this.runtime.getThinkingLevel = actions.getThinkingLevel;
+         this.runtime.setThinkingLevel = actions.setThinkingLevel;
++        // PATCH(pizzapi): expose pending-queue read/replace to extensions (remote queue sync).
++        this.runtime.getQueuedMessages = actions.getQueuedMessages;
++        this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages;
+         // Context actions (required)
+         this.getModel = contextActions.getModel;
+         this.isIdleFn = contextActions.isIdle;
+@@ -249,17 +252,24 @@ export class ExtensionRunner {
+         if (actions) {
+             this.waitForIdleFn = actions.waitForIdle;
+             this.newSessionHandler = actions.newSession;
++            // PATCH(pizzapi): make session controls available to ExtensionAPI callers.
++            this.runtime.newSession = (options) => this.newSessionHandler(options);
+             this.forkHandler = actions.fork;
++            this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+             this.navigateTreeHandler = actions.navigateTree;
+             this.switchSessionHandler = actions.switchSession;
++            this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+             this.reloadHandler = actions.reload;
+             return;
+         }
+         this.waitForIdleFn = async () => { };
+         this.newSessionHandler = async () => ({ cancelled: false });
++        this.runtime.newSession = (options) => this.newSessionHandler(options);
+         this.forkHandler = async () => ({ cancelled: false });
++        this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+         this.navigateTreeHandler = async () => ({ cancelled: false });
+         this.switchSessionHandler = async () => ({ cancelled: false });
++        this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+         this.reloadHandler = async () => { };
+     }
+     setUIContext(uiContext, mode = "print") {
+diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
+index a7d5547..3b95b7a 100644
+--- a/dist/core/extensions/types.d.ts
++++ b/dist/core/extensions/types.d.ts
+@@ -912,11 +912,32 @@ export interface ExtensionAPI {
+      */
+     sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
+         deliverAs?: "steer" | "followUp";
++        /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++        expandPromptTemplates?: boolean;
+     }): void;
+     /** Append a custom entry to the session for state persistence (not sent to LLM). */
+     appendEntry<T = unknown>(customType: string, data?: T): void;
+     /** Set the session display name (shown in session selector). */
+     setSessionName(name: string): void;
++    /** Start a new session. Available to PizzaPi remote event handlers. */
++    newSession(options?: {
++        parentSession?: string;
++        setup?: (sessionManager: SessionManager) => Promise<void>;
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Switch to a different session file. Available to PizzaPi remote event handlers. */
++    switchSession(sessionPath: string, options?: {
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Fork from a specific entry, creating a new session file. Available to PizzaPi remote event handlers. */
++    fork(entryId: string, options?: {
++        position?: "before" | "at";
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
++    /** PATCH(pizzapi): read the pending steering/follow-up queues (remote queue sync). */
++    getQueuedMessages(): { steering: string[]; followUp: string[]; };
++    /** PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals). */
++    replaceQueuedMessages(followUp: string[]): void;
+     /** Get the current session name, if set. */
+     getSessionName(): string | undefined;
+     /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
+@@ -1107,6 +1128,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+ }) => void;
+ export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
+     deliverAs?: "steer" | "followUp";
++    /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++    expandPromptTemplates?: boolean;
+ }) => void;
+ export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
+ export type SetSessionNameHandler = (name: string) => void;
+@@ -1164,6 +1187,9 @@ export interface ExtensionActions {
+     sendUserMessage: SendUserMessageHandler;
+     appendEntry: AppendEntryHandler;
+     setSessionName: SetSessionNameHandler;
++    newSession: ExtensionCommandContextActions["newSession"];
++    switchSession: ExtensionCommandContextActions["switchSession"];
++    fork: ExtensionCommandContextActions["fork"];
+     getSessionName: GetSessionNameHandler;
+     setLabel: SetLabelHandler;
+     getActiveTools: GetActiveToolsHandler;
+@@ -1174,6 +1200,9 @@ export interface ExtensionActions {
+     setModel: SetModelHandler;
+     getThinkingLevel: GetThinkingLevelHandler;
+     setThinkingLevel: SetThinkingLevelHandler;
++    /** PATCH(pizzapi): pending-queue read/replace for remote queue sync. */
++    getQueuedMessages: () => { steering: string[]; followUp: string[]; };
++    replaceQueuedMessages: (followUp: string[]) => void;
+ }
+ /**
+  * Actions for ExtensionContext (ctx.* in event handlers).
+diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
+index 4cd5156..6f41d5c 100644
+--- a/dist/core/model-resolver.js
++++ b/dist/core/model-resolver.js
+@@ -21,6 +21,7 @@ export const defaultModelPerProvider = {
+     "google-vertex": "gemini-3.1-pro-preview",
+     "github-copilot": "gpt-5.4",
+     openrouter: "moonshotai/kimi-k2.6",
++    "ollama-cloud": "glm-5.1",
+     "vercel-ai-gateway": "zai/glm-5.1",
+     xai: "grok-4.5",
+     groq: "openai/gpt-oss-120b",
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index e91e38f..8ee1013 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -13,6 +13,7 @@ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveMode
+ export { type CreateModelRuntimeOptions, ModelRuntime, type ModelRuntimeAuthOverrides, } from "./core/model-runtime.ts";
+ export type { PackageManager, PathMetadata, ProgressCallback, ProgressEvent, ResolvedPaths, ResolvedResource, } from "./core/package-manager.ts";
+ export { DefaultPackageManager } from "./core/package-manager.ts";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
+ export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.ts";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
+ export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
+diff --git a/dist/index.js b/dist/index.js
+index a2ee192..730bc33 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -13,6 +13,7 @@ export { ModelRegistry } from "./core/model-registry.js";
+ export { resolveCliModel, resolveModelScopeWithDiagnostics, } from "./core/model-resolver.js";
+ export { ModelRuntime, } from "./core/model-runtime.js";
+ export { DefaultPackageManager } from "./core/package-manager.js";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.js";
+ // SDK for programmatic usage
+ export { AgentSessionRuntime, 
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index b93d41c..b24b963 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -33,7 +33,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";
+ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
+ import { killTrackedDetachedChildren } from "../../utils/shell.js";
+ import { ensureTool } from "../../utils/tools-manager.js";
+-import { checkForNewPiVersion } from "../../utils/version-check.js";
+ import { ArminComponent } from "./components/armin.js";
+ import { AssistantMessageComponent } from "./components/assistant-message.js";
+ import { BashExecutionComponent } from "./components/bash-execution.js";
+@@ -587,12 +586,6 @@ export class InteractiveMode {
+                 .then(() => this.updateAvailableProviderCount())
+                 .catch(() => { });
+         }
+-        // Start version check asynchronously
+-        checkForNewPiVersion(this.version).then((newRelease) => {
+-            if (newRelease) {
+-                this.showNewVersionNotification(newRelease);
+-            }
+-        });
+         // Start package update check asynchronously
+         this.checkForPackageUpdates()
+             .then((updates) => {
+@@ -3169,29 +3162,6 @@ export class InteractiveMode {
+         this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+         this.ui.requestRender();
+     }
+-    showNewVersionNotification(release) {
+-        const action = theme.fg("accent", `${APP_NAME} update`);
+-        const updateInstruction = theme.fg("muted", `New version ${release.version} is available. Run `) + action;
+-        const changelogUrl = "https://pi.dev/changelog";
+-        const changelogLink = getCapabilities().hyperlinks
+-            ? hyperlink(theme.fg("accent", changelogUrl), changelogUrl)
+-            : theme.fg("accent", changelogUrl);
+-        const changelogLine = theme.fg("muted", "Changelog: ") + changelogLink;
+-        const note = release.note?.trim();
+-        this.chatContainer.addChild(new Spacer(1));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.chatContainer.addChild(new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}`, 1, 0));
+-        if (note) {
+-            this.chatContainer.addChild(new Spacer(1));
+-            this.chatContainer.addChild(new Markdown(note, 1, 0, this.getMarkdownThemeWithSettings(), {
+-                color: (text) => theme.fg("muted", text),
+-            }));
+-            this.chatContainer.addChild(new Spacer(1));
+-        }
+-        this.chatContainer.addChild(new Text(changelogLine, 1, 0));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.ui.requestRender();
+-    }
+     showPackageUpdateNotification(packages) {
+         const action = theme.fg("accent", `${APP_NAME} update --extensions`);
+         const updateInstruction = theme.fg("muted", "Package updates are available. Run ") + action;

--- a/patches/@earendil-works%2Fpi-tui@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.82.1.patch
@@ -1,0 +1,161 @@
+diff --git a/dist/terminal.js b/dist/terminal.js
+index 71db088..2cb9fe5 100644
+--- a/dist/terminal.js
++++ b/dist/terminal.js
+@@ -6,6 +6,100 @@ import { setKittyProtocolActive } from "./keys.js";
+ import { isNativeModifierPressed } from "./native-modifiers.js";
+ import { StdinBuffer } from "./stdin-buffer.js";
+ const cjsRequire = createRequire(import.meta.url);
++// PATCH(pizzapi): Windows console output lifecycle helpers
++function safeWindowsCall(fn) {
++    try {
++        return fn();
++    }
++    catch {
++        return undefined;
++    }
++}
++/**
++ * Create a Windows console lifecycle helper that enables VT output and UTF-8
++ * code pages on activation, and restores the original state on teardown.
++ */
++export function createWindowsConsoleLifecycle() {
++    let state = undefined;
++    return {
++        activate() {
++            if (process.platform !== "win32") {
++                return { stdoutMode: "unknown", stderrMode: "unknown", source: "pi-tui" };
++            }
++            const result = safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const GetConsoleCP = k32.func("uint32_t __stdcall GetConsoleCP()");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const GetConsoleOutputCP = k32.func("uint32_t __stdcall GetConsoleOutputCP()");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
++                const handleModes = { stdout: undefined, stderr: undefined };
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = new Uint32Array(1);
++                    if (GetConsoleMode(handle, mode)) {
++                        handleModes[key] = mode[0];
++                        SetConsoleMode(handle, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
++                    }
++                }
++                const inputCP = GetConsoleCP();
++                const outputCP = GetConsoleOutputCP();
++                SetConsoleCP(65001);
++                SetConsoleOutputCP(65001);
++                return { handleModes, inputCP, outputCP };
++            });
++            const stdoutOk = result?.handleModes?.stdout !== undefined;
++            const stderrOk = result?.handleModes?.stderr !== undefined;
++            const caps = {
++                stdoutMode: stdoutOk ? "unicode" : "ascii",
++                stderrMode: stderrOk ? "unicode" : "ascii",
++                source: "pi-tui",
++            };
++            state = result ?? undefined;
++            return caps;
++        },
++        restore() {
++            if (!state || process.platform !== "win32")
++                return;
++            safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = state.handleModes[key];
++                    if (mode !== undefined) {
++                        SetConsoleMode(handle, mode);
++                    }
++                }
++                if (state.inputCP !== undefined) {
++                    SetConsoleCP(state.inputCP);
++                }
++                if (state.outputCP !== undefined) {
++                    SetConsoleOutputCP(state.outputCP);
++                }
++            });
++            state = undefined;
++        },
++    };
++}
+ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
+ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
+ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
+@@ -49,6 +143,7 @@ export class ProcessTerminal {
+     stdinBuffer;
+     stdinDataHandler;
+     progressInterval;
++    windowsConsoleLifecycle;
+     writeLogPath = (() => {
+         const env = process.env.PI_TUI_WRITE_LOG || "";
+         if (!env)
+@@ -95,10 +190,29 @@ export class ProcessTerminal {
+         // events that lose modifier information. Must run AFTER setRawMode(true)
+         // since that resets console mode flags.
+         this.enableWindowsVTInput();
++        // PATCH(pizzapi): Windows console output lifecycle
++        this.setupWindowsConsole();
+         // Query Kitty keyboard protocol and fall back to modifyOtherKeys when DA confirms no Kitty response.
+         // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+         this.queryAndEnableKittyProtocol();
+     }
++    /**
++     * On Windows, set up VT output and UTF-8 code page for Unicode rendering,
++     * and publish a capability signal for downstream renderers.
++     */
++    setupWindowsConsole() {
++        if (process.platform !== "win32")
++            return;
++        try {
++            this.windowsConsoleLifecycle = createWindowsConsoleLifecycle();
++            const result = this.windowsConsoleLifecycle.activate();
++            const globalObj = globalThis;
++            globalObj.__PI_WINDOWS_CONSOLE_CAPS__ = result;
++        }
++        catch {
++            // Best-effort: if console API setup fails, leave it alone
++        }
++    }
+     /**
+      * Set up StdinBuffer to split batched input into individual sequences.
+      * This ensures components receive single events, making matchesKey/isKeyRelease work correctly.
+@@ -350,6 +464,17 @@ export class ProcessTerminal {
+             process.stdout.removeListener("resize", this.resizeHandler);
+             this.resizeHandler = undefined;
+         }
++        // PATCH(pizzapi): restore Windows console state
++        if (this.windowsConsoleLifecycle) {
++            try {
++                this.windowsConsoleLifecycle.restore();
++            }
++            catch {
++                // Best-effort restore
++            }
++            this.windowsConsoleLifecycle = undefined;
++            delete globalThis.__PI_WINDOWS_CONSOLE_CAPS__;
++        }
+         // Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
+         // re-interpreted after raw mode is disabled. This fixes a race condition
+         // where Ctrl+D could close the parent shell over SSH.

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,18 +4,18 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @earendil-works/pi-agent-core@0.82.0
+## @earendil-works/pi-agent-core@0.82.1
 
 Same runtime fix as 0.80.6, ported forward unchanged — neither patched file
 (`dist/agent.js`, `dist/agent-loop.js`) changed upstream between 0.80.6 and
 0.82.0.
 
-## @earendil-works/pi-tui@0.82.0
+## @earendil-works/pi-tui@0.82.1
 
 Same Windows console lifecycle patch as 0.80.6, ported forward unchanged —
 `dist/terminal.js` didn't change upstream between 0.80.6 and 0.82.0.
 
-## @earendil-works/pi-ai@0.82.0
+## @earendil-works/pi-ai@0.82.1
 
 Same intent as 0.80.6 (Anthropic web-search passthrough, Claude Code
 credentials fallback, Ollama Cloud support, retryable-JSON-parse patterns),
@@ -57,7 +57,7 @@ ported to upstream's restructured 0.82.0 layout:
 | `dist/types.d.ts` | Same `ollama-cloud` `KnownProvider` addition as 0.80.6 (unchanged file) |
 | `dist/utils/retry.js` | Same retryable-JSON-parse patterns as 0.80.6 (unchanged file) |
 
-## @earendil-works/pi-coding-agent@0.82.0
+## @earendil-works/pi-coding-agent@0.82.1
 
 Same PizzaPi integration changes as 0.80.6, ported forward, with two upstream
 removals absorbed elsewhere rather than restored:
@@ -412,7 +412,14 @@ this patch can be deleted.
 
 ## Previously patched (no longer needed)
 
-### @earendil-works/*@0.80.6 (replaced by 0.82.0 patches)
+### @earendil-works/*@0.82.0
+
+Regenerated verbatim against 0.82.1 — the only upstream change touching a
+patched file was two added lines in `pi-coding-agent`'s
+`dist/core/extensions/types.d.ts` (`MessageRenderOptions.outputPad`), which
+shifted hunk offsets. No patch content changed.
+
+### @earendil-works/*@0.80.6 and @0.82.0 (replaced by 0.82.1 patches)
 
 The 0.80.6 patch files are retained in this directory for history but are no
 longer referenced by `patchedDependencies`. See the 0.82.0 entries above for


### PR DESCRIPTION
## What

Bumps `@earendil-works/pi-coding-agent`, `pi-agent-core`, `pi-ai`, and `pi-tui` from `0.82.0` → `0.82.1`, and fixes Anthropic OAuth login in compiled binaries.

## Patch regeneration

All four patch files were regenerated by applying the `0.82.0` patches to pristine `0.82.1` tarballs in a throwaway git repo. **Patch content is byte-identical** — only hunk offsets and blob hashes changed.

Renaming the files was not sufficient. Upstream added two lines to `pi-coding-agent`'s `dist/core/extensions/types.d.ts` (`MessageRenderOptions.outputPad`), shifting later hunks by +2. Bun's patch applier silently fuzzed the `expandPromptTemplates` hunk into the wrong place:

```ts
export type SendMessageHandler = <T>(..., options?: {
    triggerTurn?: boolean;
    deliverAs?: "steer" | "followUp" | "nextTurn";
}) => void;
    /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
    expandPromptTemplates?: boolean;      // <-- floating outside any object
export type SendUserMessageHandler = ...
```

→ `error TS1109: Expression expected`. Fixed and verified in the regenerated patch.

## OAuth fix

Compiled binaries failed on Anthropic login:

```
Error: Failed to login to Anthropic: ResolveMessage: Cannot find module
'./anthropic.js' from '/$bunfs/root/pizza-macos-arm64'
```

`pi-ai/dist/auth/oauth/load.js` deliberately loads flow modules through a variable specifier so bundlers can't follow them into Node-only code. Upstream ships `@earendil-works/pi-ai/bun-oauth` for standalone builds; we just weren't calling it.

```ts
import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
registerBunOAuthFlows();
```

Also adds `@earendil-works/pi-ai` as an explicit `packages/cli` dependency (it was only hoisted before).

## Verification

- `bun install` — all 4 patches apply cleanly (`PATCH(pizzapi)` markers present in all packages)
- `bun run typecheck` — clean
- `bun test packages/cli/src/patches.test.ts` — 38 pass, 0 fail
- `bun scripts/test-isolated.ts packages/cli/src` — 124 pass, 1 fail (`sandbox-config.test.ts` — **pre-existing on `main`**, verified by stashing)
- Compiled a `bun-darwin-arm64` binary and confirmed the Anthropic OAuth endpoints are now embedded