### PR TITLE
feat(cli): skill/prompt path discovery via resources_discover (dual-path, Phase 2)

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -33,7 +33,10 @@ import { backgroundBashExtension } from "./background-bash.js";
 import { queueFlushExtension } from "./queue-flush.js";
 import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
 
-const CORE_EXTENSIONS: ExtensionFactory[] = [
+// resource-paths is a factory *created per call* (createResourcePathsExtension(...)),
+// so it's never reference-equal to a statically imported factory. Split the
+// otherwise-static core list around it and assert its presence/type separately.
+const CORE_EXTENSIONS_HEAD: ExtensionFactory[] = [
     ollamaCloudProviderExtension,
     providerRequestLogExtension,
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
@@ -42,6 +45,8 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     mcpExtension,
     toolSearchExtension,  // Must be after MCP to see registered MCP tools
     ollamaWebToolsExtension,
+];
+const CORE_EXTENSIONS_TAIL: ExtensionFactory[] = [
     goalExtension,
     restartExtension,
     sessionProcessesExtension,
@@ -60,6 +65,15 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     providerExtension,  // Always registered
     sessionAnalysisExtension,  // Always registered
 ];
+// +1 for the resource-paths factory inserted between HEAD and TAIL.
+const CORE_EXTENSIONS_COUNT = CORE_EXTENSIONS_HEAD.length + 1 + CORE_EXTENSIONS_TAIL.length;
+
+/** Assert the leading `CORE_EXTENSIONS_COUNT` factories match the expected core composition. */
+function expectCoreExtensionsPrefix(factories: ExtensionFactory[]) {
+    expect(factories.slice(0, CORE_EXTENSIONS_HEAD.length)).toEqual(CORE_EXTENSIONS_HEAD);
+    expect(typeof factories[CORE_EXTENSIONS_HEAD.length]).toBe("function"); // resource-paths
+    expect(factories.slice(CORE_EXTENSIONS_HEAD.length + 1, CORE_EXTENSIONS_COUNT)).toEqual(CORE_EXTENSIONS_TAIL);
+}
 
 /**
  * Tests that focus on core extension composition use skipPlugins: true
@@ -70,7 +84,8 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
 describe("buildPizzaPiExtensionFactories", () => {
     test("returns core extensions by default", () => {
         const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipPlugins: true });
-        expect(factories).toEqual(CORE_EXTENSIONS);
+        expect(factories).toHaveLength(CORE_EXTENSIONS_COUNT);
+        expectCoreExtensionsPrefix(factories);
     });
 
     test("includes initial prompt extension for worker mode", () => {
@@ -80,7 +95,9 @@ describe("buildPizzaPiExtensionFactories", () => {
             skipPlugins: true,
         });
 
-        expect(factories).toEqual([...CORE_EXTENSIONS, initialPromptExtension]);
+        expect(factories).toHaveLength(CORE_EXTENSIONS_COUNT + 1);
+        expectCoreExtensionsPrefix(factories);
+        expect(factories[CORE_EXTENSIONS_COUNT]).toBe(initialPromptExtension);
     });
 
     test("appends hooks extension when hooks are configured", () => {
@@ -94,9 +111,9 @@ describe("buildPizzaPiExtensionFactories", () => {
             skipPlugins: true,
         });
 
-        expect(factories).toHaveLength(CORE_EXTENSIONS.length + 1);
-        expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
-        expect(typeof factories[CORE_EXTENSIONS.length]).toBe("function");
+        expect(factories).toHaveLength(CORE_EXTENSIONS_COUNT + 1);
+        expectCoreExtensionsPrefix(factories);
+        expect(typeof factories[CORE_EXTENSIONS_COUNT]).toBe("function");
     });
 
     test("worker mode includes initial prompt before hooks", () => {
@@ -111,10 +128,10 @@ describe("buildPizzaPiExtensionFactories", () => {
             skipPlugins: true,
         });
 
-        expect(factories).toHaveLength(CORE_EXTENSIONS.length + 2);
-        expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
-        expect(factories[CORE_EXTENSIONS.length]).toBe(initialPromptExtension);
-        expect(typeof factories[CORE_EXTENSIONS.length + 1]).toBe("function");
+        expect(factories).toHaveLength(CORE_EXTENSIONS_COUNT + 2);
+        expectCoreExtensionsPrefix(factories);
+        expect(factories[CORE_EXTENSIONS_COUNT]).toBe(initialPromptExtension);
+        expect(typeof factories[CORE_EXTENSIONS_COUNT + 1]).toBe("function");
     });
 });
 
@@ -196,8 +213,8 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
             const factories = buildPizzaPiExtensionFactories({ cwd: projectDir });
 
             // Core + plugin extension (at minimum)
-            expect(factories.length).toBeGreaterThan(CORE_EXTENSIONS.length);
-            expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
+            expect(factories.length).toBeGreaterThan(CORE_EXTENSIONS_COUNT);
+            expectCoreExtensionsPrefix(factories);
             expect(typeof factories[factories.length - 1]).toBe("function");
         } finally {
             try { rmSync(projectDir, { recursive: true, force: true }); } catch {}
@@ -211,7 +228,7 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
             const factories = buildPizzaPiExtensionFactories({ cwd: emptyDir });
             // May or may not have plugin extension depending on real HOME plugins.
             // The key invariant: core extensions are always first.
-            expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
+            expectCoreExtensionsPrefix(factories);
         } finally {
             try { rmSync(emptyDir, { recursive: true, force: true }); } catch {}
         }
@@ -231,8 +248,8 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
             const factories = buildPizzaPiExtensionFactories({ cwd: projectDir, hooks });
 
             // Core + hooks + plugin (at least)
-            expect(factories.length).toBeGreaterThanOrEqual(CORE_EXTENSIONS.length + 2);
-            expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
+            expect(factories.length).toBeGreaterThanOrEqual(CORE_EXTENSIONS_COUNT + 2);
+            expectCoreExtensionsPrefix(factories);
         } finally {
             try { rmSync(projectDir, { recursive: true, force: true }); } catch {}
         }

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -29,6 +29,7 @@ import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
 import { providerExtension } from "./providers/extension.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
 import { providerRequestLogExtension } from "./provider-request-log.js";
+import { createResourcePathsExtension } from "./resource-paths.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -40,6 +41,8 @@ export interface BuildExtensionFactoriesOptions {
     skipPlugins?: boolean;
     /** Skip relay server connection (safe mode). */
     skipRelay?: boolean;
+    /** `config.skills` — extra skill directories from the resolved PizzaPi config. */
+    configSkills?: string[];
 }
 
 /** Tag a factory with a display name for the boot info listing. */
