### PR TITLE
fix(tests): sandbox allowWrite default assertion portable across platforms

### DIFF
--- a/packages/cli/src/sandbox-config.test.ts
+++ b/packages/cli/src/sandbox-config.test.ts
@@ -7,7 +7,7 @@
  *   - mergeSandboxConfig() security invariants (deny=union, allow=intersection, mode escalation only)
  */
 import { describe, test, expect } from "bun:test";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { resolve } from "path";
 
 import {
@@ -66,10 +66,12 @@ describe("resolveSandboxConfig — basic mode (default)", () => {
         expect(denyRead).toContain(`${HOME}/.config/gcloud`);
     });
 
-    test("basic allows write to cwd and /tmp by default", () => {
+    test("basic allows write to cwd and the platform temp dir by default", () => {
         const r = resolveSandboxConfig(CWD, cfg({ mode: "basic" }));
         expect(r.srtConfig!.filesystem.allowWrite).toContain(CWD);
-        expect(r.srtConfig!.filesystem.allowWrite).toContain("/tmp");
+        // The default uses os.tmpdir(), not a literal "/tmp" — on macOS that's
+        // /var/folders/..., on Windows %LOCALAPPDATA%\Temp (see sandbox.ts TMP_DIR).
+        expect(r.srtConfig!.filesystem.allowWrite).toContain(tmpdir());
     });
 
     test("basic denies writes to .env files", () => {


### PR DESCRIPTION
Pre-existing macOS-only failure: `sandbox-config.test.ts` asserted a literal `/tmp` in the default `allowWrite`, but the default is `os.tmpdir()` (`/var/folders/...` on macOS, `%LOCALAPPDATA%\Temp` on Windows — see `sandbox.ts` `TMP_DIR`). Passes on Linux CI, fails every local macOS full-suite run.<br /><br />Fix: assert `tmpdir()`. The explicit user-config `"/tmp"` literals elsewhere in the file are pass-through values and are intentionally unchanged.<br /><br />Verification: `bun test packages/cli/src/sandbox-config.test.ts` 53/53 on macOS.<br /><br />Godmother: `NKSAXCBg`