### PR TITLE
refactor(cli): dedupe frontmatter parsing (Phase 2)

### DIFF
--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -11,6 +11,7 @@ import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync 
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { parseFrontmatterDescription } from "./frontmatter.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -41,22 +42,10 @@ export function parseAgentFrontmatter(filePath: string): { description: string }
         return { description: "" };
     }
 
-    return parseAgentFrontmatterFromString(content);
+    return parseFrontmatterDescription(content);
 }
 
-/**
- * Parse the `description` field out of a frontmatter string.
- * Pure function — no filesystem access.
- */
-export function parseAgentFrontmatterFromString(content: string): { description: string } {
-    if (!content.startsWith("---")) return { description: "" };
-    const end = content.indexOf("\n---", 3);
-    if (end === -1) return { description: "" };
-
-    const block = content.slice(3, end);
-    const match = block.match(/^description:\s*(.+)$/m);
-    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
-}
+export { parseFrontmatterDescription as parseAgentFrontmatterFromString } from "./frontmatter.js";
 
 // ── Agent scanning ────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/frontmatter.ts
+++ b/packages/cli/src/frontmatter.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared frontmatter parsing for skills and agents markdown files.
+ *
+ * Extracted from skills.ts / agents.ts, which had byte-identical
+ * implementations of this logic.
+ */
+
+/**
+ * Parse the `description` field out of a frontmatter string.
+ * Pure function — no filesystem access.
+ */
+export function parseFrontmatterDescription(content: string): { description: string } {
+    if (!content.startsWith("---")) return { description: "" };
+    const end = content.indexOf("\n---", 3);
+    if (end === -1) return { description: "" };
+
+    const block = content.slice(3, end);
+    const match = block.match(/^description:\s*(.+)$/m);
+    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
+}

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -10,6 +10,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expandHome } from "./config.js";
+import { parseFrontmatterDescription } from "./frontmatter.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,22 +56,10 @@ export function parseSkillFrontmatter(filePath: string): { description: string }
         return { description: "" };
     }
 
-    return parseSkillFrontmatterFromString(content);
+    return parseFrontmatterDescription(content);
 }
 
-/**
- * Parse the `description` field out of a frontmatter string.
- * Pure function — no filesystem access.
- */
-export function parseSkillFrontmatterFromString(content: string): { description: string } {
-    if (!content.startsWith("---")) return { description: "" };
-    const end = content.indexOf("\n---", 3);
-    if (end === -1) return { description: "" };
-
-    const block = content.slice(3, end);
-    const match = block.match(/^description:\s*(.+)$/m);
-    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
-}
+export { parseFrontmatterDescription as parseSkillFrontmatterFromString } from "./frontmatter.js";
 
 // ── Skill scanning ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Night Shift dish p23-d. Extracts identical skill/agent frontmatter parser into frontmatter.ts; skills.ts/agents.ts keep re-export + thin shims so all import sites are unchanged. Base: feat/session-host (will be stacked).