### PR TITLE
test+docs(cli): trust-gate characterization + unification ADR (Phase 2)

### DIFF
--- a/docs/adr/trust-unification.md
+++ b/docs/adr/trust-unification.md
@@ -81,33 +81,50 @@ independent per-resource-type gates over `.pizzapi/*`.
   dedicated `trust.json`. Adopting `trust.json` would mean a second
   persistence format to keep in sync.
 
-## 4. Proposed migration (future phase, not this one)
+## 4. Why the two systems should NOT be merged by flag-remapping
 
-Add a PizzaPi extension that registers a `project_trust` handler and maps
-the resulting binary decision onto the existing per-resource gates, without
-replacing them:
+An earlier draft of this ADR proposed a `project_trust` handler that, on
+`trusted: "yes"`, would flip PizzaPi's `allowProjectHooks`,
+`allowProjectProviders`, and `trustedPlugins` open. **That proposal is
+wrong and is rejected.** Two upstream facts make it unworkable:
 
-- On `project_trust` with `trusted: "yes"` (and `remember: true`): set
-  `allowProjectHooks: true`, `allowProjectProviders: true`, and add the
-  project's plugin root(s) to `trustedPlugins` in the global config —
-  effectively "trusting a project" flips PizzaPi's independent gates open,
-  matching the granularity users already rely on today rather than
-  collapsing it.
-- On `trusted: "no"`: leave existing gates as-is (default closed);
-  optionally set them `false` explicitly if a per-directory decision needs
-  to be recorded.
-- `allowProjectMcp` / MCP loading stays warn-only and is **not** touched by
-  this handler — MCP always loads, project_trust only affects whether the
-  warning is silenced (i.e. the handler could set `allowProjectMcp: true`
-  as a side effect of "yes", but never gates the load itself).
-- The handler is additive: an extension providing `project_trust` is
-  optional infrastructure that a user session may or may not load. Without
-  it, PizzaPi's current per-flag gates behave exactly as documented in
-  section 1 — nothing about upstream's `project_trust` event is required
-  for PizzaPi to function.
+1. **The handler can't observe a resolved decision — it produces one.**
+   `ProjectTrustHandler = (event: ProjectTrustEvent, ctx) => Promise<ProjectTrustEventResult> | ProjectTrustEventResult`.
+   The event payload (`{ type: "project_trust", cwd }`) carries *only* the
+   cwd; there is no persisted-trust lookup passed in. The handler runs
+   *before* pi resolves `trust.json` / `defaultProjectTrust` — its job is to
+   supply the decision (`trusted: "yes" | "no" | "undecided"`), not to react
+   to one that already exists. A PizzaPi extension hooking this event has no
+   way to say "only run my side effect when pi decided this project is
+   trusted" — it would have to re-implement its own ask/persist/lookup logic
+   just to get that information, duplicating `ProjectTrustStore`.
+2. **PizzaPi's four gates are global, not per-directory.** `allowProjectHooks`,
+   `allowProjectProviders`, `trustedPlugins`, and `allowProjectMcp` all live in
+   `~/.pizzapi/config.json` with no cwd scoping (section 1). Setting any of
+   them from a `project_trust` handler — which fires per-cwd — would trust
+   *every* project globally the first time *any one* directory is trusted.
+   That's a strict security regression versus today's already-global (but at
+   least explicit, user-set) flags, not a migration.
 
-This mapping needs its own idea/PR with real tests before implementation;
-it is out of scope here.
+### What's actually viable, in order of laziness
+
+- **Recommended for now: don't adopt `project_trust` for these four gates.**
+  Keep them independent, global, and explicitly user-set exactly as they are
+  today. The granularity (hooks vs. MCP vs. providers vs. plugins trusted
+  separately) is a real feature upstream's single yes/no doesn't offer, and
+  `allowProjectMcp`'s warn-only UX (section 1) has no upstream equivalent to
+  map onto. Simplest, safest, zero new code — this ADR's actual recommendation.
+- **Future work, only if per-directory granularity is wanted:** give PizzaPi
+  its own per-directory trust store mirroring upstream's `trust.json`
+  (canonical path → decision, nearest-ancestor lookup) and gate resources by
+  `(cwd, resource)` instead of by resource alone. That is new persistence and
+  new call-site plumbing at every gate check — not a flag remap — and would
+  need its own idea/PR with real tests. Out of scope here.
+- **Where `project_trust` genuinely fits:** if/when PizzaPi introduces a
+  resource that only makes sense as "is this cwd trusted at all" (mirroring
+  upstream's `.pi/*` bundle), subscribing to `project_trust` to *supply* that
+  per-cwd decision is legitimate — that's the event's actual contract. It is
+  not a mechanism for retrofitting global flags.
 
 ## 5. Non-goals (this phase)
 
@@ -118,5 +135,6 @@ it is out of scope here.
 - No adoption of `trust.json` or the upstream `ProjectTrustStore` in this
   phase — PizzaPi's `~/.pizzapi/config.json`-based gates remain the only
   persistence mechanism for now.
-- No new extension registering `pi.on("project_trust", ...)` yet — section 4
-  is a proposal, not an implementation plan for this PR.
+- No new extension registering `pi.on("project_trust", ...)` — section 4
+  recommends against adopting it for the existing four gates at all, and
+  scopes any future per-directory work as a separate, out-of-scope effort.

--- a/docs/adr/trust-unification.md
+++ b/docs/adr/trust-unification.md
@@ -64,10 +64,14 @@ independent per-resource-type gates over `.pizzapi/*`.
 
 ## 3. Gap analysis
 
-- **Granularity**: PizzaPi's gates are more granular (hooks, MCP, providers,
-  plugins can each be trusted independently) than upstream's single yes/no.
-  This granularity is a feature worth keeping — e.g. a user may want to run
-  project hooks but never auto-load project MCP servers.
+- **Granularity**: PizzaPi's gates are more granular than upstream's single
+  yes/no — hooks, providers, and plugins are each independently *enforced*
+  (each can be denied on its own). This granularity is a feature worth
+  keeping — e.g. a user may want to run project hooks but never auto-load
+  project-local providers. MCP is the exception: `allowProjectMcp` is a real,
+  independent config key, but it does not gate loading (see next bullet and
+  section 1) — project MCP servers always merge in regardless of its value,
+  so MCP is not an example of enforced per-resource granularity today.
 - **MCP is deliberately looser**: `allowProjectMcp` is warn-only by design
   (see code comment history — "P0 fix: warn-and-load by default"). This is
   not something upstream's binary trust model has an equivalent for, and
