### PR TITLE
feat(subagent): run delegated work in background

### DIFF
--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -138,6 +138,12 @@ describe("buildSystemPrompt", () => {
         expect(result).not.toContain("{{>");
     });
 
+    test("contains background subagent guidance", () => {
+        const result = buildSystemPrompt();
+        expect(result).toContain("Subagents run in the background");
+        expect(result).toContain("do not poll or wait for them");
+    });
+
     test("contains subagent model recommendation", () => {
         const result = buildSystemPrompt();
         expect(result).toContain("subagent-model-selection");

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -17,7 +17,9 @@ Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks t
 <section name="subagent-tool">
 Use the `subagent` tool to delegate tasks to specialized agents with isolated context. A built-in `task` agent is always available for general-purpose work — use `subagent(agent: "task", task: "...")` to delegate any task without needing an agents folder. Additional agents are defined as markdown files in `~/.pizzapi/agents/` or `~/.claude/agents/` (user scope) and `.pizzapi/agents/` or `.claude/agents/` (project scope). Modes: single (`agent` + `task`), parallel (`tasks` array), chain (`chain` array with `\{{previous}}` placeholder). Set `agentScope: "both"` to include project-local agents.
 
-<important>Prefer `subagent` over `spawn_session` for delegating work. `subagent` is simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need a long-running background session with independent lifecycle, or when you want to interact with the child session asynchronously via triggers. For most tasks — code changes, research, reviews, refactoring — `subagent` is the right choice.</important>
+<important>Subagents run in the background. The tool returns immediately so you can continue working. Their results arrive automatically as follow-up messages that resume your session — do not poll or wait for them.</important>
+
+<important>Prefer `subagent` over `spawn_session` for delegating work. `subagent` is simpler and manages context isolation and result delivery automatically. Use `spawn_session` only when you need an independently visible session, cross-runner execution, or interactive child communication through triggers.</important>
 
 <recommendation name="subagent-model-selection">
 When calling `subagent`, the tool automatically selects the most cost-effective available model when no `model` is specified. You can override this by setting `model: { provider, id }` explicitly — either at the top level (applies to all tasks) or per-task in parallel/chain mode.

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -442,9 +442,9 @@ export interface PizzaPiConfig {
 
     /** Subagent execution settings */
     subagent?: {
-        /** Max number of parallel tasks in a single subagent call. Default: 8. */
+        /** Max parallel tasks per call and active agent slots across background calls. Default: 8. */
         maxParallelTasks?: number;
-        /** Max concurrent agent sessions running simultaneously. Default: 4. */
+        /** Max concurrent agent sessions within one parallel call. Default: 4. */
         maxConcurrency?: number;
     };
 

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect, mock } from "bun:test";
 import { registerLifecycleHandlers, type LifecycleHandlerState } from "./lifecycle-handlers.js";
 import { createFollowUpGrace } from "./followup-grace.js";
 import type { RelayContext } from "../remote-types.js";
+import { reserveSubagentSlots } from "../subagent/background-state.js";
 
 function makeState(): LifecycleHandlerState {
     return {
@@ -113,6 +114,48 @@ describe("agent_end — session_error / session_complete ordering", () => {
 
         agentEnd({ messages: [] }, agentEndCtx);
         agentSettled({}, agentEndCtx);
+
+        expect(emitted).toEqual(["session_complete"]);
+    });
+
+    test("defers session_complete until background subagents settle", () => {
+        const release = reserveSubagentSlots(1, 1)!;
+        const { agentEnd, agentSettled, emitted } = setup(null);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+        expect(emitted).toEqual([]);
+
+        release();
+        expect(emitted).toEqual(["session_complete"]);
+    });
+
+    test("does not report deferred completion after a result starts a follow-up turn", () => {
+        const release = reserveSubagentSlots(1, 1)!;
+        const { agentEnd, agentSettled, emitted } = setup(null);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+        release(true);
+        expect(emitted).toEqual([]);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+        expect(emitted).toEqual(["session_complete"]);
+    });
+
+    test("replays settlement when the last of concurrent subagents does not deliver", () => {
+        const releaseA = reserveSubagentSlots(1, 2)!;
+        const releaseB = reserveSubagentSlots(1, 2)!;
+        const { agentEnd, agentSettled, emitted } = setup(null);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+        releaseA(true);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        agentSettled({}, agentEndCtx);
+        releaseB(false);
 
         expect(emitted).toEqual(["session_complete"]);
     });

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -48,6 +48,7 @@ import { registerPlanModeTool } from "../remote-plan-mode.js";
 import { isDisabled } from "./connection.js";
 import { emitSessionActive, emitSessionMetadataUpdate } from "./chunked-delivery.js";
 import { shouldAutoClose } from "./auto-close.js";
+import { hasActiveSubagents, noteSubagentSettlementDeferred, onSubagentsIdle } from "../subagent/background-state.js";
 import type { RelayContext } from "../remote-types.js";
 import type { TriggerWaitManager } from "../trigger-wait-manager.js";
 import type { DelinkManager } from "./delink-management.js";
@@ -153,6 +154,17 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
     // fires after every attempt (including ones pi will auto-retry); completion
     // and error reporting must wait for agent_settled.
     let settledMessages: any[] | null = null;
+    let deferredSettlementCtx: any | null = null;
+    const stopWatchingSubagents = onSubagentsIdle((followUpStarted) => {
+        if (followUpStarted) {
+            deferredSettlementCtx = null;
+            return;
+        }
+        if (!deferredSettlementCtx) return;
+        const ctx = deferredSettlementCtx;
+        deferredSettlementCtx = null;
+        handleAgentSettled({}, ctx);
+    });
 
     // ── Register tools ────────────────────────────────────────────────────────
     registerAskUserTool(rctx);
@@ -340,6 +352,7 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
         followUpGrace.clearFollowUpGrace();
         stopHeartbeat();
         stopSessionNameSync();
+        stopWatchingSubagents();
         clearCtx();
         const shutdownExitReason = rctx.wasAborted ? "killed" : rctx.lastRetryableError ? "error" : "completed";
         await followUpGrace.fireSessionComplete(undefined, undefined, shutdownExitReason);
@@ -376,15 +389,22 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
         settledMessages = (event as any).messages ?? [];
     });
 
-    pi.on("agent_settled", (_event: any, ctx: any) => {
+    function handleAgentSettled(_event: any, ctx: any) {
+        if (settledMessages === null) return; // settled without a preceding agent_end
+        if (hasActiveSubagents()) {
+            deferredSettlementCtx = ctx;
+            noteSubagentSettlementDeferred();
+            return;
+        }
+
+        deferredSettlementCtx = null;
         const messages = settledMessages;
         settledMessages = null;
         const lastError = rctx.lastRetryableError;
         rctx.lastRetryableError = null;
         emitRetryStateChanged(rctx, null);
-        if (messages === null) return; // settled without a preceding agent_end
 
-        if (!ctx.hasPendingMessages()) {
+        if (!ctx.hasPendingMessages() && !rctx.isAgentActive) {
             let summary = "Session completed";
             let fullOutputPath: string | undefined;
             if (Array.isArray(messages)) {
@@ -508,7 +528,8 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
                 })();
             }
         }
-    });
+    }
+    pi.on("agent_settled", handleAgentSettled);
 
     pi.on("turn_end", (event: any) => {
         rctx.forwardEvent(event);

--- a/packages/cli/src/extensions/subagent-background.test.ts
+++ b/packages/cli/src/extensions/subagent-background.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, mock, test } from "bun:test";
+import { subagentExtension, type SingleResult } from "./subagent.js";
+import { hasActiveSubagents, reserveSubagentSlots } from "./subagent/background-state.js";
+
+const result: SingleResult = {
+    agent: "task",
+    agentSource: "user",
+    task: "Investigate",
+    exitCode: 0,
+    messages: [{ role: "assistant", content: [{ type: "text", text: "Finished investigation" }] } as any],
+    stderr: "",
+    usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 3, turns: 1 },
+};
+
+function resultFor(task: string, output: string): SingleResult {
+    return {
+        ...result,
+        task,
+        messages: [{ role: "assistant", content: [{ type: "text", text: output }] } as any],
+    };
+}
+
+function harness(runAgent: (...args: any[]) => Promise<SingleResult>) {
+    let tool: any;
+    let shutdown: (() => void | Promise<void>) | undefined;
+    const sent: Array<{ content: string; details?: unknown; options?: { deliverAs?: string; triggerTurn?: boolean } }> = [];
+    const pi = {
+        registerTool(value: any) { tool = value; },
+        on(event: string, handler: () => void) {
+            if (event === "session_shutdown") shutdown = handler;
+        },
+        sendMessage(message: { content: string; details?: unknown }, options?: { deliverAs?: string; triggerTurn?: boolean }) {
+            sent.push({ content: message.content, details: message.details, options });
+        },
+    };
+    subagentExtension(pi as any, runAgent as any);
+    return { tool, sent, shutdown: async () => { await shutdown?.(); } };
+}
+
+const nextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const ctx = {
+    cwd: process.cwd(),
+    hasUI: false,
+    modelRegistry: { find: () => undefined, getAvailable: () => [] },
+};
+
+describe("background subagents", () => {
+    test("caps globally reserved subagent slots", () => {
+        const release = reserveSubagentSlots(2, 2)!;
+        try {
+            expect(hasActiveSubagents()).toBe(true);
+            expect(reserveSubagentSlots(1, 2)).toBeUndefined();
+        } finally {
+            release();
+        }
+        expect(hasActiveSubagents()).toBe(false);
+    });
+
+    test("returns immediately and injects the result as a follow-up when done", async () => {
+        let finish!: (value: SingleResult) => void;
+        const runAgent = mock(() => new Promise<SingleResult>((resolve) => { finish = resolve; }));
+        const { tool, sent } = harness(runAgent);
+
+        const launched = await tool.execute("call-1", { agent: "task", task: "Investigate" }, undefined, undefined, ctx);
+
+        expect(launched.content[0].text).toContain("running in the background");
+        expect(sent).toEqual([]);
+
+        finish(result);
+        await nextTask();
+
+        expect(sent).toHaveLength(1);
+        expect(sent[0].content).toContain("Finished investigation");
+        expect(sent[0].options).toEqual({ deliverAs: "followUp", triggerTurn: true });
+        expect(sent[0].details).toMatchObject({ taskId: expect.any(String), mode: "single" });
+    });
+
+    test("delivers chain and parallel results after returning", async () => {
+        const chainRun = mock((...args: any[]) => Promise.resolve(
+            resultFor(args[3], args[3] === "first" ? "one" : "two"),
+        ));
+        const chain = harness(chainRun);
+
+        await chain.tool.execute("call-chain", {
+            chain: [
+                { agent: "task", task: "first" },
+                { agent: "task", task: "after {previous}" },
+            ],
+        }, undefined, undefined, ctx);
+        await nextTask();
+
+        expect(chainRun).toHaveBeenCalledTimes(2);
+        expect(chainRun.mock.calls[1][3]).toBe("after one");
+        expect(chain.sent[0].content).toContain("two");
+
+        const parallel = harness(mock((...args: any[]) => Promise.resolve(resultFor(args[3], `done ${args[3]}`))));
+        await parallel.tool.execute("call-parallel", {
+            tasks: [
+                { agent: "task", task: "alpha" },
+                { agent: "task", task: "beta" },
+            ],
+        }, undefined, undefined, ctx);
+        await nextTask();
+
+        expect(parallel.sent[0].content).toContain("done alpha");
+        expect(parallel.sent[0].content).toContain("done beta");
+    });
+
+    test("aborts background work when the parent turn is canceled", async () => {
+        let aborted = false;
+        const runAgent = mock((...args: any[]) => new Promise<SingleResult>((_resolve, reject) => {
+            const signal = args[6] as AbortSignal;
+            signal.addEventListener("abort", () => {
+                aborted = true;
+                reject(new Error("Subagent was aborted"));
+            }, { once: true });
+        }));
+        const { tool, sent } = harness(runAgent);
+        const turn = new AbortController();
+
+        await tool.execute("call-2", { agent: "task", task: "Investigate" }, turn.signal, undefined, ctx);
+        turn.abort();
+        await nextTask();
+
+        expect(aborted).toBe(true);
+        expect(sent).toEqual([]);
+    });
+
+    test("aborts background work on session shutdown without injecting a result", async () => {
+        const runAgent = mock((...args: any[]) => new Promise<SingleResult>((_resolve, reject) => {
+            const signal = args[6] as AbortSignal;
+            signal.addEventListener("abort", () => reject(new Error("Subagent was aborted")), { once: true });
+        }));
+        const { tool, sent, shutdown } = harness(runAgent);
+
+        await tool.execute("call-3", { agent: "task", task: "Investigate" }, undefined, undefined, ctx);
+        await shutdown();
+
+        expect(sent).toEqual([]);
+    });
+});

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -212,9 +212,11 @@ describe("SubagentDetails type exports", () => {
             agentScope: "user",
             projectAgentsDir: null,
             results: [],
+            background: { taskId: "task-1", status: "started" },
         };
         expect(details.mode).toBe("single");
         expect(details.results).toEqual([]);
+        expect(details.background?.status).toBe("started");
     });
 
     test("UsageStats interface shape", () => {

--- a/packages/cli/src/extensions/subagent/background-state.ts
+++ b/packages/cli/src/extensions/subagent/background-state.ts
@@ -1,0 +1,45 @@
+let activeSlots = 0;
+let followUpStarted = false;
+const idleListeners = new Set<(followUpStarted: boolean) => void>();
+
+export function hasActiveSubagents(): boolean {
+    return activeSlots > 0;
+}
+
+export function onSubagentsIdle(listener: (followUpStarted: boolean) => void): () => void {
+    idleListeners.add(listener);
+    return () => idleListeners.delete(listener);
+}
+
+export function noteSubagentSettlementDeferred(): void {
+    followUpStarted = false;
+}
+
+export function reserveSubagentSlots(count: number, max: number): ((startedFollowUp?: boolean) => void) | undefined {
+    if (activeSlots + count > max) return undefined;
+    activeSlots += count;
+    let released = false;
+    return (startedFollowUp = false) => {
+        if (released) return;
+        released = true;
+        followUpStarted ||= startedFollowUp;
+        activeSlots -= count;
+        if (activeSlots !== 0) return;
+
+        const didStartFollowUp = followUpStarted;
+        followUpStarted = false;
+        for (const listener of idleListeners) {
+            try {
+                listener(didStartFollowUp);
+            } catch (err) {
+                console.error("Subagent idle listener failed:", err);
+            }
+        }
+    };
+}
+
+export function resetSubagentState(): void {
+    activeSlots = 0;
+    followUpStarted = false;
+    idleListeners.clear();
+}

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -295,6 +295,7 @@ export async function runSingleAgent(
             ...(agent.systemPrompt.trim() && { appendSystemPrompt: [agent.systemPrompt] }),
         });
         await loader.reload();
+        if (signal?.aborted) throw new Error("Subagent was aborted");
 
         // Resolve model: tool parameter > agent frontmatter > auto-select cheapest > inherit parent default
         let resolvedModel: Model<any> | undefined;
@@ -327,6 +328,10 @@ export async function runSingleAgent(
             // fresh registry would fail with "No API key found".
             ...(modelRegistry && isFullModelRegistry(modelRegistry) && { modelRegistry }),
         });
