### PR TITLE
fix(triggers): sessions never time out waiting on a parent ack

### DIFF
--- a/packages/cli/src/extensions/remote-ask-user.ts
+++ b/packages/cli/src/extensions/remote-ask-user.ts
@@ -451,7 +451,6 @@ export function registerAskUserTool(rctx: RelayContext) {
                     deliverAs: "followUp" as const,
                     expectsResponse: true,
                     triggerId,
-                    timeoutMs: 300_000,
                     ts: new Date().toISOString(),
                 };
 
@@ -471,7 +470,8 @@ export function registerAskUserTool(rctx: RelayContext) {
                     };
                 }
 
-                const triggerResult = await rctx.waitForTriggerResponse(triggerId, trigger.timeoutMs, signal);
+                // No timeout: wait until the parent actually responds (or cancels).
+                const triggerResult = await rctx.waitForTriggerResponse(triggerId, undefined, signal);
 
                 return {
                     content: [{ type: "text", text: triggerResult.response }],

--- a/packages/cli/src/extensions/remote-ask-user.ts
+++ b/packages/cli/src/extensions/remote-ask-user.ts
@@ -448,7 +448,10 @@ export function registerAskUserTool(rctx: RelayContext) {
                         options: questions.flatMap(q => q.options),
                         questions,
                     },
-                    deliverAs: "followUp" as const,
+                    // steer: the child is blocked waiting on this answer (indefinitely,
+                    // see waitForTriggerResponse) — the parent must be interrupted to see
+                    // it now, not whenever its current turn queue happens to drain.
+                    deliverAs: "steer" as const,
                     expectsResponse: true,
                     triggerId,
                     ts: new Date().toISOString(),

--- a/packages/cli/src/extensions/remote-plan-mode.ts
+++ b/packages/cli/src/extensions/remote-plan-mode.ts
@@ -449,7 +449,6 @@ export function registerPlanModeTool(rctx: RelayContext) {
                     deliverAs: "followUp" as const,
                     expectsResponse: true,
                     triggerId,
-                    timeoutMs: 300_000,
                     ts: new Date().toISOString(),
                 };
 
@@ -467,7 +466,8 @@ export function registerPlanModeTool(rctx: RelayContext) {
                     };
                 }
 
