### PR TITLE
feat(cli): provider→pi-extension adapter (dual-path, unwired) + mapping tests (Phase 3)

### DIFF
--- a/packages/cli/src/extensions/providers/event-mapping.test.ts
+++ b/packages/cli/src/extensions/providers/event-mapping.test.ts
@@ -1,0 +1,154 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, test, expect } from "bun:test";
+import { wrapProviderAsExtension } from "./pi-bridge-adapter.js";
+import type { ExtensionProvider } from "../../providers/types.js";
+
+/**
+ * Exhaustive provider-hook <-> pi-event mapping table exercised by this file.
+ * Keep in sync with the doc comment on wrapProviderAsExtension().
+ *
+ * | Provider hook          | pi event            | Argument translation                                   |
+ * |-------------------------|----------------------|----------------------------------------------------------|
+ * | init()                  | session_start        | ProviderInitContext synthesized (config: {}, socket: null, fireTrigger/publishMetadata no-ops) |
+ * | onSessionStart           | session_start         | { reason, previousSessionFile } passed through            |
+ * | onBeforeAgentStart        | before_agent_start     | { prompt, images, systemPrompt } in; ContextContribution[] out mapped to pi's { systemPrompt } |
+ * | onTurnEnd                 | turn_end               | pi's toolResults[].{toolName,content,details,isError} -> provider's {name,output,isError} |
+ * | onSessionShutdown          | session_shutdown        | { reason, targetSessionFile } passed through               |
+ * | dispose()                  | session_shutdown        | called after onSessionShutdown                             |
+ * | onSessionClose              | (none)                   | NO PI EQUIVALENT — never invoked by this adapter            |
+ */
+
+type Handler = (event: any, ctx: any) => unknown | Promise<unknown>;
+
+function makeFakeApi() {
+  const handlers = new Map<string, Handler>();
+  const api = { on: (event: string, handler: Handler) => { handlers.set(event, handler); } } as unknown as ExtensionAPI;
+  return { api, handlers };
+}
+
+function makeCtx() {
+  return {
+    cwd: "/tmp/proj",
+    signal: new AbortController().signal,
+    sessionManager: { getSessionFile: () => "s.json" },
+  };
+}
+
+function makeProvider(overrides: Record<string, any> = {}): ExtensionProvider {
+  return {
+    id: "mapping-provider",
+    capabilities: ["context", "lifecycle"] as const,
+    init: async () => {},
+    dispose: async () => {},
+    ...overrides,
+  } as ExtensionProvider;
+}
+
+async function install(provider: ExtensionProvider) {
+  const { api, handlers } = makeFakeApi();
+  await wrapProviderAsExtension(provider)(api);
+  return handlers;
+}
+
+describe("event mapping table", () => {
+  test("only maps the four pi events with native ExtensionProvider equivalents", async () => {
+    const handlers = await install(makeProvider());
+    expect(Array.from(handlers.keys()).sort()).toEqual(
+      ["before_agent_start", "session_shutdown", "session_start", "turn_end"].sort(),
+    );
+  });
+
+  test("session_start -> init() ProviderInitContext shape", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ init: async (ctx: unknown) => { seen = ctx; } }));
+    await handlers.get("session_start")?.({ reason: "new" }, makeCtx());
+
+    expect(seen.config).toEqual({});
+    expect(seen.socket).toBeNull();
+    expect(typeof seen.fireTrigger).toBe("function");
+    expect(typeof seen.publishMetadata).toBe("function");
+    await expect(seen.fireTrigger("s", "t", {})).resolves.toBeUndefined();
+    expect(seen.publishMetadata("s", {})).toBeUndefined();
+  });
+
+  test("session_start -> onSessionStart({ reason, previousSessionFile })", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ onSessionStart: async (event: unknown) => { seen = event; } }));
+    await handlers.get("session_start")?.({ reason: "resume", previousSessionFile: "old.json" }, makeCtx());
+    expect(seen).toEqual({ reason: "resume", previousSessionFile: "old.json" });
+  });
+
+  test("before_agent_start -> onBeforeAgentStart({ prompt, images, systemPrompt })", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ onBeforeAgentStart: async (event: unknown) => { seen = event; return []; } }));
+    await handlers.get("before_agent_start")?.(
+      { prompt: "do a thing", images: [{ type: "image" }], systemPrompt: "SYS" },
+      makeCtx(),
+    );
+    expect(seen).toEqual({ prompt: "do a thing", images: [{ type: "image" }], systemPrompt: "SYS" });
+  });
+
+  test("onBeforeAgentStart ContextContribution[] -> pi's { systemPrompt } result", async () => {
+    const handlers = await install(makeProvider({
+      onBeforeAgentStart: async () => [{ text: "EXTRA", placement: "append", order: 1, summary: "extra" }],
+    }));
+    const result = await handlers.get("before_agent_start")?.({ prompt: "p", systemPrompt: "BASE" }, makeCtx()) as { systemPrompt: string };
+    expect(result).toEqual({ systemPrompt: "BASE\nEXTRA" });
+  });
+
+  test("turn_end -> onTurnEnd translates toolResults field names", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ onTurnEnd: async (event: unknown) => { seen = event; } }));
+    await handlers.get("turn_end")?.(
+      {
+        turnIndex: 7,
+        message: { role: "assistant", content: "hi" },
+        toolResults: [
+          { toolName: "read", content: "file contents", isError: false },
+          { toolName: "write", details: { path: "/x" }, isError: true },
+        ],
+      },
+      makeCtx(),
+    );
+    expect(seen).toEqual({
+      turnIndex: 7,
+      message: { role: "assistant", content: "hi" },
+      toolResults: [
+        { name: "read", output: JSON.stringify("file contents"), isError: false },
+        { name: "write", output: JSON.stringify({ path: "/x" }), isError: true },
+      ],
+    });
+  });
+
+  test("session_shutdown -> onSessionShutdown({ reason, targetSessionFile })", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ onSessionShutdown: async (event: unknown) => { seen = event; } }));
+    await handlers.get("session_shutdown")?.({ reason: "reload", targetSessionFile: "next.json" }, makeCtx());
+    expect(seen).toEqual({ reason: "reload", targetSessionFile: "next.json" });
+  });
+
+  test("session_shutdown -> dispose() runs after onSessionShutdown", async () => {
+    const order: string[] = [];
+    const handlers = await install(makeProvider({
+      onSessionShutdown: async () => { order.push("onSessionShutdown"); },
+      dispose: async () => { order.push("dispose"); },
+    }));
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+    expect(order).toEqual(["onSessionShutdown", "dispose"]);
+  });
+
+  test("onSessionClose has no pi equivalent and is never invoked", async () => {
+    let closeCalled = false;
+    const handlers = await install(makeProvider({
+      onSessionClose: async () => { closeCalled = true; return { label: "l", jobRef: {} }; },
+    }));
+
+    // Fire every mapped event; onSessionClose must never fire regardless.
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("before_agent_start")?.({ prompt: "p", systemPrompt: "s" }, makeCtx());
+    await handlers.get("turn_end")?.({ turnIndex: 0, message: { role: "assistant", content: "" }, toolResults: [] }, makeCtx());
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+
+    expect(closeCalled).toBe(false);
+  });
+});

