### PR TITLE
feat(bash): auto-background after 15s with a required title

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -530,6 +530,18 @@ export interface PizzaPiConfig {
      * Also supports per-server `deferLoading: true` in mcpServers entries.
      */
     toolSearch?: ToolSearchConfig;
+
+    /** Bash tool configuration. */
+    bash?: {
+        /**
+         * Seconds a bash command streams output in the foreground before it is
+         * auto-backgrounded (output redirected to a log file, completion message
+         * delivered on exit). Default: 15. 0 = background immediately.
+         * Overridden by PIZZAPI_BASH_BACKGROUND_SECONDS.
+         */
+        backgroundAfterSeconds?: number;
+    };
+
     /**
      * `/goal` command configuration.
      */

--- a/packages/cli/src/extensions/background-bash.test.ts
+++ b/packages/cli/src/extensions/background-bash.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds } from "./background-bash.js";
+
+// Keep the auto-background window out of the way unless a test opts in.
+beforeAll(() => { process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "30"; });
+afterAll(() => { delete process.env.PIZZAPI_BASH_BACKGROUND_SECONDS; });
+
+function mockPi() {
+    const messages: any[] = [];
+    const tools = new Map<string, any>();
+    const shortcuts = new Map<string, any>();
+    const commands = new Map<string, any>();
+    return {
+        messages,
+        tools,
+        shortcuts,
+        commands,
+        registerTool(tool: any) { tools.set(tool.name, tool); },
+        registerShortcut(key: string, opts: any) { shortcuts.set(key, opts); },
+        registerCommand(name: string, opts: any) { commands.set(name, opts); },
+        sendMessage(msg: any, opts: any) { messages.push({ msg, opts }); },
+        on: () => {},
+    };
+}
+
+function getTool() {
+    const pi = mockPi();
+    backgroundBashExtension(pi as any);
+    return { pi, tool: pi.tools.get("bash")! };
+}
+
+const run = (tool: any, params: any) => tool.execute("id", params, undefined, undefined, undefined);
+
+describe("bash override with backgrounding", () => {
+    test("overrides the built-in bash tool by name", () => {
+        const { pi } = getTool();
+        expect(pi.tools.has("bash")).toBe(true);
+        expect(pi.tools.get("bash").description).toContain("run_in_background");
+        expect(pi.tools.get("bash").parameters.required).toEqual(["command", "title"]);
+    });
+
+    test("background threshold: default 15s, env override, invalid falls back", () => {
+        const prev = process.env.PIZZAPI_BASH_BACKGROUND_SECONDS;
+        delete process.env.PIZZAPI_BASH_BACKGROUND_SECONDS;
+        expect(backgroundAfterSeconds()).toBe(15);
+        process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "0";
+        expect(backgroundAfterSeconds()).toBe(0);
+        process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "nope";
+        expect(backgroundAfterSeconds()).toBe(15);
+        process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = prev!;
+    });
+
+    test("auto-backgrounds once the foreground window elapses", async () => {
+        process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "0.3";
+        try {
+            const { pi, tool } = getTool();
+            const started = Date.now();
+            const res = await run(tool, { command: "sleep 1; echo slow", title: "Slow thing" });
+            const elapsed = Date.now() - started;
+            expect(elapsed).toBeGreaterThan(250);
+            expect(elapsed).toBeLessThan(900);
+            expect(res.content[0].text).toContain("Still running");
+            expect(res.content[0].text).toContain("Slow thing");
+            expect(pi.messages.length).toBe(0);
+
+            await Bun.sleep(1200);
+            expect(pi.messages[0].msg.content).toContain("Slow thing exited with code 0");
+        } finally {
+            process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "30";
+        }
+    });
+
+    test("foreground command returns output inline, no notification", async () => {
+        const { pi, tool } = getTool();
+        const res = await run(tool, { command: "echo hello" });
+        expect(res.content[0].text).toContain("hello");
+        expect(pi.messages.length).toBe(0);
+    });
+
+    test("foreground non-zero exit throws like the built-in", async () => {
+        const { tool } = getTool();
+        await expect(run(tool, { command: "exit 3" })).rejects.toThrow("exited with code 3");
+    });
+
+    test("run_in_background returns immediately and notifies on exit", async () => {
+        const { pi, tool } = getTool();
+        const started = Date.now();
+        const res = await run(tool, { command: "sleep 0.4; exit 7", title: "Late job", run_in_background: true });
+        expect(Date.now() - started).toBeLessThan(300);
+        expect(res.content[0].text).toContain("Still running");
+        expect(pi.messages.length).toBe(0);
+
+        await Bun.sleep(900);
+        expect(pi.messages.length).toBe(1);
+        expect(pi.messages[0].msg.content).toContain("Late job exited with code 7");
+        expect(pi.messages[0].msg.content).toContain("See full stdout/stderr in ");
+        expect(pi.messages[0].msg.details.exitCode).toBe(7);
+        expect(pi.messages[0].opts.deliverAs).toBe("followUp");
+    });
+
+    test("manual background (TUI shortcut / web exec) detaches a running foreground command", async () => {
+        const { pi, tool } = getTool();
+        const call = run(tool, { command: "sleep 0.5; echo late" });
+        await Bun.sleep(80);
+        expect(pendingCommands()).toEqual(["sleep 0.5; echo late"]);
+        expect(backgroundPendingJobs().length).toBe(1);
+
+        const res = await call;
+        expect(res.content[0].text).toContain("Still running");
+
+        await Bun.sleep(900);
+        expect(pi.messages[0].msg.content).toContain("exited with code 0");
+    });
+
+    test("bash_output returns only new output since the last call", async () => {
+        const { pi, tool } = getTool();
+        const res = await run(tool, {
+            command: "echo first; sleep 0.4; echo second",
+            run_in_background: true,
+        });
+        const pid = Number(res.content[0].text.match(/pid (\d+)/)![1]);
+        const bashOutput = pi.tools.get("bash_output")!;
+
+        await Bun.sleep(150);
+        const out1 = await bashOutput.execute("id", { pid });
+        expect(out1.content[0].text).toContain("first");
+        expect(out1.content[0].text).toContain("running");
+
+        await Bun.sleep(600);
+        const out2 = await bashOutput.execute("id", { pid });
+        const body2 = out2.content[0].text.split("\n").slice(1).join("\n"); // drop header (echoes the command)
+        expect(body2).toContain("second");
+        expect(body2).not.toContain("first"); // incremental
+        expect(out2.content[0].text).toContain("exited 0");
+
+        const listing = await bashOutput.execute("id", {});
+        expect(listing.content[0].text).toContain(`pid ${pid}`);
+    });
+
+    test("kill_shell kills the process group and the notification reports it", async () => {
+        const { pi, tool } = getTool();
+        const res = await run(tool, { command: "sleep 30", run_in_background: true });
+        const pid = Number(res.content[0].text.match(/pid (\d+)/)![1]);
+
+        const killShell = pi.tools.get("kill_shell")!;
+        const killed = await killShell.execute("id", { pid });
+        expect(killed.content[0].text).toContain(`Killed pid ${pid}`);
+
+        await Bun.sleep(300);
+        expect(pi.messages.length).toBe(1);
+        expect(pi.messages[0].msg.content).toContain("killed by");
+
+        const again = await killShell.execute("id", { pid });
+        expect(again.content[0].text).toContain("already");
+    });
+
+    test("shortcut and /background command are registered", () => {
+        const { pi } = getTool();
+        expect(pi.shortcuts.has("ctrl+shift+b")).toBe(true);
+        expect(pi.commands.has("background")).toBe(true);
+    });
+});