@@ -81,6 +84,16 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     }
 
     factories.push(named(ollamaWebToolsExtension, "ollama-web-tools"));
+
+    // resources_discover dual-path: supplies the same skill/prompt paths as
+    // DefaultResourceLoader's additionalSkillPaths/additionalPromptTemplatePaths
+    // constructor options (kept in place — see resource-paths.ts for why).
+    factories.push(
+        named(
+            createResourcePathsExtension({ configSkills: options.configSkills, skipPlugins: options.skipPlugins }),
+            "resource-paths",
+        ),
+    );
 
     factories.push(
         named(goalExtension, "goal"),

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -90,7 +90,11 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     // constructor options (kept in place — see resource-paths.ts for why).
     factories.push(
         named(
-            createResourcePathsExtension({ configSkills: options.configSkills, skipPlugins: options.skipPlugins }),
+            createResourcePathsExtension({
+                configSkills: options.configSkills,
+                skipPlugins: options.skipPlugins,
+                cwd: options.cwd,
+            }),
             "resource-paths",
         ),
     );

--- a/packages/cli/src/extensions/resource-paths.test.ts
+++ b/packages/cli/src/extensions/resource-paths.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { createResourcePathsExtension } from "./resource-paths.js";
+import { buildPromptTemplatePaths, buildSkillPaths } from "../skills.js";
+import { getPluginSkillPaths } from "./claude-plugins.js";
+
+describe("createResourcePathsExtension", () => {
+    test("resources_discover handler returns buildSkillPaths + plugin paths and buildPromptTemplatePaths for event.cwd", async () => {
+        const cwd = process.cwd();
+        const configSkills = ["/tmp/extra-skills"];
+
+        let handler: ((event: { cwd: string; reason: string }) => unknown) | undefined;
+        const pi = {
+            on: (event: string, fn: typeof handler) => {
+                if (event === "resources_discover") handler = fn;
+            },
+        };
+
+        createResourcePathsExtension({ configSkills })(pi as any);
+
+        expect(handler).toBeDefined();
+        const result = await handler!({ cwd, reason: "startup" }) as {
+            skillPaths: string[];
+            promptPaths: string[];
+        };
+
+        const expectedSkillPaths = [...buildSkillPaths(cwd, configSkills), ...getPluginSkillPaths(cwd)];
+        expect(result.skillPaths).toEqual(expectedSkillPaths);
+        expect(result.promptPaths).toEqual(buildPromptTemplatePaths(cwd));
+    });
+
+    test("skipPlugins omits plugin skill paths", async () => {
+        const cwd = process.cwd();
+        let handler: ((event: { cwd: string; reason: string }) => unknown) | undefined;
+        const pi = {
+            on: (event: string, fn: typeof handler) => {
+                if (event === "resources_discover") handler = fn;
+            },
+        };
+
+        createResourcePathsExtension({ skipPlugins: true })(pi as any);
+        const result = await handler!({ cwd, reason: "startup" }) as { skillPaths: string[] };
+
+        expect(result.skillPaths).toEqual(buildSkillPaths(cwd, undefined));
+    });
+
+    test("dual-path: DefaultResourceLoader constructor still wires additionalSkillPaths/additionalPromptTemplatePaths in worker.ts and index.ts", async () => {
+        // Belt-and-suspenders safety gate (p23-b): resources_discover is
+        // additive, not a replacement. Both call sites must still pass the
+        // constructor options directly to DefaultResourceLoader so skills load
+        // even if an extension's resources_discover handler never runs.
+        const workerSrc = await Bun.file(new URL("../runner/worker.ts", import.meta.url)).text();
+        const indexSrc = await Bun.file(new URL("../index.ts", import.meta.url)).text();
+
+        for (const src of [workerSrc, indexSrc]) {
+            expect(src).toContain("additionalSkillPaths");
+            expect(src).toContain("additionalPromptTemplatePaths");
+        }
+    });
+});

--- a/packages/cli/src/extensions/resource-paths.test.ts
+++ b/packages/cli/src/extensions/resource-paths.test.ts
@@ -43,6 +43,44 @@ describe("createResourcePathsExtension", () => {
         expect(result.skillPaths).toEqual(buildSkillPaths(cwd, undefined));
     });
 
+    test("PR #638 P2 regression: skips re-reporting paths for the baseline cwd to preserve constructor-set provenance metadata", async () => {
+        // When `cwd` matches the DefaultResourceLoader constructor's cwd, the
+        // handler must report nothing — pi's extendResources() would otherwise
+        // overwrite the constructor-derived source/scope (e.g. auto/user) with
+        // a synthetic extension/temporary tag for paths we already reported,
+        // even though the resulting path *set* stays deduplicated either way.
+        const cwd = process.cwd();
+        let handler: ((event: { cwd: string; reason: string }) => unknown) | undefined;
+        const pi = {
+            on: (event: string, fn: typeof handler) => {
+                if (event === "resources_discover") handler = fn;
+            },
+        };
+
+        createResourcePathsExtension({ cwd })(pi as any);
+        expect(handler).toBeDefined();
+
+        // Same cwd as the constructor baseline: nothing new to report.
+        const sameCwdResult = (await handler!({ cwd, reason: "startup" })) as {
+            skillPaths: string[];
+            promptPaths: string[];
+        };
+        expect(sameCwdResult.skillPaths).toEqual([]);
+        expect(sameCwdResult.promptPaths).toEqual([]);
+
+        // Different cwd (e.g. reload into another directory): still discovers.
+        const otherCwd = "/tmp";
+        const otherCwdResult = (await handler!({ cwd: otherCwd, reason: "reload" })) as {
+            skillPaths: string[];
+            promptPaths: string[];
+        };
+        expect(otherCwdResult.skillPaths).toEqual([
+            ...buildSkillPaths(otherCwd, undefined),
+            ...getPluginSkillPaths(otherCwd),
+        ]);
+        expect(otherCwdResult.promptPaths).toEqual(buildPromptTemplatePaths(otherCwd));
+    });
+
     test("dual-path: DefaultResourceLoader constructor still wires additionalSkillPaths/additionalPromptTemplatePaths in worker.ts and index.ts", async () => {
         // Belt-and-suspenders safety gate (p23-b): resources_discover is
         // additive, not a replacement. Both call sites must still pass the

--- a/packages/cli/src/extensions/resource-paths.ts
+++ b/packages/cli/src/extensions/resource-paths.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { buildPromptTemplatePaths, buildSkillPaths } from "../skills.js";
 import { getPluginSkillPaths } from "./claude-plugins.js";
@@ -19,13 +20,30 @@ import { getPluginSkillPaths } from "./claude-plugins.js";
  * `configSkills` should be `config.skills` from the resolved PizzaPi config,
  * and `skipPlugins` should mirror the `--no-plugins` / `skipPlugins` flag
  * used elsewhere so plugin skills aren't double-loaded when plugins are off.
+ *
+ * `cwd`, when provided, is the cwd already covered by that same
+ * `DefaultResourceLoader`'s constructor options. pi's `extendResources()`
+ * (called with whatever this handler returns) always tags reported paths
+ * with synthetic `{ scope: "temporary", origin: "top-level" }` provenance —
+ * and checks that tag *before* the constructor-derived metadata (see
+ * resource-loader.js `findSourceInfoForPath`). Re-reporting the same paths
+ * we already told the constructor about would silently clobber their real
+ * provenance (e.g. `auto`/`user` -> `extension:.../temporary`) for zero net
+ * new paths (PR #638 review, P2). So: skip re-reporting when `event.cwd`
+ * matches the baseline `cwd` (nothing new to say), but still discover fresh
+ * paths when it differs (e.g. a reload into a different directory).
  */
 export function createResourcePathsExtension(options: {
     configSkills?: string[];
     skipPlugins?: boolean;
+    cwd?: string;
 } = {}): ExtensionFactory {
+    const baselineCwd = options.cwd ? resolve(options.cwd) : undefined;
     return (pi) => {
         pi.on("resources_discover", (event: { cwd: string }) => {
+            if (baselineCwd && resolve(event.cwd) === baselineCwd) {
+                return { skillPaths: [], promptPaths: [] };
+            }
             const cwd = event.cwd;
             return {
                 skillPaths: [

--- a/packages/cli/src/extensions/resource-paths.ts
+++ b/packages/cli/src/extensions/resource-paths.ts
@@ -1,0 +1,39 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { buildPromptTemplatePaths, buildSkillPaths } from "../skills.js";
+import { getPluginSkillPaths } from "./claude-plugins.js";
+
+/**
+ * Resource-paths extension — supplies skill and prompt-template paths via
+ * pi's `resources_discover` event, mirroring `buildSkillPaths()` +
+ * `buildPromptTemplatePaths()` + plugin skill paths.
+ *
+ * ponytail: this duplicates the `additionalSkillPaths` /
+ * `additionalPromptTemplatePaths` constructor options still passed to
+ * `DefaultResourceLoader` in worker.ts and index.ts (dual-path, by design —
+ * see p23-b). Upstream docs/dist confirm `resources_discover` fires after
+ * `session_start` and is awaited (inside `bindExtensions()`) before any
+ * prompt is processed in every mode this codebase uses (interactive,
+ * headless worker, print/rpc), so the two paths should always agree. Remove
+ * the constructor options only once that's been observed safe in practice.
+ *
+ * `configSkills` should be `config.skills` from the resolved PizzaPi config,
+ * and `skipPlugins` should mirror the `--no-plugins` / `skipPlugins` flag
+ * used elsewhere so plugin skills aren't double-loaded when plugins are off.
+ */
+export function createResourcePathsExtension(options: {
+    configSkills?: string[];
+    skipPlugins?: boolean;
+} = {}): ExtensionFactory {
+    return (pi) => {
+        pi.on("resources_discover", (event: { cwd: string }) => {
+            const cwd = event.cwd;
+            return {
+                skillPaths: [
+                    ...buildSkillPaths(cwd, options.configSkills),
+                    ...(options.skipPlugins ? [] : getPluginSkillPaths(cwd)),
+                ],
+                promptPaths: buildPromptTemplatePaths(cwd),
+            };
+        });
+    };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -496,6 +496,7 @@ async function main() {
         skipMcp: noMcp,
         skipPlugins: noPlugins,
         skipRelay: noRelay,
+        configSkills: config.skills,
     });
 
     const loader = new DefaultResourceLoader({

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -371,6 +371,7 @@ async function main(): Promise<void> {
             skipMcp: process.env.PIZZAPI_NO_MCP === "1",
             skipPlugins,
             skipRelay: process.env.PIZZAPI_NO_RELAY === "1",
+            configSkills: config.skills,
         }),
         additionalSkillPaths: [
             ...buildSkillPaths(cwd, config.skills),


### PR DESCRIPTION
Night Shift dish p23-b. Adds a `resources_discover` extension supplying the same skill/prompt paths as `buildSkillPaths()` + `buildPromptTemplatePaths()` + plugin skill paths. Constructor options (`additionalSkillPaths`/`additionalPromptTemplatePaths`) on `DefaultResourceLoader` are RETAINED in both `worker.ts` and `index.ts` (dual-path, belt-and-suspenders) — see report in session for upstream evidence on event ordering. Base: feat/session-host (will be stacked).