@@ -98,20 +102,27 @@ wrong and is rejected.** Two upstream facts make it unworkable:
    way to say "only run my side effect when pi decided this project is
    trusted" — it would have to re-implement its own ask/persist/lookup logic
    just to get that information, duplicating `ProjectTrustStore`.
-2. **PizzaPi's four gates are global, not per-directory.** `allowProjectHooks`,
-   `allowProjectProviders`, `trustedPlugins`, and `allowProjectMcp` all live in
-   `~/.pizzapi/config.json` with no cwd scoping (section 1). Setting any of
-   them from a `project_trust` handler — which fires per-cwd — would trust
-   *every* project globally the first time *any one* directory is trusted.
-   That's a strict security regression versus today's already-global (but at
-   least explicit, user-set) flags, not a migration.
+2. **PizzaPi's boolean gates are global, not per-directory.**
+   `allowProjectHooks`, `allowProjectProviders`, and `allowProjectMcp` all
+   live in `~/.pizzapi/config.json` with no cwd scoping (section 1). Setting
+   any of them from a `project_trust` handler — which fires per-cwd — would
+   trust *every* project globally the first time *any one* directory is
+   trusted. That's a strict security regression versus today's
+   already-global (but at least explicit, user-set) flags, not a migration.
+   `trustedPlugins` is structurally different and does not have this
+   failure mode the same way: it's a path allowlist (section 1), so wiring
+   it to `project_trust` would add only the specific plugin root paths
+   discovered under that one cwd, not flip a global switch open for every
+   project. It would still bypass the explicit `pizza plugins trust` review
+   step, which is its own regression — but "trusts every project" is not an
+   accurate description of what auto-populating `trustedPlugins` would do.
 
 ### What's actually viable, in order of laziness
 
 - **Recommended for now: don't adopt `project_trust` for these four gates.**
   Keep them independent, global, and explicitly user-set exactly as they are
-  today. The granularity (hooks vs. MCP vs. providers vs. plugins trusted
-  separately) is a real feature upstream's single yes/no doesn't offer, and
+  today. The granularity (hooks vs. providers vs. plugins independently
+  enforced) is a real feature upstream's single yes/no doesn't offer, and
   `allowProjectMcp`'s warn-only UX (section 1) has no upstream equivalent to
   map onto. Simplest, safest, zero new code — this ADR's actual recommendation.
 - **Future work, only if per-directory granularity is wanted:** give PizzaPi