+        if (signal?.aborted) {
+            session.dispose();
+            throw new Error("Subagent was aborted");
+        }
 
         // Subscribe to events to track messages and usage
         const unsubscribe = session.subscribe((event) => {
@@ -372,7 +377,6 @@ export async function runSingleAgent(
         });
 
         // Handle external abort signal — use session.abort() for real cancellation
-        if (signal?.aborted) throw new Error("Subagent was aborted");
         const onAbort = () => { session.abort().catch(() => {}); };
         signal?.addEventListener("abort", onAbort, { once: true });
 

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -9,8 +9,8 @@
  *   - Chain:    { chain: [{ agent: "name", task: "... {previous} ..." }, ...] }
  *
  * Uses the pi SDK in-process (createAgentSession + session.prompt) for
- * zero-overhead execution — no child process, no JSON parsing, direct event
- * access for streaming.
+ * zero-overhead execution. Tool calls return immediately; completed results
+ * are injected into the supervisor session as follow-up messages.
  *
  * Adapted from upstream pi subagent extension (examples/extensions/subagent/)
  * with PizzaPi-specific agent discovery paths (~/.pizzapi/agents/,
@@ -19,6 +19,7 @@
  */
 
 import { mkdtempSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -36,12 +37,12 @@ import {
     shouldSpillParallelOutput,
     summarizeResultForStreaming,
     summarizeResultsForStreaming,
-    type OnUpdateCallback,
     type SubagentDetails,
     type SingleResult,
 } from "./types.js";
 import { runSingleAgent, mapWithConcurrencyLimit, type ModelOverride } from "./engine.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
+import { reserveSubagentSlots, resetSubagentState } from "./background-state.js";
 
 // ── Tool parameter schemas (JSON Schema) ───────────────────────────────
 
@@ -110,12 +111,22 @@ const SubagentParams = {
 
 // ── Extension factory ──────────────────────────────────────────────────
 
-export const subagentExtension = (pi: ExtensionAPI) => {
+export const subagentExtension = (pi: ExtensionAPI, runAgent = runSingleAgent) => {
+    const backgroundTasks = new Map<AbortController, Promise<void>>();
+
+    pi.on("session_shutdown", async () => {
+        for (const controller of backgroundTasks.keys()) controller.abort();
+        await Promise.allSettled(backgroundTasks.values());
+        backgroundTasks.clear();
+        resetSubagentState();
+    });
+
     pi.registerTool({
         name: "subagent",
         label: "Subagent",
         description: [
             "Delegate tasks to specialized subagents with isolated context.",
+            "Subagents run in the background; this tool returns immediately and automatically sends their results as a follow-up when done.",
             "Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
             'Default agent scope is "user" (from ~/.pizzapi/agents and ~/.claude/agents).',
             'To enable project-local agents in .pizzapi/agents or .claude/agents, set agentScope: "both" (or "project").',
@@ -124,7 +135,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
         ].join(" "),
         parameters: SubagentParams as any,
 
-        async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
+        async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
             // Read concurrency limits from global config only — project-local
             // config must not be able to raise fan-out limits for untrusted repos.
             const globalConfig = loadGlobalConfig();
@@ -213,99 +224,80 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                 }
             }
 
-            // ── Chain mode ─────────────────────────────────────────────
-            if (params.chain && params.chain.length > 0) {
-                const results: SingleResult[] = [];
-                let previousOutput = "";
-
-                for (let i = 0; i < params.chain.length; i++) {
-                    const step = params.chain[i];
-                    const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
-
-                    const chainUpdate: OnUpdateCallback | undefined = onUpdate
-                        ? (partial) => {
-                            const currentResult = partial.details?.results[0];
-                            if (currentResult) {
-                                const allResults = [...summarizeResultsForStreaming(results), currentResult];
-                                onUpdate({
-                                    content: partial.content,
-                                    details: makeDetails("chain")(allResults),
-                                });
-                            }
-                        }
-                        : undefined;
-
-                    const result = await runSingleAgent(
-                        ctx.cwd, agents, step.agent, taskWithContext,
-                        step.cwd, i + 1, signal, chainUpdate, makeDetails("chain"),
-                        step.model ?? params.model, ctx.modelRegistry,
-                    );
-                    results.push(result);
-
-                    if (isFailed(result)) {
-                        const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
-                        return {
-                            content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
-                            details: makeDetails("chain")(summarizeResultsForStreaming(results)),
-                            isError: true,
-                        };
-                    }
-                    previousOutput = getFinalOutput(result.messages);
-                }
+            const mode = hasChain ? "chain" : hasTasks ? "parallel" : "single";
+            if (params.tasks && params.tasks.length > maxParallelTasks) {
                 return {
-                    content: [{ type: "text", text: getFinalOutput(results[results.length - 1].messages) || "(no output)" }],
-                    details: makeDetails("chain")(summarizeResultsForStreaming(results)),
+                    content: [{ type: "text", text: `Too many parallel tasks (${params.tasks.length}). Max is ${maxParallelTasks}.` }],
+                    details: makeDetails("parallel")([]),
+                    isError: true,
                 };
             }
 
-            // ── Parallel mode ──────────────────────────────────────────
-            if (params.tasks && params.tasks.length > 0) {
-                if (params.tasks.length > maxParallelTasks)
-                    return {
-                        content: [
-                            { type: "text", text: `Too many parallel tasks (${params.tasks.length}). Max is ${maxParallelTasks}.` },
-                        ],
-                        details: makeDetails("parallel")([]),
-                    };
+            if (signal?.aborted) {
+                return {
+                    content: [{ type: "text", text: "Subagent launch canceled." }],
+                    details: makeDetails(mode)([]),
+                    isError: true,
+                };
+            }
 
-                const allResults: SingleResult[] = new Array(params.tasks.length);
-                for (let i = 0; i < params.tasks.length; i++) {
-                    allResults[i] = {
-                        agent: params.tasks[i].agent,
-                        agentSource: "unknown",
-                        task: params.tasks[i].task,
-                        exitCode: -1,
-                        messages: [],
-                        stderr: "",
-                        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+            const slotCount = params.tasks?.length ?? 1;
+            const releaseSlots = reserveSubagentSlots(slotCount, maxParallelTasks);
+            if (!releaseSlots) {
+                return {
+                    content: [{ type: "text", text: `Too many active subagents. Max is ${maxParallelTasks}.` }],
+                    details: makeDetails(mode)([]),
+                    isError: true,
+                };
+            }
+
+            const taskId = randomUUID();
+            const controller = new AbortController();
+            const onTurnAbort = () => controller.abort();
+            signal?.addEventListener("abort", onTurnAbort, { once: true });
+
+            const run = async () => {
+                // ── Chain mode ─────────────────────────────────────────
+                if (params.chain && params.chain.length > 0) {
+                    const results: SingleResult[] = [];
+                    let previousOutput = "";
+
+                    for (let i = 0; i < params.chain.length; i++) {
+                        const step = params.chain[i];
+                        const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
+
+                        const result = await runAgent(
+                            ctx.cwd, agents, step.agent, taskWithContext,
+                            step.cwd, i + 1, controller.signal, undefined, makeDetails("chain"),
+                            step.model ?? params.model, ctx.modelRegistry,
+                        );
+                        results.push(result);
+
+                        if (isFailed(result)) {
+                            const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
+                            return {
+                                content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
+                                details: makeDetails("chain")(summarizeResultsForStreaming(results)),
+                                isError: true,
+                            };
+                        }
+                        previousOutput = getFinalOutput(result.messages);
+                    }
+                    return {
+                        content: [{ type: "text", text: getFinalOutput(results[results.length - 1].messages) || "(no output)" }],
+                        details: makeDetails("chain")(summarizeResultsForStreaming(results)),
                     };
                 }
 
-                const emitParallelUpdate = () => {
-                    if (onUpdate) {
-                        const running = allResults.filter((r) => r.exitCode === -1).length;
-                        const done = allResults.filter((r) => r.exitCode !== -1).length;
-                        onUpdate({
-                            content: [{ type: "text", text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
-                            details: makeDetails("parallel")([...allResults]),
-                        });
-                    }
-                };
-
-                const results = await mapWithConcurrencyLimit(params.tasks, maxConcurrency, async (t, index) => {
-                    const result = await runSingleAgent(
-                        ctx.cwd, agents, t.agent, t.task, t.cwd, undefined, signal,
-                        (partial) => {
-                            if (partial.details?.results[0]) {
-                                allResults[index] = partial.details.results[0];
-                                emitParallelUpdate();
-                            }
-                        },
+            // ── Parallel mode ──────────────────────────────────────────
+            if (params.tasks && params.tasks.length > 0) {
+                const results = await mapWithConcurrencyLimit(params.tasks, maxConcurrency, async (t) => {
+                    const result = await runAgent(
+                        ctx.cwd, agents, t.agent, t.task, t.cwd, undefined, controller.signal,
+                        undefined,
                         makeDetails("parallel"),
                         t.model ?? params.model, ctx.modelRegistry,
                     );
-                    allResults[index] = summarizeResultForStreaming(result);
-                    emitParallelUpdate();
                     return result;
                 });
 
@@ -347,9 +339,9 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
             // ── Single mode ───────────────────────────────────────────
             if (params.agent && params.task) {
-                const result = await runSingleAgent(
+                const result = await runAgent(
                     ctx.cwd, agents, params.agent, params.task,
-                    params.cwd, undefined, signal, onUpdate, makeDetails("single"),
+                    params.cwd, undefined, controller.signal, undefined, makeDetails("single"),
                     params.model, ctx.modelRegistry,
                 );
                 if (isFailed(result)) {
@@ -371,6 +363,56 @@ export const subagentExtension = (pi: ExtensionAPI) => {
             return {
                 content: [{ type: "text", text: `Invalid parameters. Available agents: ${available}` }],
                 details: makeDetails("single")([]),
+            };
+            };
+
+            const deliver = (message: string, details?: SubagentDetails): boolean => {
+                try {
+                    pi.sendMessage({
+                        customType: "subagent-result",
+                        content: message,
+                        display: true,
+                        details: { taskId, ...details },
+                    }, { deliverAs: "followUp", triggerTurn: true });
+                    return true;
+                } catch (err) {
+                    console.error(`Failed to deliver subagent ${taskId} result:`, err);
+                    return false;
+                }
+            };
+            let deliveryStarted = false;
+            const task = run()
+                .then((result) => {
+                    if (controller.signal.aborted) return;
+                    const text = result.content
+                        .filter((part): part is { type: "text"; text: string } => part.type === "text")
+                        .map((part) => part.text)
+                        .join("\n");
+                    deliveryStarted = deliver(
+                        `[Subagent ${taskId} ${result.isError ? "failed" : "completed"}]\n\n${text || "(no output)"}`,
+                        result.details,
+                    );
+                }, (err) => {
+                    if (controller.signal.aborted) return;
+                    const message = err instanceof Error ? err.message : String(err);
+                    deliveryStarted = deliver(`[Subagent ${taskId} failed]\n\n${message}`);
+                })
+                .finally(() => {
+                    signal?.removeEventListener("abort", onTurnAbort);
+                    backgroundTasks.delete(controller);
+                    releaseSlots(deliveryStarted);
+                });
+            backgroundTasks.set(controller, task);
+
+            return {
+                content: [{
+                    type: "text",
+                    text: `Subagent ${taskId} is running in the background. Continue working; its result will arrive automatically when done.`,
+                }],
+                details: {
+                    ...makeDetails(mode)([]),
+                    background: { taskId, status: "started" as const },
+                },
             };
         },
 

--- a/packages/cli/src/extensions/subagent/types.ts
+++ b/packages/cli/src/extensions/subagent/types.ts
@@ -58,6 +58,7 @@ export interface SubagentDetails {
     agentScope: AgentScope;
     projectAgentsDir: string | null;
     results: SingleResult[];
+    background?: { taskId: string; status: "started" };
 }
 
 export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -159,8 +159,8 @@ You can also override any setting with **environment variables**.
 | `sandbox.filesystem.denyWrite` | `string[]` | *merged with preset* | Additional paths blocked from writing. |
 | `slowStartupWarning` | `boolean` | `true` | Show warnings when startup takes longer than expected (slow MCP servers, etc.). |
 | `disabledRunnerServices` | `string[]` | `[]` | Runner service IDs to skip. Built-in services: `"terminal"`, `"file-explorer"`, `"git"`, `"tunnel"`, `"time"`. Plugin services use the id declared in their manifest. |
-| `subagent.maxParallelTasks` | `number` | `8` | Max tasks in a single parallel subagent call. **Global config only.** |
-| `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions running simultaneously. **Global config only.** |
+| `subagent.maxParallelTasks` | `number` | `8` | Max parallel tasks per call and active agent slots across background calls. **Global config only.** |
+| `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions within one parallel call. **Global config only.** |
 | `goal.evaluatorModel` | `string` | cheapest available authenticated text model | Model (`provider:modelId` or `modelId`) used by the `/goal` LLM evaluator. |
 | `goal.evaluatorMaxTokens` | `number` | `512` | Maximum output tokens for each `/goal` evaluator call. |
 | `goal.evaluateEveryNTurns` | `number` | `3` | Default cadence for the LLM evaluator. `1` = every turn. Ignored by the keyword evaluator. |

--- a/packages/docs/src/content/docs/customization/subagents.mdx
+++ b/packages/docs/src/content/docs/customization/subagents.mdx
@@ -5,7 +5,7 @@ description: Delegate tasks to specialized agents with isolated context windows
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Subagents let an agent delegate work to a **child agent with its own isolated context window**. The child runs as a separate `pi` process — it gets its own token budget, executes with a scoped set of tools, and returns a distilled result to the parent. The parent's conversation stays clean and focused.
+Subagents let an agent delegate work to a **child agent with its own isolated context window**. The child runs in-process with its own token budget, executes with a scoped set of tools, and sends a distilled result back to the parent. The parent's conversation stays clean and focused.
 
 ## How it works
 
@@ -13,10 +13,10 @@ When the agent calls the `subagent` tool, PizzaPi:
 
 1. Discovers available agent definitions from multiple directories (see [Agent discovery paths](#agent-discovery-paths))
 2. Creates an in-process `AgentSession` via the pi SDK (no child process, zero overhead)
-3. Streams progress updates through the relay server for real-time Web UI display
-4. Returns the child's final output as the tool result
+3. Returns immediately so the parent can continue working
+4. Runs the child behind the scenes and injects its final output as a follow-up message when done
 
-The key difference from [`spawn_session`](/PizzaPi/running/cli-reference/#spawn_session) is that subagents run **inline** — they block like any other tool call and return their output directly. No cross-session messaging needed.
+Unlike [`spawn_session`](/PizzaPi/running/cli-reference/#spawn_session), subagents stay inside the parent session rather than creating a separately visible child session. Result delivery is automatic; the parent should not poll or wait.
 
 ## Quick start
 
@@ -45,7 +45,7 @@ The agent can invoke the subagent tool like this:
 }
 ```
 
-The subagent runs in its own context, reads the relevant files, and returns a summary. Only the summary enters the parent's context window.
+The subagent starts in its own context and the tool returns immediately. When the work finishes, the summary arrives automatically as a follow-up that resumes the parent session. Only the summary enters the parent's context window.
 
 ## Agent definitions
 
@@ -204,37 +204,23 @@ Project-scope agents (`.pizzapi/agents/` and `.claude/agents/`) are loaded from 
 - **Keep prompts short** (< 500 words) — the agent's context should be spent on the task, not the prompt
 - **Use model routing** for simple tasks — Haiku/Flash for exploration, Sonnet/Opus for analysis
 
-## Real-time streaming
+## Background execution
 
-Subagent progress is streamed through the relay server to the Web UI in real-time:
-
-- **While running:** The Web UI shows a streaming card with the subagent's current output, including which agent is active and its progress
-- **When complete:** The card collapses to show the final result with usage statistics (tokens, cost, turns)
-- **Parallel mode:** Multiple progress indicators update simultaneously as each task completes
-
-The streaming uses pi's built-in `tool_execution_update` event pipeline:
-
-1. The subagent tool calls `onUpdate()` with partial results including structured `details`
-2. Pi core fires a `tool_execution_update` event with the partial
-3. The remote extension forwards it over WebSocket to the relay server
-4. The relay broadcasts to all connected Web UI viewers
-5. The UI buffers partials via RAF-based debouncing and renders live updates
-
-No additional configuration is needed — streaming works automatically when using PizzaPi's Web UI.
+The launch card records that the subagent started in the background. The parent session remains usable while it runs. On completion or failure, PizzaPi injects the result as a follow-up message and automatically resumes the parent agent. No polling is needed.
 
 ## Comparison with spawn_session
 
 | Feature | `subagent` | `spawn_session` |
 |---------|-----------|----------------|
-| **Communication** | Tool call → result (synchronous) | Triggers + `tell_child` |
+| **Communication** | Automatic follow-up result | Triggers + `tell_child` |
 | **Context** | Isolated in-process session | Fully independent session |
 | **UI** | Inline in parent session | Separate session view |
 | **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) |
-| **Best for** | Quick delegation, research, review | Long-running parallel work, cross-runner tasks |
+| **Best for** | Background delegation with automatic results | Interactive child workflows, cross-runner tasks |
 | **Model selection** | Via agent definition or parameter | Via spawn parameter |
 | **Agent definitions** | File-based (`~/.pizzapi/agents/`) | Prompt-based (inline in spawn call) |
 
-Use `subagent` for focused, quick tasks. Use `spawn_session` for independent, long-running work.
+Use `subagent` when you only need the result. Use `spawn_session` when you need an independent session, cross-runner execution, or interactive trigger communication.
 
 ## Linked Session Triggers
 

--- a/packages/docs/src/content/docs/features/multi-agent.mdx
+++ b/packages/docs/src/content/docs/features/multi-agent.mdx
@@ -251,18 +251,18 @@ Fire a trigger into **any** session — not just children. This enables peer-to-
 
 | | `subagent` tool | `spawn_session` (linked child) |
 |---|---|---|
-| **Communication** | Tool call → result (synchronous) | Triggers + `tell_child` |
-| **Blocking** | Yes — parent waits for result | No — parent continues, triggers arrive async |
+| **Communication** | Automatic follow-up result | Triggers + `tell_child` |
+| **Blocking** | No — parent continues, result arrives async | No — parent continues, triggers arrive async |
 | **Context** | Isolated in-process session | Fully independent session + process |
 | **UI** | Inline card in parent session | Separate session in web UI |
 | **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) |
 | **Model selection** | Via agent definition `model` field | Via `model` parameter |
-| **Best for** | Quick tasks: research, review, refactor | Long-running parallel work, background tasks |
+| **Best for** | Background tasks that only need a result | Interactive children and cross-runner work |
 | **Agent definitions** | File-based (`~/.pizzapi/agents/`) | Prompt-based (inline) |
 | **Modes** | Single, parallel, chain | One session per call |
 
 <Aside type="tip">
-  **Prefer `subagent` for most delegation.** It's simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need independent lifecycle, background execution, or async trigger-based coordination. See the [Subagents guide](/PizzaPi/customization/subagents/) for full details.
+  **Prefer `subagent` for most delegation.** It's simpler, runs in the background, and delivers results automatically. Use `spawn_session` when you need an independently visible session, cross-runner execution, or interactive trigger-based coordination. See the [Subagents guide](/PizzaPi/customization/subagents/) for full details.
 </Aside>
 
 ---

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -532,7 +532,7 @@ PizzaPi registers several tools that are available in every agent session:
 
 ### `subagent`
 
-Delegate tasks to specialized subagent processes. Each subagent runs in its own isolated context window (separate `pi` process), keeping the parent session's token budget lean.
+Delegate tasks to specialized agents in isolated in-process sessions. The tool returns immediately; each result is automatically delivered as a follow-up message when ready, so the parent can keep working without polling.
 
 **Modes:**
 - **Single**: `{ agent: "name", task: "..." }` — invoke one agent

--- a/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
@@ -79,6 +79,7 @@ interface SubagentDetails {
   agentScope: "user" | "project" | "both";
   projectAgentsDir: string | null;
   results: SingleResult[];
+  background?: { taskId: string; status: "started" };
 }
 
 // ── Formatting helpers ─────────────────────────────────────────────────
@@ -428,7 +429,12 @@ export function SubagentResultCard({
         <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
           <ModeIcon className="size-3.5 shrink-0 text-violet-400" />
           <span className="text-[0.8rem] font-semibold text-zinc-300">{headerLabel}</span>
-          {isStreaming && !hasError ? (
+          {details?.background?.status === "started" ? (
+            <span className="ml-auto inline-flex items-center gap-1 text-[10px] text-violet-400 shrink-0">
+              <ZapIcon className="size-2.5" />
+              Background
+            </span>
+          ) : isStreaming && !hasError ? (
             <span className="ml-auto inline-flex items-center gap-1 text-[10px] text-violet-400 shrink-0">
               <Loader2Icon className="size-2.5 animate-spin" />
               Active


### PR DESCRIPTION
## Summary
- return from `subagent` calls immediately while delegated sessions continue in-process
- deliver completed results as automatic custom follow-up messages with structured usage details
- cancel background work on parent abort/shutdown and defer session completion safely across concurrent subagents
- update the Web UI launch state, built-in prompt, configuration reference, and subagent docs

## Validation
- `TMPDIR=/tmp bun run test`
- `bun run typecheck`
- `bun run build`
- `cd packages/docs && bun run build`
- independent P0-P2 review: LGTM