--- a/packages/cli/src/extensions/background-bash.ts
+++ b/packages/cli/src/extensions/background-bash.ts
@@ -1,0 +1,413 @@
+import { spawn } from "node:child_process";
+import { createWriteStream, openSync, readSync, closeSync, statSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { createBashToolDefinition } from "@earendil-works/pi-coding-agent";
+import { loadConfig } from "../config.js";
+
+/**
+ * Bash override with auto-backgrounding.
+ *
+ * Reuses pi's built-in bash tool (schema, streaming, truncation, renderers)
+ * via createBashToolDefinition and swaps only the exec layer. Behavior:
+ *
+ * - Every call takes a `title` (its purpose), used in status/completion messages.
+ * - Output streams normally for the first N seconds (default 15, configurable via
+ *   `bash.backgroundAfterSeconds` or PIZZAPI_BASH_BACKGROUND_SECONDS).
+ * - Past that the call returns: output keeps flowing to a tmp log file and the
+ *   model is told the command is still running (and told not to sleep/poll).
+ * - `run_in_background: true` backgrounds immediately (threshold 0).
+ * - Manual backgrounding of ANY running bash call: TUI ctrl+shift+b,
+ *   /background, or the web UI's `background_bash` exec command.
+ * - On exit — any code — a completion message is delivered into the session.
+ *
+ * Plan-mode command blocking still applies: it hooks `tool_call` by tool name,
+ * and this override keeps the name "bash".
+ */
+
+const TAIL_BYTES = 4000;
+const DEFAULT_BACKGROUND_AFTER_SECONDS = 15;
+
+/** Seconds a bash call streams in the foreground before it auto-backgrounds. 0 = immediate. */
+export function backgroundAfterSeconds(): number {
+    const raw = process.env.PIZZAPI_BASH_BACKGROUND_SECONDS ?? readConfiguredSeconds();
+    const n = Number(raw);
+    return raw !== undefined && Number.isFinite(n) && n >= 0 ? n : DEFAULT_BACKGROUND_AFTER_SECONDS;
+}
+
+// ponytail: config read once per process (bash runs often); restart to change it.
+let configuredSeconds: number | undefined | null = null;
+function readConfiguredSeconds(): number | undefined {
+    if (configuredSeconds === null) {
+        try {
+            configuredSeconds = loadConfig(process.cwd())?.bash?.backgroundAfterSeconds;
+        } catch {
+            configuredSeconds = undefined;
+        }
+    }
+    return configuredSeconds;
+}
+
+/** Running foreground bash calls, keyed by pid. Calling the value backgrounds the job now. */
+const waiting = new Map<number, { command: string; backgroundNow: () => void }>();
+
+interface BackgroundJob {
+    pid: number;
+    command: string;
+    title: string;
+    logPath: string;
+    startedAt: number;
+    /** Set once the process exits. null = killed by signal. */
+    exitCode?: number | null;
+    signal?: string | null;
+    endedAt?: number;
+    /** Byte offset of the last bash_output read — next read returns only new output. */
+    readOffset: number;
+}
+
+/** Backgrounded jobs (running or exited), keyed by pid. Kept for bash_output/kill_shell. */
+// ponytail: unbounded per-session map of tiny records (output lives on disk) — prune if sessions ever run thousands of background jobs.
+const jobs = new Map<number, BackgroundJob>();
+
+/** Read a file from `offset` to EOF. */
+function readFrom(path: string, offset: number): { text: string; newOffset: number } {
+    let fd: number | undefined;
+    try {
+        const size = statSync(path).size;
+        if (size <= offset) return { text: "", newOffset: offset };
+        const len = size - offset;
+        const buf = Buffer.allocUnsafe(len);
+        fd = openSync(path, "r");
+        readSync(fd, buf, 0, len, offset);
+        return { text: buf.toString("utf8"), newOffset: size };
+    } catch {
+        return { text: "", newOffset: offset };
+    } finally {
+        if (fd !== undefined) closeSync(fd);
+    }
+}
+
+function jobStatus(job: BackgroundJob): string {
+    if (job.endedAt === undefined) return "running";
+    if (job.signal) return `killed by ${job.signal}`;
+    return `exited ${job.exitCode}`;
+}
+
+function listJobsText(): string {
+    if (jobs.size === 0) return "No background shells.";
+    return [...jobs.values()]
+        .map((j) => `pid ${j.pid} [${jobStatus(j)}] ${j.title} — ${j.command} (log: ${j.logPath})`)
+        .join("\n");
+}
+
+/** Commands currently running in the foreground (i.e. backgroundable right now). */
+export function pendingCommands(): string[] {
+    return [...waiting.values()].map((j) => j.command);
+}
+
+/**
+ * Send every running foreground bash call to the background.
+ * Called by the TUI shortcut and the web UI's `background_bash` exec command.
+ * Returns the commands that were backgrounded.
+ */
+export function backgroundPendingJobs(): string[] {
+    const commands = pendingCommands();
+    for (const job of [...waiting.values()]) job.backgroundNow();
+    return commands;
+}
+
+/** Last `maxBytes` of a file, as text. */
+export function tailFile(path: string, maxBytes = TAIL_BYTES): string {
+    let fd: number | undefined;
+    try {
+        const size = statSync(path).size;
+        const start = Math.max(0, size - maxBytes);
+        const len = size - start;
+        if (len === 0) return "";
+        const buf = Buffer.allocUnsafe(len);
+        fd = openSync(path, "r");
+        readSync(fd, buf, 0, len, start);
+        return (start > 0 ? `…(truncated, full log at ${path})\n` : "") + buf.toString("utf8");
+    } catch {
+        return "";
+    } finally {
+        if (fd !== undefined) closeSync(fd);
+    }
+}
+
+export function formatCompletion(
+    title: string,
+    code: number | null,
+    signalName: string | null,
+    ms: number,
+    logPath: string,
+): string {
+    const status = signalName ? `was killed by ${signalName}` : `exited with code ${code}`;
+    return `${title} ${status} after ${Math.round(ms / 1000)}s\n\nSee full stdout/stderr in ${logPath}`;
+}
+
+function killTree(pid: number): void {
+    try {
+        // Detached on POSIX → child is its own group leader; kill the group.
+        process.platform === "win32" ? process.kill(pid) : process.kill(-pid);
+    } catch {
+        try { process.kill(pid); } catch { /* already gone */ }
+    }
+}
+
+// title / run_in_background handoff from the execute wrapper to ops.exec. Safe
+// without keying: the path from setting these to consuming them is fully
+// synchronous (no await between wrapper entry and ops.exec's first statement).
+let nextRunInBackground = false;
+let nextTitle = "";
+
+export const backgroundBashExtension: ExtensionFactory = (pi) => {
+    const notifyExit = (title: string, command: string, code: number | null, sig: string | null, ms: number, logPath: string, pid: number | undefined) => {
+        pi.sendMessage(
+            {
+                customType: "background-bash",
+                content: formatCompletion(title, code, sig, ms, logPath),
+                display: true,
+                details: { title, command, pid, exitCode: code, signal: sig, logPath },
+            } as any,
+            { deliverAs: "followUp", triggerTurn: true } as any,
+        );
+    };
+
+    const exec = async (
+        command: string,
+        cwd: string,
+        { onData, signal, timeout, env }: {
+            onData: (data: Buffer) => void;
+            signal?: AbortSignal;
+            timeout?: number;
+            env?: NodeJS.ProcessEnv;
+        },
+    ): Promise<{ exitCode: number | null }> => {
+        const runInBackground = nextRunInBackground;
+        const title = nextTitle || command;
+        nextRunInBackground = false;
+        nextTitle = "";
+        if (signal?.aborted) throw new Error("aborted");
+
+        const logPath = join(tmpdir(), `pizzapi-bash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.log`);
+        const log = createWriteStream(logPath);
+        const startedAt = Date.now();
+        // ponytail: shell:true instead of pi's getShellConfig — loses custom
+        // shellPath/windows stdin transport; wire pi's shell utils if that bites.
+        const child = spawn(command, {
+            shell: true,
+            cwd,
+            env,
+            detached: process.platform !== "win32",
+            windowsHide: true,
+        });
+        const pid = child.pid ?? -1;
+
+        let backgrounded = false;
+        const tee = (data: Buffer) => {
+            log.write(data);
+            if (!backgrounded) onData(data);
+        };
+        child.stdout?.on("data", tee);
+        child.stderr?.on("data", tee);
+
+        const exited = new Promise<{ code: number | null; sig: string | null }>((resolve) => {
+            child.on("close", (code, sig) => resolve({ code, sig }));
+            child.on("error", (err) => {
+                log.write(`spawn error: ${err.message}\n`);
+                resolve({ code: 127, sig: null });
+            });
+        }).then(async (r) => {
+            waiting.delete(pid);
+            const job = jobs.get(pid);
+            if (job) {
+                job.exitCode = r.code;
+                job.signal = r.sig;
+                job.endedAt = Date.now();
+            }
+            await new Promise<void>((res) => log.end(res));
+            return r;
+        });
+
+        let timedOut = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        let bgTimer: ReturnType<typeof setTimeout> | undefined;
+        if (timeout !== undefined && Number.isFinite(timeout) && timeout > 0) {
+            timer = setTimeout(() => {
+                timedOut = true;
+                killTree(pid);
+            }, timeout * 1000);
+        }
+        const onAbort = () => {
+            if (!backgrounded) killTree(pid);
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+
+        try {
+            const bg = new Promise<"bg">((resolve) => {
+                if (runInBackground) return resolve("bg");
+                waiting.set(pid, { command, backgroundNow: () => resolve("bg") });
+                // Auto-background once the foreground streaming window elapses.
+                const after = backgroundAfterSeconds();
+                bgTimer = setTimeout(() => resolve("bg"), after * 1000);
+                bgTimer.unref?.();
+            });
+
+            const raced = await Promise.race([exited, bg]);
+
+            if (raced !== "bg") {
+                // Foreground completion — built-in semantics.
+                if (signal?.aborted) throw new Error("aborted");
+                if (timedOut) throw new Error(`timeout:${timeout}`);
+                try { unlinkSync(logPath); } catch { /* best effort */ }
+                return { exitCode: raced.code };
+            }
+
+            // Backgrounded: stop streaming, let it run, notify on exit.
+            backgrounded = true;
+            waiting.delete(pid);
+            jobs.set(pid, { pid, command, title, logPath, startedAt, readOffset: 0 });
+            onData(Buffer.from(
+                `\n[Still running: "${title}" (pid ${pid}). Output now goes to ${logPath}. ` +
+                `A message will arrive in this session when it exits — do NOT use sleep or poll for it. ` +
+                `Continue with other work; use bash_output(${pid}) for new output so far, kill_shell(${pid}) to stop it.]\n`,
+            ));
+            void exited.then(({ code, sig }) => {
+                if (timer) clearTimeout(timer);
+                notifyExit(title, command, code, sig, Date.now() - startedAt, logPath, child.pid);
+            });
+            return { exitCode: 0 };
+        } finally {
+            if (bgTimer) clearTimeout(bgTimer);
+            if (!backgrounded && timer) clearTimeout(timer);
+            signal?.removeEventListener("abort", onAbort);
+        }
+    };
+
+    // ponytail: cwd captured at registration — worker/TUI processes start in the
+    // session cwd, so this matches the built-in tool's behavior.
+    const def = createBashToolDefinition(process.cwd(), { operations: { exec } });
+
+    pi.registerTool({
+        ...def,
+        description:
+            `${def.description} ` +
+            `Output streams back for the first ${backgroundAfterSeconds()}s; if the command is still running after that ` +
+            "it keeps running in the background, its output goes to a log file, and a message with the exit code " +
+            "is delivered to this session when it finishes. NEVER use `sleep` to wait for it — do other work and the " +
+            "message will arrive on its own. Set run_in_background: true to skip the wait entirely (servers, watchers).",
+        parameters: {
+            type: "object",
+            properties: {
+                command: { type: "string", description: "Bash command to execute" },
+                title: {
+                    type: "string",
+                    description: "Short description of what this command is for (e.g. 'Run server tests'). Shown while it runs and in the completion message.",
+                },
+                timeout: { type: "number", description: "Timeout in seconds (optional, no default timeout)" },
+                run_in_background: {
+                    type: "boolean",
+                    description: "Skip the foreground wait: return immediately and deliver a completion message when the command exits.",
+                },
+            },
+            required: ["command", "title"],
+        } as any,
+        async execute(toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) {
+            nextRunInBackground = params?.run_in_background === true;
+            nextTitle = typeof params?.title === "string" ? params.title.trim() : "";
+            return def.execute(toolCallId, params, signal, onUpdate, ctx);
+        },
+    } as any);
+
+    // ── bash_output — incremental output from a background shell ─────────────
+    pi.registerTool({
+        name: "bash_output",
+        label: "Bash Output",
+        description:
+            "Get new output from a background shell since the last bash_output call (incremental — already-seen output is not repeated). Call without pid to list all background shells and their status. Use this to check progress instead of re-reading the log file.",
+        parameters: {
+            type: "object",
+            properties: {
+                pid: { type: "number", description: "Pid of the background shell (from the bash result). Omit to list all background shells." },
+            },
+        } as any,
+        async execute(_toolCallId: string, params: any) {
+            const pid = params?.pid;
+            if (pid === undefined || pid === null) {
+                return { content: [{ type: "text" as const, text: listJobsText() }], details: undefined };
+            }
+            const job = jobs.get(pid);
+            if (!job) {
+                return {
+                    content: [{ type: "text" as const, text: `No background shell with pid ${pid}.\n${listJobsText()}` }],
+                    details: undefined,
+                };
+            }
+            const { text, newOffset } = readFrom(job.logPath, job.readOffset);
+            job.readOffset = newOffset;
+            const runtime = Math.round(((job.endedAt ?? Date.now()) - job.startedAt) / 1000);
+            const header = `[pid ${job.pid}, ${jobStatus(job)}, ${runtime}s] ${job.command}`;
+            return {
+                content: [{ type: "text" as const, text: `${header}\n${text || "(no new output)"}` }],
+                details: { pid: job.pid, status: jobStatus(job), exitCode: job.exitCode },
+            };
+        },
+    } as any);
+
+    // ── kill_shell — kill a background shell's whole process group ───────────
+    pi.registerTool({
+        name: "kill_shell",
+        label: "Kill Shell",
+        description:
+            "Kill a background shell and its entire process group (children included — plain `kill <pid>` leaves orphans). The completion notification for the shell will report it as killed.",
+        parameters: {
+            type: "object",
+            properties: {
+                pid: { type: "number", description: "Pid of the background shell to kill" },
+            },
+            required: ["pid"],
+        } as any,
+        async execute(_toolCallId: string, params: any) {
+            const job = jobs.get(params?.pid);
+            if (!job) {
+                return {
+                    content: [{ type: "text" as const, text: `No background shell with pid ${params?.pid}.\n${listJobsText()}` }],
+                    details: undefined,
+                };
+            }
+            if (job.endedAt !== undefined) {
+                return {
+                    content: [{ type: "text" as const, text: `pid ${job.pid} already ${jobStatus(job)}: ${job.command}` }],
+                    details: undefined,
+                };
+            }
+            killTree(job.pid);
+            return {
+                content: [{ type: "text" as const, text: `Killed pid ${job.pid}: ${job.command}` }],
+                details: undefined,
+            };
+        },
+    } as any);
+
+    const backgroundNow = (ui?: { notify?: (msg: string, level?: string) => void }) => {
+        const backgrounded = backgroundPendingJobs();
+        const msg = backgrounded.length
+            ? `Backgrounded: ${backgrounded.join(", ")}`
+            : "Nothing to background (no bash command is running)";
+        ui?.notify?.(msg, backgrounded.length ? "info" : "warning");
+        return backgrounded;
+    };
+
+    // ponytail: ctrl+b is taken by cursorLeft; ctrl+shift+b is free.
+    pi.registerShortcut("ctrl+shift+b", {
+        description: "Send the running bash command to the background",
+        handler: async (ctx: any) => { backgroundNow(ctx?.ui); },
+    });
+
+    pi.registerCommand("background", {
+        description: "Send the running bash command to the background",
+        handler: async (_args: string, ctx: any) => { backgroundNow(ctx?.ui); },
+    });
+};

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -29,6 +29,7 @@ import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
 import { providerRequestLogExtension } from "./provider-request-log.js";
 import { sessionProcessesExtension } from "./session-processes.js";
+import { backgroundBashExtension } from "./background-bash.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     providerRequestLogExtension,
@@ -43,6 +44,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     sessionProcessesExtension,
     setSessionNameExtension,
     currentTimeExtension,
+    backgroundBashExtension,
     updateTodoExtension,
     memoryExtension,
     spawnSessionExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -9,6 +9,7 @@ import { sessionProcessesExtension } from "./session-processes.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
 import { currentTimeExtension } from "./current-time.js";
+import { backgroundBashExtension } from "./background-bash.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { memoryExtension } from "./memory/index.js";
@@ -80,6 +81,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
         named(currentTimeExtension, "current-time"),
+        named(backgroundBashExtension, "background-bash"),
         named(updateTodoExtension, "todo"),
         named(memoryExtension, "memory"),
         named(spawnSessionExtension, "spawn-session"),

--- a/packages/cli/src/extensions/remote-commands.ts
+++ b/packages/cli/src/extensions/remote-commands.ts
@@ -2,6 +2,7 @@ export type RemoteExecRequest =
     | { type: "exec"; id: string; command: "get_commands" }
     | { type: "exec"; id: string; command: "mcp"; action?: "status" | "reload" }
     | { type: "exec"; id: string; command: "abort" }
+    | { type: "exec"; id: string; command: "background_bash" }
     | { type: "exec"; id: string; command: "set_model"; provider: string; modelId: string }
     | { type: "exec"; id: string; command: "cycle_model" }
     | { type: "exec"; id: string; command: "get_available_models" }

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -11,6 +11,7 @@ import { toggleMcpServer, saveGlobalConfig, loadConfig, loadGlobalConfig, resolv
 import { isPlanModeEnabled, togglePlanModeFromRemote, setPlanModeFromRemote } from "./plan-mode/index.js";
 import { isSandboxActive, getSandboxMode, getViolations, getResolvedConfig } from "@pizzapi/tools";
 import { refreshAllUsage, buildProviderUsage } from "./remote-provider-usage.js";
+import { backgroundPendingJobs } from "./background-bash.js";
 import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js";
 import type { RelayContext, RelayModelInfo } from "./remote-types.js";
 import { emitThinkingLevelChanged, emitCompactStarted, emitCompactEnded, emitRetryStateChanged, emitPluginTrustResolved } from "./remote-meta-events.js";
@@ -109,6 +110,16 @@ export async function handleExecFromWeb(
             }
             const snapshot = await bridge.reload();
             replyOk({ ...snapshot as object, action: "reload", toggledServer: serverName, disabled });
+            return;
+        }
+
+        if (req.command === "background_bash") {
+            const backgrounded = backgroundPendingJobs();
+            if (backgrounded.length === 0) {
+                replyErr("No bash command is running");
+                return;
+            }
+            replyOk({ backgrounded });
             return;
         }
 

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -149,6 +149,7 @@ You can also override any setting with **environment variables**.
 | `oauthCallbackPort` | `number` | `0` | Global default local callback port for MCP OAuth redirect URI. `0` means OS-assigned ephemeral port. Per-server values take precedence. |
 | `mcpTimeout` | `number` | `30000` | Timeout (ms) for each MCP server's `tools/list` call during startup. Set to `0` to disable. |
 | `toolSearch` | `object` | — | Dynamic MCP tool discovery config. See [Tool Search](/PizzaPi/customization/tool-search/). |
+| `bash.backgroundAfterSeconds` | `number` | `15` | Seconds a `bash` command streams output in the foreground before it auto-backgrounds. `0` = background immediately. See [Bash auto-backgrounding](#bash-auto-backgrounding). |
 | `sandbox` | `object` | *(see below)* | OS-level sandbox config. See [Agent Sandbox](/PizzaPi/security/sandbox/). |
 | `sandbox.mode` | `string` | `"basic"` | Preset: `"none"`, `"basic"`, or `"full"`. |
 | `sandbox.network.allowedDomains` | `string[]` | `[]` (full) / unset (basic) | Domains the agent may reach. Required for outbound access in `full` mode. |
@@ -166,6 +167,37 @@ You can also override any setting with **environment variables**.
 | `allowProjectProviders` | `boolean` | `false` | Allow loading extension providers from project-local `.pizzapi/providers/` directories. **Global config only.** |
 | `providers` | `object` | — | Extension provider configurations keyed by provider ID. See [Extension Providers](/PizzaPi/customization/providers/). |
 | `providerSettings` | `object` | — | Provider-specific settings. See [Web Search](#web-search) and [Per-Provider Overrides](#per-provider-overrides) below. |
+
+---
+
+## Bash Auto-Backgrounding
+
+The `bash` tool streams output normally for the first 15 seconds. If the command is still
+running after that, the tool call returns, the process keeps running, its output is redirected
+to a temp log file, and a message is delivered into the session when it exits:
+
+```
+Run server tests exited with code 1 after 92s
+
+See full stdout/stderr in /tmp/pizzapi-bash-1761...log
+```
+
+Every `bash` call takes a `title` describing its purpose — that is the name used in the running
+and completion messages. The agent is instructed never to `sleep`-poll for a backgrounded
+command; it can call `bash_output(pid)` for incremental output or `kill_shell(pid)` to stop it.
+Setting `run_in_background: true` skips the foreground wait entirely.
+
+```json
+{
+  "bash": {
+    "backgroundAfterSeconds": 15
+  }
+}
+```
+
+Override per-process with `PIZZAPI_BASH_BACKGROUND_SECONDS`. Users can also background a
+running command manually with <kbd>ctrl+shift+b</kbd>, `/background`, or the web UI's
+background button.
 
 ---
 

--- a/packages/docs/src/content/docs/features/slash-commands.mdx
+++ b/packages/docs/src/content/docs/features/slash-commands.mdx
@@ -46,6 +46,7 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 | `/resume` | Resume a previous session. Opens a session picker showing recent sessions. |
 | `/rewind` | Rewind the conversation to a previous user message (forks the session). `/fork` is an alias. |
 | `/stop` | Abort the current generation. |
+| `/background` | Send the currently running bash command to the background (also `ctrl+shift+b` in the TUI). |
 | `/restart` | Restart the underlying CLI process. |
 
 ### Session history

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -58,6 +58,12 @@ These variables control the [Agent Sandbox](/PizzaPi/security/sandbox/) behavior
 | `PIZZAPI_SANDBOX` | Override sandbox mode: `enforce`, `audit`, or `off`. | Config value |
 | `PIZZAPI_NO_SANDBOX` | Set to `1` to disable sandbox (shorthand for `PIZZAPI_SANDBOX=off`). | — |
 
+### Bash Tool Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `PIZZAPI_BASH_BACKGROUND_SECONDS` | Seconds a `bash` command streams output in the foreground before it auto-backgrounds. `0` backgrounds immediately. Overrides `bash.backgroundAfterSeconds` in `config.json`. | `15` |
+
 ### Web Search Variables
 
 These variables control provider web search tools. They can also be configured via `providerSettings.<provider>.webSearch` in `config.json`. See [Configuration → Web Search](/PizzaPi/customization/configuration/#web-search) for details.

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -36,6 +36,7 @@ The following commands are always available in the chat input:
 | `/goal clear` | Clear the active goal. Aliases: `stop`, `off`, `cancel`, `reset`, `none`. |
 | `/copy` | Copy the last assistant message to clipboard. |
 | `/stop` | Abort the currently running agent generation. |
+| `/background` | Send the currently running bash command to the background. The agent gets a notification with the exit code and output when it finishes. |
 | `/restart` | Restart the underlying CLI process — useful if the agent is stuck or needs a fresh start. |
 | `/sandbox` | Show current sandbox status (mode, platform, recent violations) if a runner is connected. |
 | `/sandbox status` | Show current sandbox status (default). |

--- a/packages/tools/src/bash.test.ts
+++ b/packages/tools/src/bash.test.ts
@@ -393,4 +393,18 @@ describe("bashTool", () => {
             expect(bashTool.parameters).toBeDefined();
         });
     });
+
+    // ── stdin ──────────────────────────────────────────────────────────────
+    // Regression: exec() leaves stdin open, so commands that read stdin hang
+    // until the timeout fires. Uses the real exec, not the mock.
+
+    describe("stdin is closed", () => {
+        test.skipIf(process.platform === "win32")("a stdin-reading command exits immediately", async () => {
+            const real = createBashTool();
+            const start = Date.now();
+            const result: any = await real.execute("stdin-test", { command: "cat", timeout: 5000 });
+            expect(Date.now() - start).toBeLessThan(4000);
+            expect(result.details.stdout).toBe("");
+        });
+    });
 });

--- a/packages/tools/src/bash.ts
+++ b/packages/tools/src/bash.ts
@@ -1,7 +1,6 @@
 import { Type } from "@earendil-works/pi-ai";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { exec } from "child_process";
-import { promisify } from "util";
 import { wrapCommand, getSandboxEnv, isSandboxActive } from "./sandbox.js";
 import { resolvePosixShell } from "./posix-shell.js";
 
@@ -39,7 +38,21 @@ export function createBashTool(deps?: Partial<BashDeps>): AgentTool {
                 };
             }
 
