### PR TITLE
fix(models): close hidden-model leak paths and refresh mid-conversation

### DIFF
--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -12,6 +12,7 @@ import { isPlanModeEnabled, togglePlanModeFromRemote, setPlanModeFromRemote } fr
 import { isSandboxActive, getSandboxMode, getViolations, getResolvedConfig } from "@pizzapi/tools";
 import { refreshAllUsage, buildProviderUsage } from "./remote-provider-usage.js";
 import { backgroundPendingJobs } from "./background-bash.js";
+import { isModelHidden } from "../hidden-models.js";
 import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js";
 import type { RelayContext, RelayModelInfo } from "./remote-types.js";
 import { emitThinkingLevelChanged, emitCompactStarted, emitCompactEnded, emitRetryStateChanged, emitPluginTrustResolved } from "./remote-meta-events.js";
@@ -146,7 +147,8 @@ export async function handleExecFromWeb(
                 replyErr("No active session");
                 return;
             }
-            const models = rctx.getConfiguredModels();
+            // Cycle only through models the user hasn't hidden.
+            const models = rctx.getConfiguredModels().filter((m: RelayModelInfo) => !isModelHidden(m.provider, m.id));
             const state = rctx.buildSessionState();
             const currentKey = state?.model ? `${(state.model as any).provider}/${(state.model as any).id}` : null;
             const idx = currentKey ? models.findIndex((m: RelayModelInfo) => `${m.provider}/${m.id}` === currentKey) : -1;

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -28,6 +28,7 @@ import { emitSessionActive } from "./chunked-delivery.js";
 import { resetRelayRegistrationGate, signalRelayRegistered } from "./registration-gate.js";
 import { decideRegisteredParentState } from "../remote-registered-parent-state.js";
 import { waitForWorkerStartupComplete } from "../worker-startup-gate.js";
+import { setHiddenModelKeys } from "../../hidden-models.js";
 import { resolveInputDeliverAs } from "./deliver-as-default.js";
 import { sendSessionCompleteFollowUp } from "./session-complete-followup.js";
 