--- a/docs/adr/trust-unification.md
+++ b/docs/adr/trust-unification.md
@@ -1,0 +1,122 @@
+# ADR: Trust-gate unification (Phase 2 — characterization only)
+
+- Status: Proposed (no code change in this phase)
+- Related: `packages/cli/src/config/trust-gates.test.ts` (source of truth for current behavior)
+
+## 1. Current state: four gates, inconsistent enforcement
+
+PizzaPi has four independent trust gates, all reading `~/.pizzapi/config.json`
+(global config) plus env-var overrides. None of them consult project config —
+that would be self-authorization.
+
+| Gate | Enforced? | Config key | Env override | Code |
+|---|---|---|---|---|
+| Project hooks | **Yes** — dropped (warn) unless trusted | `allowProjectHooks` | `PIZZAPI_ALLOW_PROJECT_HOOKS=1` | `config/io.ts` `isProjectHooksTrusted` / `loadConfig` |
+| Project MCP servers | **No — warn-only** | `allowProjectMcp` | `PIZZAPI_ALLOW_PROJECT_MCP=1` | `config/io.ts` `isProjectMcpTrusted` / `loadConfig` |
+| Project providers (`.pizzapi/providers/`) | **Yes** — excluded unless trusted | `allowProjectProviders` | none | `providers/loader.ts` `discoverProviders({allowProject})`, wired in `extensions/providers/extension.ts` |
+| Claude-Code plugins | **Yes** — path allowlist, no global on/off switch | `trustedPlugins: string[]` | none | `config/io.ts` `isPluginTrusted`/`trustPlugin`/`untrustPlugin` |
+
+The MCP gate is the outlier: `loadConfig` always merges `mcpServers` /
+`mcp.servers` from the project config into the effective config regardless of
+`allowProjectMcp`. The flag only silences a one-time warning
+(`"project-mcp-untrusted"`). This is intentional per the code comment ("P0
+fix: warn-and-load by default") — not a bug, but a deliberately looser gate
+than the other three. Part 1 tests (`trust-gates.test.ts`, "warn-only gate"
+describe block) pin this exact behavior so it isn't silently "fixed" by a
+future refactor without a conscious decision.
+
+The plugin gate is also structurally different: it's a path allowlist
+(`trustPlugin`/`untrustPlugin`), not a boolean flag — a plugin is trusted
+per-install, not per-project.
+
+## 2. Upstream: pi 0.82.1's `project_trust` event
+
+Verified against `@earendil-works/pi-coding-agent@0.82.1`
+(`dist/core/trust-manager.d.ts`, `dist/core/project-trust.d.ts`,
+`dist/core/extensions/types.d.ts`, `docs/security.md`).
+
+Upstream pi has a single, binary, per-directory trust decision:
+
+- **Event**: extensions can register `pi.on("project_trust", handler)`.
+  `ProjectTrustEvent = { type: "project_trust", cwd }`. The handler returns
+  `ProjectTrustEventResult = { trusted: "yes" | "no" | "undecided", remember?: boolean }`.
+  The first extension to return a non-`"undecided"` decision owns the
+  outcome (`extensions.md`/`types.d.ts` comment).
+- **Persistence**: `ProjectTrustStore` (`core/trust-manager.ts`) reads/writes
+  `~/.pi/agent/trust.json` — a flat map of canonical directory path →
+  `true | false | null`, with nearest-ancestor lookup (`findNearestTrustEntry`)
+  so trusting a parent folder covers subdirectories. Writes are file-locked
+  (`proper-lockfile`).
+- **Default policy**: `defaultProjectTrust: "ask" | "always" | "never"`
+  (`settings-manager.d.ts`). `"ask"` prompts interactively when UI is
+  available; non-interactive modes (`-p`, `json`, `rpc`) without a saved
+  decision treat `"ask"`/`"never"` as untrusted and `"always"` as trusted.
+  `--approve`/`--no-approve` override for a single run.
+- **Scope gated**: trusting a project unlocks `.pi/settings.json`,
+  `.pi/extensions`, `.pi/skills`, `.pi/prompts`, `.pi/themes`,
+  `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md`, and project-local `.agents/skills`
+  (`TRUST_REQUIRING_PROJECT_CONFIG_RESOURCES` in `trust-manager.ts`,
+  confirmed in `docs/security.md`). `AGENTS.md`/`CLAUDE.md` load regardless.
+
+So upstream trust is **one binary decision per directory** that gates a
+fixed bundle of `.pi/*` resources — a different shape from PizzaPi's four
+independent per-resource-type gates over `.pizzapi/*`.
+
+## 3. Gap analysis
+
+- **Granularity**: PizzaPi's gates are more granular (hooks, MCP, providers,
+  plugins can each be trusted independently) than upstream's single yes/no.
+  This granularity is a feature worth keeping — e.g. a user may want to run
+  project hooks but never auto-load project MCP servers.
+- **MCP is deliberately looser**: `allowProjectMcp` is warn-only by design
+  (see code comment history — "P0 fix: warn-and-load by default"). This is
+  not something upstream's binary trust model has an equivalent for, and
+  this ADR does not propose changing it.
+- **No overlap today**: PizzaPi does not currently subscribe to
+  `project_trust` or read/write `~/.pi/agent/trust.json` anywhere in
+  `packages/cli/src` (verified by grep). The two trust systems are
+  completely separate; nothing currently double-gates.
+- **Persistence shape differs**: PizzaPi stores gates as flags/allowlists in
+  `~/.pizzapi/config.json`; upstream stores a directory→decision map in a
+  dedicated `trust.json`. Adopting `trust.json` would mean a second
+  persistence format to keep in sync.
+
+## 4. Proposed migration (future phase, not this one)
+
+Add a PizzaPi extension that registers a `project_trust` handler and maps
+the resulting binary decision onto the existing per-resource gates, without
+replacing them:
+
+- On `project_trust` with `trusted: "yes"` (and `remember: true`): set
+  `allowProjectHooks: true`, `allowProjectProviders: true`, and add the
+  project's plugin root(s) to `trustedPlugins` in the global config —
+  effectively "trusting a project" flips PizzaPi's independent gates open,
+  matching the granularity users already rely on today rather than
+  collapsing it.
+- On `trusted: "no"`: leave existing gates as-is (default closed);
+  optionally set them `false` explicitly if a per-directory decision needs
+  to be recorded.
+- `allowProjectMcp` / MCP loading stays warn-only and is **not** touched by
+  this handler — MCP always loads, project_trust only affects whether the
+  warning is silenced (i.e. the handler could set `allowProjectMcp: true`
+  as a side effect of "yes", but never gates the load itself).
+- The handler is additive: an extension providing `project_trust` is
+  optional infrastructure that a user session may or may not load. Without
+  it, PizzaPi's current per-flag gates behave exactly as documented in
+  section 1 — nothing about upstream's `project_trust` event is required
+  for PizzaPi to function.
+
+This mapping needs its own idea/PR with real tests before implementation;
+it is out of scope here.
+
+## 5. Non-goals (this phase)
+
+- No production behavior change. Zero lines of non-test, non-doc code
+  changed in this PR.
+- No change to any default value (`allowProjectHooks`, `allowProjectMcp`,
+  `allowProjectProviders`, `trustedPlugins` all keep today's defaults).
+- No adoption of `trust.json` or the upstream `ProjectTrustStore` in this
+  phase — PizzaPi's `~/.pizzapi/config.json`-based gates remain the only
+  persistence mechanism for now.
+- No new extension registering `pi.on("project_trust", ...)` yet — section 4
+  is a proposal, not an implementation plan for this PR.

--- a/packages/cli/src/config/trust-gates.test.ts
+++ b/packages/cli/src/config/trust-gates.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Characterization tests for the four PizzaPi trust gates.
+ *
+ * These tests pin CURRENT behavior — they do not assert what "should"
+ * happen. See docs/adr/trust-unification.md for the gap analysis and
+ * migration plan. If a gate's real behavior looks surprising, the comment
+ * on that test explains why; the fix (if any) is a separate change.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+    loadConfig,
+    isProjectHooksTrusted,
+    isProjectMcpTrusted,
+    getTrustedPlugins,
+    isPluginTrusted,
+    trustPlugin,
+    untrustPlugin,
+    _setGlobalConfigDir,
+} from "./io.js";
+import { discoverProviders, globalProvidersDir } from "../providers/loader.js";
+
+let tmpHome: string;
+let projectDir: string;
+const ENV_KEYS = ["PIZZAPI_ALLOW_PROJECT_HOOKS", "PIZZAPI_ALLOW_PROJECT_MCP"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pizzapi-trust-gates-"));
+    projectDir = join(tmpHome, "project");
+    mkdirSync(projectDir, { recursive: true });
+    _setGlobalConfigDir(tmpHome);
+    for (const k of ENV_KEYS) {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+    }
+});
+
+afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tmpHome, { recursive: true, force: true });
+    for (const k of ENV_KEYS) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+    }
+});
+
+function writeGlobalConfig(config: Record<string, unknown>): void {
+    writeFileSync(join(tmpHome, "config.json"), JSON.stringify(config));
+}
+
+function writeProjectConfig(config: Record<string, unknown>): void {
+    const dir = join(projectDir, ".pizzapi");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "config.json"), JSON.stringify(config));
+}
+
+// ── 1. allowProjectHooks — ENFORCED ─────────────────────────────────────────
+
+describe("allowProjectHooks (enforced gate)", () => {
+    test("isProjectHooksTrusted defaults to false with no config", () => {
+        expect(isProjectHooksTrusted({})).toBe(false);
+    });
+
+    test("isProjectHooksTrusted true when global config sets allowProjectHooks: true", () => {
+        expect(isProjectHooksTrusted({ allowProjectHooks: true })).toBe(true);
+    });
+
+    test("isProjectHooksTrusted false when global config explicitly sets allowProjectHooks: false", () => {
+        expect(isProjectHooksTrusted({ allowProjectHooks: false })).toBe(false);
+    });
+
+    test("isProjectHooksTrusted true via PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var, even if global config is false", () => {
+        process.env.PIZZAPI_ALLOW_PROJECT_HOOKS = "1";
+        expect(isProjectHooksTrusted({ allowProjectHooks: false })).toBe(true);
+    });
+
+    test("loadConfig DROPS project hooks by default (untrusted) — global hooks still run", () => {
+        writeGlobalConfig({
+            hooks: { SessionStart: [{ command: "echo global" }] },
+        });
+        writeProjectConfig({
+            hooks: { SessionStart: [{ command: "echo project" }] },
+        });
+
+        const config = loadConfig(projectDir);
+        expect(config.hooks?.SessionStart).toHaveLength(1);
+        expect(config.hooks?.SessionStart?.[0]).toEqual({ command: "echo global" });
+    });
+
+    test("loadConfig MERGES project hooks with global hooks when allowProjectHooks: true", () => {
+        writeGlobalConfig({
+            allowProjectHooks: true,
+            hooks: { SessionStart: [{ command: "echo global" }] },
+        });
+        writeProjectConfig({
+            hooks: { SessionStart: [{ command: "echo project" }] },
+        });
+
+        const config = loadConfig(projectDir);
+        expect(config.hooks?.SessionStart).toHaveLength(2);
+    });
+
+    test("loadConfig merges project hooks when trusted via env var instead of global config", () => {
+        process.env.PIZZAPI_ALLOW_PROJECT_HOOKS = "1";
+        writeGlobalConfig({});
+        writeProjectConfig({
+            hooks: { SessionStart: [{ command: "echo project" }] },
+        });
+
+        const config = loadConfig(projectDir);
+        expect(config.hooks?.SessionStart).toHaveLength(1);
+    });
+});
+
+// ── 2. allowProjectMcp — WARN-ONLY (not enforced) ───────────────────────────
+
+describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)", () => {
+    test("isProjectMcpTrusted defaults to false with no config", () => {
+        expect(isProjectMcpTrusted({})).toBe(false);
+    });
+
+    test("isProjectMcpTrusted true when global config sets allowProjectMcp: true", () => {
+        expect(isProjectMcpTrusted({ allowProjectMcp: true })).toBe(true);
+    });
+
+    test("isProjectMcpTrusted true via PIZZAPI_ALLOW_PROJECT_MCP=1 env var", () => {
+        process.env.PIZZAPI_ALLOW_PROJECT_MCP = "1";
+        expect(isProjectMcpTrusted({ allowProjectMcp: false })).toBe(true);
+    });
+
+    // CRITICAL: this is the "warn-and-load" behavior (see io.ts loadConfig,
+    // ~"P0 fix: warn-and-load by default"). The flag only silences the
+    // warning — it does NOT gate whether the servers are merged into config.
+    // A future unification must preserve this unless a deliberate behavior
+    // change is made and documented.
+    test("mcpServers format: project servers ARE MERGED even when untrusted (flag absent)", () => {
+        writeGlobalConfig({
+            mcpServers: { globalServer: { command: "global-cmd" } },
+        });
+        writeProjectConfig({
+            mcpServers: { projectServer: { command: "project-cmd" } },
+        });
+
+        const config = loadConfig(projectDir);
+        expect((config as any).mcpServers).toEqual({
+            globalServer: { command: "global-cmd" },
+            projectServer: { command: "project-cmd" },
+        });
+    });
+
+    test("mcpServers format: project servers ARE MERGED even when allowProjectMcp: false explicitly", () => {
+        writeGlobalConfig({
+            allowProjectMcp: false,
+            mcpServers: { globalServer: { command: "global-cmd" } },
+        });
+        writeProjectConfig({
+            mcpServers: { projectServer: { command: "project-cmd" } },
+        });
+
+        const config = loadConfig(projectDir);
+        expect((config as any).mcpServers).toHaveProperty("projectServer");
+    });
+
+    test("mcp.servers (array) format: project servers ARE MERGED even when untrusted", () => {
+        writeGlobalConfig({
+            mcp: { servers: [{ name: "global-srv", command: "g" }] },
+        });
+        writeProjectConfig({
+            mcp: { servers: [{ name: "project-srv", command: "p" }] },
+        });
+
+        const config = loadConfig(projectDir);
+        const names = ((config as any).mcp.servers as Array<{ name: string }>).map((s) => s.name);
+        expect(names.sort()).toEqual(["global-srv", "project-srv"]);
+    });
+
+    test("mcp.servers (array) format: project entry with same name overwrites global entry, still merged when untrusted", () => {
+        writeGlobalConfig({
+            mcp: { servers: [{ name: "shared", command: "global-version" }] },
+        });
+        writeProjectConfig({
+            mcp: { servers: [{ name: "shared", command: "project-version" }] },
+        });
+
+        const config = loadConfig(projectDir);
+        const servers = (config as any).mcp.servers as Array<{ name: string; command: string }>;
+        expect(servers).toHaveLength(1);
+        expect(servers[0].command).toBe("project-version");
+    });
+
+    test("warns once (console.warn) when project mcpServers present and flag not set, but STILL loads them", () => {
+        const warnCalls: unknown[][] = [];
+        const orig = console.warn;
+        console.warn = (...args: unknown[]) => { warnCalls.push(args); };
+        try {
+            writeGlobalConfig({});
+            writeProjectConfig({
+                mcpServers: { projectServer: { command: "project-cmd" } },
+            });
+            const config = loadConfig(projectDir);
+            expect((config as any).mcpServers).toHaveProperty("projectServer");
+            const joined = warnCalls.map((a) => a.join(" ")).join("\n");
+            expect(joined).toContain("Project MCP servers found");
+        } finally {
+            console.warn = orig;
+        }
+    });
+
+    test("no warning when allowProjectMcp: true (still loads, silences the warning)", () => {
+        const warnCalls: unknown[][] = [];
+        const orig = console.warn;
+        console.warn = (...args: unknown[]) => { warnCalls.push(args); };
+        try {
+            writeGlobalConfig({ allowProjectMcp: true });
+            writeProjectConfig({
+                mcpServers: { projectServer: { command: "project-cmd" } },
+            });
+            const config = loadConfig(projectDir);
+            expect((config as any).mcpServers).toHaveProperty("projectServer");
+            const joined = warnCalls.map((a) => a.join(" ")).join("\n");
+            expect(joined).not.toContain("Project MCP servers found");
+        } finally {
+            console.warn = orig;
+        }
+    });
+
+    test("empty project mcpServers object does not trigger a warning (skips placeholder objects)", () => {
+        const warnCalls: unknown[][] = [];
+        const orig = console.warn;
+        console.warn = (...args: unknown[]) => { warnCalls.push(args); };
+        try {
+            writeGlobalConfig({});
+            writeProjectConfig({ mcpServers: {} });
+            loadConfig(projectDir);
+            const joined = warnCalls.map((a) => a.join(" ")).join("\n");
+            expect(joined).not.toContain("Project MCP servers found");
+        } finally {
+            console.warn = orig;
+        }
+    });
+});
+
+// ── 3. allowProjectProviders — ENFORCED ─────────────────────────────────────
+
+describe("allowProjectProviders (enforced gate, via discoverProviders({allowProject}))", () => {
+    let origHome: string | undefined;
+
+    beforeEach(() => {
+        origHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+    });
+
+    afterEach(() => {
+        process.env.HOME = origHome;
+    });
+
+    function writeProvider(dir: string, id: string): void {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "index.ts"),
+            `export default {
+                id: ${JSON.stringify(id)},
+                capabilities: ["lifecycle"],
+                init() {},
+                dispose() {},
+                onSessionStart: async () => {},
+            };`,
+        );
+    }
+
+    test("allowProject: false (default) returns ONLY global providers, project provider excluded", async () => {
+        writeProvider(join(globalProvidersDir(), "global-prov"), "global-prov");
+        writeProvider(join(projectDir, ".pizzapi", "providers", "project-prov"), "project-prov");
+
+        const result = await discoverProviders({ cwd: projectDir, allowProject: false });
+        expect(result.providers.map((p) => p.provider.id)).toEqual(["global-prov"]);
+    });
+
+    test("allowProject omitted (undefined) also excludes project providers — default is false", async () => {
+        writeProvider(join(globalProvidersDir(), "global-prov"), "global-prov");
+        writeProvider(join(projectDir, ".pizzapi", "providers", "project-prov"), "project-prov");
+
+        const result = await discoverProviders({ cwd: projectDir });
+        expect(result.providers.map((p) => p.provider.id)).toEqual(["global-prov"]);
+    });
+
+    test("allowProject: true includes both global and project providers", async () => {
+        writeProvider(join(globalProvidersDir(), "global-prov"), "global-prov");
+        writeProvider(join(projectDir, ".pizzapi", "providers", "project-prov"), "project-prov");
+
+        const result = await discoverProviders({ cwd: projectDir, allowProject: true });
+        expect(result.providers.map((p) => p.provider.id).sort()).toEqual(["global-prov", "project-prov"]);
+    });
+});
+
+// ── 4. trustedPlugins — path-based allowlist ────────────────────────────────
+
+describe("trustedPlugins (path-based allowlist)", () => {
+    test("getTrustedPlugins returns empty array with no config", () => {
+        expect(getTrustedPlugins()).toEqual([]);
+    });
+
+    test("isPluginTrusted false for an untrusted path", () => {
+        expect(isPluginTrusted(join(tmpHome, "some-plugin"))).toBe(false);
+    });
+
+    test("trustPlugin adds a path, isPluginTrusted then returns true", () => {
+        const pluginPath = join(tmpHome, "my-plugin");
+        mkdirSync(pluginPath, { recursive: true });
+
+        const added = trustPlugin(pluginPath);
+        expect(added).toBe(true);
+        expect(isPluginTrusted(pluginPath)).toBe(true);
+        expect(getTrustedPlugins()).toContain(pluginPath.replace(/[\\/]+$/, ""));
+    });
+
+    test("trustPlugin is idempotent — trusting an already-trusted path returns false", () => {
+        const pluginPath = join(tmpHome, "my-plugin");
+        mkdirSync(pluginPath, { recursive: true });
+        trustPlugin(pluginPath);
+        expect(trustPlugin(pluginPath)).toBe(false);
+        expect(getTrustedPlugins()).toHaveLength(1);
+    });
+
+    test("untrustPlugin removes a trusted path, isPluginTrusted then returns false", () => {
+        const pluginPath = join(tmpHome, "my-plugin");
+        mkdirSync(pluginPath, { recursive: true });
+        trustPlugin(pluginPath);
+
+        const removed = untrustPlugin(pluginPath);
+        expect(removed).toBe(true);
+        expect(isPluginTrusted(pluginPath)).toBe(false);
+    });
+
+    test("untrustPlugin returns false when the path was never trusted", () => {
+        expect(untrustPlugin(join(tmpHome, "never-trusted"))).toBe(false);
+    });
+
+    test("isPluginTrusted matches paths with a trailing slash the same as without", () => {
+        const pluginPath = join(tmpHome, "trailing-slash-plugin");
+        mkdirSync(pluginPath, { recursive: true });
+        trustPlugin(pluginPath);
+        expect(isPluginTrusted(pluginPath + "/")).toBe(true);
+    });
+
+    test("isPluginTrusted resolves relative paths against process.cwd() before comparing", () => {
+        // trustPlugin canonicalizes with resolve(), so a relative path passed to
+        // isPluginTrusted must resolve to the same absolute path to match.
+        const pluginPath = join(tmpHome, "relative-check");
+        mkdirSync(pluginPath, { recursive: true });
+        trustPlugin(pluginPath);
+
+        const relative = pluginPath.startsWith(process.cwd())
+            ? pluginPath.slice(process.cwd().length + 1)
+            : pluginPath; // fall back if tmpdir isn't under cwd (still absolute, still matches)
+        expect(isPluginTrusted(relative)).toBe(true);
+    });
+});