-            const execAsync = promisify(execFn);
+            // ponytail: hand-rolled instead of promisify(exec) so we can close the
+            // child's stdin. exec() leaves stdin as an open pipe, so any command that
+            // reads stdin (e.g. `rtk`) blocks forever waiting for EOF.
+            const execAsync = (cmd: string, opts: any) =>
+                new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+                    const child = execFn(cmd, opts, (err: any, stdout: any, stderr: any) => {
+                        if (err) {
+                            Object.assign(err, { stdout, stderr });
+                            reject(err);
+                        } else {
+                            resolve({ stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+                        }
+                    });
+                    child?.stdin?.end();
+                });
             const timeout = params.timeout ?? 30_000;
             // ponytail: 10 MB stdout+stderr cap; raise if a legitimate tool genuinely needs larger output
             const maxBuffer = 10 * 1024 * 1024;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2182,6 +2182,12 @@ export function App() {
         return;
       }
 
+      if (command === "background_bash") {
+        const list = Array.isArray(result?.backgrounded) ? (result.backgrounded as string[]) : [];
+        setLifecycleStatus(`Backgrounded: ${list.join(", ")}`);
+        return;
+      }
+
       if (command === "refresh_usage") {
         const nextUsage = result?.providerUsage && typeof result.providerUsage === "object"
           ? (result.providerUsage as ProviderUsageMap)

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -142,7 +142,7 @@ export function useSlashCommands(
       new Set([
         "new", "resume", "rewind", "fork", "mcp", "plugins", "skills", "agents", "model",
         "cycle_model", "effort", "cycle_effort", "compact", "name", "copy",
-        "stop", "restart", "remote", "plan", "sandbox", "goal",
+        "stop", "restart", "remote", "plan", "sandbox", "goal", "background",
       ]),
     [],
   );
@@ -174,6 +174,7 @@ export function useSlashCommands(
       { name: "name", description: "Set session name" },
       { name: "copy", description: "Copy last assistant message" },
       { name: "stop", description: "Abort current generation" },
+      { name: "background", description: "Send the running command to the background" },
       { name: "restart", description: "Restart the CLI process" },
       { name: "plan", description: "Toggle plan mode (read-only exploration)" },
       {
@@ -825,6 +826,14 @@ export function useSlashCommands(
 
       if (rawCommand === "copy") {
         onExec({ type: "exec", id, command: "get_last_assistant_text" });
+        setInput("");
+        setCommandOpen(false);
+        setCommandQuery("");
+        return true;
+      }
+
+      if (rawCommand === "background") {
+        onExec({ type: "exec", id, command: "background_bash" });
         setInput("");
         setCommandOpen(false);
         setCommandQuery("");

--- a/packages/ui/src/lib/remote-exec.ts
+++ b/packages/ui/src/lib/remote-exec.ts
@@ -2,6 +2,7 @@ export type RemoteExecCommand =
   | { command: "get_commands" }
   | { command: "mcp"; action?: "status" | "reload" }
   | { command: "abort" }
+  | { command: "background_bash" }
   | { command: "set_model"; provider: string; modelId: string }
   | { command: "cycle_model" }
   | { command: "get_available_models" }


### PR DESCRIPTION
The bash tool no longer needs the model to predict which commands are slow.<br /><br />**Behavior**<br />- Every `bash` call takes a required `title` (its purpose), used in the running/completion messages.<br />- Output streams normally for the first 15s. Still running after that? The call returns, the process keeps going, output redirects to a tmp log file, and the model is told it's still running — and explicitly told not to `sleep`/poll.<br />- On exit (any code) a message is delivered into the session:<br /><br />```<br />Run server tests exited with code 1 after 92s<br /><br />See full stdout/stderr in /tmp/pizzapi-bash-….log<br />```<br /><br />- Configurable via `bash.backgroundAfterSeconds` (config.json) or `PIZZAPI_BASH_BACKGROUND_SECONDS`. `run_in_background: true` = threshold 0.<br />- `bash_output(pid)`, `kill_shell(pid)`, ctrl+shift+b / `/background` unchanged.<br /><br />**Drive-by fix**<br />`packages/tools/src/bash.ts` never closed the child's stdin — `exec()` hands the child an open pipe, so any command that reads stdin (e.g. `rtk`, which the RTK hook rewrites `rg`/`grep` into) blocked until the timeout. Now closed, with a regression test (`cat` must exit instantly).<br /><br />**Verification**<br />- `bun run typecheck` clean<br />- 38 tests pass, incl. new coverage for the threshold, auto-backgrounding, and the completion message format<br />- Docs updated: `customization/configuration.mdx`, `reference/environment-variables.mdx`