### PR TITLE
fix: run provider onSessionClose in the worker process (cross-process no-op)

### DIFF
--- a/packages/cli/src/extensions/providers/__fixtures__/signal-close-harness.ts
+++ b/packages/cli/src/extensions/providers/__fixtures__/signal-close-harness.ts
@@ -1,0 +1,43 @@
+/**
+ * Test fixture: simulates the worker's shutdown wiring for provider
+ * onSessionClose (see runner/worker.ts `shutdown()`).
+ *
+ * Spawned as a subprocess by session-close-signal.test.ts. Installs a
+ * SIGTERM handler that runs runProviderSessionClose — the same in-process
+ * close path the worker uses — with a provider that writes a marker file.
+ * The parent test SIGTERMs this process and asserts the marker exists,
+ * proving the close hook fires across a real process/signal boundary
+ * (regression for the daemon-side cross-process no-op, idea jg017xa4).
+ */
+import { writeFileSync } from "node:fs";
+import { runProviderSessionClose, __setBridgeForTest } from "../extension";
+import { ProviderBridge } from "../../../providers/bridge";
+
+const markerPath = process.env.CLOSE_MARKER_PATH;
+if (!markerPath) {
+  console.error("CLOSE_MARKER_PATH not set");
+  process.exit(1);
+}
+
+const provider = {
+  id: "signal-close-fixture",
+  capabilities: ["lifecycle"],
+  init: async () => {},
+  dispose: () => {},
+  onSessionClose: async (event: { reason: string }) => {
+    writeFileSync(markerPath, JSON.stringify({ reason: event.reason }));
+    return { label: "fixture-archived" };
+  },
+};
+
+__setBridgeForTest(new ProviderBridge([provider as any]));
+
+process.on("SIGTERM", () => {
+  void runProviderSessionClose("close")
+    .catch(() => {})
+    .finally(() => process.exit(0));
+});
+
+// Signal readiness and stay alive until SIGTERM.
+console.log("ready");
+setInterval(() => {}, 1_000);

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -101,10 +101,57 @@ describe("provider extension", () => {
     const first = await mod.runProviderSessionClose("complete");
     expect(first?.label).toBe("archived");
     expect(calls).toEqual([{ reason: "complete" }]);
-    // Idempotent — second shutdown path must not re-run providers.
+    // Idempotent — second shutdown path must not re-run providers. It shares
+    // the first call's cached result rather than running again or short-
+    // circuiting to null (which would let a caller proceed to exit() before
+    // the real close settled — see the concurrent-shutdown test below).
     const second = await mod.runProviderSessionClose("close");
-    expect(second).toBeNull();
+    expect(second?.label).toBe("archived");
     expect(calls.length).toBe(1);
+    mod.__setBridgeForTest(null);
+  });
+
+  test("runProviderSessionClose: concurrent callers await the same in-flight close", async () => {
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+    let resolveClose: ((v: { label: string }) => void) | undefined;
+    let callCount = 0;
+    const provider = {
+      id: "slow-close",
+      capabilities: ["lifecycle"],
+      init: async () => {},
+      dispose: () => {},
+      onSessionClose: async () => {
+        callCount++;
+        return new Promise((resolve) => {
+          resolveClose = resolve;
+        });
+      },
+    };
+    mod.__setBridgeForTest(new ProviderBridge([provider as any]));
+
+    // First caller (e.g. a signal handler) starts the close but doesn't await
+    // yet. A second caller (e.g. an extension-initiated shutdownHandler)
+    // fires concurrently, before the provider's promise resolves.
+    const firstCall = mod.runProviderSessionClose("close");
+    await Promise.resolve(); // let the first call reach the in-flight provider promise
+    const secondCall = mod.runProviderSessionClose("complete");
+
+    // The second caller must NOT resolve early (e.g. to null) while the first
+    // close is still in-flight — that's what let a shutdown path terminate a
+    // real in-flight provider close.
+    let secondResolved = false;
+    secondCall.then(() => {
+      secondResolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(secondResolved).toBe(false);
+
+    resolveClose!({ label: "flushed" });
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+    expect(first?.label).toBe("flushed");
+    expect(second?.label).toBe("flushed");
+    expect(callCount).toBe(1);
     mod.__setBridgeForTest(null);
   });
 
@@ -124,6 +171,53 @@ describe("provider extension", () => {
     const elapsed = Date.now() - start;
     expect(result).toBeNull();
     expect(elapsed).toBeLessThan(2000);
+    mod.__setBridgeForTest(null);
+  });
+
+  test("runProviderSessionClose bounds N hung providers by one overall deadline, not N * timeoutMs", async () => {
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+    const hungProvider = (id: string) => ({
+      id,
+      capabilities: ["lifecycle"],
+      init: async () => {},
+      dispose: () => {},
+      onSessionClose: () => new Promise(() => {}),
+    });
+    mod.__setBridgeForTest(
+      new ProviderBridge([hungProvider("p1"), hungProvider("p2"), hungProvider("p3")] as any),
+    );
+    const start = Date.now();
+    const result = await mod.runProviderSessionClose("close", { timeoutMs: 100 });
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    // Bridge runs providers sequentially. A per-provider (not overall)
+    // timeout would let 3 hung providers add up to ~300ms; the shared
+    // deadline should keep total time close to the single 100ms budget.
+    expect(elapsed).toBeLessThan(250);
+    mod.__setBridgeForTest(null);
+  });
+
+  test("runProviderSessionClose aborts its signal once the overall deadline elapses", async () => {
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+    let sawAbort = false;
+    const provider = {
+      id: "abort-aware",
+      capabilities: ["lifecycle"],
+      init: async () => {},
+      dispose: () => {},
+      onSessionClose: (_event: unknown, ctx: { signal: AbortSignal }) =>
+        new Promise((resolve) => {
+          ctx.signal.addEventListener("abort", () => {
+            sawAbort = true;
+            resolve(null);
+          });
+        }),
+    };
+    mod.__setBridgeForTest(new ProviderBridge([provider as any]));
+    await mod.runProviderSessionClose("close", { timeoutMs: 50 });
+    expect(sawAbort).toBe(true);
     mod.__setBridgeForTest(null);
   });
 

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -72,9 +72,59 @@ describe("provider extension", () => {
     expect(typeof mod.default).toBe("function");
   });
 
-  test("triggerSessionClose is exported", async () => {
+  test("runProviderSessionClose is exported", async () => {
     const mod = await import("./extension");
-    expect(typeof mod.triggerSessionClose).toBe("function");
+    expect(typeof mod.runProviderSessionClose).toBe("function");
+  });
+
+  test("runProviderSessionClose returns null with no bridge", async () => {
+    const mod = await import("./extension");
+    mod.__setBridgeForTest(null);
+    expect(await mod.runProviderSessionClose("close")).toBeNull();
+  });
+
+  test("runProviderSessionClose invokes provider onSessionClose with reason, once", async () => {
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+    const calls: Array<{ reason: string }> = [];
+    const provider = {
+      id: "close-test",
+      capabilities: ["lifecycle"],
+      init: async () => {},
+      dispose: () => {},
+      onSessionClose: async (event: { reason: string }) => {
+        calls.push({ reason: event.reason });
+        return { label: "archived" };
+      },
+    };
+    mod.__setBridgeForTest(new ProviderBridge([provider as any]));
+    const first = await mod.runProviderSessionClose("complete");
+    expect(first?.label).toBe("archived");
+    expect(calls).toEqual([{ reason: "complete" }]);
+    // Idempotent — second shutdown path must not re-run providers.
+    const second = await mod.runProviderSessionClose("close");
+    expect(second).toBeNull();
+    expect(calls.length).toBe(1);
+    mod.__setBridgeForTest(null);
+  });
+
+  test("runProviderSessionClose bounds a hung provider via timeout", async () => {
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+    const provider = {
+      id: "hung-provider",
+      capabilities: ["lifecycle"],
+      init: async () => {},
+      dispose: () => {},
+      onSessionClose: () => new Promise(() => {}),
+    };
+    mod.__setBridgeForTest(new ProviderBridge([provider as any]));
+    const start = Date.now();
+    const result = await mod.runProviderSessionClose("close", { timeoutMs: 100 });
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    expect(elapsed).toBeLessThan(2000);
+    mod.__setBridgeForTest(null);
   });
 
   test("extension registers on session_start, before_agent_start, turn_end, session_shutdown", async () => {

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -14,8 +14,14 @@ let bridge: ProviderBridge | null = null;
 let providerInstances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
 /** Last-known session identity for close-time context (updated on session_start/turn_end). */
 let currentSessionInfo: { sessionFile?: string; cwd?: string } | null = null;
-/** Run-once guard so concurrent shutdown paths (signal + shutdownHandler) fire close once. */
-let sessionCloseCompleted = false;
+/**
+ * Cached in-flight/completed close promise so concurrent shutdown paths
+ * (signal handler + extension shutdownHandler) share one close instead of
+ * racing: the second caller awaits the SAME promise rather than seeing a
+ * "completed" flag and returning early while the first close is still
+ * running (which let callers proceed to process.exit() mid-close).
+ */
+let sessionClosePromise: Promise<SessionCloseResult | null> | null = null;
 /** Current prompt boundary ID — generated once per user prompt. */
 let currentPromptId: string | null = null;
 /** Turn counter within the current prompt. Reset on new prompt. */
@@ -56,26 +62,45 @@ function makeProviderContext(
  * so a daemon-side import of this module sees `null` (that cross-process
  * call was a guaranteed no-op — see idea jg017xa4).
  *
- * Idempotent: only the first invocation runs providers; later calls return
- * null. Bounded: default 2.5s per provider so the worker stays inside the
- * daemon's SIGTERM→SIGKILL escalation window.
+ * Idempotent: only the first invocation runs providers; concurrent/later
+ * calls await and share that same invocation's result rather than racing
+ * ahead (see sessionClosePromise). Bounded: default 2.5s overall — one
+ * deadline for the whole (possibly multi-provider) close, not per provider
+ * — so the worker stays inside the daemon's SIGTERM→SIGKILL escalation
+ * window.
  */
 export async function runProviderSessionClose(
   reason: "close" | "error" | "complete",
   opts?: { timeoutMs?: number },
 ): Promise<SessionCloseResult | null> {
-  if (sessionCloseCompleted) return null;
-  sessionCloseCompleted = true;
+  if (sessionClosePromise) return sessionClosePromise;
+  sessionClosePromise = doRunProviderSessionClose(reason, opts);
+  return sessionClosePromise;
+}
+
+async function doRunProviderSessionClose(
+  reason: "close" | "error" | "complete",
+  opts?: { timeoutMs?: number },
+): Promise<SessionCloseResult | null> {
   if (!bridge) return null;
   const sessionId = process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown";
   const sessionFile = currentSessionInfo?.sessionFile ?? sessionId;
   const cwd = currentSessionInfo?.cwd ?? process.cwd();
+  const timeoutMs = opts?.timeoutMs ?? 2500;
+  const deadline = Date.now() + timeoutMs;
+  // Overall deadline is enforced twice: the bridge's own Promise.race stops
+  // WAITING on a slow provider, but a well-behaved hook can also watch
+  // ctx.signal and cancel its own in-flight work — abort it here so hooks
+  // that honor AbortSignal get a chance to clean up rather than being cut off.
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const result = await bridge.onSessionClose(
       { reason, sessionFile },
       {
-        signal: new AbortController().signal,
-        timeoutMs: opts?.timeoutMs ?? 2500,
+        signal: controller.signal,
+        timeoutMs,
+        deadline,
         sessionId,
         sessionFile,
         cwd,
@@ -88,13 +113,15 @@ export async function runProviderSessionClose(
   } catch (err) {
     log.error("Provider close failed:", err);
     return null;
+  } finally {
+    clearTimeout(abortTimer);
   }
 }
 
 /** Test-only: inject a bridge without running provider discovery. */
 export function __setBridgeForTest(b: ProviderBridge | null): void {
   bridge = b;
-  sessionCloseCompleted = false;
+  sessionClosePromise = null;
 }
 
 export async function providerExtension(pi: ExtensionAPI) {
@@ -135,7 +162,7 @@ export async function providerExtension(pi: ExtensionAPI) {
       sessionFile: ctx.sessionManager?.getSessionFile?.() ?? undefined,
       cwd: ctx.cwd,
     };
-    sessionCloseCompleted = false;
+    sessionClosePromise = null;
 
     if (enabledProviders.length === 0) {
       bridge = null;

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -12,6 +12,10 @@ const log = createLogger("provider-extension");
 let bridge: ProviderBridge | null = null;
 /** Provider instances tracked separately for disposal (bridge doesn't own lifecycle). */
 let providerInstances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
+/** Last-known session identity for close-time context (updated on session_start/turn_end). */
+let currentSessionInfo: { sessionFile?: string; cwd?: string } | null = null;
+/** Run-once guard so concurrent shutdown paths (signal + shutdownHandler) fire close once. */
+let sessionCloseCompleted = false;
 /** Current prompt boundary ID — generated once per user prompt. */
 let currentPromptId: string | null = null;
 /** Turn counter within the current prompt. Reset on new prompt. */
@@ -45,26 +49,52 @@ function makeProviderContext(
 }
 
 /**
- * Called by the daemon when a session is being archived.
- * Returns the close result if any provider handles it, or null.
+ * Run provider onSessionClose hooks in-process, from the worker's own
+ * shutdown paths (SIGTERM/SIGINT/IPC shutdown and extension-initiated
+ * shutdownHandler). This MUST run in the worker process: `bridge` is a
+ * module-global initialized by providerExtension's session_start handler,
+ * so a daemon-side import of this module sees `null` (that cross-process
+ * call was a guaranteed no-op — see idea jg017xa4).
+ *
+ * Idempotent: only the first invocation runs providers; later calls return
+ * null. Bounded: default 2.5s per provider so the worker stays inside the
+ * daemon's SIGTERM→SIGKILL escalation window.
  */
-export async function triggerSessionClose(
-  sessionId: string,
-  sessionFile: string,
+export async function runProviderSessionClose(
   reason: "close" | "error" | "complete",
-  cwd: string,
+  opts?: { timeoutMs?: number },
 ): Promise<SessionCloseResult | null> {
+  if (sessionCloseCompleted) return null;
+  sessionCloseCompleted = true;
   if (!bridge) return null;
-  return bridge.onSessionClose(
-    { reason, sessionFile },
-    {
-      signal: new AbortController().signal,
-      timeoutMs: 5000,
-      sessionId,
-      sessionFile,
-      cwd,
-    },
-  );
+  const sessionId = process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown";
+  const sessionFile = currentSessionInfo?.sessionFile ?? sessionId;
+  const cwd = currentSessionInfo?.cwd ?? process.cwd();
+  try {
+    const result = await bridge.onSessionClose(
+      { reason, sessionFile },
+      {
+        signal: new AbortController().signal,
+        timeoutMs: opts?.timeoutMs ?? 2500,
+        sessionId,
+        sessionFile,
+        cwd,
+      },
+    );
+    if (result) {
+      log.info(`Provider close: ${result.label}`);
+    }
+    return result;
+  } catch (err) {
+    log.error("Provider close failed:", err);
+    return null;
+  }
+}
+
+/** Test-only: inject a bridge without running provider discovery. */
+export function __setBridgeForTest(b: ProviderBridge | null): void {
+  bridge = b;
+  sessionCloseCompleted = false;
 }
 
 export async function providerExtension(pi: ExtensionAPI) {
@@ -100,6 +130,12 @@ export async function providerExtension(pi: ExtensionAPI) {
       }
       return true;
     });
+
+    currentSessionInfo = {
+      sessionFile: ctx.sessionManager?.getSessionFile?.() ?? undefined,
+      cwd: ctx.cwd,
+    };
+    sessionCloseCompleted = false;
 
     if (enabledProviders.length === 0) {
       bridge = null;
@@ -185,6 +221,13 @@ export async function providerExtension(pi: ExtensionAPI) {
 
     currentTurnId++;
 
+    // Keep close-time context fresh — headless switchSession/newSession may
+    // swap the session file without a session_start in this process.
+    currentSessionInfo = {
+      sessionFile: ctx.sessionManager?.getSessionFile?.() ?? currentSessionInfo?.sessionFile,
+      cwd: ctx.cwd ?? currentSessionInfo?.cwd,
+    };
+
     await bridge.onTurnEnd(
       {
         turnIndex: event.turnIndex,
@@ -207,8 +250,8 @@ export async function providerExtension(pi: ExtensionAPI) {
   // ── Session Shutdown: dispose providers ───────────────────────
   pi.on("session_shutdown", async (event, ctx) => {
     if (bridge) {
-      // SessionClose is called separately by daemon before session_shutdown.
-      // Here we only notify shutdown and dispose.
+      // SessionClose runs from the worker's process shutdown paths (see
+      // runProviderSessionClose). Here we only notify shutdown and dispose.
       await bridge.onSessionShutdown(
         { reason: event.reason as "quit", targetSessionFile: event.targetSessionFile },
         makeProviderContext(ctx),

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -115,6 +115,7 @@ async function doRunProviderSessionClose(
     return null;
   } finally {
     clearTimeout(abortTimer);
+    controller.abort();
   }
 }
 

--- a/packages/cli/src/extensions/providers/session-close-signal.test.ts
+++ b/packages/cli/src/extensions/providers/session-close-signal.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Cross-process regression test for provider onSessionClose (idea jg017xa4).
+ *
+ * The historical bug: the daemon imported triggerSessionClose and called it
+ * in its own process, where the module-global provider bridge is never
+ * initialized — a guaranteed no-op. The fix runs close inside the worker's
+ * own shutdown paths. This test proves the close hook actually fires across
+ * a real process + signal boundary: it spawns a subprocess wired exactly
+ * like the worker's SIGTERM path and asserts the provider's onSessionClose
+ * side effect materialized after SIGTERM.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const FIXTURE = join(import.meta.dir, "__fixtures__", "signal-close-harness.ts");
+
+describe("provider onSessionClose across process boundary", () => {
+  test("SIGTERM to the worker-like process runs provider close before exit", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "session-close-signal-"));
+    const markerPath = join(tmp, "close-marker.json");
+    try {
+      const proc = Bun.spawn(["bun", FIXTURE], {
+        cwd: import.meta.dir,
+        env: {
+          ...process.env,
+          CLOSE_MARKER_PATH: markerPath,
+          HOME: tmp, // isolate from any real ~/.pizzapi config
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // Wait for the harness to signal readiness (bounded).
+      const reader = proc.stdout.getReader();
+      const deadline = Date.now() + 15_000;
+      let ready = false;
+      let buffered = "";
+      while (!ready && Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffered += new TextDecoder().decode(value);
+        if (buffered.includes("ready")) ready = true;
+      }
+      expect(ready).toBe(true);
+
+      proc.kill("SIGTERM");
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(existsSync(markerPath)).toBe(true);
+      const marker = JSON.parse(readFileSync(markerPath, "utf-8"));
+      expect(marker.reason).toBe("close");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/providers/bridge.test.ts
+++ b/packages/cli/src/providers/bridge.test.ts
@@ -219,4 +219,58 @@ describe("ProviderBridge", () => {
     const result = await bridge.onSessionClose({ reason: "close", sessionFile: "/tmp/s.jsonl" }, ctx);
     expect(result).toEqual({ label: "Flushing beta", jobRef: { id: "j1" } });
   });
+
+  test("onSessionClose bounds sequential providers by one overall ctx.deadline, not N * timeoutMs", async () => {
+    let attempts = 0;
+    const hung = (id: string) => makeProvider({
+      id,
+      capabilities: ["lifecycle"] as const,
+      onSessionClose: async () => {
+        attempts++;
+        return new Promise(() => {}); // never resolves
+      },
+    });
+
+    const bridge = new ProviderBridge([hung("p1"), hung("p2"), hung("p3")]);
+    const timeoutMs = 100;
+    const deadline = Date.now() + 120;
+    const ctx = { signal: new AbortController().signal, timeoutMs, deadline, sessionId: "s1", cwd: "/tmp" };
+
+    const start = Date.now();
+    const result = await bridge.onSessionClose({ reason: "close", sessionFile: "/tmp/s.jsonl" }, ctx);
+    const elapsed = Date.now() - start;
+
+    expect(result).toBeNull();
+    // Per-provider (not overall) timeouts would let 3 hung providers add up to
+    // ~3 * 100ms = 300ms. One shared deadline should stay close to the 120ms
+    // budget instead.
+    expect(elapsed).toBeLessThan(200);
+    // The deadline should stop the loop from even attempting every provider.
+    expect(attempts).toBeLessThan(3);
+  });
+
+  test("onSessionClose skips remaining providers once ctx.deadline has already elapsed", async () => {
+    let attempts = 0;
+    const provider = makeProvider({
+      id: "late",
+      capabilities: ["lifecycle"] as const,
+      onSessionClose: async () => {
+        attempts++;
+        return { label: "should not run", jobRef: {} };
+      },
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = {
+      signal: new AbortController().signal,
+      timeoutMs: 1000,
+      deadline: Date.now() - 1, // already elapsed
+      sessionId: "s1",
+      cwd: "/tmp",
+    };
+
+    const result = await bridge.onSessionClose({ reason: "close", sessionFile: "/tmp/s.jsonl" }, ctx);
+    expect(result).toBeNull();
+    expect(attempts).toBe(0);
+  });
 });

--- a/packages/cli/src/providers/bridge.ts
+++ b/packages/cli/src/providers/bridge.ts
@@ -202,6 +202,11 @@ export class ProviderBridge {
       if (this.#disabled.has(provider.id)) continue;
       if (!isLifecycleHook(provider)) continue;
       if (!provider.onSessionClose) continue;
+      // Providers run sequentially; without this check N providers could add
+      // up to N * timeoutMs of wall time. ctx.deadline (set by the caller,
+      // e.g. runProviderSessionClose) is one overall budget for the whole
+      // loop, not per provider — stop trying once it's gone.
+      if (ctx.deadline !== undefined && Date.now() >= ctx.deadline) break;
       try {
         const result = await this.#withTimeout(
           provider.onSessionClose(event, ctx),
@@ -230,11 +235,20 @@ export class ProviderBridge {
       throw new Error(`Provider "${providerId}" call aborted before execution`);
     }
 
+    // ctx.deadline (if set) is one overall budget shared across a loop over
+    // providers — cap this call's timeout to whatever's left of it so N
+    // providers can't each burn a full timeoutMs.
+    const remainingMs = ctx.deadline !== undefined ? ctx.deadline - Date.now() : ctx.timeoutMs;
+    const effectiveTimeoutMs = Math.max(0, Math.min(ctx.timeoutMs, remainingMs));
+    if (effectiveTimeoutMs === 0) {
+      throw new Error(`Provider "${providerId}" call skipped: overall deadline already elapsed`);
+    }
+
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`Provider "${providerId}" timed out after ${ctx.timeoutMs}ms`));
-      }, ctx.timeoutMs);
+        reject(new Error(`Provider "${providerId}" timed out after ${effectiveTimeoutMs}ms`));
+      }, effectiveTimeoutMs);
     });
 
     const abortPromise = new Promise<never>((_, reject) => {

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -33,6 +33,13 @@ export interface ProviderContext {
   promptId?: string;
   turnId?: number;
   isFirstTurn?: boolean;
+  /**
+   * Absolute epoch-ms deadline shared across a whole hook invocation that may
+   * loop over multiple providers (e.g. onSessionClose). When set, it caps
+   * `timeoutMs` per provider call so N providers can't add up to N *
+   * timeoutMs — the whole loop is bounded by this one deadline.
+   */
+  deadline?: number;
 }
 
 // ── Context Injection ─────────────────────────────────────────

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -31,7 +31,6 @@ import { loadGlobalConfig, saveGlobalConfig, defaultAgentDir, expandHome, loadCo
 import type { PizzaPiConfig } from "../config.js";
 import { findSessionPathById } from "./session-list-cache.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
-import { triggerSessionClose } from "../extensions/providers/extension.js";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
@@ -503,49 +502,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             }
             return windows;
         };
-        const normalizeSessionCloseReason = (reason: unknown): "close" | "error" | "complete" => {
-            const text = typeof reason === "string" ? reason.toLowerCase() : "";
-            if (text.includes("error") || text.includes("crash") || text.includes("orphan")) return "error";
-            if (text.includes("complete")) return "complete";
-            return "close";
-        };
-        const resolveSessionFileForClose = async (sessionId: string, explicitSessionFile?: string): Promise<string> => {
-            if (explicitSessionFile) return explicitSessionFile;
-            const remembered = sessionCloseMetadata.get(sessionId)?.sessionFile;
-            if (remembered) return remembered;
-
-            try {
-                const sessionsRootDir = join(resolveConfiguredAgentDir(sessionCloseMetadata.get(sessionId)?.cwd), "sessions");
-                const found = await findSessionPathById(sessionsRootDir, sessionId);
-                if (found) return found;
-            } catch {
-                // Best-effort only — providers may still be able to use the relay session id.
-            }
-
-            return sessionId;
-        };
-        const notifyProviderSessionClose = async (
-            sessionId: string,
-            reason: unknown,
-            explicitSessionFile?: string,
-        ) => {
-            const metadata = sessionCloseMetadata.get(sessionId);
-            const cwd = metadata?.cwd ?? process.cwd();
-            const sessionFile = await resolveSessionFileForClose(sessionId, explicitSessionFile);
-            try {
-                const closeResult = await triggerSessionClose(
-                    sessionId,
-                    sessionFile,
-                    normalizeSessionCloseReason(reason),
-                    cwd,
-                );
-                if (closeResult) {
-                    logInfo(`[daemon] Provider close: ${closeResult.label}`);
-                }
-            } catch (err) {
-                logWarn(`[daemon] Provider close failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
-            }
-        };
+        // NOTE: provider onSessionClose runs IN THE WORKER PROCESS during its
+        // SIGTERM/shutdownHandler paths (see extensions/providers/extension.ts
+        // runProviderSessionClose). The daemon previously imported
+        // triggerSessionClose here, but that was a guaranteed no-op: the
+        // provider bridge is a module-global initialized only in the worker.
+        // Daemon-side crash finalization (worker died without running close)
+        // is tracked as the Phase 3 finalizer contract (idea jg017xa4).
         const tunnelService = new TunnelService();
         if (isServiceDisabled("tunnel")) {
             logInfo('[services] built-in service "tunnel" disabled by config');
@@ -1376,7 +1339,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                                 logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
                             );
                         } else {
-                            escalateToSigkill(child, `session ${sessionId}`);
+                            // 8s (not the 5s default): the worker's shutdown runs
+                            // provider close (≤2.5s) + sandbox cleanup (≤5s) before
+                            // exiting — give it room to finish before SIGKILL.
+                            escalateToSigkill(child, `session ${sessionId}`, 8_000);
                         }
                     } catch {}
                 } else if (entry.adopted) {
@@ -1386,7 +1352,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 }
                 runningSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
-                await notifyProviderSessionClose(sessionId, "close", entry.sessionFile);
                 cleanupSessionServices(sessionId);
                 sessionCloseMetadata.delete(sessionId);
                 logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
@@ -1420,7 +1385,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             }
 
             const entry = runningSessions.get(sessionId);
-            let shouldNotifyProviderClose = false;
+            let sessionFullyEnded = false;
             if (entry) {
                 // If the child process is still alive AND this is a transient
                 // relay disconnect (not an expiry/orphan sweep), keep the entry
@@ -1436,26 +1401,18 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 runningSessions.delete(sessionId);
                 killedSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
-                shouldNotifyProviderClose = true;
+                sessionFullyEnded = true;
                 logInfo(`session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {
                 // First duplicate — log once then suppress subsequent copies
                 endedSessionIds.set(sessionId, Date.now());
-                shouldNotifyProviderClose = true;
+                sessionFullyEnded = true;
                 logInfo(`session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore
 
-            if (shouldNotifyProviderClose) {
-                await notifyProviderSessionClose(
-                    sessionId,
-                    reason,
-                    typeof sessionFile === "string" ? sessionFile : entry?.sessionFile,
-                );
-            }
-
             cleanupSessionServices(sessionId);
-            if (shouldNotifyProviderClose) sessionCloseMetadata.delete(sessionId);
+            if (sessionFullyEnded) sessionCloseMetadata.delete(sessionId);
 
             // Clean up persisted attachments.  For spawned sessions child.on("exit")
             // already ran cleanup, so this is a no-op (idempotent).  For adopted sessions

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -152,12 +152,21 @@ export function initServiceHandlers(
 }
 
 /**
+ * Grace window for a worker's graceful shutdown before SIGKILL, on every
+ * escalation path (process-group signal, single-child SIGTERM/message
+ * fallback). Must cover the worker's own shutdown budget: provider close
+ * (<=2.5s, one overall deadline — see runProviderSessionClose) + sandbox
+ * cleanup (<=5s) = 7.5s worst case.
+ */
+const SESSION_SHUTDOWN_GRACE_MS = 8_000;
+
+/**
  * Escalate a SIGTERM to SIGKILL after `timeoutMs` if the child has not exited.
  * The timer is cleared automatically when the child exits.
  * ponytail: child-process escalation is hard to unit-test without real spawned
  * processes; covered by the real SIGTERM/SIGKILL behavior in session-spawner.
  */
-function escalateToSigkill(child: ChildProcess, label: string, timeoutMs = 5_000): void {
+function escalateToSigkill(child: ChildProcess, label: string, timeoutMs = SESSION_SHUTDOWN_GRACE_MS): void {
     const timer = setTimeout(() => {
         try {
             if (!child.killed && child.exitCode === null) {
@@ -1335,14 +1344,17 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         // plain SIGTERM elsewhere) if group signaling fails.
                         const child = entry.child;
                         if (!killSessionProcessGroup(child.pid)) {
-                            requestChildShutdown(child, (timeoutMs) =>
-                                logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
+                            // Same grace window as the process-group path below —
+                            // the default 5s in process-kill.ts's signature is too
+                            // short for provider close + sandbox cleanup.
+                            requestChildShutdown(
+                                child,
+                                (timeoutMs) =>
+                                    logWarn(`[daemon] session ${sessionId} did not exit after ${timeoutMs}ms; force-killing`),
+                                SESSION_SHUTDOWN_GRACE_MS,
                             );
                         } else {
-                            // 8s (not the 5s default): the worker's shutdown runs
-                            // provider close (≤2.5s) + sandbox cleanup (≤5s) before
-                            // exiting — give it room to finish before SIGKILL.
-                            escalateToSigkill(child, `session ${sessionId}`, 8_000);
+                            escalateToSigkill(child, `session ${sessionId}`, SESSION_SHUTDOWN_GRACE_MS);
                         }
                     } catch {}
                 } else if (entry.adopted) {

--- a/packages/cli/src/runner/process-kill.ts
+++ b/packages/cli/src/runner/process-kill.ts
@@ -55,7 +55,11 @@ export function forceKillTree(child: ChildProcess): void {
 export function requestChildShutdown(
     child: ChildProcess,
     onEscalate?: (timeoutMs: number) => void,
-    timeoutMs = 5_000,
+    // ponytail: 8s default, not 5s — a worker's own shutdown budget is provider
+    // close (<=2.5s) + sandbox cleanup (<=5s) = 7.5s worst case; 5s would
+    // SIGKILL mid-cleanup. Callers with a smaller/larger known budget can
+    // still override.
+    timeoutMs = 8_000,
 ): void {
     let requested = false;
     if (process.platform === "win32") {

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -186,6 +186,7 @@ async function createModelRuntimeWithRetry(authPath: string, modelsPath: string,
 import { forwardCliError } from "../extensions/remote.js";
 import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
 import { armWorkerStartupGate, markWorkerStartupComplete } from "../extensions/worker-startup-gate.js";
+import { runProviderSessionClose } from "../extensions/providers/extension.js";
 
 // ── Session metadata / context tracking ──────────────────────────────────
 
@@ -669,11 +670,19 @@ async function main(): Promise<void> {
             },
         },
         shutdownHandler: () => {
-            try {
-                session.dispose();
-            } finally {
-                process.exit(0);
-            }
+            // Extension-initiated shutdown (e.g. auto-close after session
+            // completion) — run provider close with "complete" semantics.
+            // ponytail: reason is a heuristic (any ctx.shutdown() maps to
+            // "complete"); plumb an explicit reason if a second caller appears.
+            void runProviderSessionClose("complete")
+                .catch(() => {})
+                .finally(() => {
+                    try {
+                        session.dispose();
+                    } finally {
+                        process.exit(0);
+                    }
+                });
         },
         onError: (err) => {
             logError(`[extension] ${err.extensionPath}: ${err.error}`);
@@ -751,6 +760,13 @@ async function main(): Promise<void> {
             logWarn("[worker] cleanup did not finish in time; forcing process exit");
             process.exit(0);
         }, hardExitTimeoutMs);
+        // Provider close hooks run first (data flush/archival is the most
+        // valuable cleanup) and in-process — the daemon cannot reach the
+        // provider bridge across the process boundary. Bounded at 2.5s so
+        // close + sandbox cleanup stay inside the daemon's SIGKILL escalation.
+        try {
+            await runProviderSessionClose("close");
+        } catch {}
         try {
             await Promise.race([
                 cleanupSandbox(),

--- a/packages/ui/dev-dist/sw.js
+++ b/packages/ui/dev-dist/sw.js
@@ -67,7 +67,7 @@ if (!self.define) {
     });
   };
 }
-define(['./workbox-e44ca4aa'], (function (workbox) { 'use strict';
+define(['./workbox-0cb42a3e'], (function (workbox) { 'use strict';
 
   importScripts("sw-push.js");
   self.skipWaiting();
@@ -80,13 +80,14 @@ define(['./workbox-e44ca4aa'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "/index.html",
-    "revision": "0.lpasq5j3cf"
+    "revision": "0.vurtt4r1eco"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {
     allowlist: [/^\/$/],
     denylist: [/^\/api\//]
   }));
+  workbox.registerRoute(/\/api\//, new workbox.NetworkOnly(), 'GET');
   workbox.registerRoute(/\.js$/, new workbox.StaleWhileRevalidate({
     "cacheName": "js-chunks",
     plugins: [new workbox.ExpirationPlugin({
@@ -94,7 +95,6 @@ define(['./workbox-e44ca4aa'], (function (workbox) { 'use strict';
       maxAgeSeconds: 604800
     })]
   }), 'GET');
-  workbox.registerRoute(/^\/api\//, new workbox.NetworkOnly(), 'GET');
   workbox.registerRoute(/^\/ws\//, new workbox.NetworkOnly(), 'GET');
 
 }));


### PR DESCRIPTION
## Summary

Provider `onSessionClose` never fired: the daemon called `triggerSessionClose` in **its own process**, where the module-global provider bridge (initialized only by the worker's `session_start` handler) is always `null`. Found during an adversarial architecture review; tracked as Godmother idea `jg017xa4` (follow-up to `9tipJSVt`, which wired the call sites but not the process boundary).

## Changes

- **`extensions/providers/extension.ts`** — `triggerSessionClose` → `runProviderSessionClose(reason, opts)`: runs in-process via the worker's own bridge; idempotent (first shutdown path wins); bounded (default 2.5s); tracks last-known session file/cwd from `session_start`/`turn_end`. Adds `__setBridgeForTest` for tests.
- **`runner/worker.ts`** — close hooks wired into both exit paths: signal `shutdown()` (reason `close`, before sandbox cleanup — data flush is the most valuable cleanup) and extension-initiated `shutdownHandler` (reason `complete`).
- **`runner/daemon.ts`** — dead cross-process path removed (`notifyProviderSessionClose` + helpers); `kill_session` SIGKILL escalation widened 5s → 8s so provider close (≤2.5s) + sandbox cleanup (≤5s) fit in the window.

## Tests

- Unit: reason mapping, idempotence (second shutdown path no-ops), hung-provider timeout bounding, null-bridge no-op.
- **Cross-process regression** (`session-close-signal.test.ts`): spawns a subprocess wired like the worker's SIGTERM path, SIGTERMs it, asserts the provider's `onSessionClose` side effect materialized — the exact boundary the bug lived on.

## Verification

- `bun run typecheck` — clean
- `bun test packages/cli/src/extensions/providers packages/cli/src/providers` — 41/41
- Full `bun run test` — 126 files pass; 1 **pre-existing** failure (`sandbox-config.test.ts` expects literal `/tmp`, code uses `os.tmpdir()` → fails on macOS, tracked as `NKSAXCBg`, fix shipping separately)

## Not in scope

Daemon-side **crash** finalization (worker dies without running close) — Phase 3 finalizer contract, noted in the daemon comment.
