### PR TITLE
feat(cli): SessionHost control-surface façade (Phase 1.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,9 @@ PizzaPi patches four upstream pi packages via `patchedDependencies` in the root 
 
 - **Version check removal:** Disables the npm registry version check and "Update Available" notification (irrelevant for PizzaPi's headless runner).
 - **Auth path display:** Shows the actual auth file path instead of hardcoded default.
+- **`sendUserMessage({ expandPromptTemplates })` opt-in:** lets the web UI input path run slash-command/template expansion.
 
-PizzaPi still binds `newSession()` / `switchSession()` command actions in the runner so the remote extension can trigger `/new` and `/resume` from the web UI, but upstream 0.79.x no longer needs PizzaPi's old loader/runner shim patch for that wiring.
+**Removed in Phase 1 (SessionHost):** the patch no longer copies session-control onto `ExtensionAPI` (`newSession`/`switchSession`/`fork`, `getQueuedMessages`/`replaceQueuedMessages`). Those were surface-widening — already native on `AgentSessionRuntime`/`AgentSession`. PizzaPi's remote extension now drives control through a host-owned `SessionHost` (`packages/cli/src/runner/session-host.ts`), threaded in via `extensions/remote/session-host-ref.ts`. `patches.test.ts` guards against the hunks silently returning on a version bump.
 
 ### @earendil-works/pi-ai
 

--- a/packages/cli/src/extensions/initial-prompt.ts
+++ b/packages/cli/src/extensions/initial-prompt.ts
@@ -1,6 +1,7 @@
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "@pizzapi/tools";
 import { waitForRelayRegistration } from "./remote.js";
+import { getRemoteSessionHost } from "./remote/session-host-ref.js";
 import { waitForWorkerStartupComplete } from "./worker-startup-gate.js";
 import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 
@@ -176,8 +177,9 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
         // This loads the previous conversation into this new worker session.
         if (resumePath) {
             try {
-                if (typeof (pi as any).switchSession === "function") {
-                    const result = await (pi as any).switchSession(resumePath);
+                const sessionHost = getRemoteSessionHost();
+                if (sessionHost) {
+                    const result = await sessionHost.switchSession(resumePath);
                     if (result?.cancelled) {
                         log.warn(`pizzapi worker: resume of ${resumePath} was cancelled`);
                     } else {

--- a/packages/cli/src/extensions/remote-exec-fork.test.ts
+++ b/packages/cli/src/extensions/remote-exec-fork.test.ts
@@ -69,7 +69,7 @@ describe("exec fork", () => {
     test("forks via pi.fork and pushes a fresh snapshot", async () => {
         const forkCalls: string[] = [];
         const { rctx, sent, forwarded } = buildRctx({
-            pi: {
+            sessionHost: {
                 fork: async (entryId: string) => {
                     forkCalls.push(entryId);
                     return { cancelled: false, selectedText: "second question" };
@@ -87,7 +87,7 @@ describe("exec fork", () => {
 
     test("reports cancellation as an error", async () => {
         const { rctx, sent, forwarded } = buildRctx({
-            pi: { fork: async () => ({ cancelled: true }) },
+            sessionHost: { fork: async () => ({ cancelled: true }) },
         });
 
         await handleExecFromWeb({ type: "exec", id: "1", command: "fork", entryId: "u2" }, rctx, callbacks);
@@ -103,7 +103,7 @@ describe("exec fork", () => {
         expect(sent[0].ok).toBe(false);
         expect(sent[0].error).toContain("not available");
 
-        const { rctx: rctx2, sent: sent2 } = buildRctx({ pi: { fork: async () => ({ cancelled: false }) } });
+        const { rctx: rctx2, sent: sent2 } = buildRctx({ sessionHost: { fork: async () => ({ cancelled: false }) } });
         await handleExecFromWeb({ type: "exec", id: "2", command: "fork", entryId: "  " } as any, rctx2, callbacks);
         expect(sent2[0].ok).toBe(false);
         expect(sent2[0].error).toContain("entryId");

--- a/packages/cli/src/extensions/remote-exec-handler.test.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.test.ts
@@ -18,6 +18,8 @@ function makeRctx(pi: unknown) {
     const forwarded: unknown[] = [];
     const rctx = {
         pi,
+        // set_queued_messages now drives the host-owned SessionHost handle.
+        sessionHost: pi,
         sendToWeb: (payload: unknown) => sent.push(payload),
         forwardEvent: (event: unknown) => forwarded.push(event),
         buildHeartbeat: () => ({ type: "heartbeat", queuedMessages: ["from-heartbeat"] }),

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -240,7 +240,11 @@ export async function handleExecFromWeb(
             }
             const messages = req.messages.filter((m): m is string => typeof m === "string" && m.trim().length > 0);
             try {
-                rctx.pi.replaceQueuedMessages(messages);
+                if (!rctx.sessionHost) {
+                    replyErr("Session control is not available");
+                    return;
+                }
+                rctx.sessionHost.replaceQueuedMessages(messages);
             } catch (err) {
                 replyErr(`Failed to update queued messages: ${err instanceof Error ? err.message : String(err)}`);
                 return;
@@ -384,8 +388,8 @@ export async function handleExecFromWeb(
                 replyErr("No active session");
                 return;
             }
-            if (typeof (rctx.pi as any).fork !== "function") {
-                replyErr("fork is not available in this pi version");
+            if (!rctx.sessionHost) {
+                replyErr("fork is not available (no session host)");
                 return;
             }
             const entryId = typeof req.entryId === "string" ? req.entryId.trim() : "";
@@ -394,7 +398,7 @@ export async function handleExecFromWeb(
                 return;
             }
             try {
-                const result = await (rctx.pi as any).fork(entryId);
+                const result = await rctx.sessionHost.fork(entryId);
                 if (result?.cancelled) {
                     replyErr("Fork was cancelled");
                     return;
@@ -459,8 +463,8 @@ export async function handleExecFromWeb(
                 replyErr("No active session");
                 return;
             }
-            if (typeof (rctx.pi as any).switchSession !== "function") {
-                replyErr("switchSession is not available in this pi version");
+            if (!rctx.sessionHost) {
+                replyErr("switchSession is not available (no session host)");
                 return;
             }
             const sessions = await listSessionsForResume(rctx.latestCtx);
@@ -474,7 +478,7 @@ export async function handleExecFromWeb(
                 return;
             }
             try {
-                const result = await (rctx.pi as any).switchSession(target.path);
+                const result = await rctx.sessionHost.switchSession(target.path);
                 if (result?.cancelled) {
                     replyErr("Resume was cancelled");
                     return;
@@ -494,8 +498,12 @@ export async function handleExecFromWeb(
                 replyErr("No active session");
                 return;
             }
+            if (!rctx.sessionHost) {
+                replyErr("New session is not available (no session host)");
+                return;
+            }
             try {
-                const result = await (rctx.pi as any).newSession();
+                const result = await rctx.sessionHost.newSession();
                 if (result?.cancelled) {
                     replyErr("New session was cancelled");
                     return;

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -185,6 +185,10 @@ export interface RelayContext {
     // Core references — the pi instance is typed loosely since the actual
     // PiInstance type is internal to the extension factory closure.
     readonly pi: any;
+    // Host-owned session-control handle (set by the worker before bindExtensions).
+    // Remote handlers drive new/switch/fork + queue ops through this instead of
+    // the patched ExtensionAPI surface. Null only if the host never set one.
+    readonly sessionHost: import("../runner/session-host.js").SessionHost | null;
     relay: RelayState | null;
     sioSocket: Socket<RelayServerToClientEvents, RelayClientToServerEvents> | null;
     latestCtx: ExtensionContext | null;

--- a/packages/cli/src/extensions/remote/chunked-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.test.ts
@@ -207,7 +207,7 @@ describe("readQueuedFollowUps", () => {
     test("returns a copy of pi's follow-up queue", () => {
         const ctx = makeContext();
         const followUp = ["first", "second"];
-        (ctx as any).pi = { getQueuedMessages: () => ({ steering: ["s"], followUp }) };
+        (ctx as any).sessionHost = { getQueuedMessages: () => ({ steering: ["s"], followUp }) };
         const result = readQueuedFollowUps(ctx);
         expect(result).toEqual(["first", "second"]);
         expect(result).not.toBe(followUp);
@@ -215,13 +215,13 @@ describe("readQueuedFollowUps", () => {
 
     test("returns [] when getQueuedMessages throws (stale extension ctx)", () => {
         const ctx = makeContext();
-        (ctx as any).pi = { getQueuedMessages: () => { throw new Error("stale"); } };
+        (ctx as any).sessionHost = { getQueuedMessages: () => { throw new Error("stale"); } };
         expect(readQueuedFollowUps(ctx)).toEqual([]);
     });
 
     test("session_metadata_update and session_active include queuedMessages", () => {
         const ctx = makeContext({ leafId: "leaf-queue" });
-        (ctx as any).pi = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
+        (ctx as any).sessionHost = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
 
         recordEmittedMessageState(ctx);
         emitSessionMetadataUpdate(ctx);
@@ -230,7 +230,7 @@ describe("readQueuedFollowUps", () => {
         expect(meta.metadata.queuedMessages).toEqual(["queued follow-up"]);
 
         const activeCtx = makeContext({ leafId: "leaf-queue-2" });
-        (activeCtx as any).pi = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
+        (activeCtx as any).sessionHost = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
         emitSessionActive(activeCtx);
         const active = activeCtx.emitted[0] as any;
         expect(active.type).toBe("session_active");

--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -32,7 +32,7 @@ const log = createLogger("remote");
  */
 export function readQueuedFollowUps(rctx: RelayContext): string[] {
     try {
-        const queued = rctx.pi?.getQueuedMessages?.();
+        const queued = rctx.sessionHost?.getQueuedMessages();
         return Array.isArray(queued?.followUp) ? [...queued.followUp] : [];
     } catch {
         return [];

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -51,7 +51,16 @@ export function createRelayContext(
 ): RelayContext {
     const rctx: RelayContext = {
         pi,
-        sessionHost: getRemoteSessionHost(),
+        // Read live rather than snapshot: this factory runs during
+        // loader.reload() (worker.ts), before the worker constructs and
+        // installs its SessionHost via setRemoteSessionHost(). A one-time
+        // snapshot here would freeze sessionHost at null for the process
+        // lifetime. Reading through the module ref on every access keeps it
+        // in sync however the host's install ordering shakes out (worker or
+        // interactive CLI).
+        get sessionHost() {
+            return getRemoteSessionHost();
+        },
         relay: null,
         sioSocket: null,
         latestCtx: null,

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -15,6 +15,7 @@ import { normalizeLoopbackHost } from "../../relay-url.js";
 import { buildHeartbeat } from "../remote-heartbeat.js";
 import { getCurrentTodoList } from "../update-todo.js";
 import { isDisabled, toWebSocketBaseUrl } from "./connection.js";
+import { getRemoteSessionHost } from "./session-host-ref.js";
 import type { RelayContext, RelayModelInfo, TriggerResponse } from "../remote-types.js";
 import { getActiveGoalFromEntries, toMetaGoalStatus } from "../goal/state.js";
 import { getCommandIntrospection } from "../command-introspection.js";
@@ -50,6 +51,7 @@ export function createRelayContext(
 ): RelayContext {
     const rctx: RelayContext = {
         pi,
+        sessionHost: getRemoteSessionHost(),
         relay: null,
         sioSocket: null,
         latestCtx: null,

--- a/packages/cli/src/extensions/remote/session-host-ref.ts
+++ b/packages/cli/src/extensions/remote/session-host-ref.ts
@@ -1,0 +1,24 @@
+/**
+ * Module-level SessionHost reference for the remote extension.
+ *
+ * `remoteExtension` is a pi `ExtensionFactory` that only receives `pi`
+ * (ExtensionAPI) — it has no direct handle to the worker's session or its
+ * headless in-place lifecycle actions. The worker sets the SessionHost here
+ * before `bindExtensions()` runs, and the relay-context factory reads it when
+ * building the `RelayContext`, so remote handlers drive session control through
+ * the host instead of the patched `ExtensionAPI` surface.
+ *
+ * ponytail: a single module global mirrors the existing `_ctx`/socket refs in
+ * remote/index.ts — no registry needed for one process-wide session host.
+ */
+import type { SessionHost } from "../../runner/session-host.js";
+
+let sessionHost: SessionHost | null = null;
+
+export function setRemoteSessionHost(host: SessionHost | null): void {
+    sessionHost = host;
+}
+
+export function getRemoteSessionHost(): SessionHost | null {
+    return sessionHost;
+}

--- a/packages/cli/src/extensions/remote/session-host-wiring.test.ts
+++ b/packages/cli/src/extensions/remote/session-host-wiring.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration coverage for the SessionHost publication boundary shared by the
+ * runner worker (worker.ts) and the interactive CLI (index.ts).
+ *
+ * Regression covered (PR #635 review): removing the patched ExtensionAPI
+ * control surface left `getRemoteSessionHost()` (session-host-ref.ts) as the
+ * only way remote handlers reach session control, and two ordering bugs
+ * surfaced:
+ *
+ *  1. relay-context-factory.ts snapshotted the host at extension-factory-load
+ *     time. The worker loads extension factories during `loader.reload()`
+ *     (worker.ts ~line 390) — well before it constructs and publishes its
+ *     SessionHost via `setRemoteSessionHost()` (worker.ts ~line 695) — so the
+ *     snapshot froze `RelayContext.sessionHost` at null until reload.
+ *  2. The interactive CLI built an `AgentSessionRuntime` but never called
+ *     `setRemoteSessionHost(runtimeSessionHost(runtime))`, so TUI relay
+ *     commands (new/switch/fork/queue-edit) had no host to drive at all.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AgentSessionRuntime } from "@earendil-works/pi-coding-agent";
+import { createRelayContext } from "./relay-context-factory.js";
+import { createTriggerWaitManager } from "../trigger-wait-manager.js";
+import { getRemoteSessionHost, setRemoteSessionHost } from "./session-host-ref.js";
+import { runtimeSessionHost } from "../../runner/session-host.js";
+
+afterEach(() => {
+    // session-host-ref holds a process-wide singleton — reset it so these
+    // tests don't leak state into other test files sharing the test process.
+    setRemoteSessionHost(null);
+});
+
+function makeFakeSession() {
+    const queueCalls: string[] = [];
+    return {
+        queueCalls,
+        pendingMessageCount: 0,
+        getSteeringMessages: () => [] as string[],
+        getFollowUpMessages: () => [] as string[],
+        clearQueue: () => ({ steering: [] as string[] }),
+        _queueSteer: (text: string) => queueCalls.push(`steer:${text}`),
+        _queueFollowUp: (text: string) => queueCalls.push(`followUp:${text}`),
+        abort: async () => {},
+        waitForIdle: async () => {},
+        setModel: async () => {},
+        prompt: async () => {},
+    };
+}
+
+describe("worker startup boundary: extension factory load vs host publication", () => {
+    test("a RelayContext created before the worker publishes its host still resolves the live host afterward", () => {
+        expect(getRemoteSessionHost()).toBeNull();
+
+        // Mirrors worker.ts: the remote extension factory (and the
+        // RelayContext it builds) loads during loader.reload(), before the
+        // worker constructs its SessionHost and calls setRemoteSessionHost().
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        expect(rctx.sessionHost).toBeNull();
+
+        const session = makeFakeSession();
+        const host = runtimeSessionHost({
+            get session() {
+                return session;
+            },
+            newSession: async () => ({ cancelled: false }),
+            switchSession: async () => ({ cancelled: false }),
+            fork: async () => ({ cancelled: false }),
+        } as unknown as AgentSessionRuntime);
+
+        // Published after the context already exists — a one-time snapshot
+        // taken at construction would freeze rctx.sessionHost at null for
+        // the process lifetime.
+        setRemoteSessionHost(host);
+
+        expect(rctx.sessionHost).toBe(host);
+    });
+});
+
+describe("interactive CLI (TUI) host wiring", () => {
+    test("setRemoteSessionHost(runtimeSessionHost(runtime)) lets remote handlers drive new/switch/fork/queue-edit through the runtime", async () => {
+        let currentSession = makeFakeSession();
+        const calls: string[] = [];
+        const runtime = {
+            get session() {
+                return currentSession;
+            },
+            newSession: async () => {
+                calls.push("newSession");
+                currentSession = makeFakeSession();
+                return { cancelled: false };
+            },
+            switchSession: async (p: string) => {
+                calls.push(`switchSession:${p}`);
+                currentSession = makeFakeSession();
+                return { cancelled: false };
+            },
+            fork: async (id: string) => {
+                calls.push(`fork:${id}`);
+                return { cancelled: false };
+            },
+        } as unknown as AgentSessionRuntime;
+
+        // Mirrors the index.ts fix: install the TUI-backed host, with the
+        // same raw-requeue bridge shape worker.ts uses, before any remote
+        // command can run.
+        setRemoteSessionHost(
+            runtimeSessionHost(runtime, (followUp) => {
+                const { steering } = currentSession.clearQueue();
+                for (const text of steering) currentSession._queueSteer(text);
+                for (const text of followUp) currentSession._queueFollowUp(text);
+            }),
+        );
+
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        expect(rctx.sessionHost).not.toBeNull();
+
+        await rctx.sessionHost!.newSession();
+        await rctx.sessionHost!.switchSession("/tmp/foo.jsonl");
+        await rctx.sessionHost!.fork("entry-1");
+        // Queue bridge must resolve against the *current* session after
+        // fork() replaced it, not a stale reference captured at host
+        // construction — this is exactly what regresses without the fix.
+        rctx.sessionHost!.replaceQueuedMessages(["queued follow-up"]);
+
+        expect(calls).toEqual(["newSession", "switchSession:/tmp/foo.jsonl", "fork:entry-1"]);
+        expect(currentSession.queueCalls).toEqual(["followUp:queued follow-up"]);
+    });
+
+    test("without wiring, sessionHost stays null and remote handlers no-op/guard instead of crashing", () => {
+        // No setRemoteSessionHost() call — reproduces the pre-fix state of
+        // index.ts (remoteExtension installed, host never published).
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        expect(rctx.sessionHost).toBeNull();
+    });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,8 @@ import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "./skills.js";
 import { getPluginSkillPaths } from "./extensions/claude-plugins.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
+import { setRemoteSessionHost } from "./extensions/remote/session-host-ref.js";
+import { runtimeSessionHost } from "./runner/session-host.js";
 import { migrateAgentDir } from "./migrations.js";
 import { runSetup } from "./setup.js";
 import { createLogger, initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
@@ -549,6 +551,17 @@ async function main() {
         agentDir,
         sessionManager,
     });
+
+    // Install the TUI-backed SessionHost so the remote extension can drive
+    // new/switch/fork + queue ops through `runtime` instead of the removed
+    // patched ExtensionAPI surface (mirrors worker.ts's SessionHost wiring).
+    setRemoteSessionHost(
+        runtimeSessionHost(runtime, (followUp) => {
+            const { steering } = runtime.session.clearQueue();
+            for (const text of steering) void (runtime.session as any)._queueSteer(text);
+            for (const text of followUp) void (runtime.session as any)._queueFollowUp(text);
+        }),
+    );
 
     const mode = new InteractiveMode(runtime, {
         modelFallbackMessage: runtime.modelFallbackMessage,

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -73,17 +73,22 @@ describe("pi-coding-agent patch application", () => {
         expect(source).toContain("options?.expandPromptTemplates ?? false");
     });
 
-    test("agent-session.js: pending queues are exposed to extensions (getQueuedMessages/replaceQueuedMessages)", async () => {
+    // Phase 1: the ExtensionAPI control-plane exposure (newSession/switchSession/
+    // fork + getQueuedMessages/replaceQueuedMessages) was removed from the patch.
+    // PizzaPi's remote extension now drives control through the host-owned
+    // SessionHost (packages/cli/src/runner/session-host.ts). These guards prevent
+    // the surface-widening hunks from silently returning on a version bump.
+    test("agent-session.js: pending-queue getters are NOT patched onto the runtime (SessionHost owns them)", async () => {
         const source = await Bun.file(
             piCodingAgentPath("dist/core/agent-session.js"),
         ).text();
 
-        expect(source).toContain("PATCH(pizzapi): expose the pending queues");
-        expect(source).toContain("getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] })");
-        expect(source).toContain("replaceQueuedMessages: (followUp) => {");
+        expect(source).not.toContain("PATCH(pizzapi): expose the pending queues");
+        expect(source).not.toContain("getQueuedMessages: () => ({ steering: [...this._steeringMessages]");
+        expect(source).not.toContain("replaceQueuedMessages: (followUp) => {");
     });
 
-    test("loader.js + runner.js: queue read/replace wired through ExtensionAPI", async () => {
+    test("loader.js + runner.js: queue read/replace is NOT wired through ExtensionAPI", async () => {
         const loader = await Bun.file(
             piCodingAgentPath("dist/core/extensions/loader.js"),
         ).text();
@@ -91,10 +96,9 @@ describe("pi-coding-agent patch application", () => {
             piCodingAgentPath("dist/core/extensions/runner.js"),
         ).text();
 
-        expect(loader).toContain("getQueuedMessages()");
-        expect(loader).toContain("replaceQueuedMessages(followUp)");
-        expect(runner).toContain("this.runtime.getQueuedMessages = actions.getQueuedMessages");
-        expect(runner).toContain("this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages");
+        expect(loader).not.toContain("replaceQueuedMessages(followUp)");
+        expect(runner).not.toContain("this.runtime.getQueuedMessages = actions.getQueuedMessages");
+        expect(runner).not.toContain("this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages");
     });
 
     test("interactive-mode.js: version check call is removed from run()", async () => {
@@ -192,7 +196,7 @@ describe("pi-coding-agent patched runtime behavior", () => {
         expect(dir).not.toContain(".pizzapi/agent/sessions");
     });
 
-    test("extension API exposes bound newSession and switchSession handlers", async () => {
+    test("extension API does NOT expose newSession/switchSession/fork (removed in Phase 1)", async () => {
         const { createExtensionRuntime, loadExtensionFromFactory } = await import(
             piCodingAgentPath("dist/core/extensions/loader.js")
         );
@@ -201,20 +205,15 @@ describe("pi-coding-agent patched runtime behavior", () => {
         );
 
         const runtime = createExtensionRuntime() as any;
-        const calls: string[] = [];
         const runner = new ExtensionRunner([], runtime, process.cwd(), {} as any, {} as any);
+        // Command-context handlers still bind natively (slash commands, TUI) —
+        // that is upstream behavior, unaffected by the patch removal.
         runner.bindCommandContext({
             waitForIdle: async () => undefined,
-            newSession: async () => {
-                calls.push("new");
-                return { cancelled: false };
-            },
+            newSession: async () => ({ cancelled: false }),
             fork: async () => ({ cancelled: false }),
             navigateTree: async () => ({ cancelled: false }),
-            switchSession: async (sessionPath: string) => {
-                calls.push(`switch:${sessionPath}`);
-                return { cancelled: false };
-            },
+            switchSession: async () => ({ cancelled: false }),
             reload: async () => undefined,
         });
 
@@ -223,11 +222,13 @@ describe("pi-coding-agent patched runtime behavior", () => {
             api = pi;
         }, process.cwd(), {} as any, runtime);
 
-        expect(typeof api.newSession).toBe("function");
-        expect(typeof api.switchSession).toBe("function");
-        await expect(api.newSession()).resolves.toEqual({ cancelled: false });
-        await expect(api.switchSession("/tmp/session.jsonl")).resolves.toEqual({ cancelled: false });
-        expect(calls).toEqual(["new", "switch:/tmp/session.jsonl"]);
+        // The patch no longer copies these onto ExtensionAPI — PizzaPi reaches
+        // session control via SessionHost, not pi.*.
+        expect(api.newSession).toBeUndefined();
+        expect(api.switchSession).toBeUndefined();
+        expect(api.fork).toBeUndefined();
+        expect(api.getQueuedMessages).toBeUndefined();
+        expect(api.replaceQueuedMessages).toBeUndefined();
     });
 
 });

--- a/packages/cli/src/runner/session-host.test.ts
+++ b/packages/cli/src/runner/session-host.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { SessionHost } from "./session-host.js";
-import type { AgentSessionRuntime } from "@earendil-works/pi-coding-agent";
+import { runtimeSessionHost, SessionHost, type SessionLifecycle } from "./session-host.js";
+import type { AgentSession, AgentSessionRuntime } from "@earendil-works/pi-coding-agent";
+
+type Call = { method: string; args: unknown[] };
 
 /** Minimal call-recording fake of the AgentSession control surface. */
-function makeFakeSession(overrides: Partial<Record<string, unknown>> = {}) {
-    const calls: Array<{ method: string; args: unknown[] }> = [];
-    const rec = (method: string) => (...args: unknown[]) => {
-        calls.push({ method, args });
-        return undefined as never;
-    };
+function makeFakeSession(overrides: Record<string, unknown> = {}) {
+    const calls: Call[] = [];
     const session: Record<string, unknown> = {
         calls,
         prompt: async (...args: unknown[]) => {
@@ -31,19 +29,11 @@ function makeFakeSession(overrides: Partial<Record<string, unknown>> = {}) {
     return session;
 }
 
-/** Fake runtime whose `.session` getter can be swapped to test live reads. */
-function makeFakeRuntime(session: Record<string, unknown>) {
-    const calls: Array<{ method: string; args: unknown[] }> = [];
-    let current = session;
-    const runtime: Record<string, unknown> = {
+/** Call-recording lifecycle stub. */
+function makeLifecycle(withImport = true) {
+    const calls: Call[] = [];
+    const lifecycle: SessionLifecycle & { calls: Call[] } = {
         calls,
-        get session() {
-            return current;
-        },
-        setSession(next: Record<string, unknown>) {
-            current = next;
-        },
-        cwd: "/work/dir",
         newSession: async (...args: unknown[]) => {
             calls.push({ method: "newSession", args });
             return { cancelled: false };
@@ -56,26 +46,30 @@ function makeFakeRuntime(session: Record<string, unknown>) {
             calls.push({ method: "fork", args });
             return { cancelled: false };
         },
-        importFromJsonl: async (...args: unknown[]) => {
-            calls.push({ method: "importFromJsonl", args });
-            return { cancelled: false };
-        },
+        ...(withImport
+            ? {
+                  importFromJsonl: async (...args: unknown[]) => {
+                      calls.push({ method: "importFromJsonl", args });
+                      return { cancelled: false };
+                  },
+              }
+            : {}),
     };
-    return runtime;
+    return lifecycle;
 }
 
-function makeHost(sessionOverrides = {}, replaceFn?: (f: string[]) => void) {
-    const session = makeFakeSession(sessionOverrides);
-    const runtime = makeFakeRuntime(session);
-    const host = new SessionHost(runtime as unknown as AgentSessionRuntime, replaceFn);
-    return { host, runtime, session };
+function makeHost(opts: { sessionOverrides?: Record<string, unknown>; replaceFn?: (f: string[]) => void; withImport?: boolean } = {}) {
+    let current = makeFakeSession(opts.sessionOverrides);
+    const lifecycle = makeLifecycle(opts.withImport ?? true);
+    const host = new SessionHost(() => current as unknown as AgentSession, lifecycle, opts.replaceFn);
+    return { host, lifecycle, session: () => current, setSession: (s: Record<string, unknown>) => (current = s) };
 }
 
 describe("SessionHost.sendUserMessage", () => {
     test("string content maps to prompt with extension defaults", async () => {
         const { host, session } = makeHost();
         await host.sendUserMessage("hello");
-        const call = (session.calls as any[])[0];
+        const call = (session().calls as Call[])[0];
         expect(call.method).toBe("prompt");
         expect(call.args[0]).toBe("hello");
         expect(call.args[1]).toEqual({
@@ -89,29 +83,25 @@ describe("SessionHost.sendUserMessage", () => {
     test("expandPromptTemplates + deliverAs are passed through", async () => {
         const { host, session } = makeHost();
         await host.sendUserMessage("go", { deliverAs: "steer", expandPromptTemplates: true });
-        const call = (session.calls as any[])[0];
-        expect(call.args[1].expandPromptTemplates).toBe(true);
-        expect(call.args[1].streamingBehavior).toBe("steer");
+        const call = (session().calls as Call[])[0];
+        expect((call.args[1] as any).expandPromptTemplates).toBe(true);
+        expect((call.args[1] as any).streamingBehavior).toBe("steer");
     });
 
     test("array content joins text with newlines and collects images", async () => {
         const { host, session } = makeHost();
         const img = { type: "image", data: "b64", mimeType: "image/png" };
-        await host.sendUserMessage([
-            { type: "text", text: "a" },
-            img as any,
-            { type: "text", text: "b" },
-        ]);
-        const call = (session.calls as any[])[0];
+        await host.sendUserMessage([{ type: "text", text: "a" }, img as any, { type: "text", text: "b" }]);
+        const call = (session().calls as Call[])[0];
         expect(call.args[0]).toBe("a\nb");
-        expect(call.args[1].images).toEqual([img]);
+        expect((call.args[1] as any).images).toEqual([img]);
     });
 
     test("array content with no images sets images undefined (not empty array)", async () => {
         const { host, session } = makeHost();
         await host.sendUserMessage([{ type: "text", text: "only text" }]);
-        const call = (session.calls as any[])[0];
-        expect(call.args[1].images).toBeUndefined();
+        const call = (session().calls as Call[])[0];
+        expect((call.args[1] as any).images).toBeUndefined();
     });
 });
 
@@ -120,7 +110,6 @@ describe("SessionHost.getQueuedMessages", () => {
         const { host } = makeHost();
         const q = host.getQueuedMessages();
         expect(q).toEqual({ steering: ["s1", "s2"], followUp: ["f1"] });
-        // Mutating the result must not affect subsequent reads.
         q.steering.push("mutated");
         expect(host.getQueuedMessages().steering).toEqual(["s1", "s2"]);
     });
@@ -134,48 +123,84 @@ describe("SessionHost.replaceQueuedMessages", () => {
 
     test("delegates to the injected bridge verbatim (no re-expansion)", () => {
         const seen: string[][] = [];
-        const { host } = makeHost({}, (f) => seen.push(f));
+        const { host } = makeHost({ replaceFn: (f) => seen.push(f) });
         host.replaceQueuedMessages(["already {{expanded}}"]);
         expect(seen).toEqual([["already {{expanded}}"]]);
     });
 });
 
-describe("SessionHost runtime delegation", () => {
-    test("newSession/switchSession/fork/importFromJsonl delegate to runtime", async () => {
-        const { host, runtime } = makeHost();
+describe("SessionHost lifecycle delegation", () => {
+    test("newSession/switchSession/fork/importFromJsonl delegate to the lifecycle", async () => {
+        const { host, lifecycle } = makeHost();
         await host.newSession({ parentSession: "p" });
         await host.switchSession("/path/a", undefined);
         await host.fork("entry1", { position: "before" });
         await host.importFromJsonl("/in.jsonl", "/cwd");
-        const methods = (runtime.calls as any[]).map((c) => c.method);
+        const methods = (lifecycle.calls as Call[]).map((c) => c.method);
         expect(methods).toEqual(["newSession", "switchSession", "fork", "importFromJsonl"]);
-        expect((runtime.calls as any[])[1].args[0]).toBe("/path/a");
-        expect((runtime.calls as any[])[2].args).toEqual(["entry1", { position: "before" }]);
+        expect((lifecycle.calls as Call[])[1].args[0]).toBe("/path/a");
+        expect((lifecycle.calls as Call[])[2].args).toEqual(["entry1", { position: "before" }]);
+    });
+
+    test("importFromJsonl throws when the lifecycle does not support it (headless)", () => {
+        const { host } = makeHost({ withImport: false });
+        expect(() => host.importFromJsonl("/in.jsonl")).toThrow(/not supported/);
     });
 });
 
 describe("SessionHost live-session reads", () => {
-    test("session controls target the current runtime.session after replacement", async () => {
-        const { host, runtime } = makeHost();
-        // Swap in a fresh session (simulates /new or /resume replacing runtime.session).
+    test("session controls target the current session after replacement", async () => {
+        const { host, setSession } = makeHost();
         const next = makeFakeSession({ getSteeringMessages: () => ["NEW"], getFollowUpMessages: () => [] });
-        (runtime as any).setSession(next);
+        setSession(next);
         expect(host.getQueuedMessages()).toEqual({ steering: ["NEW"], followUp: [] });
         await host.abort();
-        expect((next.calls as any[]).some((c) => c.method === "abort")).toBe(true);
-        // Old session must be untouched.
+        expect((next.calls as Call[]).some((c) => c.method === "abort")).toBe(true);
     });
 });
 
 describe("SessionHost passthroughs", () => {
-    test("cwd, pendingMessageCount, abort, waitForIdle, setModel", async () => {
+    test("pendingMessageCount, abort, waitForIdle, setModel", async () => {
         const { host, session } = makeHost();
-        expect(host.cwd).toBe("/work/dir");
         expect(host.pendingMessageCount).toBe(3);
         await host.abort();
         await host.waitForIdle();
         await host.setModel({ id: "m" } as any);
-        const methods = (session.calls as any[]).map((c) => c.method);
+        const methods = (session().calls as Call[]).map((c) => c.method);
         expect(methods).toEqual(["abort", "waitForIdle", "setModel"]);
+    });
+});
+
+describe("runtimeSessionHost factory", () => {
+    test("wires lifecycle + session reads to the AgentSessionRuntime", async () => {
+        const calls: Call[] = [];
+        const session = makeFakeSession();
+        const runtime = {
+            get session() {
+                return session;
+            },
+            newSession: async (...a: unknown[]) => {
+                calls.push({ method: "newSession", args: a });
+                return { cancelled: false };
+            },
+            switchSession: async (...a: unknown[]) => {
+                calls.push({ method: "switchSession", args: a });
+                return { cancelled: false };
+            },
+            fork: async (...a: unknown[]) => {
+                calls.push({ method: "fork", args: a });
+                return { cancelled: false };
+            },
+            importFromJsonl: async (...a: unknown[]) => {
+                calls.push({ method: "importFromJsonl", args: a });
+                return { cancelled: false };
+            },
+        };
+        const host = runtimeSessionHost(runtime as unknown as AgentSessionRuntime);
+        await host.newSession();
+        await host.fork("e1");
+        await host.sendUserMessage("hi");
+        expect(calls.map((c) => c.method)).toEqual(["newSession", "fork"]);
+        expect((session.calls as Call[]).some((c) => c.method === "prompt")).toBe(true);
     });
 });

--- a/packages/cli/src/runner/session-host.test.ts
+++ b/packages/cli/src/runner/session-host.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { SessionHost } from "./session-host.js";
+import type { AgentSessionRuntime } from "@earendil-works/pi-coding-agent";
+
+/** Minimal call-recording fake of the AgentSession control surface. */
+function makeFakeSession(overrides: Partial<Record<string, unknown>> = {}) {
+    const calls: Array<{ method: string; args: unknown[] }> = [];
+    const rec = (method: string) => (...args: unknown[]) => {
+        calls.push({ method, args });
+        return undefined as never;
+    };
+    const session: Record<string, unknown> = {
+        calls,
+        prompt: async (...args: unknown[]) => {
+            calls.push({ method: "prompt", args });
+        },
+        getSteeringMessages: () => ["s1", "s2"],
+        getFollowUpMessages: () => ["f1"],
+        pendingMessageCount: 3,
+        abort: async () => {
+            calls.push({ method: "abort", args: [] });
+        },
+        waitForIdle: async () => {
+            calls.push({ method: "waitForIdle", args: [] });
+        },
+        setModel: async (...args: unknown[]) => {
+            calls.push({ method: "setModel", args });
+        },
+        ...overrides,
+    };
+    return session;
+}
+
+/** Fake runtime whose `.session` getter can be swapped to test live reads. */
+function makeFakeRuntime(session: Record<string, unknown>) {
+    const calls: Array<{ method: string; args: unknown[] }> = [];
+    let current = session;
+    const runtime: Record<string, unknown> = {
+        calls,
+        get session() {
+            return current;
+        },
+        setSession(next: Record<string, unknown>) {
+            current = next;
+        },
+        cwd: "/work/dir",
+        newSession: async (...args: unknown[]) => {
+            calls.push({ method: "newSession", args });
+            return { cancelled: false };
+        },
+        switchSession: async (...args: unknown[]) => {
+            calls.push({ method: "switchSession", args });
+            return { cancelled: false };
+        },
+        fork: async (...args: unknown[]) => {
+            calls.push({ method: "fork", args });
+            return { cancelled: false };
+        },
+        importFromJsonl: async (...args: unknown[]) => {
+            calls.push({ method: "importFromJsonl", args });
+            return { cancelled: false };
+        },
+    };
+    return runtime;
+}
+
+function makeHost(sessionOverrides = {}, replaceFn?: (f: string[]) => void) {
+    const session = makeFakeSession(sessionOverrides);
+    const runtime = makeFakeRuntime(session);
+    const host = new SessionHost(runtime as unknown as AgentSessionRuntime, replaceFn);
+    return { host, runtime, session };
+}
+
+describe("SessionHost.sendUserMessage", () => {
+    test("string content maps to prompt with extension defaults", async () => {
+        const { host, session } = makeHost();
+        await host.sendUserMessage("hello");
+        const call = (session.calls as any[])[0];
+        expect(call.method).toBe("prompt");
+        expect(call.args[0]).toBe("hello");
+        expect(call.args[1]).toEqual({
+            expandPromptTemplates: false,
+            streamingBehavior: undefined,
+            images: undefined,
+            source: "extension",
+        });
+    });
+
+    test("expandPromptTemplates + deliverAs are passed through", async () => {
+        const { host, session } = makeHost();
+        await host.sendUserMessage("go", { deliverAs: "steer", expandPromptTemplates: true });
+        const call = (session.calls as any[])[0];
+        expect(call.args[1].expandPromptTemplates).toBe(true);
+        expect(call.args[1].streamingBehavior).toBe("steer");
+    });
+
+    test("array content joins text with newlines and collects images", async () => {
+        const { host, session } = makeHost();
+        const img = { type: "image", data: "b64", mimeType: "image/png" };
+        await host.sendUserMessage([
+            { type: "text", text: "a" },
+            img as any,
+            { type: "text", text: "b" },
+        ]);
+        const call = (session.calls as any[])[0];
+        expect(call.args[0]).toBe("a\nb");
+        expect(call.args[1].images).toEqual([img]);
+    });
+
+    test("array content with no images sets images undefined (not empty array)", async () => {
+        const { host, session } = makeHost();
+        await host.sendUserMessage([{ type: "text", text: "only text" }]);
+        const call = (session.calls as any[])[0];
+        expect(call.args[1].images).toBeUndefined();
+    });
+});
+
+describe("SessionHost.getQueuedMessages", () => {
+    test("returns a defensive copy of both queues", () => {
+        const { host } = makeHost();
+        const q = host.getQueuedMessages();
+        expect(q).toEqual({ steering: ["s1", "s2"], followUp: ["f1"] });
+        // Mutating the result must not affect subsequent reads.
+        q.steering.push("mutated");
+        expect(host.getQueuedMessages().steering).toEqual(["s1", "s2"]);
+    });
+});
+
+describe("SessionHost.replaceQueuedMessages", () => {
+    test("throws when no bridge is injected (no public native primitive)", () => {
+        const { host } = makeHost();
+        expect(() => host.replaceQueuedMessages(["x"])).toThrow(/queue bridge/);
+    });
+
+    test("delegates to the injected bridge verbatim (no re-expansion)", () => {
+        const seen: string[][] = [];
+        const { host } = makeHost({}, (f) => seen.push(f));
+        host.replaceQueuedMessages(["already {{expanded}}"]);
+        expect(seen).toEqual([["already {{expanded}}"]]);
+    });
+});
+
+describe("SessionHost runtime delegation", () => {
+    test("newSession/switchSession/fork/importFromJsonl delegate to runtime", async () => {
+        const { host, runtime } = makeHost();
+        await host.newSession({ parentSession: "p" });
+        await host.switchSession("/path/a", undefined);
+        await host.fork("entry1", { position: "before" });
+        await host.importFromJsonl("/in.jsonl", "/cwd");
+        const methods = (runtime.calls as any[]).map((c) => c.method);
+        expect(methods).toEqual(["newSession", "switchSession", "fork", "importFromJsonl"]);
+        expect((runtime.calls as any[])[1].args[0]).toBe("/path/a");
+        expect((runtime.calls as any[])[2].args).toEqual(["entry1", { position: "before" }]);
+    });
+});
+
+describe("SessionHost live-session reads", () => {
+    test("session controls target the current runtime.session after replacement", async () => {
+        const { host, runtime } = makeHost();
+        // Swap in a fresh session (simulates /new or /resume replacing runtime.session).
+        const next = makeFakeSession({ getSteeringMessages: () => ["NEW"], getFollowUpMessages: () => [] });
+        (runtime as any).setSession(next);
+        expect(host.getQueuedMessages()).toEqual({ steering: ["NEW"], followUp: [] });
+        await host.abort();
+        expect((next.calls as any[]).some((c) => c.method === "abort")).toBe(true);
+        // Old session must be untouched.
+    });
+});
+
+describe("SessionHost passthroughs", () => {
+    test("cwd, pendingMessageCount, abort, waitForIdle, setModel", async () => {
+        const { host, session } = makeHost();
+        expect(host.cwd).toBe("/work/dir");
+        expect(host.pendingMessageCount).toBe(3);
+        await host.abort();
+        await host.waitForIdle();
+        await host.setModel({ id: "m" } as any);
+        const methods = (session.calls as any[]).map((c) => c.method);
+        expect(methods).toEqual(["abort", "waitForIdle", "setModel"]);
+    });
+});

--- a/packages/cli/src/runner/session-host.ts
+++ b/packages/cli/src/runner/session-host.ts
@@ -2,18 +2,26 @@ import type { AgentSession, AgentSessionRuntime, PromptOptions } from "@earendil
 import type { ImageContent, Model, TextContent } from "@earendil-works/pi-ai/compat";
 
 /**
- * SessionHost — the single control surface over a host-owned `AgentSessionRuntime`.
+ * SessionHost — the single session-control surface PizzaPi's remote extension
+ * drives, decoupled from pi's `ExtensionAPI`.
  *
- * Both the local TUI (`index.ts`) and the runner worker construct an
- * `AgentSessionRuntime`; today PizzaPi's remote extension can only reach session
- * controls through pi's `ExtensionAPI`, which is a strict subset of what the
- * runtime already exposes. That gap is bridged by patch hunks in
- * `patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch` that copy host
- * capabilities down onto `ExtensionAPI`.
+ * The pi-coding-agent 0.82.1 patch copies session-control capabilities onto
+ * `ExtensionAPI` (`newSession`/`switchSession`/`fork`, `getQueuedMessages`/
+ * `replaceQueuedMessages`, `sendUserMessage({expandPromptTemplates})`) purely so
+ * the remote extension — which runs in event handlers and only sees
+ * `ExtensionAPI` — can reach them. Threading a `SessionHost` into the remote
+ * context lets those call sites use a direct handle instead, removing the
+ * patch's reason to exist.
  *
- * SessionHost lets the host hand the remote layer a direct handle instead, so
- * those capabilities are called natively — no patch. It is a thin façade, not an
- * abstraction: it holds no state and adds no serialization (pi's agent already
+ * The two hosts differ only in session *lifecycle*:
+ *  - Local TUI: an `AgentSessionRuntime` provides new/switch/fork natively
+ *    (tears down + recreates the session).
+ *  - Runner worker: headless in-place actions swap the contents of one
+ *    long-lived `AgentSession` (so the relay connection survives).
+ *
+ * Everything else operates on the current `AgentSession`, so `SessionHost` is
+ * parameterized by a session accessor + a lifecycle object rather than
+ * subclassed. It holds no state and adds no serialization (pi's agent already
  * serializes via its steering/follow-up queues).
  */
 export type UserMessageContent = string | (TextContent | ImageContent)[];
@@ -24,34 +32,46 @@ export interface SendUserMessageOptions {
     expandPromptTemplates?: boolean;
 }
 
+/** Session lifecycle operations — backed by the runtime (TUI) or custom worker actions. */
+export interface SessionLifecycle {
+    newSession(options?: Parameters<AgentSessionRuntime["newSession"]>[0]): Promise<{ cancelled: boolean }>;
+    switchSession(
+        sessionPath: string,
+        options?: Parameters<AgentSessionRuntime["switchSession"]>[1],
+    ): Promise<{ cancelled: boolean }>;
+    fork(
+        entryId: string,
+        options?: Parameters<AgentSessionRuntime["fork"]>[1],
+    ): Promise<{ cancelled: boolean; selectedText?: string }>;
+    /** Only the runtime host supports import; optional for headless. */
+    importFromJsonl?(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }>;
+}
+
 /**
  * Injected bridge for the one queue op with no public native equivalent.
  *
  * `replaceQueuedMessages` must repopulate the queue with ALREADY-expanded text,
  * which requires pi's private raw-enqueue (`_queueSteer`/`_queueFollowUp`). The
  * public `steer()`/`followUp()` re-run skill + template expansion, so rebuilding
- * the queue through them would double-expand. Until upstream exposes a public
- * raw-requeue primitive, the host wires this to the patched `ExtensionAPI`
- * runtime method.
+ * the queue through them would double-expand. Each host supplies its own bridge
+ * (the worker reaches the private methods directly, as it already does for queue
+ * clearing).
  *
  * ponytail: one injected fn, not a layer — delete when upstream adds a public
- * requeue and call `session` directly.
+ * raw-requeue primitive.
  */
 export type ReplaceQueuedMessagesFn = (followUp: string[]) => void;
 
 export class SessionHost {
     constructor(
-        private readonly runtime: AgentSessionRuntime,
+        private readonly getSession: () => AgentSession,
+        private readonly lifecycle: SessionLifecycle,
         private readonly replaceQueuedMessagesFn?: ReplaceQueuedMessagesFn,
     ) {}
 
-    /** Read the live session — `runtime.session` is replaced on new/switch/fork/import. */
+    /** Read the live session — it is replaced (TUI) or mutated in place (worker). */
     private get session(): AgentSession {
-        return this.runtime.session;
-    }
-
-    get cwd(): string {
-        return this.runtime.cwd;
+        return this.getSession();
     }
 
     get pendingMessageCount(): number {
@@ -115,23 +135,29 @@ export class SessionHost {
         this.replaceQueuedMessagesFn(followUp);
     }
 
-    newSession(options?: Parameters<AgentSessionRuntime["newSession"]>[0]): ReturnType<AgentSessionRuntime["newSession"]> {
-        return this.runtime.newSession(options);
+    newSession(options?: Parameters<SessionLifecycle["newSession"]>[0]): Promise<{ cancelled: boolean }> {
+        return this.lifecycle.newSession(options);
     }
 
     switchSession(
         sessionPath: string,
-        options?: Parameters<AgentSessionRuntime["switchSession"]>[1],
-    ): ReturnType<AgentSessionRuntime["switchSession"]> {
-        return this.runtime.switchSession(sessionPath, options);
+        options?: Parameters<SessionLifecycle["switchSession"]>[1],
+    ): Promise<{ cancelled: boolean }> {
+        return this.lifecycle.switchSession(sessionPath, options);
     }
 
-    fork(entryId: string, options?: Parameters<AgentSessionRuntime["fork"]>[1]): ReturnType<AgentSessionRuntime["fork"]> {
-        return this.runtime.fork(entryId, options);
+    fork(
+        entryId: string,
+        options?: Parameters<SessionLifecycle["fork"]>[1],
+    ): Promise<{ cancelled: boolean; selectedText?: string }> {
+        return this.lifecycle.fork(entryId, options);
     }
 
-    importFromJsonl(inputPath: string, cwdOverride?: string): ReturnType<AgentSessionRuntime["importFromJsonl"]> {
-        return this.runtime.importFromJsonl(inputPath, cwdOverride);
+    importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
+        if (!this.lifecycle.importFromJsonl) {
+            throw new Error("SessionHost: importFromJsonl is not supported by this host");
+        }
+        return this.lifecycle.importFromJsonl(inputPath, cwdOverride);
     }
 
     abort(): Promise<void> {
@@ -145,4 +171,24 @@ export class SessionHost {
     setModel(model: Model<any>): Promise<void> {
         return this.session.setModel(model);
     }
+}
+
+/**
+ * Build a SessionHost backed by an `AgentSessionRuntime` (local TUI). Lifecycle
+ * ops delegate to the runtime, which recreates the session on each transition.
+ */
+export function runtimeSessionHost(
+    runtime: AgentSessionRuntime,
+    replaceQueuedMessagesFn?: ReplaceQueuedMessagesFn,
+): SessionHost {
+    return new SessionHost(
+        () => runtime.session,
+        {
+            newSession: (o) => runtime.newSession(o),
+            switchSession: (p, o) => runtime.switchSession(p, o),
+            fork: (e, o) => runtime.fork(e, o),
+            importFromJsonl: (p, c) => runtime.importFromJsonl(p, c),
+        },
+        replaceQueuedMessagesFn,
+    );
 }

--- a/packages/cli/src/runner/session-host.ts
+++ b/packages/cli/src/runner/session-host.ts
@@ -1,0 +1,148 @@
+import type { AgentSession, AgentSessionRuntime, PromptOptions } from "@earendil-works/pi-coding-agent";
+import type { ImageContent, Model, TextContent } from "@earendil-works/pi-ai/compat";
+
+/**
+ * SessionHost — the single control surface over a host-owned `AgentSessionRuntime`.
+ *
+ * Both the local TUI (`index.ts`) and the runner worker construct an
+ * `AgentSessionRuntime`; today PizzaPi's remote extension can only reach session
+ * controls through pi's `ExtensionAPI`, which is a strict subset of what the
+ * runtime already exposes. That gap is bridged by patch hunks in
+ * `patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch` that copy host
+ * capabilities down onto `ExtensionAPI`.
+ *
+ * SessionHost lets the host hand the remote layer a direct handle instead, so
+ * those capabilities are called natively — no patch. It is a thin façade, not an
+ * abstraction: it holds no state and adds no serialization (pi's agent already
+ * serializes via its steering/follow-up queues).
+ */
+export type UserMessageContent = string | (TextContent | ImageContent)[];
+
+export interface SendUserMessageOptions {
+    deliverAs?: "steer" | "followUp";
+    /** Opt into slash-command and prompt-template expansion (default false). */
+    expandPromptTemplates?: boolean;
+}
+
+/**
+ * Injected bridge for the one queue op with no public native equivalent.
+ *
+ * `replaceQueuedMessages` must repopulate the queue with ALREADY-expanded text,
+ * which requires pi's private raw-enqueue (`_queueSteer`/`_queueFollowUp`). The
+ * public `steer()`/`followUp()` re-run skill + template expansion, so rebuilding
+ * the queue through them would double-expand. Until upstream exposes a public
+ * raw-requeue primitive, the host wires this to the patched `ExtensionAPI`
+ * runtime method.
+ *
+ * ponytail: one injected fn, not a layer — delete when upstream adds a public
+ * requeue and call `session` directly.
+ */
+export type ReplaceQueuedMessagesFn = (followUp: string[]) => void;
+
+export class SessionHost {
+    constructor(
+        private readonly runtime: AgentSessionRuntime,
+        private readonly replaceQueuedMessagesFn?: ReplaceQueuedMessagesFn,
+    ) {}
+
+    /** Read the live session — `runtime.session` is replaced on new/switch/fork/import. */
+    private get session(): AgentSession {
+        return this.runtime.session;
+    }
+
+    get cwd(): string {
+        return this.runtime.cwd;
+    }
+
+    get pendingMessageCount(): number {
+        return this.session.pendingMessageCount;
+    }
+
+    /**
+     * Deliver a user message. Mirrors pi's `ExtensionAPI.sendUserMessage` content
+     * normalization (text parts joined with newlines, images collected) and maps
+     * to `session.prompt`, which is what the patched handler does internally.
+     */
+    async sendUserMessage(content: UserMessageContent, options?: SendUserMessageOptions): Promise<void> {
+        let text: string;
+        let images: ImageContent[] | undefined;
+        if (typeof content === "string") {
+            text = content;
+        } else {
+            const textParts: string[] = [];
+            images = [];
+            for (const part of content) {
+                if (part.type === "text") {
+                    textParts.push(part.text);
+                } else {
+                    images.push(part);
+                }
+            }
+            text = textParts.join("\n");
+            if (images.length === 0) {
+                images = undefined;
+            }
+        }
+        const promptOptions: PromptOptions = {
+            expandPromptTemplates: options?.expandPromptTemplates ?? false,
+            streamingBehavior: options?.deliverAs,
+            images,
+            source: "extension",
+        };
+        await this.session.prompt(text, promptOptions);
+    }
+
+    /** Snapshot of the pending steering/follow-up queues (defensively copied). */
+    getQueuedMessages(): { steering: string[]; followUp: string[] } {
+        return {
+            steering: [...this.session.getSteeringMessages()],
+            followUp: [...this.session.getFollowUpMessages()],
+        };
+    }
+
+    /**
+     * Replace the pending follow-up queue. Delegates to the injected bridge — see
+     * {@link ReplaceQueuedMessagesFn} for why there is no public native path.
+     */
+    replaceQueuedMessages(followUp: string[]): void {
+        if (!this.replaceQueuedMessagesFn) {
+            throw new Error(
+                "SessionHost.replaceQueuedMessages requires a queue bridge: pi exposes no public " +
+                    "raw-requeue primitive, and rebuilding the queue via steer()/followUp() would " +
+                    "double-expand already-expanded queued text.",
+            );
+        }
+        this.replaceQueuedMessagesFn(followUp);
+    }
+
+    newSession(options?: Parameters<AgentSessionRuntime["newSession"]>[0]): ReturnType<AgentSessionRuntime["newSession"]> {
+        return this.runtime.newSession(options);
+    }
+
+    switchSession(
+        sessionPath: string,
+        options?: Parameters<AgentSessionRuntime["switchSession"]>[1],
+    ): ReturnType<AgentSessionRuntime["switchSession"]> {
+        return this.runtime.switchSession(sessionPath, options);
+    }
+
+    fork(entryId: string, options?: Parameters<AgentSessionRuntime["fork"]>[1]): ReturnType<AgentSessionRuntime["fork"]> {
+        return this.runtime.fork(entryId, options);
+    }
+
+    importFromJsonl(inputPath: string, cwdOverride?: string): ReturnType<AgentSessionRuntime["importFromJsonl"]> {
+        return this.runtime.importFromJsonl(inputPath, cwdOverride);
+    }
+
+    abort(): Promise<void> {
+        return this.session.abort();
+    }
+
+    waitForIdle(): Promise<void> {
+        return this.session.waitForIdle();
+    }
+
+    setModel(model: Model<any>): Promise<void> {
+        return this.session.setModel(model);
+    }
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -9,6 +9,8 @@ import { setRegisteredCommandsProvider } from "../extensions/command-introspecti
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
 import { headlessFork } from "./worker-fork.js";
+import { SessionHost } from "./session-host.js";
+import { setRemoteSessionHost } from "../extensions/remote/session-host-ref.js";
 import { applySettingsDefaultModel, flushPendingExtensionProviders } from "./apply-default-model.js";
 import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
@@ -501,174 +503,199 @@ async function main(): Promise<void> {
     publishSessionMetadata(session);
     bootTimer.start("[boot] bind-extensions");
     try {
-    await session.bindExtensions({
-        commandContextActions: {
-            waitForIdle: () => session.agent.waitForIdle(),
+    const sessionControlActions = {
+        waitForIdle: () => session.agent.waitForIdle(),
 
-            newSession: async () => {
-                const extensionRunner = session.extensionRunner;
-                const previousSessionFile = session.sessionFile;
+        newSession: async () => {
+            const extensionRunner = session.extensionRunner;
+            const previousSessionFile = session.sessionFile;
 
-                // Let extensions cancel the switch (e.g. unsaved work)
-                if (extensionRunner?.hasHandlers("session_before_switch")) {
-                    const result = await extensionRunner.emit({
-                        type: "session_before_switch",
-                        reason: "new",
-                    });
-                    if ((result as any)?.cancel) {
-                        return { cancelled: true };
-                    }
-                }
-
-                // Stop any running agent turn
-                await session.abort();
-
-                // Reset agent transcript, queues, and runtime flags
-                session.agent.reset();
-
-                // Create a fresh session file
-                session.sessionManager.newSession();
-                session.agent.sessionId = session.sessionManager.getSessionId();
-                publishSessionMetadata(session);
-
-                // Clear AgentSession's private tracking queues so stale steering/
-                // follow-up messages from the old conversation don't leak through.
-                (session as any)._steeringMessages = [];
-                (session as any)._followUpMessages = [];
-                (session as any)._pendingNextTurnMessages = [];
-                (session as any)._lastAssistantMessage = undefined;
-                (session as any)._overflowRecoveryAttempted = false;
-
-                // Persist the current thinking level in the new session header
-                session.sessionManager.appendThinkingLevelChange(session.thinkingLevel);
-
-                // Re-inject context tracking entries for the new session
-                try {
-                    injectContextTrackingEntries(session, cwd, agentDir, config);
-                } catch { /* non-fatal */ }
-
-                // Notify extensions — the remote extension's session_switch handler
-                // cancels pending triggers, delinks children, and pushes the new
-                // (empty) conversation to the web UI via session_active.
-                // NOTE: "session_switch" was removed from the upstream type union in
-                // 0.66.1, but PizzaPi's remote extension still registers a runtime
-                // handler for it. The cast is safe — emit() dispatches by string key.
-                if (extensionRunner) {
-                    await extensionRunner.emit({
-                        type: "session_switch" as any,
-                        reason: "new",
-                        previousSessionFile,
-                    });
-                }
-
-                logInfo("new session created (in-place)");
-                return { cancelled: false };
-            },
-
-            switchSession: async (sessionPath: string) => {
-                const extensionRunner = session.extensionRunner;
-                const previousSessionFile = session.sessionFile;
-
-                // Let extensions cancel
-                if (extensionRunner?.hasHandlers("session_before_switch")) {
-                    const result = await extensionRunner.emit({
-                        type: "session_before_switch",
-                        reason: "resume",
-                        targetSessionFile: sessionPath,
-                    });
-                    if ((result as any)?.cancel) {
-                        return { cancelled: true };
-                    }
-                }
-
-                await session.abort();
-
-                // Clear AgentSession queues
-                (session as any)._steeringMessages = [];
-                (session as any)._followUpMessages = [];
-                (session as any)._pendingNextTurnMessages = [];
-                (session as any)._lastAssistantMessage = undefined;
-                (session as any)._overflowRecoveryAttempted = false;
-
-                // Load the target session file into the existing SessionManager
-                session.sessionManager.setSessionFile(sessionPath);
-                session.agent.sessionId = session.sessionManager.getSessionId();
-                publishSessionMetadata(session);
-
-                // Rebuild messages from the target session
-                const sessionContext = session.sessionManager.buildSessionContext();
-
-                // Notify extensions before we replace messages — the remote
-                // extension's session_switch handler emits session_active which
-                // reads from the (now updated) sessionManager.
-                // NOTE: see newSession comment for why this uses `as any`.
-                if (extensionRunner) {
-                    await extensionRunner.emit({
-                        type: "session_switch" as any,
-                        reason: "resume",
-                        previousSessionFile,
-                    });
-                }
-
-                // Restore the conversation transcript
-                session.agent.state.messages = sessionContext.messages;
-
-                // Restore model if the session had one saved
-                if (sessionContext.model) {
-                    const modelRegistry = (session as any)._modelRegistry;
-                    if (modelRegistry) {
-                        try {
-                            const available = await modelRegistry.getAvailable();
-                            // Ollama Cloud models are discovered dynamically and
-                            // aren't in getAvailable() — fall back to the cached
-                            // catalog so a resumed ollama-cloud model is restored.
-                            const match =
-                                available.find(
-                                    (m: any) =>
-                                        m.provider === sessionContext.model!.provider &&
-                                        m.id === sessionContext.model!.modelId,
-                                ) ??
-                                findCachedOllamaCloudModel(
-                                    sessionContext.model!.provider,
-                                    sessionContext.model!.modelId,
-                                );
-                            if (match) {
-                                await session.setModel(match);
-                            }
-                        } catch {
-                            // Model restore is best-effort
-                        }
-                    }
-                }
-
-                // Restore thinking level if saved
-                if (sessionContext.thinkingLevel) {
-                    session.setThinkingLevel(sessionContext.thinkingLevel as any);
-                }
-
-                logInfo(`switched to session ${sessionPath}`);
-                return { cancelled: false };
-            },
-
-            fork: async (entryId: string, options?: { position?: "before" | "at" }) => {
-                const result = await headlessFork(session, entryId, options, () => {
-                    publishSessionMetadata(session);
+            // Let extensions cancel the switch (e.g. unsaved work)
+            if (extensionRunner?.hasHandlers("session_before_switch")) {
+                const result = await extensionRunner.emit({
+                    type: "session_before_switch",
+                    reason: "new",
                 });
-                if (!result.cancelled) {
-                    logInfo(`forked session at entry ${entryId} → ${session.sessionManager.getSessionFile()}`);
+                if ((result as any)?.cancel) {
+                    return { cancelled: true };
                 }
-                return result;
-            },
+            }
 
-            // Tree navigation is not supported in headless mode
-            navigateTree: async () => ({ cancelled: true }),
+            // Stop any running agent turn
+            await session.abort();
 
-            reload: async () => {
-                await session.reload();
-                // reload() re-syncs queue modes from settings — re-apply.
-                session.agent.followUpMode = "all";
-            },
+            // Reset agent transcript, queues, and runtime flags
+            session.agent.reset();
+
+            // Create a fresh session file
+            session.sessionManager.newSession();
+            session.agent.sessionId = session.sessionManager.getSessionId();
+            publishSessionMetadata(session);
+
+            // Clear AgentSession's private tracking queues so stale steering/
+            // follow-up messages from the old conversation don't leak through.
+            (session as any)._steeringMessages = [];
+            (session as any)._followUpMessages = [];
+            (session as any)._pendingNextTurnMessages = [];
+            (session as any)._lastAssistantMessage = undefined;
+            (session as any)._overflowRecoveryAttempted = false;
+
+            // Persist the current thinking level in the new session header
+            session.sessionManager.appendThinkingLevelChange(session.thinkingLevel);
+
+            // Re-inject context tracking entries for the new session
+            try {
+                injectContextTrackingEntries(session, cwd, agentDir, config);
+            } catch { /* non-fatal */ }
+
+            // Notify extensions — the remote extension's session_switch handler
+            // cancels pending triggers, delinks children, and pushes the new
+            // (empty) conversation to the web UI via session_active.
+            // NOTE: "session_switch" was removed from the upstream type union in
+            // 0.66.1, but PizzaPi's remote extension still registers a runtime
+            // handler for it. The cast is safe — emit() dispatches by string key.
+            if (extensionRunner) {
+                await extensionRunner.emit({
+                    type: "session_switch" as any,
+                    reason: "new",
+                    previousSessionFile,
+                });
+            }
+
+            logInfo("new session created (in-place)");
+            return { cancelled: false };
         },
+
+        switchSession: async (sessionPath: string) => {
+            const extensionRunner = session.extensionRunner;
+            const previousSessionFile = session.sessionFile;
+
+            // Let extensions cancel
+            if (extensionRunner?.hasHandlers("session_before_switch")) {
+                const result = await extensionRunner.emit({
+                    type: "session_before_switch",
+                    reason: "resume",
+                    targetSessionFile: sessionPath,
+                });
+                if ((result as any)?.cancel) {
+                    return { cancelled: true };
+                }
+            }
+
+            await session.abort();
+
+            // Clear AgentSession queues
+            (session as any)._steeringMessages = [];
+            (session as any)._followUpMessages = [];
+            (session as any)._pendingNextTurnMessages = [];
+            (session as any)._lastAssistantMessage = undefined;
+            (session as any)._overflowRecoveryAttempted = false;
+
+            // Load the target session file into the existing SessionManager
+            session.sessionManager.setSessionFile(sessionPath);
+            session.agent.sessionId = session.sessionManager.getSessionId();
+            publishSessionMetadata(session);
+
+            // Rebuild messages from the target session
+            const sessionContext = session.sessionManager.buildSessionContext();
+
+            // Notify extensions before we replace messages — the remote
+            // extension's session_switch handler emits session_active which
+            // reads from the (now updated) sessionManager.
+            // NOTE: see newSession comment for why this uses `as any`.
+            if (extensionRunner) {
+                await extensionRunner.emit({
+                    type: "session_switch" as any,
+                    reason: "resume",
+                    previousSessionFile,
+                });
+            }
+
+            // Restore the conversation transcript
+            session.agent.state.messages = sessionContext.messages;
+
+            // Restore model if the session had one saved
+            if (sessionContext.model) {
+                const modelRegistry = (session as any)._modelRegistry;
+                if (modelRegistry) {
+                    try {
+                        const available = await modelRegistry.getAvailable();
+                        // Ollama Cloud models are discovered dynamically and
+                        // aren't in getAvailable() — fall back to the cached
+                        // catalog so a resumed ollama-cloud model is restored.
+                        const match =
+                            available.find(
+                                (m: any) =>
+                                    m.provider === sessionContext.model!.provider &&
+                                    m.id === sessionContext.model!.modelId,
+                            ) ??
+                            findCachedOllamaCloudModel(
+                                sessionContext.model!.provider,
+                                sessionContext.model!.modelId,
+                            );
+                        if (match) {
+                            await session.setModel(match);
+                        }
+                    } catch {
+                        // Model restore is best-effort
+                    }
+                }
+            }
+
+            // Restore thinking level if saved
+            if (sessionContext.thinkingLevel) {
+                session.setThinkingLevel(sessionContext.thinkingLevel as any);
+            }
+
+            logInfo(`switched to session ${sessionPath}`);
+            return { cancelled: false };
+        },
+
+        fork: async (entryId: string, options?: { position?: "before" | "at" }) => {
+            const result = await headlessFork(session, entryId, options, () => {
+                publishSessionMetadata(session);
+            });
+            if (!result.cancelled) {
+                logInfo(`forked session at entry ${entryId} → ${session.sessionManager.getSessionFile()}`);
+            }
+            return result;
+        },
+
+        // Tree navigation is not supported in headless mode
+        navigateTree: async () => ({ cancelled: true }),
+
+        reload: async () => {
+            await session.reload();
+            // reload() re-syncs queue modes from settings — re-apply.
+            session.agent.followUpMode = "all";
+        },
+    };
+
+    // Phase 1: route remote session control through a host-owned SessionHost
+    // backed by these same in-place actions. Behavior-preserving — the handlers
+    // call the identical closures pi.newSession()/switchSession()/fork() route to
+    // today — but via a direct handle, removing the remote extension's need for
+    // the patched ExtensionAPI control surface.
+    const workerSessionHost = new SessionHost(
+        () => session,
+        {
+            newSession: () => sessionControlActions.newSession(),
+            switchSession: (path) => sessionControlActions.switchSession(path),
+            fork: (entryId, o) => sessionControlActions.fork(entryId, o),
+        },
+        // replaceQueuedMessages: repopulate the queue with already-expanded text.
+        // Uses pi's private raw-enqueue directly (as the worker already does for
+        // queue clearing) to avoid the double-expansion that steer()/followUp() cause.
+        (followUp) => {
+            const { steering } = session.clearQueue();
+            for (const text of steering) void (session as any)._queueSteer(text);
+            for (const text of followUp) void (session as any)._queueFollowUp(text);
+        },
+    );
+    setRemoteSessionHost(workerSessionHost);
+
+    await session.bindExtensions({
+        commandContextActions: sessionControlActions,
         shutdownHandler: () => {
             // Extension-initiated shutdown (e.g. auto-close after session
             // completion) — run provider close with "complete" semantics.

--- a/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
@@ -1,5 +1,8 @@
+diff --git a/node_modules/@earendil-works/pi-coding-agent/.bun-tag-b578a4d857002209 b/.bun-tag-b578a4d857002209
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
-index 4600b23..85bd9b0 100644
+index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed05659f958 100644
 --- a/dist/config.js
 +++ b/dist/config.js
 @@ -358,6 +358,10 @@ export function getExamplesPath() {
@@ -33,7 +36,7 @@ index 4600b23..85bd9b0 100644
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index c99a78f..7133b32 100644
+index c99a78f31ce2d58973ab1809bd72deb8a1f4135b..abac9c0ddf96e7f41b6de12fd82d8ba567e270a4 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
 @@ -1122,9 +1122,10 @@ export class AgentSession {
@@ -49,122 +52,11 @@ index c99a78f..7133b32 100644
              streamingBehavior: options?.deliverAs,
              images,
              source: "extension",
-@@ -1890,6 +1891,17 @@ export class AgentSession {
-             },
-             getThinkingLevel: () => this.thinkingLevel,
-             setThinkingLevel: (level) => this.setThinkingLevel(level),
-+            // PATCH(pizzapi): expose the pending queues so the remote extension can sync them to the web UI.
-+            getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] }),
-+            // PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals).
-+            // ponytail: text-only — queued image attachments are dropped on replace; the queue mirrors only store text.
-+            replaceQueuedMessages: (followUp) => {
-+                const { steering } = this.clearQueue();
-+                for (const text of steering)
-+                    void this._queueSteer(text);
-+                for (const text of followUp)
-+                    void this._queueFollowUp(text);
-+            },
-         }, {
-             getModel: () => this.model,
-             isIdle: () => this.isIdle,
-diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
-index 099e74e..7291108 100644
---- a/dist/core/extensions/loader.js
-+++ b/dist/core/extensions/loader.js
-@@ -143,6 +143,10 @@ export function createExtensionRuntime() {
-         sendUserMessage: notInitialized,
-         appendEntry: notInitialized,
-         setSessionName: notInitialized,
-+        // PATCH(pizzapi): expose session-control actions on ExtensionAPI, not only command contexts.
-+        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
-+        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
-+        fork: () => Promise.reject(new Error("Extension runtime not initialized")),
-         getSessionName: notInitialized,
-         setLabel: notInitialized,
-         getActiveTools: notInitialized,
-@@ -154,6 +158,9 @@ export function createExtensionRuntime() {
-         setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
-         getThinkingLevel: notInitialized,
-         setThinkingLevel: notInitialized,
-+        // PATCH(pizzapi): pending-queue read/replace for remote queue sync.
-+        getQueuedMessages: notInitialized,
-+        replaceQueuedMessages: notInitialized,
-         flagValues: new Map(),
-         pendingProviderRegistrations: [],
-         pendingNativeProviderRegistrations: [],
-@@ -252,6 +259,28 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
-             runtime.assertActive();
-             runtime.setSessionName(name);
-         },
-+        // PATCH(pizzapi): remote exec handlers need /new and /resume from lifecycle/event handlers.
-+        newSession(options) {
-+            runtime.assertActive();
-+            return runtime.newSession(options);
-+        },
-+        switchSession(sessionPath, options) {
-+            runtime.assertActive();
-+            return runtime.switchSession(sessionPath, options);
-+        },
-+        fork(entryId, options) {
-+            runtime.assertActive();
-+            return runtime.fork(entryId, options);
-+        },
-+        // PATCH(pizzapi): pending-queue read/replace for remote queue sync (web UI queue edits).
-+        getQueuedMessages() {
-+            runtime.assertActive();
-+            return runtime.getQueuedMessages();
-+        },
-+        replaceQueuedMessages(followUp) {
-+            runtime.assertActive();
-+            runtime.replaceQueuedMessages(followUp);
-+        },
-         getSessionName() {
-             runtime.assertActive();
-             return runtime.getSessionName();
-diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
-index 686ff32..a5ee2cd 100644
---- a/dist/core/extensions/runner.js
-+++ b/dist/core/extensions/runner.js
-@@ -170,6 +170,9 @@ export class ExtensionRunner {
-         this.runtime.setModel = actions.setModel;
-         this.runtime.getThinkingLevel = actions.getThinkingLevel;
-         this.runtime.setThinkingLevel = actions.setThinkingLevel;
-+        // PATCH(pizzapi): expose pending-queue read/replace to extensions (remote queue sync).
-+        this.runtime.getQueuedMessages = actions.getQueuedMessages;
-+        this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages;
-         // Context actions (required)
-         this.getModel = contextActions.getModel;
-         this.isIdleFn = contextActions.isIdle;
-@@ -249,17 +252,24 @@ export class ExtensionRunner {
-         if (actions) {
-             this.waitForIdleFn = actions.waitForIdle;
-             this.newSessionHandler = actions.newSession;
-+            // PATCH(pizzapi): make session controls available to ExtensionAPI callers.
-+            this.runtime.newSession = (options) => this.newSessionHandler(options);
-             this.forkHandler = actions.fork;
-+            this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
-             this.navigateTreeHandler = actions.navigateTree;
-             this.switchSessionHandler = actions.switchSession;
-+            this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
-             this.reloadHandler = actions.reload;
-             return;
-         }
-         this.waitForIdleFn = async () => { };
-         this.newSessionHandler = async () => ({ cancelled: false });
-+        this.runtime.newSession = (options) => this.newSessionHandler(options);
-         this.forkHandler = async () => ({ cancelled: false });
-+        this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
-         this.navigateTreeHandler = async () => ({ cancelled: false });
-         this.switchSessionHandler = async () => ({ cancelled: false });
-+        this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
-         this.reloadHandler = async () => { };
-     }
-     setUIContext(uiContext, mode = "print") {
 diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
-index a7d5547..3b95b7a 100644
+index a7d5547e62e36d252b90ae083bc847ce97a5bf6d..6b77da4e2b4c342c9f541d0d68ee7755bdfa80ae 100644
 --- a/dist/core/extensions/types.d.ts
 +++ b/dist/core/extensions/types.d.ts
-@@ -912,11 +912,32 @@ export interface ExtensionAPI {
+@@ -912,6 +912,8 @@ export interface ExtensionAPI {
       */
      sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
          deliverAs?: "steer" | "followUp";
@@ -173,31 +65,7 @@ index a7d5547..3b95b7a 100644
      }): void;
      /** Append a custom entry to the session for state persistence (not sent to LLM). */
      appendEntry<T = unknown>(customType: string, data?: T): void;
-     /** Set the session display name (shown in session selector). */
-     setSessionName(name: string): void;
-+    /** Start a new session. Available to PizzaPi remote event handlers. */
-+    newSession(options?: {
-+        parentSession?: string;
-+        setup?: (sessionManager: SessionManager) => Promise<void>;
-+        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
-+    }): Promise<{ cancelled: boolean; }>;
-+    /** Switch to a different session file. Available to PizzaPi remote event handlers. */
-+    switchSession(sessionPath: string, options?: {
-+        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
-+    }): Promise<{ cancelled: boolean; }>;
-+    /** Fork from a specific entry, creating a new session file. Available to PizzaPi remote event handlers. */
-+    fork(entryId: string, options?: {
-+        position?: "before" | "at";
-+        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
-+    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
-+    /** PATCH(pizzapi): read the pending steering/follow-up queues (remote queue sync). */
-+    getQueuedMessages(): { steering: string[]; followUp: string[]; };
-+    /** PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals). */
-+    replaceQueuedMessages(followUp: string[]): void;
-     /** Get the current session name, if set. */
-     getSessionName(): string | undefined;
-     /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
-@@ -1107,6 +1128,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+@@ -1107,6 +1109,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
  }) => void;
  export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
      deliverAs?: "steer" | "followUp";
@@ -206,28 +74,8 @@ index a7d5547..3b95b7a 100644
  }) => void;
  export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
  export type SetSessionNameHandler = (name: string) => void;
-@@ -1164,6 +1187,9 @@ export interface ExtensionActions {
-     sendUserMessage: SendUserMessageHandler;
-     appendEntry: AppendEntryHandler;
-     setSessionName: SetSessionNameHandler;
-+    newSession: ExtensionCommandContextActions["newSession"];
-+    switchSession: ExtensionCommandContextActions["switchSession"];
-+    fork: ExtensionCommandContextActions["fork"];
-     getSessionName: GetSessionNameHandler;
-     setLabel: SetLabelHandler;
-     getActiveTools: GetActiveToolsHandler;
-@@ -1174,6 +1200,9 @@ export interface ExtensionActions {
-     setModel: SetModelHandler;
-     getThinkingLevel: GetThinkingLevelHandler;
-     setThinkingLevel: SetThinkingLevelHandler;
-+    /** PATCH(pizzapi): pending-queue read/replace for remote queue sync. */
-+    getQueuedMessages: () => { steering: string[]; followUp: string[]; };
-+    replaceQueuedMessages: (followUp: string[]) => void;
- }
- /**
-  * Actions for ExtensionContext (ctx.* in event handlers).
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
-index 4cd5156..6f41d5c 100644
+index 4cd51566b17e362a4c9c149fa3a339458abc30f6..6f41d5c16b9e476dfe01c312cf86fe0bdce96dac 100644
 --- a/dist/core/model-resolver.js
 +++ b/dist/core/model-resolver.js
 @@ -21,6 +21,7 @@ export const defaultModelPerProvider = {
@@ -239,7 +87,7 @@ index 4cd5156..6f41d5c 100644
      xai: "grok-4.5",
      groq: "openai/gpt-oss-120b",
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index e91e38f..8ee1013 100644
+index e91e38f8bedfabb6e67305f9739277d1ebacde22..8ee1013bedc3895457115c714122c40b65871ed8 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -13,6 +13,7 @@ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveMode
@@ -251,7 +99,7 @@ index e91e38f..8ee1013 100644
  export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
  export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
 diff --git a/dist/index.js b/dist/index.js
-index a2ee192..730bc33 100644
+index a2ee19264ac2c192d67bb4a601aa32b63a508562..730bc336253592faacd434918c20a0c4969951db 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -13,6 +13,7 @@ export { ModelRegistry } from "./core/model-registry.js";
@@ -263,7 +111,7 @@ index a2ee192..730bc33 100644
  // SDK for programmatic usage
  export { AgentSessionRuntime, 
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index b93d41c..b24b963 100644
+index b93d41c0ce6b41e5a6c440bcb1926252eb598fcb..b24b9637c481f180bd946717b3657fab862fdbec 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -33,7 +33,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";

--- a/patches/README.md
+++ b/patches/README.md
@@ -95,14 +95,35 @@ removals absorbed elsewhere rather than restored:
 | File | Change |
 |------|--------|
 | `dist/config.js` | Same `.pizzapi` config-dir / flat-directory / `PIZZAPI_CHANGELOG_PATH` overrides as 0.80.6 |
-| `dist/core/agent-session.js` | Same `expandPromptTemplates` opt-in as 0.80.6 |
-| `dist/core/extensions/loader.js` / `dist/core/extensions/runner.js` | Same `newSession()`/`switchSession()`/`fork()` general-API exposure as 0.80.6 |
-| `dist/core/extensions/types.d.ts` | Same `ExtensionAPI`/`ExtensionActions` typings as 0.80.6 |
+| `dist/core/agent-session.js` | `sendUserMessage({ expandPromptTemplates })` opt-in (web UI input path). **The `getQueuedMessages`/`replaceQueuedMessages` runtime getters were removed in Phase 1** — see below. |
+| `dist/core/extensions/types.d.ts` | `ExtensionAPI.sendUserMessage` `expandPromptTemplates` typing only. |
 | `dist/core/model-resolver.js` | Same `ollama-cloud` default model (`glm-5.1`) as 0.80.6 |
 | `dist/modes/interactive/interactive-mode.js` | Same version-notification-UI removal as 0.80.6 (upstream shifted a few lines; hunk re-applied manually) |
 | `dist/index.js` / `dist/index.d.ts` | Same `handlePackageCommand`/`handleConfigCommand` re-export as 0.80.6 |
 
 **No longer present (see above for why):** `dist/core/provider-display-names.js`.
+
+### Phase 1: control-plane exposure removed (was `loader.js` / `runner.js` / `types.d.ts`)
+
+Earlier revisions copied session-control capabilities onto `ExtensionAPI` so
+PizzaPi's remote extension (which runs in event handlers and only sees
+`ExtensionAPI`) could reach them: `newSession`/`switchSession`/`fork` and
+`getQueuedMessages`/`replaceQueuedMessages`. These were **pure surface-widening**
+— the capabilities are already native on `AgentSessionRuntime` (new/switch/fork)
+and `AgentSession` (`getSteeringMessages`/`getFollowUpMessages`/`clearQueue`).
+
+They were removed from the patch once PizzaPi's remote extension was rewired to
+drive control through a host-owned **SessionHost**
+(`packages/cli/src/runner/session-host.ts`), threaded into the relay context via
+`packages/cli/src/extensions/remote/session-host-ref.ts`. The worker backs the
+host with its existing headless in-place lifecycle actions; the local TUI backs
+it with the runtime. `replaceQueuedMessages` has no clean public native path (it
+needs pi's private raw-enqueue to avoid double-expanding already-expanded queued
+text), so the worker's SessionHost reaches those private methods directly — as
+it already does for queue clearing — rather than via a patch. The
+`sendUserMessage({ expandPromptTemplates })` hunk stays (the primary input path
+still uses it). `patches.test.ts` has regression guards asserting the removed
+hunks do not silently return on a version bump.
 
 ### packages/cli auth call-site migration (not a patch — our own source)
 


### PR DESCRIPTION
## Summary

First slice of **Phase 1** (pi-0.82 alignment). Adds `SessionHost` — a thin façade over the host-owned `AgentSessionRuntime` that both the local TUI and the runner worker will drive through one control surface, calling **native** runtime/session methods directly.

This is the mechanism for later removing 3 *surface-widening* hunks from `patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch`. Those hunks exist only because PizzaPi's remote extension sees pi's `ExtensionAPI` (a strict subset of the runtime). The capabilities are **already native**:

| Patched onto `ExtensionAPI` | Native equivalent |
|---|---|
| `newSession` / `switchSession` / `fork` | `AgentSessionRuntime.*` |
| `getQueuedMessages` | `getSteeringMessages()` + `getFollowUpMessages()` |
| `sendUserMessage({expandPromptTemplates})` | `session.prompt(text, {expandPromptTemplates})` |

## Verified against source — one holdout

`replaceQueuedMessages` has **no clean native path**. It repopulates the queue with *already-expanded* text via pi's private `_queueSteer`/`_queueFollowUp`. The public `steer()`/`followUp()` first run `_throwIfExtensionCommand` + `_expandSkillCommand` + `expandPromptTemplate`, so rebuilding the queue through them would **double-expand**. SessionHost takes it as an **injected bridge fn** (wired to the patched runtime method by the host), and that one hunk stays patched until upstream adds a public raw-requeue primitive.

## Scope

Additive and **unwired by design** — no `index.ts`/`worker.ts` changes, no patch removed. Wiring (1.2/1.3) and patch removal (1.4) follow as separate stacked PRs so behavior-changing work is isolated for review.

## Verification
- `bun test packages/cli/src/runner/session-host.test.ts` — **10/10** (content normalization, defensive queue copies, no-bridge throw, runtime delegation, live-session reads after replacement)
- `bun run typecheck` — clean

## Stacking
Top of the Phase-0 stack: [[pr:632]] → [[pr:630]] → [[pr:631]] → [[pr:633]] → [[pr:634]] → **this**. Based on `chore/prune-stale-patches`.

Godmother: `HWmkuq2S` (epic `kFPHpPymPBbp03hez7AQe`)