--- a/packages/cli/src/extensions/providers/event-mapping.test.ts
+++ b/packages/cli/src/extensions/providers/event-mapping.test.ts
@@ -81,6 +81,7 @@ describe("event mapping table", () => {
   test("before_agent_start -> onBeforeAgentStart({ prompt, images, systemPrompt })", async () => {
     let seen: any;
     const handlers = await install(makeProvider({ onBeforeAgentStart: async (event: unknown) => { seen = event; return []; } }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("before_agent_start")?.(
       { prompt: "do a thing", images: [{ type: "image" }], systemPrompt: "SYS" },
       makeCtx(),
@@ -92,6 +93,7 @@ describe("event mapping table", () => {
     const handlers = await install(makeProvider({
       onBeforeAgentStart: async () => [{ text: "EXTRA", placement: "append", order: 1, summary: "extra" }],
     }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     const result = await handlers.get("before_agent_start")?.({ prompt: "p", systemPrompt: "BASE" }, makeCtx()) as { systemPrompt: string };
     expect(result).toEqual({ systemPrompt: "BASE\nEXTRA" });
   });
@@ -99,6 +101,7 @@ describe("event mapping table", () => {
   test("turn_end -> onTurnEnd translates toolResults field names", async () => {
     let seen: any;
     const handlers = await install(makeProvider({ onTurnEnd: async (event: unknown) => { seen = event; } }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("turn_end")?.(
       {
         turnIndex: 7,
@@ -123,6 +126,7 @@ describe("event mapping table", () => {
   test("session_shutdown -> onSessionShutdown({ reason, targetSessionFile })", async () => {
     let seen: any;
     const handlers = await install(makeProvider({ onSessionShutdown: async (event: unknown) => { seen = event; } }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("session_shutdown")?.({ reason: "reload", targetSessionFile: "next.json" }, makeCtx());
     expect(seen).toEqual({ reason: "reload", targetSessionFile: "next.json" });
   });
@@ -133,6 +137,7 @@ describe("event mapping table", () => {
       onSessionShutdown: async () => { order.push("onSessionShutdown"); },
       dispose: async () => { order.push("dispose"); },
     }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
     expect(order).toEqual(["onSessionShutdown", "dispose"]);
   });

--- a/packages/cli/src/extensions/providers/event-mapping.test.ts
+++ b/packages/cli/src/extensions/providers/event-mapping.test.ts
@@ -11,7 +11,7 @@ import type { ExtensionProvider } from "../../providers/types.js";
  * |-------------------------|----------------------|----------------------------------------------------------|
  * | init()                  | session_start        | ProviderInitContext synthesized (config: {}, socket: null, fireTrigger/publishMetadata no-ops) |
  * | onSessionStart           | session_start         | { reason, previousSessionFile } passed through            |
- * | onBeforeAgentStart        | before_agent_start     | { prompt, images, systemPrompt } in; ContextContribution[] out mapped to pi's { systemPrompt } |
+ * | onBeforeAgentStart        | before_agent_start     | { prompt, systemPrompt } passed through; images translated pi's ImageContent {type,data,mimeType} -> ExtensionProvider's {type,source:{type,mediaType,data}}; ContextContribution[] out mapped to pi's { systemPrompt } |
  * | onTurnEnd                 | turn_end               | pi's toolResults[].{toolName,content,details,isError} -> provider's {name,output,isError} |
  * | onSessionShutdown          | session_shutdown        | { reason, targetSessionFile } passed through               |
  * | dispose()                  | session_shutdown        | called after onSessionShutdown                             |
@@ -83,10 +83,22 @@ describe("event mapping table", () => {
     const handlers = await install(makeProvider({ onBeforeAgentStart: async (event: unknown) => { seen = event; return []; } }));
     await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("before_agent_start")?.(
-      { prompt: "do a thing", images: [{ type: "image" }], systemPrompt: "SYS" },
+      { prompt: "do a thing", images: [{ type: "image", data: "BASE64==", mimeType: "image/png" }], systemPrompt: "SYS" },
       makeCtx(),
     );
-    expect(seen).toEqual({ prompt: "do a thing", images: [{ type: "image" }], systemPrompt: "SYS" });
+    expect(seen).toEqual({
+      prompt: "do a thing",
+      images: [{ type: "image", source: { type: "base64", mediaType: "image/png", data: "BASE64==" } }],
+      systemPrompt: "SYS",
+    });
+  });
+
+  test("before_agent_start -> onBeforeAgentStart with no images passes images: undefined through, not an empty array", async () => {
+    let seen: any;
+    const handlers = await install(makeProvider({ onBeforeAgentStart: async (event: unknown) => { seen = event; return []; } }));
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("before_agent_start")?.({ prompt: "do a thing", systemPrompt: "SYS" }, makeCtx());
+    expect(seen.images).toBeUndefined();
   });
 
   test("onBeforeAgentStart ContextContribution[] -> pi's { systemPrompt } result", async () => {

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -81,6 +81,7 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     const result = await handlers.get("before_agent_start")?.(
       { prompt: "hello", images: [], systemPrompt: "BASE" },
       makeCtx(),
@@ -97,6 +98,7 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("turn_end")?.(
       {
         turnIndex: 3,
@@ -121,6 +123,7 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     await handlers.get("session_shutdown")?.({ reason: "quit", targetSessionFile: undefined }, makeCtx());
 
     expect(order).toEqual(["shutdown", "dispose"]);
@@ -174,6 +177,7 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider, { timeoutMs: 200 });
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     for (let i = 0; i < 5; i++) {
       await handlers.get("before_agent_start")?.({ prompt: `p${i}`, systemPrompt: "BASE" }, makeCtx());
     }
@@ -181,5 +185,38 @@ describe("wrapProviderAsExtension", () => {
     // Bridge disables the provider after the 3rd consecutive error, so calls
     // 4 and 5 never reach the provider hook.
     expect(calls).toBe(3);
+  });
+
+  test("disabled-provider state does not leak across sessions (P1 regression)", async () => {
+    let calls = 0;
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => {
+        calls++;
+        throw new Error("boom");
+      },
+    });
+
+    const handlers = await install(provider, { timeoutMs: 200 });
+
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    // 3 consecutive errors disable the provider within this session's bridge.
+    for (let i = 0; i < 3; i++) {
+      await handlers.get("before_agent_start")?.({ prompt: `p${i}`, systemPrompt: "BASE" }, makeCtx());
+    }
+    expect(calls).toBe(3);
+
+    // Confirm it's actually disabled: one more call does not reach the provider.
+    await handlers.get("before_agent_start")?.({ prompt: "p3", systemPrompt: "BASE" }, makeCtx());
+    expect(calls).toBe(3);
+
+    // End the session, then start a new one.
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    // A fresh session must get a fresh bridge: the provider is invoked again,
+    // not permanently disabled from the prior session's error streak.
+    await handlers.get("before_agent_start")?.({ prompt: "q0", systemPrompt: "BASE" }, makeCtx());
+    expect(calls).toBe(4);
   });
 });

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -1,0 +1,185 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, test, expect } from "bun:test";
+import { wrapProviderAsExtension } from "./pi-bridge-adapter.js";
+import type { ExtensionProvider } from "../../providers/types.js";
+
+type Handler = (event: any, ctx: any) => unknown | Promise<unknown>;
+
+function makeFakeApi() {
+  const handlers = new Map<string, Handler>();
+  const api = {
+    on(event: string, handler: Handler) {
+      handlers.set(event, handler);
+    },
+  } as unknown as ExtensionAPI;
+  return { api, handlers };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: "/tmp/project",
+    signal: new AbortController().signal,
+    sessionManager: { getSessionFile: () => "session-abc.json" },
+    ...overrides,
+  };
+}
+
+function makeProvider(overrides: Record<string, any> = {}): ExtensionProvider {
+  return {
+    id: "mock-provider",
+    capabilities: ["context", "lifecycle"] as const,
+    init: async () => {},
+    dispose: async () => {},
+    ...overrides,
+  } as ExtensionProvider;
+}
+
+async function install(provider: ExtensionProvider, opts?: { timeoutMs?: number }) {
+  const { api, handlers } = makeFakeApi();
+  await wrapProviderAsExtension(provider, opts)(api);
+  return handlers;
+}
+
+describe("wrapProviderAsExtension", () => {
+  test("session_start calls provider.init() once and onSessionStart with mapped args", async () => {
+    const initCalls: unknown[] = [];
+    const startCalls: unknown[] = [];
+    const provider = makeProvider({
+      init: async (ctx: unknown) => { initCalls.push(ctx); },
+      onSessionStart: async (event: unknown) => { startCalls.push(event); },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.(
+      { reason: "startup", previousSessionFile: "prev.json" },
+      makeCtx(),
+    );
+
+    expect(initCalls.length).toBe(1);
+    expect(initCalls[0]).toMatchObject({ config: {}, socket: null });
+    expect(typeof (initCalls[0] as any).fireTrigger).toBe("function");
+    expect(typeof (initCalls[0] as any).publishMetadata).toBe("function");
+
+    expect(startCalls).toEqual([{ reason: "startup", previousSessionFile: "prev.json" }]);
+
+    // A second session_start must not re-init.
+    await handlers.get("session_start")?.({ reason: "reload" }, makeCtx());
+    expect(initCalls.length).toBe(1);
+    expect(startCalls.length).toBe(2);
+  });
+
+  test("before_agent_start calls onBeforeAgentStart and maps contributions onto { systemPrompt }", async () => {
+    const calls: unknown[] = [];
+    const provider = makeProvider({
+      onBeforeAgentStart: async (event: unknown) => {
+        calls.push(event);
+        return [
+          { text: "PRE", placement: "prepend", order: 50, summary: "pre" },
+          { text: "POST", placement: "append", order: 50, summary: "post" },
+        ];
+      },
+    });
+
+    const handlers = await install(provider);
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hello", images: [], systemPrompt: "BASE" },
+      makeCtx(),
+    ) as { systemPrompt: string };
+
+    expect(calls).toEqual([{ prompt: "hello", images: [], systemPrompt: "BASE" }]);
+    expect(result.systemPrompt).toBe("PRE\nBASE\nPOST");
+  });
+
+  test("turn_end maps pi's toolResults onto the provider's TurnEndEvent shape", async () => {
+    const calls: unknown[] = [];
+    const provider = makeProvider({
+      onTurnEnd: async (event: unknown) => { calls.push(event); },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("turn_end")?.(
+      {
+        turnIndex: 3,
+        message: { role: "assistant", content: "done" },
+        toolResults: [{ toolName: "bash", content: { ok: true }, isError: false }],
+      },
+      makeCtx(),
+    );
+
+    expect(calls).toEqual([{
+      turnIndex: 3,
+      message: { role: "assistant", content: "done" },
+      toolResults: [{ name: "bash", output: JSON.stringify({ ok: true }), isError: false }],
+    }]);
+  });
+
+  test("session_shutdown calls onSessionShutdown then provider.dispose()", async () => {
+    const order: string[] = [];
+    const provider = makeProvider({
+      onSessionShutdown: async () => { order.push("shutdown"); },
+      dispose: async () => { order.push("dispose"); },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_shutdown")?.({ reason: "quit", targetSessionFile: undefined }, makeCtx());
+
+    expect(order).toEqual(["shutdown", "dispose"]);
+  });
+
+  test("onSessionClose is never called — pi has no equivalent event", async () => {
+    let closeCalled = false;
+    const provider = makeProvider({
+      onSessionClose: async () => { closeCalled = true; return { label: "x", jobRef: {} }; },
+    });
+
+    const handlers = await install(provider);
+    // Only these four events are ever registered by the adapter.
+    expect(Array.from(handlers.keys()).sort()).toEqual(
+      ["before_agent_start", "session_shutdown", "session_start", "turn_end"].sort(),
+    );
+
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("before_agent_start")?.({ prompt: "hi", systemPrompt: "s" }, makeCtx());
+    await handlers.get("turn_end")?.({ turnIndex: 0, message: { role: "assistant", content: "" }, toolResults: [] }, makeCtx());
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+
+    expect(closeCalled).toBe(false);
+  });
+
+  test("enforces the configured timeout on a hung provider hook", async () => {
+    const provider = makeProvider({
+      onBeforeAgentStart: () => new Promise(() => {}), // never resolves
+    });
+
+    const handlers = await install(provider, { timeoutMs: 50 });
+    const start = Date.now();
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hi", systemPrompt: "BASE" },
+      makeCtx(),
+    );
+    const elapsed = Date.now() - start;
+
+    // Timed out and swallowed by the bridge -> no contributions -> no return value.
+    expect(result).toBeUndefined();
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("disables the provider after 3 consecutive errors (delegated to ProviderBridge)", async () => {
+    let calls = 0;
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => {
+        calls++;
+        throw new Error("boom");
+      },
+    });
+
+    const handlers = await install(provider, { timeoutMs: 200 });
+    for (let i = 0; i < 5; i++) {
+      await handlers.get("before_agent_start")?.({ prompt: `p${i}`, systemPrompt: "BASE" }, makeCtx());
+    }
+
+    // Bridge disables the provider after the 3rd consecutive error, so calls
+    // 4 and 5 never reach the provider hook.
+    expect(calls).toBe(3);
+  });
+});

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -173,6 +173,32 @@ describe("wrapProviderAsExtension", () => {
     expect(disposeCalls).toBe(1);
   });
 
+  test("two overlapping (concurrent) shutdowns only notify/dispose once each", async () => {
+    let shutdownCalls = 0;
+    let disposeCalls = 0;
+    const provider = makeProvider({
+      onSessionShutdown: async () => {
+        shutdownCalls++;
+        // Yield so a second concurrent invocation has a chance to race in
+        // before this one reaches its state-reset.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      },
+      dispose: async () => { disposeCalls++; },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    const shutdown = handlers.get("session_shutdown")!;
+    await Promise.all([
+      shutdown({ reason: "quit" }, makeCtx()),
+      shutdown({ reason: "quit" }, makeCtx()),
+    ]);
+
+    expect(shutdownCalls).toBe(1);
+    expect(disposeCalls).toBe(1);
+  });
+
   test("onSessionClose is never called — pi has no equivalent event", async () => {
     let closeCalled = false;
     const provider = makeProvider({

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -34,9 +34,12 @@ function makeProvider(overrides: Record<string, any> = {}): ExtensionProvider {
   } as ExtensionProvider;
 }
 
-async function install(provider: ExtensionProvider, opts?: { timeoutMs?: number }) {
+async function install(
+  provider: ExtensionProvider | ExtensionProvider[],
+  opts?: { timeoutMs?: number; initContext?: Record<string, unknown> },
+) {
   const { api, handlers } = makeFakeApi();
-  await wrapProviderAsExtension(provider, opts)(api);
+  await wrapProviderAsExtension(provider, opts as any)(api);
   return handlers;
 }
 
@@ -253,7 +256,12 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider, { timeoutMs: 200 });
-    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx({ signal: controller.signal }));
+    // session_start itself must NOT use the aborted signal here: init() is now
+    // also abort-checked (P2 regression), and a session that never starts
+    // leaves `bridge` null, which would make the before_agent_start assertion
+    // below pass vacuously regardless of abort handling. Only before_agent_start
+    // gets the pre-aborted signal, which is what this test exercises.
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
     const result = await handlers.get("before_agent_start")?.(
       { prompt: "hi", systemPrompt: "BASE" },
       makeCtx({ signal: controller.signal }),
@@ -288,11 +296,6 @@ describe("wrapProviderAsExtension", () => {
   });
 
   test("sorts contributions by order, then providerId, before mapping onto systemPrompt", async () => {
-    // Two providers registered directly on a single-provider bridge cannot be
-    // exercised through wrapProviderAsExtension (it only wraps one provider),
-    // so this drives the sort via multiple contributions from one provider
-    // with distinct orders — the bridge sorts the full collected set the same
-    // way regardless of provider count.
     const provider = makeProvider({
       onBeforeAgentStart: async () => [
         { text: "THIRD", placement: "append", order: 30, summary: "c" },
@@ -309,6 +312,177 @@ describe("wrapProviderAsExtension", () => {
     ) as { systemPrompt: string };
 
     expect(result.systemPrompt).toBe("BASE\nFIRST\nSECOND\nTHIRD");
+  });
+
+  test("P1 regression: multiple providers passed together share ONE bridge, so contributions are sorted across all of them by order", async () => {
+    // Registered in "wrong" order (zeta before alpha) and with zeta's order
+    // number lower than alpha's — if each provider got its own private bridge
+    // (the bug), results would come back in registration/array order instead
+    // of sorted by `order`.
+    const zeta = makeProvider({
+      id: "zeta",
+      onBeforeAgentStart: async () => [
+        { text: "ZETA", placement: "append", order: 10, summary: "z" },
+      ],
+    });
+    const alpha = makeProvider({
+      id: "alpha",
+      onBeforeAgentStart: async () => [
+        { text: "ALPHA", placement: "append", order: 20, summary: "a" },
+      ],
+    });
+
+    const handlers = await install([zeta, alpha]);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "p", systemPrompt: "BASE" },
+      makeCtx(),
+    ) as { systemPrompt: string };
+
+    expect(result.systemPrompt).toBe("BASE\nZETA\nALPHA");
+  });
+
+  test("P1 regression: pi's ImageContent {type,data,mimeType} translates to ExtensionProvider {type,source:{type,mediaType,data}}", async () => {
+    let seenImages: unknown;
+    const provider = makeProvider({
+      onBeforeAgentStart: async (event: any) => { seenImages = event.images; return []; },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("before_agent_start")?.(
+      { prompt: "p", systemPrompt: "BASE", images: [{ type: "image", data: "BASE64==", mimeType: "image/png" }] },
+      makeCtx(),
+    );
+
+    expect(seenImages).toEqual([
+      { type: "image", source: { type: "base64", mediaType: "image/png", data: "BASE64==" } },
+    ]);
+  });
+
+  test("P1 regression: session_shutdown enforces the configured timeout instead of hanging on a stuck dispose()", async () => {
+    const provider = makeProvider({ dispose: () => new Promise(() => {}) }); // never resolves
+
+    const handlers = await install(provider, { timeoutMs: 50 });
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    const start = Date.now();
+    // The dispose() timeout rejects, which the handler re-throws — assert it
+    // rejects quickly rather than hanging past the configured timeoutMs.
+    await expect(handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx())).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("P1 regression: one provider's failing dispose() doesn't block another provider's dispose() from running", async () => {
+    const disposed: string[] = [];
+    const failing = makeProvider({
+      id: "failing",
+      dispose: async () => { throw new Error("boom"); },
+    });
+    const healthy = makeProvider({
+      id: "healthy",
+      dispose: async () => { disposed.push("healthy"); },
+    });
+
+    const handlers = await install([failing, healthy]);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    // The failure still surfaces to the caller...
+    await expect(handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx())).rejects.toThrow("boom");
+    // ...but the healthy provider's dispose() still ran.
+    expect(disposed).toEqual(["healthy"]);
+  });
+
+  test("P2 regression: an already-aborted signal skips provider.init() and provider.dispose() (no side effects)", async () => {
+    let initCalls = 0;
+    let disposeCalls = 0;
+    const provider = makeProvider({
+      init: async () => { initCalls++; },
+      dispose: async () => { disposeCalls++; },
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx({ signal: controller.signal })).catch(() => {});
+    expect(initCalls).toBe(0);
+
+    // Start for real so shutdown has state to act on, then shut down aborted.
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    expect(initCalls).toBe(1);
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx({ signal: controller.signal })).catch(() => {});
+    expect(disposeCalls).toBe(0);
+  });
+
+  test("P2 regression: opts.initContext is a wiring point merged onto the default no-op ProviderInitContext", async () => {
+    let seen: any;
+    const provider = makeProvider({ init: async (ctx: unknown) => { seen = ctx; } });
+
+    const handlers = await install(provider, { initContext: { config: { apiKey: "secret" } } });
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    expect(seen.config).toEqual({ apiKey: "secret" });
+    expect(seen.socket).toBeNull();
+    expect(typeof seen.fireTrigger).toBe("function");
+  });
+
+  test("P2 regression: provider context carries sessionId (env-derived) distinct from sessionFile (pi's session file)", async () => {
+    let seen: any;
+    const provider = makeProvider({
+      onSessionStart: async (_event: unknown, ctx: unknown) => { seen = ctx; },
+    });
+
+    const prevEnv = { id: process.env.PIZZAPI_SESSION_ID, alt: process.env.SESSION_ID };
+    process.env.PIZZAPI_SESSION_ID = "session-xyz";
+    delete process.env.SESSION_ID;
+    try {
+      const handlers = await install(provider);
+      await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    } finally {
+      if (prevEnv.id === undefined) delete process.env.PIZZAPI_SESSION_ID; else process.env.PIZZAPI_SESSION_ID = prevEnv.id;
+      if (prevEnv.alt === undefined) delete process.env.SESSION_ID; else process.env.SESSION_ID = prevEnv.alt;
+    }
+
+    expect(seen.sessionId).toBe("session-xyz");
+    expect(seen.sessionFile).toBe("session-abc.json");
+  });
+
+  test("P2 regression: session_start passes ctx.model through to the provider's SessionStartEvent", async () => {
+    let seen: any;
+    const provider = makeProvider({
+      onSessionStart: async (event: unknown) => { seen = event; },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.(
+      { reason: "startup" },
+      makeCtx({ model: { provider: "anthropic", id: "claude-x", name: "Claude X", extraField: "ignored" } }),
+    );
+
+    expect(seen.model).toEqual({ provider: "anthropic", id: "claude-x", name: "Claude X" });
+  });
+
+  test("P2 regression: turn_end carries the same promptId as the prompt's before_agent_start, with an incrementing turnId", async () => {
+    const promptIdsSeen: (string | undefined)[] = [];
+    const turnIdsSeen: (number | undefined)[] = [];
+    let beforeAgentStartPromptId: string | undefined;
+    const provider = makeProvider({
+      onBeforeAgentStart: async (_event: unknown, ctx: any) => { beforeAgentStartPromptId = ctx.promptId; return []; },
+      onTurnEnd: async (_event: unknown, ctx: any) => { promptIdsSeen.push(ctx.promptId); turnIdsSeen.push(ctx.turnId); },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("before_agent_start")?.({ prompt: "p", systemPrompt: "BASE" }, makeCtx());
+    await handlers.get("turn_end")?.({ turnIndex: 0, message: { role: "assistant", content: "" } }, makeCtx());
+    await handlers.get("turn_end")?.({ turnIndex: 1, message: { role: "assistant", content: "" } }, makeCtx());
+
+    expect(promptIdsSeen).toEqual([beforeAgentStartPromptId, beforeAgentStartPromptId]);
+    expect(turnIdsSeen).toEqual([1, 2]);
   });
 
   test("resets dedupe state on each before_agent_start prompt boundary", async () => {

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect } from "bun:test";
 import { wrapProviderAsExtension } from "./pi-bridge-adapter.js";
 import type { ExtensionProvider } from "../../providers/types.js";
 
-type Handler = (event: any, ctx: any) => unknown | Promise<unknown>;
+type Handler = (event: any, ctx: any) => Promise<unknown>;
 
 function makeFakeApi() {
   const handlers = new Map<string, Handler>();

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.test.ts
@@ -129,6 +129,50 @@ describe("wrapProviderAsExtension", () => {
     expect(order).toEqual(["shutdown", "dispose"]);
   });
 
+  test("shutdown cleanup is exception-safe: a throwing dispose() still resets lifecycle state", async () => {
+    let initCalls = 0;
+    let disposeCalls = 0;
+    const provider = makeProvider({
+      init: async () => { initCalls++; },
+      dispose: async () => { disposeCalls++; throw new Error("dispose boom"); },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    expect(initCalls).toBe(1);
+
+    // dispose() throws — the handler itself must not throw past this point in
+    // a way that leaves stale state; whether the rejection surfaces to the
+    // caller or not, the NEXT session_start must re-init rather than skip it.
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx()).catch(() => {});
+
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    expect(initCalls).toBe(2);
+    expect(disposeCalls).toBe(1);
+  });
+
+  test("a shutdown before any session_start is a no-op (does not call dispose)", async () => {
+    let disposeCalls = 0;
+    const provider = makeProvider({ dispose: async () => { disposeCalls++; } });
+
+    const handlers = await install(provider);
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+
+    expect(disposeCalls).toBe(0);
+  });
+
+  test("two shutdowns in a row only dispose once", async () => {
+    let disposeCalls = 0;
+    const provider = makeProvider({ dispose: async () => { disposeCalls++; } });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx());
+
+    expect(disposeCalls).toBe(1);
+  });
+
   test("onSessionClose is never called — pi has no equivalent event", async () => {
     let closeCalled = false;
     const provider = makeProvider({
@@ -155,6 +199,11 @@ describe("wrapProviderAsExtension", () => {
     });
 
     const handlers = await install(provider, { timeoutMs: 50 });
+    // Bridge only exists after session_start — without this, before_agent_start
+    // hits the `if (!bridge) return;` guard and the test would pass vacuously
+    // (0ms) regardless of whether timeout enforcement exists.
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
     const start = Date.now();
     const result = await handlers.get("before_agent_start")?.(
       { prompt: "hi", systemPrompt: "BASE" },
@@ -164,7 +213,104 @@ describe("wrapProviderAsExtension", () => {
 
     // Timed out and swallowed by the bridge -> no contributions -> no return value.
     expect(result).toBeUndefined();
+    expect(elapsed).toBeGreaterThanOrEqual(45);
     expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("propagates an already-aborted signal into the provider hook call", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    // Resolves (does not reject) so an already-settled-but-unraced promise
+    // can't trip an unrelated unhandled-rejection warning in the test run.
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => [{ text: "X", placement: "append", order: 1, summary: "x" }],
+    });
+
+    const handlers = await install(provider, { timeoutMs: 200 });
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx({ signal: controller.signal }));
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hi", systemPrompt: "BASE" },
+      makeCtx({ signal: controller.signal }),
+    );
+
+    // Aborted before execution -> bridge rejects the call -> no contributions,
+    // even though the provider hook itself would have succeeded.
+    expect(result).toBeUndefined();
+  });
+
+  test("aborting mid-call rejects the in-flight provider hook", async () => {
+    const controller = new AbortController();
+    const provider = makeProvider({
+      onBeforeAgentStart: () => new Promise(() => {}), // never resolves on its own
+    });
+
+    const handlers = await install(provider, { timeoutMs: 5000 });
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx({ signal: controller.signal }));
+
+    const start = Date.now();
+    const call = handlers.get("before_agent_start")?.(
+      { prompt: "hi", systemPrompt: "BASE" },
+      makeCtx({ signal: controller.signal }),
+    );
+    setTimeout(() => controller.abort(), 20);
+    const result = await call;
+    const elapsed = Date.now() - start;
+
+    // Aborted well before the 5000ms timeout would have fired.
+    expect(result).toBeUndefined();
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("sorts contributions by order, then providerId, before mapping onto systemPrompt", async () => {
+    // Two providers registered directly on a single-provider bridge cannot be
+    // exercised through wrapProviderAsExtension (it only wraps one provider),
+    // so this drives the sort via multiple contributions from one provider
+    // with distinct orders — the bridge sorts the full collected set the same
+    // way regardless of provider count.
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => [
+        { text: "THIRD", placement: "append", order: 30, summary: "c" },
+        { text: "FIRST", placement: "append", order: 10, summary: "a" },
+        { text: "SECOND", placement: "append", order: 20, summary: "b" },
+      ],
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "p", systemPrompt: "BASE" },
+      makeCtx(),
+    ) as { systemPrompt: string };
+
+    expect(result.systemPrompt).toBe("BASE\nFIRST\nSECOND\nTHIRD");
+  });
+
+  test("resets dedupe state on each before_agent_start prompt boundary", async () => {
+    let calls = 0;
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => {
+        calls++;
+        return [{ text: `CTX-${calls}`, placement: "append", order: 1, summary: "s", dedupeKey: "same-key" }];
+      },
+    });
+
+    const handlers = await install(provider);
+    await handlers.get("session_start")?.({ reason: "startup" }, makeCtx());
+
+    const first = await handlers.get("before_agent_start")?.(
+      { prompt: "p1", systemPrompt: "BASE" },
+      makeCtx(),
+    ) as { systemPrompt: string };
+    expect(first.systemPrompt).toBe("BASE\nCTX-1");
+
+    // A second prompt boundary must re-run the provider and emit fresh text
+    // for the same dedupeKey, not silently reuse the first prompt's entry.
+    const second = await handlers.get("before_agent_start")?.(
+      { prompt: "p2", systemPrompt: "BASE" },
+      makeCtx(),
+    ) as { systemPrompt: string };
+    expect(second.systemPrompt).toBe("BASE\nCTX-2");
+    expect(calls).toBe(2);
   });
 
   test("disables the provider after 3 consecutive errors (delegated to ProviderBridge)", async () => {

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent";
-import { ProviderBridge } from "../../providers/bridge.js";
-import { isContextProvider, isLifecycleHook } from "../../providers/types.js";
-import type { ExtensionProvider, ProviderContext } from "../../providers/types.js";
+import type { ImageContent } from "@earendil-works/pi-ai";
+import { ProviderBridge, withProviderTimeout } from "../../providers/bridge.js";
+import type { BeforeAgentStartEvent, ExtensionProvider, ProviderContext, ProviderInitContext } from "../../providers/types.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -9,11 +9,12 @@ const DEFAULT_TIMEOUT_MS = 5000;
  * Provider -> pi extension event mapping (see event-mapping.test.ts for the
  * exhaustive, assertable table):
  *
- *   session_start     -> provider.init() once, then onSessionStart (lifecycle hook)
- *   before_agent_start -> onBeforeAgentStart (context provider), mapped onto pi's
- *                         `{ systemPrompt }` return
+ *   session_start     -> provider.init() once per provider, then a single
+ *                        shared ProviderBridge.onSessionStart (lifecycle hook)
+ *   before_agent_start -> shared bridge's onBeforeAgentStart (context provider),
+ *                         mapped onto pi's `{ systemPrompt }` return
  *   turn_end           -> onTurnEnd, mapping pi's `event.toolResults`
- *   session_shutdown   -> onSessionShutdown, then provider.dispose()
+ *   session_shutdown   -> onSessionShutdown, then provider.dispose() per provider
  *   (no pi event)      -> onSessionClose is INTENTIONALLY NOT WIRED. pi has no
  *                         event for "produce a close-time artifact before the
  *                         process exits" — that's driven today from the worker's
@@ -22,31 +23,57 @@ const DEFAULT_TIMEOUT_MS = 5000;
  *                         `ExtensionAPI.on(...)` event. Wiring it here would be
  *                         speculative; left unimplemented until pi grows an
  *                         equivalent event.
+ *
+ * All provider hook invocations (init, onSessionStart, onBeforeAgentStart,
+ * onTurnEnd, onSessionShutdown, dispose) go through `withProviderTimeout`
+ * (shared with ProviderBridge — see bridge.ts), so an already-aborted signal
+ * or an expired timeout skips the hook rather than running it and discarding
+ * the result, and shutdown can never hang indefinitely.
  */
 function makeProviderContext(
   ctx: { signal?: AbortSignal; cwd: string },
-  sessionId: string,
+  sessionFile: string,
   timeoutMs: number,
   overrides?: Partial<ProviderContext>,
 ): ProviderContext {
   return {
     signal: ctx.signal ?? new AbortController().signal,
     timeoutMs,
-    sessionId,
+    // Matches providerExtension's production semantics (extension.ts):
+    // sessionId is the external session identifier (env var), sessionFile is
+    // pi's on-disk session file path — the two are never the same value.
+    sessionId: process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown",
+    sessionFile,
     cwd: ctx.cwd,
     ...overrides,
   };
 }
 
+/** pi's `ImageContent` (`{ type, data, mimeType }`) -> ExtensionProvider's
+ * `{ type, source: { type, mediaType, data } }`. Shapes look similar but
+ * differ in nesting; a raw cast previously left providers reading
+ * `image.source.data`/`.mediaType` as `undefined`. */
+function translateImages(images?: ImageContent[]): BeforeAgentStartEvent["images"] {
+  return images?.map((img) => ({
+    type: "image" as const,
+    source: { type: "base64" as const, mediaType: img.mimeType, data: img.data },
+  }));
+}
+
 /**
- * Wraps a single `ExtensionProvider` as a native pi `ExtensionFactory`.
+ * Wraps one or more `ExtensionProvider`s as a single native pi `ExtensionFactory`.
  *
  * PURELY ADDITIVE / UNWIRED building block: not imported by `providerExtension`
  * or any other production entrypoint. Delegates timeout enforcement,
  * error-count auto-disable (3 consecutive errors), contribution sorting
- * (order, then providerId), and dedupe-state reset to a private
- * single-provider `ProviderBridge` instance so those semantics can never
- * drift from the existing multi-provider bridge — no reimplementation.
+ * (order, then providerId), and dedupe-state reset to a single shared
+ * `ProviderBridge` instance holding *all* wrapped providers — so those
+ * semantics can never drift from the existing multi-provider bridge, and
+ * `order`-based contribution ordering is correct across all of them. Passing
+ * providers to N separate `wrapProviderAsExtension()` calls each gets its own
+ * private single-provider bridge, which sorts trivially (nothing to sort
+ * against) — always pass every provider that must share ordering to *one*
+ * call.
  *
  * Matches production's per-session bridge lifecycle (see providerExtension in
  * extension.ts): a fresh `ProviderBridge` is created on every `session_start`
@@ -58,47 +85,71 @@ function makeProviderContext(
  * `opts.timeoutMs` defaults to the same 5000ms the existing providerExtension
  * hardcodes; exposed as a param (not a config file) purely so tests can
  * exercise timeout enforcement without a real 5s wait.
+ *
+ * `opts.initContext` is a wiring point for callers whose providers need real
+ * config/services in `init()` — it's merged onto the default no-op
+ * `ProviderInitContext` (`config: {}`, `socket: null`, no-op
+ * `fireTrigger`/`publishMetadata`). The adapter itself stays unwired to any
+ * config source, per the PR description; this just gives callers somewhere
+ * to plug one in instead of forcing a fork.
  */
 export function wrapProviderAsExtension(
-  provider: ExtensionProvider,
-  opts?: { timeoutMs?: number },
+  providers: ExtensionProvider | ExtensionProvider[],
+  opts?: { timeoutMs?: number; initContext?: Partial<ProviderInitContext> },
 ): ExtensionFactory {
+  const providerList = Array.isArray(providers) ? providers : [providers];
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   return async (pi: ExtensionAPI) => {
     // Recreated fresh on every session_start, cleared on session_shutdown —
     // never reused across sessions (see lifecycle note above).
     let bridge: ProviderBridge | null = null;
     let initialized = false;
+    // Prompt/turn boundary tracking, mirrored from providerExtension
+    // (extension.ts) so onTurnEnd sees the same promptId/turnId the prompt's
+    // onBeforeAgentStart call generated, instead of always undefined/0.
+    let currentPromptId: string | null = null;
+    let currentTurnId = 0;
 
     pi.on("session_start", async (event, ctx) => {
+      const sessionFile = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      const initCtx = makeProviderContext(ctx, sessionFile, timeoutMs);
       if (!initialized) {
-        await provider.init({
-          config: {},
-          fireTrigger: async () => {},
-          socket: null,
-          publishMetadata: () => {},
-        });
+        for (const provider of providerList) {
+          await withProviderTimeout(
+            () => Promise.resolve(provider.init({
+              config: {},
+              fireTrigger: async () => {},
+              socket: null,
+              publishMetadata: () => {},
+              ...opts?.initContext,
+            })),
+            initCtx,
+            provider.id,
+          );
+        }
         initialized = true;
       }
-      bridge = new ProviderBridge([provider]);
-      if (!isLifecycleHook(provider)) return;
-      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      bridge = new ProviderBridge(providerList);
+      const model = ctx.model
+        ? { provider: ctx.model.provider, id: ctx.model.id, name: ctx.model.name }
+        : undefined;
       await bridge.onSessionStart(
-        { reason: event.reason, previousSessionFile: event.previousSessionFile },
-        makeProviderContext(ctx, sessionId, timeoutMs),
+        { reason: event.reason, previousSessionFile: event.previousSessionFile, model },
+        initCtx,
       );
     });
 
     pi.on("before_agent_start", async (event, ctx) => {
       if (!bridge) return;
-      if (!isContextProvider(provider)) return;
+      currentPromptId = `prompt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      currentTurnId = 0;
       bridge.resetDedupeState();
-      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      const sessionFile = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
       const result = await bridge.onBeforeAgentStart(
-        { prompt: event.prompt, images: event.images as any, systemPrompt: event.systemPrompt },
-        makeProviderContext(ctx, sessionId, timeoutMs, {
-          promptId: `prompt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          turnId: 0,
+        { prompt: event.prompt, images: translateImages(event.images), systemPrompt: event.systemPrompt },
+        makeProviderContext(ctx, sessionFile, timeoutMs, {
+          promptId: currentPromptId,
+          turnId: currentTurnId,
           isFirstTurn: true,
         }),
       );
@@ -112,8 +163,8 @@ export function wrapProviderAsExtension(
 
     pi.on("turn_end", async (event, ctx) => {
       if (!bridge) return;
-      if (!isLifecycleHook(provider)) return;
-      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      currentTurnId++;
+      const sessionFile = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
       await bridge.onTurnEnd(
         {
           turnIndex: event.turnIndex,
@@ -129,7 +180,10 @@ export function wrapProviderAsExtension(
             isError: tr.isError ?? false,
           })),
         },
-        makeProviderContext(ctx, sessionId, timeoutMs),
+        makeProviderContext(ctx, sessionFile, timeoutMs, {
+          promptId: currentPromptId ?? undefined,
+          turnId: currentTurnId,
+        }),
       );
     });
 
@@ -148,20 +202,32 @@ export function wrapProviderAsExtension(
       // shutdown captures null/false locals and no-ops instead.
       initialized = false;
       bridge = null;
-      if (activeBridge && isLifecycleHook(provider)) {
-        const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      const sessionFile = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      // ProviderBridge.onSessionShutdown is bounded by ctx.timeoutMs/signal
+      // (see bridge.ts) — a hung onSessionShutdown can no longer hang
+      // dispose/reload/new/resume/quit indefinitely.
+      const shutdownCtx = makeProviderContext(ctx, sessionFile, timeoutMs);
+      if (activeBridge) {
         await activeBridge.onSessionShutdown(
           { reason: event.reason, targetSessionFile: event.targetSessionFile },
-          makeProviderContext(ctx, sessionId, timeoutMs),
+          shutdownCtx,
         );
       }
       // NOTE: onSessionClose is not called here — see module doc comment above.
       if (wasInitialized) {
-        // Errors from dispose() propagate to the caller unchanged (matches
-        // the previous behavior: no catch here). State is already claimed
-        // above, so a throwing dispose() still leaves initialized/bridge
-        // cleared for the next session_start to re-init.
-        await provider.dispose();
+        // Bounded per provider (withProviderTimeout) so one hung dispose()
+        // can't hang shutdown forever. Promise.allSettled so one provider's
+        // failing/timing-out dispose() doesn't block the rest from being
+        // attempted — then the first failure (if any) re-throws, preserving
+        // the previous single-provider behavior of surfacing dispose errors
+        // to the caller unchanged.
+        const results = await Promise.allSettled(
+          providerList.map((provider) =>
+            withProviderTimeout(() => Promise.resolve(provider.dispose()), shutdownCtx, provider.id),
+          ),
+        );
+        const firstFailure = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+        if (firstFailure) throw firstFailure.reason;
       }
     });
   };

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
@@ -48,6 +48,13 @@ function makeProviderContext(
  * single-provider `ProviderBridge` instance so those semantics can never
  * drift from the existing multi-provider bridge — no reimplementation.
  *
+ * Matches production's per-session bridge lifecycle (see providerExtension in
+ * extension.ts): a fresh `ProviderBridge` is created on every `session_start`
+ * and dropped on `session_shutdown`. This is required because the bridge
+ * auto-disables a provider after 3 consecutive errors — if the same bridge
+ * instance were reused across sessions, that disabled state (and error
+ * counters) would leak into a brand-new session forever.
+ *
  * `opts.timeoutMs` defaults to the same 5000ms the existing providerExtension
  * hardcodes; exposed as a param (not a config file) purely so tests can
  * exercise timeout enforcement without a real 5s wait.
@@ -58,7 +65,9 @@ export function wrapProviderAsExtension(
 ): ExtensionFactory {
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   return async (pi: ExtensionAPI) => {
-    const bridge = new ProviderBridge([provider]);
+    // Recreated fresh on every session_start, cleared on session_shutdown —
+    // never reused across sessions (see lifecycle note above).
+    let bridge: ProviderBridge | null = null;
     let initialized = false;
 
     pi.on("session_start", async (event, ctx) => {
@@ -71,6 +80,7 @@ export function wrapProviderAsExtension(
         });
         initialized = true;
       }
+      bridge = new ProviderBridge([provider]);
       if (!isLifecycleHook(provider)) return;
       const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
       await bridge.onSessionStart(
@@ -80,6 +90,7 @@ export function wrapProviderAsExtension(
     });
 
     pi.on("before_agent_start", async (event, ctx) => {
+      if (!bridge) return;
       if (!isContextProvider(provider)) return;
       bridge.resetDedupeState();
       const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
@@ -100,6 +111,7 @@ export function wrapProviderAsExtension(
     });
 
     pi.on("turn_end", async (event, ctx) => {
+      if (!bridge) return;
       if (!isLifecycleHook(provider)) return;
       const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
       await bridge.onTurnEnd(
@@ -122,7 +134,7 @@ export function wrapProviderAsExtension(
     });
 
     pi.on("session_shutdown", async (event, ctx) => {
-      if (isLifecycleHook(provider)) {
+      if (bridge && isLifecycleHook(provider)) {
         const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
         await bridge.onSessionShutdown(
           { reason: event.reason, targetSessionFile: event.targetSessionFile },
@@ -132,6 +144,9 @@ export function wrapProviderAsExtension(
       // NOTE: onSessionClose is not called here — see module doc comment above.
       await provider.dispose();
       initialized = false;
+      // Drop the bridge so a new session_start builds a fresh one — error
+      // counters and disabled-provider state must not leak across sessions.
+      bridge = null;
     });
   };
 }

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
@@ -1,0 +1,137 @@
+import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { ProviderBridge } from "../../providers/bridge.js";
+import { isContextProvider, isLifecycleHook } from "../../providers/types.js";
+import type { ExtensionProvider, ProviderContext } from "../../providers/types.js";
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Provider -> pi extension event mapping (see event-mapping.test.ts for the
+ * exhaustive, assertable table):
+ *
+ *   session_start     -> provider.init() once, then onSessionStart (lifecycle hook)
+ *   before_agent_start -> onBeforeAgentStart (context provider), mapped onto pi's
+ *                         `{ systemPrompt }` return
+ *   turn_end           -> onTurnEnd, mapping pi's `event.toolResults`
+ *   session_shutdown   -> onSessionShutdown, then provider.dispose()
+ *   (no pi event)      -> onSessionClose is INTENTIONALLY NOT WIRED. pi has no
+ *                         event for "produce a close-time artifact before the
+ *                         process exits" — that's driven today from the worker's
+ *                         own process-shutdown signal handlers
+ *                         (runProviderSessionClose in extension.ts), not from an
+ *                         `ExtensionAPI.on(...)` event. Wiring it here would be
+ *                         speculative; left unimplemented until pi grows an
+ *                         equivalent event.
+ */
+function makeProviderContext(
+  ctx: { signal?: AbortSignal; cwd: string },
+  sessionId: string,
+  timeoutMs: number,
+  overrides?: Partial<ProviderContext>,
+): ProviderContext {
+  return {
+    signal: ctx.signal ?? new AbortController().signal,
+    timeoutMs,
+    sessionId,
+    cwd: ctx.cwd,
+    ...overrides,
+  };
+}
+
+/**
+ * Wraps a single `ExtensionProvider` as a native pi `ExtensionFactory`.
+ *
+ * PURELY ADDITIVE / UNWIRED building block: not imported by `providerExtension`
+ * or any other production entrypoint. Delegates timeout enforcement,
+ * error-count auto-disable (3 consecutive errors), contribution sorting
+ * (order, then providerId), and dedupe-state reset to a private
+ * single-provider `ProviderBridge` instance so those semantics can never
+ * drift from the existing multi-provider bridge — no reimplementation.
+ *
+ * `opts.timeoutMs` defaults to the same 5000ms the existing providerExtension
+ * hardcodes; exposed as a param (not a config file) purely so tests can
+ * exercise timeout enforcement without a real 5s wait.
+ */
+export function wrapProviderAsExtension(
+  provider: ExtensionProvider,
+  opts?: { timeoutMs?: number },
+): ExtensionFactory {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return async (pi: ExtensionAPI) => {
+    const bridge = new ProviderBridge([provider]);
+    let initialized = false;
+
+    pi.on("session_start", async (event, ctx) => {
+      if (!initialized) {
+        await provider.init({
+          config: {},
+          fireTrigger: async () => {},
+          socket: null,
+          publishMetadata: () => {},
+        });
+        initialized = true;
+      }
+      if (!isLifecycleHook(provider)) return;
+      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      await bridge.onSessionStart(
+        { reason: event.reason, previousSessionFile: event.previousSessionFile },
+        makeProviderContext(ctx, sessionId, timeoutMs),
+      );
+    });
+
+    pi.on("before_agent_start", async (event, ctx) => {
+      if (!isContextProvider(provider)) return;
+      bridge.resetDedupeState();
+      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      const result = await bridge.onBeforeAgentStart(
+        { prompt: event.prompt, images: event.images as any, systemPrompt: event.systemPrompt },
+        makeProviderContext(ctx, sessionId, timeoutMs, {
+          promptId: `prompt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          turnId: 0,
+          isFirstTurn: true,
+        }),
+      );
+
+      if (result.prepend.length === 0 && result.append.length === 0) return;
+
+      const prependBlock = result.prepend.length > 0 ? result.prepend.join("\n") + "\n" : "";
+      const appendBlock = result.append.length > 0 ? "\n" + result.append.join("\n") : "";
+      return { systemPrompt: prependBlock + event.systemPrompt + appendBlock };
+    });
+
+    pi.on("turn_end", async (event, ctx) => {
+      if (!isLifecycleHook(provider)) return;
+      const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+      await bridge.onTurnEnd(
+        {
+          turnIndex: event.turnIndex,
+          message: {
+            role: "assistant",
+            content: typeof (event.message as any)?.content === "string"
+              ? (event.message as any).content
+              : JSON.stringify((event.message as any)?.content ?? ""),
+          },
+          toolResults: event.toolResults?.map((tr: any) => ({
+            name: tr.toolName ?? "unknown",
+            output: JSON.stringify(tr.content ?? tr.details ?? ""),
+            isError: tr.isError ?? false,
+          })),
+        },
+        makeProviderContext(ctx, sessionId, timeoutMs),
+      );
+    });
+
+    pi.on("session_shutdown", async (event, ctx) => {
+      if (isLifecycleHook(provider)) {
+        const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+        await bridge.onSessionShutdown(
+          { reason: event.reason, targetSessionFile: event.targetSessionFile },
+          makeProviderContext(ctx, sessionId, timeoutMs),
+        );
+      }
+      // NOTE: onSessionClose is not called here — see module doc comment above.
+      await provider.dispose();
+      initialized = false;
+    });
+  };
+}

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
@@ -134,19 +134,31 @@ export function wrapProviderAsExtension(
     });
 
     pi.on("session_shutdown", async (event, ctx) => {
-      if (bridge && isLifecycleHook(provider)) {
-        const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
-        await bridge.onSessionShutdown(
-          { reason: event.reason, targetSessionFile: event.targetSessionFile },
-          makeProviderContext(ctx, sessionId, timeoutMs),
-        );
+      // Guard on active state: a shutdown before any session_start, or two
+      // shutdowns in a row, must be a no-op — nothing to notify or dispose.
+      if (!initialized && !bridge) return;
+      try {
+        if (bridge && isLifecycleHook(provider)) {
+          const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+          await bridge.onSessionShutdown(
+            { reason: event.reason, targetSessionFile: event.targetSessionFile },
+            makeProviderContext(ctx, sessionId, timeoutMs),
+          );
+        }
+        // NOTE: onSessionClose is not called here — see module doc comment above.
+        if (initialized) {
+          await provider.dispose();
+        }
+      } finally {
+        // Reset lifecycle state even if onSessionShutdown/dispose() throws —
+        // mirrors production's defensive cleanup (extension.ts session_shutdown):
+        // a failed dispose must never leave stale state for the next session to
+        // skip init() or reuse a disabled/error-laden bridge.
+        initialized = false;
+        // Drop the bridge so a new session_start builds a fresh one — error
+        // counters and disabled-provider state must not leak across sessions.
+        bridge = null;
       }
-      // NOTE: onSessionClose is not called here — see module doc comment above.
-      await provider.dispose();
-      initialized = false;
-      // Drop the bridge so a new session_start builds a fresh one — error
-      // counters and disabled-provider state must not leak across sessions.
-      bridge = null;
     });
   };
 }

--- a/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
+++ b/packages/cli/src/extensions/providers/pi-bridge-adapter.ts
@@ -136,28 +136,32 @@ export function wrapProviderAsExtension(
     pi.on("session_shutdown", async (event, ctx) => {
       // Guard on active state: a shutdown before any session_start, or two
       // shutdowns in a row, must be a no-op — nothing to notify or dispose.
-      if (!initialized && !bridge) return;
-      try {
-        if (bridge && isLifecycleHook(provider)) {
-          const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
-          await bridge.onSessionShutdown(
-            { reason: event.reason, targetSessionFile: event.targetSessionFile },
-            makeProviderContext(ctx, sessionId, timeoutMs),
-          );
-        }
-        // NOTE: onSessionClose is not called here — see module doc comment above.
-        if (initialized) {
-          await provider.dispose();
-        }
-      } finally {
-        // Reset lifecycle state even if onSessionShutdown/dispose() throws —
-        // mirrors production's defensive cleanup (extension.ts session_shutdown):
-        // a failed dispose must never leave stale state for the next session to
-        // skip init() or reuse a disabled/error-laden bridge.
-        initialized = false;
-        // Drop the bridge so a new session_start builds a fresh one — error
-        // counters and disabled-provider state must not leak across sessions.
-        bridge = null;
+      const activeBridge = bridge;
+      const wasInitialized = initialized;
+      if (!wasInitialized && !activeBridge) return;
+      // Claim the lifecycle state synchronously, before the first await.
+      // Two overlapping session_shutdown invocations both pass the guard
+      // above before either reaches an await — resetting state only in a
+      // `finally` (the old approach) left a TOCTOU window where the second
+      // invocation would see stale `initialized`/`bridge` and re-run
+      // onSessionShutdown()/dispose(). Resetting here means a concurrent
+      // shutdown captures null/false locals and no-ops instead.
+      initialized = false;
+      bridge = null;
+      if (activeBridge && isLifecycleHook(provider)) {
+        const sessionId = ctx.sessionManager?.getSessionFile?.() ?? "unknown";
+        await activeBridge.onSessionShutdown(
+          { reason: event.reason, targetSessionFile: event.targetSessionFile },
+          makeProviderContext(ctx, sessionId, timeoutMs),
+        );
+      }
+      // NOTE: onSessionClose is not called here — see module doc comment above.
+      if (wasInitialized) {
+        // Errors from dispose() propagate to the caller unchanged (matches
+        // the previous behavior: no catch here). State is already claimed
+        // above, so a throwing dispose() still leaves initialized/bridge
+        // cleared for the next session_start to re-init.
+        await provider.dispose();
       }
     });
   };

--- a/packages/cli/src/providers/bridge.test.ts
+++ b/packages/cli/src/providers/bridge.test.ts
@@ -201,6 +201,44 @@ describe("ProviderBridge", () => {
     expect(calls).toEqual(["start-startup", "turn-1", "shutdown-quit"]);
   });
 
+  test("onSessionShutdown is bounded by timeoutMs (P1 regression: a hung onSessionShutdown must not hang shutdown)", async () => {
+    const provider = makeProvider({
+      id: "hangs",
+      capabilities: ["lifecycle"] as const,
+      onSessionShutdown: () => new Promise(() => {}), // never resolves
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 50, sessionId: "s1", cwd: "/tmp" };
+
+    const start = Date.now();
+    // Silently swallowed (matches existing "we're shutting down" contract) but
+    // must resolve well inside the timeout window, not hang forever.
+    await bridge.onSessionShutdown({ reason: "quit" }, ctx);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("an already-aborted signal skips invoking onSessionShutdown entirely", async () => {
+    let called = false;
+    const provider = makeProvider({
+      id: "lifecycle",
+      capabilities: ["lifecycle"] as const,
+      onSessionShutdown: async () => { called = true; },
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: controller.signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp" };
+
+    await bridge.onSessionShutdown({ reason: "quit" }, ctx);
+
+    expect(called).toBe(false);
+  });
+
   test("onSessionClose returns first non-null result", async () => {
     const a = makeProvider({
       id: "alpha",

--- a/packages/cli/src/providers/bridge.ts
+++ b/packages/cli/src/providers/bridge.ts
@@ -24,6 +24,59 @@ interface CollectedContribution {
 
 const MAX_CONSECUTIVE_ERRORS = 3;
 
+/**
+ * Races a provider hook against `ctx.timeoutMs` and `ctx.signal`. Takes a
+ * thunk (not an already-created promise) so an already-aborted signal skips
+ * *invoking* the hook entirely instead of calling it and discarding the
+ * result — promise arguments are evaluated eagerly in JS, so `withTimeout(p(),
+ * ...)` would already have started `p()`'s side effects by the time the
+ * abort check runs.
+ *
+ * Exported (not a private ProviderBridge method) so callers that invoke
+ * provider hooks outside the bridge — e.g. the pi extension adapter's
+ * `provider.init()`/`provider.dispose()`, which the bridge doesn't own — get
+ * the exact same bounded-cancellation semantics instead of a bespoke copy.
+ */
+export async function withProviderTimeout<T>(
+  fn: () => Promise<T>,
+  ctx: ProviderContext,
+  providerId: string,
+): Promise<T> {
+  if (ctx.signal.aborted) {
+    throw new Error(`Provider "${providerId}" call aborted before execution`);
+  }
+
+  // A deadline is a shared budget for sequential provider hooks, not a fresh
+  // timeout per provider.
+  const remainingMs = ctx.deadline !== undefined ? ctx.deadline - Date.now() : ctx.timeoutMs;
+  const effectiveTimeoutMs = Math.max(0, Math.min(ctx.timeoutMs, remainingMs));
+  if (effectiveTimeoutMs === 0) {
+    throw new Error(`Provider "${providerId}" call skipped: overall deadline already elapsed`);
+  }
+
+  const promise = fn();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Provider "${providerId}" timed out after ${effectiveTimeoutMs}ms`));
+    }, effectiveTimeoutMs);
+  });
+
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      ctx.signal.removeEventListener("abort", onAbort);
+      reject(new Error(`Provider "${providerId}" call aborted`));
+    };
+    ctx.signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise, abortPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export class ProviderBridge {
   #providers: ExtensionProvider[];
   #disabled = new Set<string>();
@@ -54,8 +107,8 @@ export class ProviderBridge {
       if (!isContextProvider(provider)) continue;
 
       try {
-        const contributions = await this.#withTimeout(
-          provider.onBeforeAgentStart(event, ctx),
+        const contributions = await withProviderTimeout(
+          () => provider.onBeforeAgentStart(event, ctx),
           ctx,
           provider.id,
         );
@@ -154,25 +207,28 @@ export class ProviderBridge {
     for (const provider of this.#providers) {
       if (this.#disabled.has(provider.id)) continue;
       if (!isLifecycleHook(provider)) continue;
-      if (!provider.onSessionStart) continue;
+      const hook = provider.onSessionStart;
+      if (!hook) continue;
       try {
-        await this.#withTimeout(
-          provider.onSessionStart(event, ctx),
-          ctx,
-          provider.id,
-        );
+        await withProviderTimeout(() => hook(event, ctx), ctx, provider.id);
       } catch (err) {
         this.#recordError(provider.id, err);
       }
     }
   }
 
+  /**
+   * Bounded by `ctx.timeoutMs`/`ctx.signal` via `withProviderTimeout`, same as
+   * every other hook — a hung `onSessionShutdown` used to be able to hang the
+   * whole shutdown path (dispose/reload/new/resume/quit) indefinitely.
+   */
   async onSessionShutdown(event: SessionShutdownEvent, ctx: ProviderContext): Promise<void> {
     for (const provider of this.#providers) {
       if (!isLifecycleHook(provider)) continue;
-      if (!provider.onSessionShutdown) continue;
+      const hook = provider.onSessionShutdown;
+      if (!hook) continue;
       try {
-        await provider.onSessionShutdown(event, ctx);
+        await withProviderTimeout(() => hook(event, ctx), ctx, provider.id);
       } catch {
         // Silent — we're shutting down
       }
@@ -183,13 +239,10 @@ export class ProviderBridge {
     for (const provider of this.#providers) {
       if (this.#disabled.has(provider.id)) continue;
       if (!isLifecycleHook(provider)) continue;
-      if (!provider.onTurnEnd) continue;
+      const hook = provider.onTurnEnd;
+      if (!hook) continue;
       try {
-        await this.#withTimeout(
-          provider.onTurnEnd(event, ctx),
-          ctx,
-          provider.id,
-        );
+        await withProviderTimeout(() => hook(event, ctx), ctx, provider.id);
         this.#errorCounts.set(provider.id, 0);
       } catch (err) {
         this.#recordError(provider.id, err);
@@ -201,70 +254,21 @@ export class ProviderBridge {
     for (const provider of this.#providers) {
       if (this.#disabled.has(provider.id)) continue;
       if (!isLifecycleHook(provider)) continue;
-      if (!provider.onSessionClose) continue;
+      const hook = provider.onSessionClose;
+      if (!hook) continue;
       // Providers run sequentially; without this check N providers could add
       // up to N * timeoutMs of wall time. ctx.deadline (set by the caller,
       // e.g. runProviderSessionClose) is one overall budget for the whole
       // loop, not per provider — stop trying once it's gone.
       if (ctx.deadline !== undefined && Date.now() >= ctx.deadline) break;
       try {
-        const result = await this.#withTimeout(
-          provider.onSessionClose(event, ctx),
-          ctx,
-          provider.id,
-        );
+        const result = await withProviderTimeout(() => hook(event, ctx), ctx, provider.id);
         if (result) return result;
       } catch (err) {
         this.#recordError(provider.id, err);
       }
     }
     return null;
-  }
-
-  /**
-   * Wraps a provider hook promise with timeout and abort signal enforcement.
-   * If the abort signal fires, the promise is rejected with an AbortError.
-   * If the timeout elapses, the promise is rejected with a timeout error.
-   */
-  async #withTimeout<T>(
-    promise: Promise<T>,
-    ctx: ProviderContext,
-    providerId: string,
-  ): Promise<T> {
-    if (ctx.signal.aborted) {
-      throw new Error(`Provider "${providerId}" call aborted before execution`);
-    }
-
-    // ctx.deadline (if set) is one overall budget shared across a loop over
-    // providers — cap this call's timeout to whatever's left of it so N
-    // providers can't each burn a full timeoutMs.
-    const remainingMs = ctx.deadline !== undefined ? ctx.deadline - Date.now() : ctx.timeoutMs;
-    const effectiveTimeoutMs = Math.max(0, Math.min(ctx.timeoutMs, remainingMs));
-    if (effectiveTimeoutMs === 0) {
-      throw new Error(`Provider "${providerId}" call skipped: overall deadline already elapsed`);
-    }
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => {
-        reject(new Error(`Provider "${providerId}" timed out after ${effectiveTimeoutMs}ms`));
-      }, effectiveTimeoutMs);
-    });
-
-    const abortPromise = new Promise<never>((_, reject) => {
-      const onAbort = () => {
-        ctx.signal.removeEventListener("abort", onAbort);
-        reject(new Error(`Provider "${providerId}" call aborted`));
-      };
-      ctx.signal.addEventListener("abort", onAbort, { once: true });
-    });
-
-    try {
-      const result = await Promise.race([promise, timeoutPromise, abortPromise]);
-      return result;
-    } finally {
-      if (timer !== undefined) clearTimeout(timer);
-    }
   }
 
   #recordError(providerId: string, err: unknown): void {


### PR DESCRIPTION
Night Shift dish p23-c. Adds wrapProviderAsExtension() building block that maps ExtensionProvider lifecycle onto native pi extension events (onSessionClose intentionally unwired). Purely additive — not imported by any production path. Base: feat/session-host (will be stacked).