--- a/packages/cli/src/config/trust-gates.test.ts
+++ b/packages/cli/src/config/trust-gates.test.ts
@@ -9,7 +9,8 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, relative, resolve } from "path";
+import { EventEmitter } from "node:events";
 
 import {
     loadConfig,
@@ -22,6 +23,7 @@ import {
     _setGlobalConfigDir,
 } from "./io.js";
 import { discoverProviders, globalProvidersDir } from "../providers/loader.js";
+import { createClaudePluginExtension, getPluginSkillPaths, getPluginAgentPaths } from "../extensions/claude-plugins.js";
 
 let tmpHome: string;
 let projectDir: string;
@@ -192,7 +194,7 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
         expect(servers[0].command).toBe("project-version");
     });
 
-    test("warns once (console.warn) when project mcpServers present and flag not set, but STILL loads them", () => {
+    test("warns once (console.warn) when project mcpServers present and flag not set, but STILL loads them on every call — the warning itself is deduped, not the loading", () => {
         const warnCalls: unknown[][] = [];
         const orig = console.warn;
         console.warn = (...args: unknown[]) => { warnCalls.push(args); };
@@ -201,10 +203,20 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
             writeProjectConfig({
                 mcpServers: { projectServer: { command: "project-cmd" } },
             });
+
             const config = loadConfig(projectDir);
             expect((config as any).mcpServers).toHaveProperty("projectServer");
             const joined = warnCalls.map((a) => a.join(" ")).join("\n");
             expect(joined).toContain("Project MCP servers found");
+            expect(warnCalls.length).toBe(1);
+
+            // Second load of the SAME project: servers are still merged (the
+            // gate never blocks loading — see describe title), but the warning
+            // does not fire again. warnLoadConfigOnce dedupes per (projectPath,
+            // code, message) for the lifetime of the process.
+            const config2 = loadConfig(projectDir);
+            expect((config2 as any).mcpServers).toHaveProperty("projectServer");
+            expect(warnCalls.length).toBe(1);
         } finally {
             console.warn = orig;
         }
@@ -255,7 +267,12 @@ describe("allowProjectProviders (enforced gate, via discoverProviders({allowProj
     });
 
     afterEach(() => {
-        process.env.HOME = origHome;
+        // Bun (like Node) does not delete an env var when you assign
+        // `undefined` to it — it coerces to the string "undefined", leaking
+        // a bogus HOME key into the process for the rest of the test run
+        // whenever origHome was unset. Delete explicitly in that case.
+        if (origHome === undefined) delete process.env.HOME;
+        else process.env.HOME = origHome;
     });
 
     function writeProvider(dir: string, id: string): void {
@@ -350,13 +367,210 @@ describe("trustedPlugins (path-based allowlist)", () => {
     test("isPluginTrusted resolves relative paths against process.cwd() before comparing", () => {
         // trustPlugin canonicalizes with resolve(), so a relative path passed to
         // isPluginTrusted must resolve to the same absolute path to match.
+        //
+        // path.relative()/path.resolve() are exact lexical inverses (pure
+        // string manipulation, no filesystem access) — resolve(cwd,
+        // relative(cwd, p)) === p always holds, even when p is outside cwd's
+        // subtree (relative() just emits "../" segments). Using them
+        // unconditionally guarantees this test actually exercises a relative
+        // path, unlike a "use absolute if not under cwd" fallback, which
+        // could silently degrade to re-testing the absolute-path case
+        // depending on where the OS puts tmpdir() relative to cwd.
         const pluginPath = join(tmpHome, "relative-check");
         mkdirSync(pluginPath, { recursive: true });
         trustPlugin(pluginPath);
 
-        const relative = pluginPath.startsWith(process.cwd())
-            ? pluginPath.slice(process.cwd().length + 1)
-            : pluginPath; // fall back if tmpdir isn't under cwd (still absolute, still matches)
-        expect(isPluginTrusted(relative)).toBe(true);
+        const relativePath = relative(process.cwd(), pluginPath);
+        expect(relativePath).not.toBe(pluginPath); // sanity: genuinely relative, not accidentally absolute
+        expect(resolve(process.cwd(), relativePath)).toBe(resolve(pluginPath));
+        expect(isPluginTrusted(relativePath)).toBe(true);
+    });
+});
+
+// ── 5. allowProjectProviders — enforced at the REAL call site ───────────────
+//
+// Section 3 above pins discoverProviders({allowProject}) directly — useful,
+// but discoverProviders is a low-level helper. The only place that actually
+// decides `allowProject` from persisted config is providerExtension's
+// session_start handler (extensions/providers/extension.ts: `allowProject:
+// loadGlobalConfig().allowProjectProviders === true`). A regression there
+// (e.g. flipping the comparison, or dropping the config read) would pass
+// every test in section 3 while silently loading untrusted project
+// providers in production. These tests go through providerExtension itself.
+
+describe("allowProjectProviders enforcement via providerExtension session_start (real production call site)", () => {
+    let origHome: string | undefined;
+
+    beforeEach(() => {
+        origHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+        (globalThis as any).__trustGateProviderInits = [];
+    });
+
+    afterEach(() => {
+        if (origHome === undefined) delete process.env.HOME;
+        else process.env.HOME = origHome;
+        delete (globalThis as any).__trustGateProviderInits;
+    });
+
+    function writeTrackingProvider(dir: string, id: string): void {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "index.ts"),
+            `export default {
+                id: ${JSON.stringify(id)},
+                capabilities: ["lifecycle"],
+                init() {
+                    globalThis.__trustGateProviderInits.push(${JSON.stringify(id)});
+                },
+                dispose() {},
+                onSessionStart: async () => {},
+            };`,
+        );
+    }
+
+    /** Registers providerExtension with a minimal fake ExtensionAPI and fires session_start — the real production path, not a direct discoverProviders() call. */
+    async function runProviderExtensionSessionStart(cwd: string): Promise<void> {
+        const { default: providerExtension } = await import("../extensions/providers/extension.js");
+        const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+        const mockPi = {
+            on(event: string, handler: (event: unknown, ctx: unknown) => unknown) { handlers.set(event, handler); },
+            registerCommand() {},
+        } as any;
+        await providerExtension(mockPi);
+        await handlers.get("session_start")?.(
+            { reason: "startup" },
+            { cwd, signal: new AbortController().signal, sessionManager: { getSessionFile: () => "test-session.json" } },
+        );
+    }
+
+    test("project provider is NOT initialized when allowProjectProviders is unset (config default)", async () => {
+        writeTrackingProvider(join(globalProvidersDir(), "global-a"), "global-a");
+        writeTrackingProvider(join(projectDir, ".pizzapi", "providers", "project-a"), "project-a");
+        writeGlobalConfig({});
+
+        await runProviderExtensionSessionStart(projectDir);
+
+        expect((globalThis as any).__trustGateProviderInits).toEqual(["global-a"]);
+    });
+
+    test("project provider is NOT initialized when allowProjectProviders: false explicitly", async () => {
+        writeTrackingProvider(join(globalProvidersDir(), "global-b"), "global-b");
+        writeTrackingProvider(join(projectDir, ".pizzapi", "providers", "project-b"), "project-b");
+        writeGlobalConfig({ allowProjectProviders: false });
+
+        await runProviderExtensionSessionStart(projectDir);
+
+        expect((globalThis as any).__trustGateProviderInits).toEqual(["global-b"]);
+    });
+
+    test("project provider IS initialized when allowProjectProviders: true", async () => {
+        writeTrackingProvider(join(globalProvidersDir(), "global-c"), "global-c");
+        writeTrackingProvider(join(projectDir, ".pizzapi", "providers", "project-c"), "project-c");
+        writeGlobalConfig({ allowProjectProviders: true });
+
+        await runProviderExtensionSessionStart(projectDir);
+
+        expect(((globalThis as any).__trustGateProviderInits as string[]).sort()).toEqual(["global-c", "project-c"]);
+    });
+});
+
+// ── 6. trustedPlugins — enforced at the REAL call sites ─────────────────────
+//
+// Section 4 above pins isPluginTrusted/trustPlugin/untrustPlugin — the
+// path-allowlist storage layer only. It never exercises the code that
+// actually decides whether a discovered plugin's commands/hooks get
+// registered (createClaudePluginExtension, claude-plugins.ts) or whether
+// its skills/agents are added to pi's search paths (getPluginSkillPaths /
+// getPluginAgentPaths, used by worker.ts and index.ts). A regression that
+// dropped the isPluginTrusted() filter at any of those call sites would
+// pass every test in section 4 while silently loading untrusted
+// project-local plugin code in production.
+
+describe("trustedPlugins enforcement via createClaudePluginExtension / getPluginSkillPaths / getPluginAgentPaths (real production call sites)", () => {
+    function writeLocalPlugin(name: string, opts: { skill?: boolean; agent?: boolean } = {}): string {
+        const pluginDir = join(projectDir, ".pizzapi", "plugins", name);
+        mkdirSync(join(pluginDir, "commands"), { recursive: true });
+        writeFileSync(join(pluginDir, "commands", "test.md"), "# test\nHello from " + name + ".");
+        if (opts.skill) {
+            mkdirSync(join(pluginDir, "skills", "foo"), { recursive: true });
+            writeFileSync(join(pluginDir, "skills", "foo", "SKILL.md"), "# Foo skill");
+        }
+        if (opts.agent) {
+            mkdirSync(join(pluginDir, "agents"), { recursive: true });
+            writeFileSync(join(pluginDir, "agents", "helper.md"), "# Helper agent");
+        }
+        return pluginDir;
+    }
+
+    function makeMockPi() {
+        const commands = new Map<string, unknown>();
+        const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+        const events = new EventEmitter();
+        const api = {
+            registerCommand(name: string, opts: unknown) { commands.set(name, opts); },
+            on(event: string, handler: (event: unknown, ctx: unknown) => unknown) { handlers.set(event, handler); },
+            sendUserMessage() {},
+            events,
+        };
+        return { api, commands, handlers, events };
+    }
+
+    test("untrusted local plugin's command is NOT registered when the trust prompt is declined", async () => {
+        writeLocalPlugin("untrusted-cmd");
+        const factory = createClaudePluginExtension(projectDir);
+        expect(factory).not.toBeNull();
+
+        const { api, commands, handlers, events } = makeMockPi();
+        factory!(api as any);
+        events.on("plugin:trust_prompt", (data: any) => data.respond(false));
+
+        await handlers.get("session_start")?.(
+            { type: "session_start" },
+            { hasUI: false, ui: { notify() {} }, cwd: projectDir },
+        );
+
+        expect(commands.has("test")).toBe(false);
+    });
+
+    test("pre-trusted local plugin's command IS registered on session_start, with no prompt (real trustPlugin \u2192 createClaudePluginExtension path)", async () => {
+        const pluginDir = writeLocalPlugin("trusted-cmd");
+        trustPlugin(pluginDir);
+
+        const factory = createClaudePluginExtension(projectDir);
+        const { api, commands, handlers, events } = makeMockPi();
+        let prompted = false;
+        events.on("plugin:trust_prompt", () => { prompted = true; });
+        factory!(api as any);
+
+        await handlers.get("session_start")?.(
+            { type: "session_start" },
+            { hasUI: false, ui: { notify() {} }, cwd: projectDir },
+        );
+
+        expect(commands.has("test")).toBe(true);
+        expect(prompted).toBe(false);
+    });
+
+    test("getPluginSkillPaths excludes an untrusted local plugin's skills dir", () => {
+        const pluginDir = writeLocalPlugin("untrusted-skill", { skill: true });
+        expect(getPluginSkillPaths(projectDir)).not.toContain(join(pluginDir, "skills"));
+    });
+
+    test("getPluginSkillPaths includes a trusted local plugin's skills dir", () => {
+        const pluginDir = writeLocalPlugin("trusted-skill", { skill: true });
+        trustPlugin(pluginDir);
+        expect(getPluginSkillPaths(projectDir)).toContain(join(pluginDir, "skills"));
+    });
+
+    test("getPluginAgentPaths excludes an untrusted local plugin's agents dir", () => {
+        const pluginDir = writeLocalPlugin("untrusted-agent", { agent: true });
+        expect(getPluginAgentPaths(projectDir)).not.toContain(join(pluginDir, "agents"));
+    });
+
+    test("getPluginAgentPaths includes a trusted local plugin's agents dir", () => {
+        const pluginDir = writeLocalPlugin("trusted-agent", { agent: true });
+        trustPlugin(pluginDir);
+        expect(getPluginAgentPaths(projectDir)).toContain(join(pluginDir, "agents"));
     });
 });


### PR DESCRIPTION
Night Shift dish p23-a. Characterization tests pinning current trust-gate behavior (allowProjectHooks enforced, allowProjectMcp WARN-ONLY, allowProjectProviders enforced, trustedPlugins path-list) + trust-unification ADR. Zero production behavior change. Base: feat/session-host (will be stacked).