-                const triggerResult = await rctx.waitForTriggerResponse(triggerId, trigger.timeoutMs, signal);
+                // No timeout: wait until the parent actually responds (or cancels).
+                const triggerResult = await rctx.waitForTriggerResponse(triggerId, undefined, signal);
 
                 // Treat timeout / delivery-failure as cancellation
                 if (triggerResult.cancelled) {

--- a/packages/cli/src/extensions/remote-plan-mode.ts
+++ b/packages/cli/src/extensions/remote-plan-mode.ts
@@ -446,7 +446,10 @@ export function registerPlanModeTool(rctx: RelayContext) {
                         steps,
                         description: description ?? undefined,
                     },
-                    deliverAs: "followUp" as const,
+                    // steer: the child is blocked waiting on this decision (indefinitely,
+                    // see waitForTriggerResponse) — the parent must be interrupted to see
+                    // it now, not whenever its current turn queue happens to drain.
+                    deliverAs: "steer" as const,
                     expectsResponse: true,
                     triggerId,
                     ts: new Date().toISOString(),

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -245,7 +245,7 @@ export interface RelayContext {
     // Trigger helpers (for child session trigger pattern)
     emitTrigger(trigger: ConversationTrigger): void;
     emitTriggerWithAck(trigger: ConversationTrigger): Promise<{ ok: boolean; error?: string }>;
-    waitForTriggerResponse(triggerId: string, timeoutMs: number, signal?: AbortSignal): Promise<TriggerResponse>;
+    waitForTriggerResponse(triggerId: string, timeoutMs?: number, signal?: AbortSignal): Promise<TriggerResponse>;
 
     // Session name sync
     markSessionNameBroadcasted(): void;

--- a/packages/cli/src/extensions/remote/followup-grace.test.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createFollowUpGrace, isManualAbort, type FollowUpGraceState } from "./followup-grace.js";
 
 describe("isManualAbort", () => {
@@ -17,7 +17,6 @@ const mockLogger = {
 function makeState(): FollowUpGraceState {
     return {
         sessionCompleteFired: false,
-        followUpGraceTimer: null,
         followUpGraceShutdown: null,
         sessionCompleteGeneration: 0,
         sessionCompleteTransportGeneration: 0,
@@ -37,6 +36,41 @@ function makeRelayContext() {
         sioSocket: { connected: true },
     } as any;
 }
+
+describe("startFollowUpGrace / shutdownFollowUpGraceImmediately", () => {
+    test("startFollowUpGrace never schedules a timer — no auto-shutdown clock", () => {
+        const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), { logger: mockLogger });
+        const shutdown = mock(() => {});
+
+        followUpGrace.startFollowUpGrace({ shutdown });
+
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+        expect(shutdown).not.toHaveBeenCalled();
+        setTimeoutSpy.mockRestore();
+    });
+
+    test("shutdownFollowUpGraceImmediately still shuts down on an explicit parent delink", () => {
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), { logger: mockLogger });
+        const shutdown = mock(() => {});
+
+        followUpGrace.startFollowUpGrace({ shutdown });
+        followUpGrace.shutdownFollowUpGraceImmediately();
+
+        expect(shutdown).toHaveBeenCalledTimes(1);
+    });
+
+    test("clearFollowUpGrace disarms without ever invoking shutdown", () => {
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), { logger: mockLogger });
+        const shutdown = mock(() => {});
+
+        followUpGrace.startFollowUpGrace({ shutdown });
+        followUpGrace.clearFollowUpGrace();
+        followUpGrace.shutdownFollowUpGraceImmediately();
+
+        expect(shutdown).not.toHaveBeenCalled();
+    });
+});
 
 describe("createFollowUpGrace fireSessionComplete", () => {
     beforeEach(() => {

--- a/packages/cli/src/extensions/remote/followup-grace.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.ts
@@ -1,9 +1,15 @@
 /**
  * Follow-up grace period and session-complete trigger for child sessions.
  *
- * After a child session's agent_end, the parent has a configurable grace
- * period to send a follow-up message.  If no follow-up arrives the session
- * shuts down automatically.
+ * After a child session's agent_end, it fires session_complete and then
+ * waits for the parent to deal with it — ack, follow up, or explicitly tear
+ * it down (cleanup_child_session / delink). There is no auto-shutdown clock:
+ * a completed child is cheap to leave idle, and a timer here would repeat
+ * the exact bug this module's sibling fix addressed for waitForTriggerResponse
+ * — killing a session out from under a parent that just hasn't gotten to it
+ * yet. The only shutdown paths are explicit: new work arriving (turn_start
+ * clears the grace state) or the parent permanently delinking
+ * (shutdownFollowUpGraceImmediately, a real event, not a timeout).
  *
  * fireSessionComplete emits the session_complete trigger to the parent once
  * and is idempotent thereafter.
@@ -15,7 +21,6 @@ import { createLogger } from "@pizzapi/tools";
 import type { RelayContext } from "../remote-types.js";
 import { emitSessionCompleteWithAck } from "./session-complete-delivery.js";
 
-const FOLLOWUP_GRACE_MS = 10 * 60 * 1_000;
 const SESSION_COMPLETE_RETRY_MS = 3_000;
 const log = createLogger("remote");
 
@@ -23,7 +28,7 @@ const log = createLogger("remote");
  * True when an agent_end on a child session came from a manual abort (Esc /
  * abort exec) rather than a real shutdown. In that case session_complete must
  * NOT be sent — the parent would ack "killed" and tear the session down — and
- * no follow-up grace timer should start: the user took control and will steer
+ * no follow-up grace should start: the user took control and will steer
  * or end the session themselves.
  */
 export function isManualAbort(opts: { wasAborted: boolean; shuttingDown: boolean }): boolean {
@@ -33,7 +38,7 @@ export function isManualAbort(opts: { wasAborted: boolean; shuttingDown: boolean
 export interface FollowUpGraceState {
     /** Set to true once session_complete has been emitted — prevents double-fire. */
     sessionCompleteFired: boolean;
-    followUpGraceTimer: ReturnType<typeof setTimeout> | null;
+    /** The shutdown callback to invoke if the parent explicitly delinks. No timer ever fires this on its own. */
     followUpGraceShutdown: (() => void) | null;
     /** Increments on each new turn/session so stale completion promises can be ignored. */
     sessionCompleteGeneration: number;
@@ -69,10 +74,6 @@ export function createFollowUpGrace(
     const logger = deps?.logger ?? log;
 
     function clearFollowUpGrace(): void {
-        if (state.followUpGraceTimer !== null) {
-            clearTimeout(state.followUpGraceTimer);
-            state.followUpGraceTimer = null;
-        }
         if (state.sessionCompleteRetryTimer !== null) {
             clearTimeout(state.sessionCompleteRetryTimer);
             state.sessionCompleteRetryTimer = null;
@@ -80,7 +81,7 @@ export function createFollowUpGrace(
         state.followUpGraceShutdown = null;
     }
 
-    /** If the grace timer is running, fire its shutdown callback immediately. */
+    /** If grace is armed, fire its shutdown callback immediately (parent permanently delinked — a real event, not a timeout). */
     function shutdownFollowUpGraceImmediately(): void {
         if (state.followUpGraceShutdown) {
             const shutdown = state.followUpGraceShutdown;
@@ -91,26 +92,15 @@ export function createFollowUpGrace(
     }
 
     /**
-     * Start the follow-up grace period.  After FOLLOWUP_GRACE_MS without a
-     * follow-up from the parent the session shuts itself down.
+     * Arm the follow-up grace: remember how to shut down, but never do so on
+     * a clock. The session waits — indefinitely — for the parent to ack,
+     * follow up (clearFollowUpGrace via turn_start), or explicitly delink
+     * (shutdownFollowUpGraceImmediately).
      */
     function startFollowUpGrace(ctx: { shutdown: () => void }): void {
         clearFollowUpGrace();
         state.followUpGraceShutdown = ctx.shutdown;
-        logger.info(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1_000}s for parent follow-up before shutting down`);
-        state.followUpGraceTimer = setTimeout(() => {
-            state.followUpGraceTimer = null;
-            state.followUpGraceShutdown = null;
-            logger.info("pizzapi: follow-up grace period expired — shutting down");
-            ctx.shutdown();
-        }, FOLLOWUP_GRACE_MS);
-        if (
-            state.followUpGraceTimer &&
-            typeof state.followUpGraceTimer === "object" &&
-            "unref" in state.followUpGraceTimer
-        ) {
-            (state.followUpGraceTimer as NodeJS.Timeout).unref();
-        }
+        logger.info("pizzapi: session complete — waiting for parent ack/follow-up (no auto-shutdown)");
     }
 
     /**

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -107,9 +107,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         pendingCancellations: [] as Array<{ triggerId: string; childSessionId: string }>,
         pendingCancellationRetryTimer: null as ReturnType<typeof setInterval> | null,
         pendingCancellationRetryInFlight: false,
-        // Follow-up grace state
+        // Follow-up grace state (no timer — see followup-grace.ts)
         sessionCompleteFired: false,
-        followUpGraceTimer: null as ReturnType<typeof setTimeout> | null,
         followUpGraceShutdown: null as (() => void) | null,
         sessionCompleteGeneration: 0,
         sessionCompleteTransportGeneration: 0,

--- a/packages/cli/src/extensions/remote/relay-context-factory.test.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.test.ts
@@ -128,4 +128,30 @@ describe("createRelayContext child trigger delivery", () => {
             cancelled: false,
         });
     });
+
+    test("waitForTriggerResponse with no timeoutMs never auto-cancels — only settles on a real response", async () => {
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        const socket = createSocketMock();
+        rctx.relay = { sessionId: "child-1", token: "relay-token", shareUrl: "", seq: 0, ackedSeq: 0 };
+        rctx.sioSocket = socket as any;
+        rctx.parentSessionId = "parent-1";
+
+        const responsePromise = rctx.waitForTriggerResponse("trigger-1");
+
+        // Still unsettled well past what used to be an arbitrary bounded wait —
+        // with no timeoutMs, nothing should auto-cancel it.
+        const raceResult = await Promise.race([
+            responsePromise.then(() => "settled" as const),
+            new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 50)),
+        ]);
+        expect(raceResult).toBe("pending");
+
+        socket.fire("trigger_response", { triggerId: "trigger-1", response: "Approved", action: "approve" });
+
+        await expect(responsePromise).resolves.toEqual({
+            response: "Approved",
+            action: "approve",
+            cancelled: false,
+        });
+    });
 });

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -296,7 +296,7 @@ export function createRelayContext(
 
         waitForTriggerResponse(
             triggerId: string,
-            timeoutMs: number,
+            timeoutMs?: number,
             signal?: AbortSignal,
         ): Promise<TriggerResponse> {
             return new Promise<TriggerResponse>((resolve) => {
@@ -310,12 +310,19 @@ export function createRelayContext(
                     resolve(result);
                 };
 
-                const timeout = setTimeout(() => {
-                    finish({
-                        response: "Trigger timed out — no response from parent within 5 minutes.",
-                        cancelled: true,
-                    });
-                }, timeoutMs);
+                // ponytail: no default timeout — a session waiting on a parent's
+                // ack (plan review / question answer) waits until it gets a real
+                // response, an explicit cancel, a delivery failure, or its own
+                // connection/abort tears it down. Callers may still opt into a
+                // bounded wait by passing a positive timeoutMs.
+                const timeout = timeoutMs && timeoutMs > 0
+                    ? setTimeout(() => {
+                        finish({
+                            response: `Trigger timed out — no response from parent within ${Math.round(timeoutMs / 1000)}s.`,
+                            cancelled: true,
+                        });
+                    }, timeoutMs)
+                    : undefined;
 
                 const handler = (data: { triggerId: string; response: string; action?: string }) => {
                     if (data.triggerId === triggerId) {
@@ -341,7 +348,7 @@ export function createRelayContext(
                 };
 
                 const cleanup = () => {
-                    clearTimeout(timeout);
+                    if (timeout) clearTimeout(timeout);
                     unregisterWait();
                     rctx.sioSocket?.off("trigger_response" as any, handler);
                     rctx.sioSocket?.off("session_message_error" as any, errorHandler);

--- a/packages/cli/src/extensions/remote/session-complete-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/session-complete-delivery.test.ts
@@ -33,7 +33,7 @@ describe("emitSessionCompleteWithAck", () => {
                 sourceSessionId: "child-1",
                 targetSessionId: "parent-1",
                 triggerId: "trigger-1",
-                deliverAs: "followUp",
+                deliverAs: "steer",
                 expectsResponse: true,
                 payload: {
                     summary: "Done",

--- a/packages/cli/src/extensions/remote/session-complete-delivery.ts
+++ b/packages/cli/src/extensions/remote/session-complete-delivery.ts
@@ -43,7 +43,10 @@ function buildSessionCompleteTrigger(
             exitReason: opts.exitReason,
             ...(opts.fullOutputPath ? { fullOutputPath: opts.fullOutputPath } : {}),
         },
-        deliverAs: "followUp",
+        // steer: the child now waits indefinitely for an ack/follow-up (no more
+        // shutdown-by-clock, see followup-grace.ts) — the parent must be interrupted
+        // to notice, not left to find out whenever it next goes idle.
+        deliverAs: "steer",
         expectsResponse: true,
         triggerId: opts.triggerId,
         ts: new Date().toISOString(),

--- a/packages/cli/src/extensions/triggers/extension.test.ts
+++ b/packages/cli/src/extensions/triggers/extension.test.ts
@@ -61,12 +61,6 @@ async function simulateRespondToTrigger(
         return { text: `Error: No pending trigger with ID ${params.triggerId}` };
     }
 
-    const TRIGGER_TTL_MS = 10 * 60 * 1000;
-    if (Date.now() - pending.trackedAt > TRIGGER_TTL_MS) {
-        receivedTriggers.delete(params.triggerId);
-        return { text: `Error: Trigger ${params.triggerId} has expired` };
-    }
-
     if (pending.type === "session_complete") {
         const action = params.action ?? "ack";
         if (action === "followUp") {
@@ -232,20 +226,20 @@ describe("respond_to_trigger handling for session_complete", () => {
         expect(receivedTriggers.has("trig_plan_fail")).toBe(true);
     });
 
-    it("expired triggers are rejected and removed", async () => {
+    it("triggers never expire — an old pending trigger can still be responded to", async () => {
         const conn = createMockSocket();
         trackReceivedTrigger("trig_old", "child-old", "session_complete");
         const pending = receivedTriggers.get("trig_old");
-        if (pending) pending.trackedAt = Date.now() - (11 * 60 * 1000);
+        if (pending) pending.trackedAt = Date.now() - 60 * 60 * 1000; // 1 hour ago
 
         const result = await simulateRespondToTrigger(
             { triggerId: "trig_old", response: "late ack", action: "ack" },
             conn,
         );
 
-        expect(result?.text).toContain("expired");
+        expect(result?.text).toBe("Acknowledged session completion from child-old");
         expect(receivedTriggers.has("trig_old")).toBe(false);
-        expect(conn.emitted.length).toBe(0);
+        expect(conn.emitted.some((e) => e.event === "cleanup_child_session")).toBe(true);
     });
 });
 

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -39,11 +39,16 @@ function isJsonValue(value: unknown): value is JsonValue {
     return false;
 }
 
-/** Tracks triggers this session has received (as parent) for response routing. */
+/** Tracks triggers this session has received (as parent) for response routing.
+ *  No TTL: a trigger stays pending until explicitly handled (markTriggerHandled)
+ *  or cleared (clearAndCancelPendingTriggers on /new). A parent that takes a
+ *  long time to respond must never find its own bookkeeping expired the
+ *  trigger out from under it — see waitForTriggerResponse, which likewise no
+ *  longer times out the child side of this same wait. */
 export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
+// Dedup guard so a re-delivered triggerId (e.g. after escalation) isn't re-tracked as new.
 const handledTriggerTombstones = new Map<string, number>();
 
-const TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const TRIGGER_RESPONSE_ACK_TIMEOUT_MS = 10_000;
 
 export async function sendTriggerResponseWithAck(
@@ -135,27 +140,14 @@ export function clearAndCancelPendingTriggers(
     return { cancelled: count, sent, failed };
 }
 
-function pruneTriggerTracking(now: number): void {
-    for (const [id, entry] of receivedTriggers) {
-        if (now - entry.trackedAt > TRIGGER_TTL_MS) receivedTriggers.delete(id);
-    }
-    for (const [id, handledAt] of handledTriggerTombstones) {
-        if (now - handledAt > TRIGGER_TTL_MS) handledTriggerTombstones.delete(id);
-    }
-}
-
 export function markTriggerHandled(triggerId: string): void {
-    const now = Date.now();
-    handledTriggerTombstones.set(triggerId, now);
+    handledTriggerTombstones.set(triggerId, Date.now());
     receivedTriggers.delete(triggerId);
-    pruneTriggerTracking(now);
 }
 
 export function trackReceivedTrigger(triggerId: string, sourceSessionId: string, type: string): boolean {
-    const now = Date.now();
-    pruneTriggerTracking(now);
     if (receivedTriggers.has(triggerId) || handledTriggerTombstones.has(triggerId)) return false;
-    receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: now });
+    receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: Date.now() });
     return true;
 }
 
@@ -310,12 +302,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
             }
             const pending = receivedTriggers.get(params.triggerId);
             if (!pending) {
-                return { content: [{ type: "text" as const, text: `Error: No pending trigger with ID ${params.triggerId}. It may have already been responded to or timed out.` }], details: null as any };
-            }
-            // Enforce TTL — reject if the trigger has expired (child likely already timed out)
-            if (Date.now() - pending.trackedAt > TRIGGER_TTL_MS) {
-                receivedTriggers.delete(params.triggerId);
-                return { content: [{ type: "text" as const, text: `Error: Trigger ${params.triggerId} has expired (older than ${TRIGGER_TTL_MS / 60_000} minutes). The child session likely already timed out.` }], details: null as any };
+                return { content: [{ type: "text" as const, text: `Error: No pending trigger with ID ${params.triggerId}. It may have already been responded to.` }], details: null as any };
             }
 
             // session_complete is respondable but handled differently:

--- a/packages/cli/src/extensions/triggers/integration.test.ts
+++ b/packages/cli/src/extensions/triggers/integration.test.ts
@@ -90,16 +90,16 @@ describe("trigger routing flow", () => {
             expect(receivedTriggers.has("trigger-1")).toBe(false);
         });
 
-        it("prunes stale entries when tracking new triggers", () => {
-            // Manually insert a stale entry (older than TTL)
-            receivedTriggers.set("stale-trigger", {
+        it("does not prune old entries when tracking new triggers — pending triggers never expire", () => {
+            // Manually insert an old entry (a parent that's taken a long time to respond)
+            receivedTriggers.set("old-trigger", {
                 sourceSessionId: "old-child",
                 type: "ask_user_question",
-                trackedAt: Date.now() - 15 * 60 * 1000, // 15 minutes ago (TTL is 10 min)
+                trackedAt: Date.now() - 60 * 60 * 1000, // 1 hour ago
             });
-            // Tracking a new trigger should prune the stale one
+            // Tracking a new trigger must not evict the old, still-pending one.
             trackReceivedTrigger("fresh-trigger", "new-child", "plan_review");
-            expect(receivedTriggers.has("stale-trigger")).toBe(false);
+            expect(receivedTriggers.has("old-trigger")).toBe(true);
             expect(receivedTriggers.has("fresh-trigger")).toBe(true);
         });
     });

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -285,7 +285,9 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // that clearAndCancelPendingTriggers() emitted just before this event.
             // The trigger_response handler checks targetSession.parentSessionId; if
             // we clear it concurrently, the check fails with "Sender is not the
-            // parent" and the child is left blocked until its 5-minute timeout.
+            // parent" and the child is left blocked indefinitely — child-side waits
+            // no longer have a fallback timeout (see waitForTriggerResponse), so the
+            // parent_delinked event below is now the only way to unblock it.
             //
             // Instead, parentSessionId is cleaned up lazily: registerTuiSession
             // checks isChildDelinked() on reconnect and clears the stale field


### PR DESCRIPTION
## Problem

A child session blocked on a parent's response (`plan_mode` / `AskUserQuestion` fired as a `plan_review`/`ask_user_question` trigger) auto-cancelled itself after a hard-coded 5-minute timeout in `waitForTriggerResponse`, treating "no answer yet" as "cancelled".

The parent side made this worse: `TRIGGER_TTL_MS` (10 min) silently pruned pending triggers out of `receivedTriggers`, so if the parent took a while to get around to it, `respond_to_trigger` would reject with "has expired... likely already timed out" even though the child was still patiently waiting. This is the exact failure mode already captured in Godmother idea `ix8M4p39` ("respond_to_trigger can fail with 'No pending trigger'"), and is explicitly called out as a known race in a `child-lifecycle.ts` comment ("the child is left blocked until its 5-minute timeout").

Two more instances of the same shape of bug were found and fixed in review:

- `followup-grace.ts` had its own 10-minute auto-shutdown clock after `session_complete` — if the parent hadn't acked/followed-up in time, the child just killed itself.
- `plan_review` / `ask_user_question` / `session_complete` triggers were delivered as `deliverAs: "followUp"` (queued until the parent's entire turn queue drains), which combined with the removed timeouts meant the parent might not even notice the trigger for a very long time.

## Fix

- `waitForTriggerResponse`: `timeoutMs` is now optional and only arms a timer when a caller passes a positive value. With none, the wait only ends on a real `trigger_response`, a delivery failure, or an abort/disconnect — all of which were already wired up separately (`TriggerWaitManager.cancelAll` on explicit parent delink / session switch, which is not a timeout, it's an actual "the parent is gone" event).
- `remote-plan-mode.ts` / `remote-ask-user.ts`: stop passing `timeoutMs: 300_000` — plan review and question triggers now wait indefinitely for the parent's answer.
- `triggers/extension.ts`: removed `TRIGGER_TTL_MS` / `pruneTriggerTracking` and the "has expired" rejection in `respond_to_trigger`. A pending trigger now lives until it's explicitly handled (`markTriggerHandled`) or cleared via `/new` (`clearAndCancelPendingTriggers`) — never on a clock.
- `followup-grace.ts`: removed the post-`session_complete` auto-shutdown timer. The child now waits indefinitely for the parent to ack, follow up, or explicitly delink — the only shutdown paths left are real events (`turn_start` clearing the grace state when new work arrives, `shutdownFollowUpGraceImmediately` on an explicit parent delink), never a clock.
- `plan_review`, `ask_user_question`, and `session_complete` triggers now use `deliverAs: "steer"` instead of `"followUp"`, so they interrupt the parent as soon as its current turn's tool calls finish rather than waiting for its entire work queue to drain. Matches the intent already captured in Godmother idea `WAPgu635` ("Child triggers should act as steer messages").
- Updated the now-stale "blocked until its 5-minute timeout" comment in `child-lifecycle.ts`.

## Out of scope

- Short (seconds-scale) socket-ack timeouts confirming delivery to the relay (`emitSessionTriggerWithAck`, `sendTriggerResponseWithAck`) — those bound network confirmation, not the parent's conversational response, and already degrade gracefully.

## Testing

- `bun run typecheck` — clean.
- `bun scripts/test-isolated.ts packages/cli/src` — 125/126 files pass; the sole failure (`sandbox-config.test.ts`) is a pre-existing macOS-only flake (`os.tmpdir()` returns `/var/folders/...` not `/tmp`) unrelated to this change (zero diff on that file vs `main`).
- Updated `extension.test.ts` / `integration.test.ts` to assert triggers no longer expire.
- Added a new test in `relay-context-factory.test.ts` proving a `waitForTriggerResponse` call with no `timeoutMs` never auto-cancels and still resolves correctly once a real response arrives.
- Added tests in `followup-grace.test.ts` proving `startFollowUpGrace` never schedules a timer, that an explicit delink still shuts down immediately, and that `clearFollowUpGrace` disarms without ever firing shutdown.
- Updated `session-complete-delivery.test.ts`'s `deliverAs` assertion to `"steer"`.
- `packages/server` `child-lifecycle.test.ts` — passes (comment-only change there).

Godmother: `nMoyBOKL` (branched from `ix8M4p39`, epic "Runner & Session Reliability").