@@ -423,6 +424,10 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
 
     sock.on("model_set", (data) => {
         void handlers.setModelFromWeb(data.provider, data.modelId);
+    });
+
+    sock.on("hidden_models_update", (data) => {
+        setHiddenModelKeys(data?.hiddenModels);
     });
 
     sock.on("session_message", (data) => {

--- a/packages/cli/src/extensions/remote/model-selection.test.ts
+++ b/packages/cli/src/extensions/remote/model-selection.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setModelFromWeb } from "./model-selection.js";
 
+// Hermetic: the dev/CI machine may itself run under a PizzaPi worker with
+// PIZZAPI_HIDDEN_MODELS set — that must not leak into these tests.
+delete process.env.PIZZAPI_HIDDEN_MODELS;
+
 async function withTempHome(fn: () => Promise<void> | void) {
     const previousHome = process.env.HOME;
     const tempHome = mkdtempSync(join(tmpdir(), "model-selection-test-"));
@@ -70,6 +74,30 @@ function createRctx(modelFromRegistry?: any) {
 }
 
 describe("setModelFromWeb", () => {
+    test("rejects hidden models before touching the registry", async () => {
+        const previous = process.env.PIZZAPI_HIDDEN_MODELS;
+        process.env.PIZZAPI_HIDDEN_MODELS = JSON.stringify(["ollama-cloud/glm-5.2"]);
+        try {
+            const { rctx, events } = createRctx(ollamaCloudModel("glm-5.2"));
+            let called = false;
+            const pi = { setModel: async () => { called = true; return true; } };
+
+            await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+            expect(called).toBe(false);
+            expect(events).toContainEqual({
+                type: "model_set_result",
+                ok: false,
+                provider: "ollama-cloud",
+                modelId: "glm-5.2",
+                message: "Model is hidden by user preferences.",
+            });
+        } finally {
+            if (previous === undefined) delete process.env.PIZZAPI_HIDDEN_MODELS;
+            else process.env.PIZZAPI_HIDDEN_MODELS = previous;
+        }
+    });
+
     test("returns without side effects when there is no session context", async () => {
         const events: any[] = [];
         const pi = { setModel: async () => true };

--- a/packages/cli/src/extensions/remote/model-selection.ts
+++ b/packages/cli/src/extensions/remote/model-selection.ts
@@ -8,6 +8,7 @@ import type { RelayContext } from "../remote-types.js";
 import { getAuthSource } from "../remote-auth-source.js";
 import { emitSessionActive } from "./chunked-delivery.js";
 import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
+import { isModelHidden } from "../../hidden-models.js";
 
 /**
  * Handle a web-initiated model change request.
@@ -23,6 +24,16 @@ export async function setModelFromWeb(
     if (!rctx.latestCtx) return;
 
     try {
+        if (isModelHidden(provider, modelId)) {
+            rctx.forwardEvent({
+                type: "model_set_result",
+                ok: false,
+                provider,
+                modelId,
+                message: "Model is hidden by user preferences.",
+            });
+            return;
+        }
         const model =
             rctx.latestCtx.modelRegistry.find(provider, modelId) ??
             findCachedOllamaCloudModel(provider, modelId);

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../config.js";
 import { normalizeLoopbackHost } from "../relay-url.js";
 import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../ollama-cloud-models.js";
 import { mergeModelLists } from "../session-models-cache.js";
+import { isModelHidden } from "../hidden-models.js";
 import { getRelaySessionId } from "./remote.js";
 import { buildProviderUsage, refreshAllUsage } from "./remote-provider-usage.js";
 import { formatProviderUsage, getUsageKey, normalizeUsageKeys } from "./format-usage.js";
@@ -279,20 +280,10 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
         async execute(_toolCallId, rawParams, _signal, _onUpdate, ctx) {
             const params = (rawParams ?? {}) as { onlyAvailable?: boolean };
 
-            // Load hidden models from env (set by the runner daemon from user preferences).
-            // Format: JSON array of "provider/modelId" strings.
-            let hiddenModelKeys: Set<string>;
-            try {
-                const raw = process.env.PIZZAPI_HIDDEN_MODELS;
-                hiddenModelKeys = raw
-                    ? new Set(JSON.parse(raw).filter((x: unknown): x is string => typeof x === "string"))
-                    : new Set();
-            } catch {
-                hiddenModelKeys = new Set();
-            }
-
+            // Hidden models: seeded via PIZZAPI_HIDDEN_MODELS at spawn, kept
+            // fresh by the relay's hidden_models_update push.
             const isHidden = (m: { provider: string | symbol; id: string }) =>
-                hiddenModelKeys.has(`${String(m.provider)}/${m.id}`);
+                isModelHidden(m.provider, m.id);
 
             // Ollama Cloud models are discovered dynamically (fetched live from ollama.com,
             // not baked into the static registry) — merge in the runner's cached list, same

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -17,6 +17,10 @@ import {
 } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
 
+// Hermetic: the dev/CI machine may itself run under a PizzaPi worker with
+// PIZZAPI_HIDDEN_MODELS set — that must not leak into these tests.
+delete process.env.PIZZAPI_HIDDEN_MODELS;
+
 /**
  * Tests for the subagent tool utility functions.
  *
@@ -390,6 +394,31 @@ describe("resolveModelSpec", () => {
     const makeRegistry = (models: Array<{ provider: string; id: string; available?: boolean }>) => ({
         find: (provider: string, modelId: string) => models.find(m => m.provider === provider && m.id === modelId) as any,
         getAvailable: () => models.filter(m => m.available !== false) as any[],
+    });
+
+    test("refuses hidden models", () => {
+        process.env.PIZZAPI_HIDDEN_MODELS = JSON.stringify(["anthropic/claude-haiku-4-5"]);
+        try {
+            const registry = makeRegistry([{ provider: "anthropic", id: "claude-haiku-4-5" }]);
+            expect(resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry)).toBeUndefined();
+        } finally {
+            delete process.env.PIZZAPI_HIDDEN_MODELS;
+        }
+    });
+
+    test("same-id provider fallback skips hidden providers", () => {
+        process.env.PIZZAPI_HIDDEN_MODELS = JSON.stringify(["claude-subscription/claude-haiku-4-5"]);
+        try {
+            const registry = makeRegistry([
+                { provider: "anthropic", id: "claude-haiku-4-5", available: false },
+                { provider: "claude-subscription", id: "claude-haiku-4-5" },
+            ]);
+            const model = resolveModelSpec({ provider: "anthropic", id: "claude-haiku-4-5" }, registry);
+            // Falls through to the credential-less exact match instead of the hidden provider
+            expect(model!.provider).toBe("anthropic");
+        } finally {
+            delete process.env.PIZZAPI_HIDDEN_MODELS;
+        }
     });
 
     test("resolves an exact provider/id match", () => {

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -16,6 +16,7 @@ import type { AgentConfig } from "../subagent-agents.js";
 import type { Model } from "@earendil-works/pi-ai";
 import { defaultAgentDir } from "../../config.js";
 import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
+import { isModelHidden } from "../../hidden-models.js";
 import type { SingleResult, SubagentDetails, OnUpdateCallback } from "./types.js";
 import { getFinalOutput, summarizeResultForStreaming } from "./types.js";
 
@@ -144,7 +145,7 @@ function isFullModelRegistry(registry: ModelRegistryLike): registry is ModelRegi
  *   3. If no available models, return undefined (fall back to default).
  */
 export function selectLightweightModel(registry: ModelRegistryLike): Model<any> | undefined {
-    const available = registry.getAvailable();
+    const available = registry.getAvailable().filter((m) => !isModelHidden(m.provider, m.id));
     if (available.length === 0) return undefined;
 
     // Sort by output token cost ascending — cheapest first
@@ -167,13 +168,16 @@ export function selectLightweightModel(registry: ModelRegistryLike): Model<any> 
  *      the provider the caller actually asked for.
  */
 export function resolveModelSpec(spec: ModelOverride, registry: ModelRegistryLike): Model<any> | undefined {
+    // Hidden models are hard-blocked by name everywhere (spawn route, model
+    // switching) — subagents included.
+    if (isModelHidden(spec.provider, spec.id)) return undefined;
     const exact = registry.find(spec.provider, spec.id);
     const available = registry.getAvailable();
     if (exact && available.includes(exact)) return exact;
     return (
         findCachedOllamaCloudModel(spec.provider, spec.id) ??
         // ponytail: same-id fallback only, no fuzzy matching
-        available.find((m) => m.id === spec.id) ??
+        available.find((m) => m.id === spec.id && !isModelHidden(m.provider, m.id)) ??
         exact
     );
 }

--- a/packages/cli/src/hidden-models.test.ts
+++ b/packages/cli/src/hidden-models.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getHiddenModelKeys, isModelHidden, setHiddenModelKeys } from "./hidden-models.js";
+
+const previous = process.env.PIZZAPI_HIDDEN_MODELS;
+
+afterEach(() => {
+    if (previous === undefined) delete process.env.PIZZAPI_HIDDEN_MODELS;
+    else process.env.PIZZAPI_HIDDEN_MODELS = previous;
+});
+
+describe("hidden-models env helpers", () => {
+    test("empty/missing env yields empty set", () => {
+        delete process.env.PIZZAPI_HIDDEN_MODELS;
+        expect(getHiddenModelKeys().size).toBe(0);
+        expect(isModelHidden("anthropic", "claude-3-5-haiku")).toBe(false);
+    });
+
+    test("corrupt env yields empty set", () => {
+        process.env.PIZZAPI_HIDDEN_MODELS = "not json";
+        expect(getHiddenModelKeys().size).toBe(0);
+    });
+
+    test("isModelHidden matches provider/id keys, including ids with slashes", () => {
+        process.env.PIZZAPI_HIDDEN_MODELS = JSON.stringify([
+            "anthropic/claude-3-5-haiku",
+            "openrouter/vendor/model",
+        ]);
+        expect(isModelHidden("anthropic", "claude-3-5-haiku")).toBe(true);
+        expect(isModelHidden("openrouter", "vendor/model")).toBe(true);
+        expect(isModelHidden("anthropic", "claude-sonnet-4")).toBe(false);
+    });
+
+    test("setHiddenModelKeys updates the env for subsequent reads", () => {
+        setHiddenModelKeys(["ollama-cloud/glm-5.2"]);
+        expect(isModelHidden("ollama-cloud", "glm-5.2")).toBe(true);
+        setHiddenModelKeys([]);
+        expect(isModelHidden("ollama-cloud", "glm-5.2")).toBe(false);
+        // Non-array input clears the list instead of throwing
+        setHiddenModelKeys("garbage" as unknown);
+        expect(getHiddenModelKeys().size).toBe(0);
+    });
+});

--- a/packages/cli/src/hidden-models.ts
+++ b/packages/cli/src/hidden-models.ts
@@ -1,0 +1,36 @@
+/**
+ * Worker-side hidden-model awareness.
+ *
+ * The runner daemon seeds PIZZAPI_HIDDEN_MODELS (JSON array of
+ * "provider/modelId" keys) at spawn time from the owning user's preferences.
+ * The relay pushes `hidden_models_update` when the user edits the list
+ * mid-session; `setHiddenModelKeys` refreshes the env var so every consumer
+ * (list_models tool, model switching, cycling, subagents) reads a fresh list.
+ *
+ * This is a user preference / hard-block by name — not a security boundary.
+ * The authoritative copy lives server-side (user_hidden_model table).
+ */
+
+/** Parse the current hidden-model key set from the environment. */
+export function getHiddenModelKeys(): Set<string> {
+    try {
+        const raw = process.env.PIZZAPI_HIDDEN_MODELS;
+        if (!raw) return new Set();
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return new Set();
+        return new Set(parsed.filter((x): x is string => typeof x === "string"));
+    } catch {
+        return new Set();
+    }
+}
+
+/** Replace the hidden-model list (called from the relay push handler). */
+export function setHiddenModelKeys(keys: unknown): void {
+    const list = Array.isArray(keys) ? keys.filter((x): x is string => typeof x === "string") : [];
+    process.env.PIZZAPI_HIDDEN_MODELS = JSON.stringify(list);
+}
+
+/** True when provider/id is on the hidden list. */
+export function isModelHidden(provider: string | symbol, id: string): boolean {
+    return getHiddenModelKeys().has(`${String(provider)}/${id}`);
+}

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -162,6 +162,11 @@ export interface RelayServerToClientEvents {
     modelId: string;
   }) => void;
 
+  /** Pushes the owner's updated hidden-model list to a running session */
+  hidden_models_update: (data: {
+    hiddenModels: string[];
+  }) => void;
+
   /** Remote command execution request from viewer */
   exec: (data: {
     id: string;

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -436,7 +436,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 hiddenModels = [];
             }
             const visible = models.filter((m: any) =>
-                !hiddenModels.includes(`${m.provider}/${m.id}`)
+                !isHiddenModel(hiddenModels, { provider: String(m.provider ?? ""), id: String(m.id ?? "") })
             );
             return Response.json({ models: visible });
         } catch {

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -4,7 +4,39 @@
 
 import { requireSession } from "../middleware.js";
 import { getHiddenModels, setHiddenModels } from "../user-hidden-models.js";
+import { getAllRunners } from "../ws/sio-state/index.js";
+import { getConnectedSessionsForRunner } from "../ws/sio-registry/runners.js";
+import { getLocalTuiSocket } from "../ws/sio-registry/sessions.js";
+import { emitToRelaySession } from "../ws/sio-registry/context.js";
+import { createLogger } from "@pizzapi/tools";
 import type { RouteHandler } from "./types.js";
+
+const log = createLogger("settings");
+
+/**
+ * Best-effort push of the updated hidden-model list to every running worker
+ * session owned by the user, so mid-conversation model switching, cycling,
+ * and the list_models tool reflect the change without a restart.
+ */
+async function pushHiddenModelsToUserSessions(userId: string, hiddenModels: string[]): Promise<void> {
+    try {
+        const runners = await getAllRunners(userId);
+        for (const runner of runners) {
+            const sessions = await getConnectedSessionsForRunner(runner.runnerId).catch(() => []);
+            for (const { sessionId } of sessions) {
+                const tuiSocket = getLocalTuiSocket(sessionId);
+                if (tuiSocket) {
+                    tuiSocket.emit("hidden_models_update" as string, { hiddenModels });
+                } else {
+                    // Cross-node: route through the relay adapter.
+                    emitToRelaySession(sessionId, "hidden_models_update", { hiddenModels });
+                }
+            }
+        }
+    } catch (err) {
+        log.warn("Failed to push hidden models to sessions:", err);
+    }
+}
 
 export const handleSettingsRoute: RouteHandler = async (req, url) => {
     if (url.pathname === "/api/settings/hidden-models" && req.method === "GET") {
@@ -31,6 +63,7 @@ export const handleSettingsRoute: RouteHandler = async (req, url) => {
             : [];
 
         await setHiddenModels(identity.userId, hiddenModels);
+        void pushHiddenModelsToUserSessions(identity.userId, hiddenModels);
         return Response.json({ ok: true, hiddenModels });
     }
 

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -34,6 +34,8 @@
  */
 
 import { requireSession, validateApiKey } from "../middleware.js";
+import { getHiddenModels } from "../user-hidden-models.js";
+import { isHiddenModel } from "./model-guard.js";
 import {
     getSharedSession,
     getLocalTuiSocket,
@@ -1045,9 +1047,21 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             });
             const runnerSocket = getLocalRunnerSocket(runnerId);
             if (runnerSocket) {
+                // Fire-time hidden-model recheck: the listener's model was
+                // validated at create/update time, but may have been hidden
+                // since. Drop it (runner default) rather than failing the spawn.
+                const hiddenModels = runnerData.userId
+                    ? await getHiddenModels(runnerData.userId).catch(() => [] as string[])
+                    : [];
                 for (const listener of matchingListeners) {
                     const spawnedSessionId = randomUUID();
                     const ackPromise = waitForSpawnAck(spawnedSessionId, 10_000);
+                    const listenerModel = listener.model && !isHiddenModel(hiddenModels, listener.model)
+                        ? listener.model
+                        : undefined;
+                    if (listener.model && !listenerModel) {
+                        log.warn(`trigger auto-spawn: dropping hidden model ${listener.model.provider}/${listener.model.id}, using runner default`);
+                    }
                     try {
                         // Don't pass the listener prompt as the initial prompt —
                         // it's already merged into the trigger payload below.
@@ -1056,7 +1070,8 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                         runnerSocket.emit("new_session", {
                             sessionId: spawnedSessionId,
                             ...(listener.cwd ? { cwd: listener.cwd } : {}),
-                            ...(listener.model ? { model: listener.model } : {}),
+                            ...(listenerModel ? { model: listenerModel } : {}),
+                            ...(hiddenModels.length > 0 ? { hiddenModels } : {}),
                             ...(listener.autoClose ? { autoClose: true } : {}),
                         });
                         const ack = await ackPromise;

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -111,6 +111,13 @@ mock.module("../sessions/trigger-store.js", () => ({
     pushTriggerHistory: mockPushTriggerHistory,
 }));
 
+// ── Mock hidden models ─────────────────────────────────────────────────
+const mockGetHiddenModels = mock((_userId: string) => Promise.resolve([] as string[]));
+
+mock.module("../user-hidden-models.js", () => ({
+    getHiddenModels: mockGetHiddenModels,
+}));
+
 // Import AFTER mocks
 const { handleWebhooksRoute } = await import("./webhooks.js");
 
@@ -182,6 +189,19 @@ describe("POST /api/webhooks — create webhook", () => {
         expect(res?.status).toBe(400);
         const body = await res!.json();
         expect(body.error).toContain("name");
+    });
+
+    test("returns 403 when the requested model is hidden", async () => {
+        mockGetHiddenModels.mockReturnValue(Promise.resolve(["anthropic/claude-opus-4"]));
+        const [req, url] = makeReq("POST", "/api/webhooks", {
+            name: "Hook",
+            source: "custom",
+            model: { provider: "anthropic", id: "claude-opus-4" },
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(403);
+        expect(mockCreateWebhook).not.toHaveBeenCalled();
+        mockGetHiddenModels.mockReturnValue(Promise.resolve([]));
     });
 
     test("returns 400 when source is missing", async () => {
@@ -889,6 +909,48 @@ describe("POST /api/webhooks/:id/fire — spawn behavior", () => {
         mockGetRunnerData.mockReturnValue(
             Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
         );
+    });
+
+    test("drops a since-hidden model at fire time and forwards hiddenModels", async () => {
+        mockGetHiddenModels.mockReturnValue(Promise.resolve(["anthropic/claude-opus-4"]));
+        const hook = { ...ACTIVE_WEBHOOK, model: { provider: "anthropic", id: "claude-opus-4" } };
+        mockGetWebhook.mockReturnValue(Promise.resolve(hook));
+
+        const runnerEmitMock = mock(() => {});
+        mockGetLocalRunnerSocket.mockReturnValue({ emit: runnerEmitMock });
+        mockWaitForSpawnAck.mockReturnValue(Promise.resolve({ ok: true }));
+        const sessionEmitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock });
+
+        const [req, url] = makeFireReq("/api/webhooks/wh-1/fire", { event: "x" }, ACTIVE_WEBHOOK.secret);
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(200);
+
+        const spawnArgs = (runnerEmitMock.mock.calls[0] as any[])[1];
+        expect(spawnArgs.model).toBeUndefined();
+        expect(spawnArgs.hiddenModels).toEqual(["anthropic/claude-opus-4"]);
+        mockGetHiddenModels.mockReturnValue(Promise.resolve([]));
+    });
+
+    test("keeps a visible model at fire time", async () => {
+        mockGetHiddenModels.mockReturnValue(Promise.resolve(["anthropic/claude-opus-4"]));
+        const hook = { ...ACTIVE_WEBHOOK, model: { provider: "anthropic", id: "claude-haiku-4-5" } };
+        mockGetWebhook.mockReturnValue(Promise.resolve(hook));
+
+        const runnerEmitMock = mock(() => {});
+        mockGetLocalRunnerSocket.mockReturnValue({ emit: runnerEmitMock });
+        mockWaitForSpawnAck.mockReturnValue(Promise.resolve({ ok: true }));
+        const sessionEmitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock });
+
+        const [req, url] = makeFireReq("/api/webhooks/wh-1/fire", { event: "x" }, ACTIVE_WEBHOOK.secret);
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(200);
+
+        const spawnArgs = (runnerEmitMock.mock.calls[0] as any[])[1];
+        expect(spawnArgs.model).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+        expect(spawnArgs.hiddenModels).toEqual(["anthropic/claude-opus-4"]);
+        mockGetHiddenModels.mockReturnValue(Promise.resolve([]));
     });
 
     test("passes cwd and prompt to runner spawn", async () => {

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -51,6 +51,8 @@ import {
     deleteWebhook,
     toPublicWebhook,
 } from "../webhooks/store.js";
+import { getHiddenModels } from "../user-hidden-models.js";
+import { isHiddenModel } from "./model-guard.js";
 
 const log = createLogger("webhooks-api");
 
@@ -117,6 +119,16 @@ async function spawnSessionForWebhook(
         );
     }
 
+    // Re-check the stored model against the owner's *current* hidden list —
+    // it may have been hidden after the webhook was configured. Hidden model
+    // → spawn without it (runner default) rather than failing the delivery.
+    const hiddenModels = await getHiddenModels(webhookUserId).catch(() => [] as string[]);
+    let effectiveModel = model;
+    if (model && isHiddenModel(hiddenModels, model)) {
+        log.warn(`webhook spawn: dropping hidden model ${model.provider}/${model.id}, using runner default`);
+        effectiveModel = null;
+    }
+
     const sessionId = randomUUID();
     const ackPromise = waitForSpawnAck(sessionId, SPAWN_ACK_TIMEOUT_MS);
 
@@ -125,7 +137,8 @@ async function spawnSessionForWebhook(
             sessionId,
             ...(cwd ? { cwd } : {}),
             ...(prompt ? { prompt } : {}),
-            ...(model ? { model } : {}),
+            ...(effectiveModel ? { model: effectiveModel } : {}),
+            ...(hiddenModels.length > 0 ? { hiddenModels } : {}),
         });
     } catch {
         return Response.json(
@@ -314,6 +327,9 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
                 model = { provider: mp.trim(), id: mi.trim() };
             }
         }
+        if (model && isHiddenModel(await getHiddenModels(identity.userId).catch(() => []), model)) {
+            return Response.json({ error: "Model is hidden and cannot be used" }, { status: 403 });
+        }
 
         const webhook = await createWebhook({
             userId: identity.userId,
@@ -423,7 +439,11 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
                 const mp = (body.model as any).provider;
                 const mi = (body.model as any).id;
                 if (typeof mp === "string" && mp.trim() && typeof mi === "string" && mi.trim()) {
-                    updates.model = { provider: mp.trim(), id: mi.trim() };
+                    const candidate = { provider: mp.trim(), id: mi.trim() };
+                    if (isHiddenModel(await getHiddenModels(identity.userId).catch(() => []), candidate)) {
+                        return Response.json({ error: "Model is hidden and cannot be used" }, { status: 403 });
+                    }
+                    updates.model = candidate;
                 }
             }
         }

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -43,6 +43,8 @@ import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
 import { recordTriggerResponse } from "../../sessions/trigger-store.js";
+import { getHiddenModels } from "../../user-hidden-models.js";
+import { isHiddenModel } from "../../routes/model-guard.js";
 import { createLogger } from "@pizzapi/tools";
 import { hydrateViewerFromCache, sendCachedDeltaReplayEvents, sendLatestSnapshotFromCache } from "./viewer-cache.js";
 import { getBestSnapshot } from "./snapshot-provider.js";
@@ -653,6 +655,18 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             if (!currentSessionId) return;
             const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
+
+            // Hard-block hidden models by name (same rule as the spawn route).
+            // Fresh DB read — the worker's env copy may be stale.
+            try {
+                const hiddenModels = await getHiddenModels(viewerUserId);
+                if (isHiddenModel(hiddenModels, { provider: String(data?.provider ?? ""), id: String(data?.modelId ?? "") })) {
+                    log.warn(`blocked model_set of hidden model ${data.provider}/${data.modelId} on ${currentSessionId}`);
+                    return;
+                }
+            } catch {
+                // On lookup failure, fall through — the worker-side guard still applies.
+            }
 
             const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (!tuiSocket) return;


### PR DESCRIPTION
## Problem

Hidden models (per-user preference, intended as a hard block by name) were only enforced at three points: the spawn route, `GET /api/runners/:id/models`, and trigger-listener create/update. Audit found these leaks:

| # | Path | Leak |
|---|------|------|
| 1 | viewer socket `model_set` | hidden model selectable by name mid-conversation, no guard anywhere |
| 2 | exec `set_model` / `cycle_model` | same; cycling iterated the **unfiltered** model list |
| 3 | `PIZZAPI_HIDDEN_MODELS` env | frozen at worker spawn — preference changes never reached running sessions (`list_models` stayed stale forever; restarts reused the spawn-time closure) |
| 4 | webhooks | create/update accepted hidden models; fire-time spawn used a since-hidden stored model and passed **no** `hiddenModels` to the worker |
| 5 | trigger-listener auto-spawn | validated at create/update only; same fire-time + missing-env problems as webhooks |
| 6 | `subagent` tool | in-process model resolution had zero hidden-model awareness |
| 7 | `GET /runners/:id/models` | raw `includes()` compare while every other path used normalizing `isHiddenModel()` |

## Fix

**Worker** — new `packages/cli/src/hidden-models.ts` (env-backed `getHiddenModelKeys` / `setHiddenModelKeys` / `isModelHidden`), used by:
- `setModelFromWeb` — rejects hidden models with a proper `model_set_result` error (covers `model_set` + exec `set_model`)
- `cycle_model` — cycles only visible models
- `list_models` tool — same behavior as before, now via the shared helper
- subagent engine — `resolveModelSpec` refuses hidden specs (and the same-id provider fallback skips hidden providers); `selectLightweightModel` ignores hidden models

**Freshness** — new `hidden_models_update` relay event: `PUT /api/settings/hidden-models` pushes the fresh list to every live worker session owned by the user (local socket, relay fallback cross-node); the worker updates its env so all guards read current data. This fixes "hidden models not updated mid-conversation".

**Server** (fresh DB reads at the trust boundary):
- viewer `model_set` handler blocks hidden models before forwarding
- webhooks: 403 on create/update with a hidden model; fire-time recheck drops a since-hidden model (falls back to runner default rather than failing the automation) and forwards `hiddenModels` to the spawned session
- trigger-listener auto-spawn: same fire-time recheck + `hiddenModels` forwarding
- `GET /runners/:id/models` now uses `isHiddenModel()` normalization

## Explicitly out of scope
- Session-state `availableModels` still carries the full list — the Model Visibility manager needs hidden entries to un-hide them; the UI picker already filters client-side.
- Agent frontmatter `model:` on disk is honored as written (user-authored config).
- glm-5.2 display-name inconsistency is upstream (pi-ai static registry predates it; dynamic Ollama Cloud discovery uses `name = id`) — fixed by the next registry bump, not this PR.
- Note: stale branch `fix/runner-model-visibility` explored moving visibility into runner config; this PR instead fixes the current per-user DB architecture on main.

## Testing
- `bun run typecheck` clean
- New tests: env helper round-trip, `setModelFromWeb` hidden rejection, subagent `resolveModelSpec` hidden refusal + fallback skip, webhook create 403 + fire-time drop/forward (all pass)
- Isolated suites: `packages/server/src` 72/72 files pass; `packages/cli/src` passes except `sandbox-config.test.ts`, which fails identically on `main` (environment-specific, unrelated)
- Tests made hermetic against ambient `PIZZAPI_HIDDEN_MODELS` (dev machines running under a PizzaPi worker inherit it)