### PR TITLE
feat(ui): file sigils open the file in the file explorer

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -76,6 +76,7 @@ import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, set
 import { useRunnerData } from "@/hooks/useRunnerData";
 import { SigilProvider } from "@/components/sigils/SigilContext";
 import { PizzaPiNavProvider, type PizzaPiNavActions } from "@/components/sigils/PizzaPiNavContext";
+import { resolveFilePath } from "@/components/file-explorer/utils";
 import { ServicePanelButtons, ServicePanelOverflowItems, useServicePanelState, useVisibleServicePanels } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
@@ -4456,10 +4457,22 @@ export function App() {
     handleToggleServicePanel(serviceId, undefined, undefined, override);
   }, [buttonPositions.positions, activeServicePanels, handleToggleServicePanel]);
 
+  // File sigils → open the file in the file explorer panel.
+  const [fileToOpen, setFileToOpen] = React.useState<{ path: string } | null>(null);
+  const handleOpenFileInExplorer = React.useCallback((path: string) => {
+    const cwd = activeSessionInfo?.cwd;
+    if (!cwd || !activeSessionInfo?.runnerId) return;
+    const abs = resolveFilePath(cwd, path);
+    setFileToOpen({ path: abs });
+    setShowFileExplorer(true);
+    handleCombinedTabChange("files");
+  }, [activeSessionInfo?.cwd, activeSessionInfo?.runnerId, setShowFileExplorer, handleCombinedTabChange]);
+
   const pizzaPiNavActions = React.useMemo<PizzaPiNavActions>(() => ({
     toggleServicePanel: handleToggleServicePanel,
     setActiveSessionId: (sessionId: string) => handleOpenSession(sessionId),
-  }), [handleToggleServicePanel, handleOpenSession]);
+    openFile: handleOpenFileInExplorer,
+  }), [handleToggleServicePanel, handleOpenSession, handleOpenFileInExplorer]);
 
   const terminalPanelTab = React.useMemo<CombinedPanelTab | null>(() => showTerminal ? {
     id: "terminal",
@@ -4505,10 +4518,11 @@ export function App() {
           runnerId={activeSessionInfo.runnerId}
           cwd={activeSessionInfo.cwd}
           className="h-full"
+          openFile={fileToOpen}
         />
       </Suspense>
     ),
-  } : null, [showFileExplorer, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleFilesPositionChange]);
+  } : null, [showFileExplorer, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleFilesPositionChange, fileToOpen]);
 
   const gitPanelTab = React.useMemo<CombinedPanelTab | null>(() => (showGit && activeSessionInfo?.runnerId && activeSessionInfo?.cwd) ? {
     id: "git",

--- a/packages/ui/src/components/file-explorer/FileExplorer.tsx
+++ b/packages/ui/src/components/file-explorer/FileExplorer.tsx
@@ -137,7 +137,7 @@ const FileTreeRow = React.memo(function FileTreeRow({ node, isExpanded, isLoadin
 
 // ── Main File Explorer Component ──────────────────────────────────────────────
 
-export function FileExplorer({ runnerId, cwd, className, onClose, position = "left", onPositionChange, onDragStart }: FileExplorerProps) {
+export function FileExplorer({ runnerId, cwd, className, onClose, position = "left", onPositionChange, onDragStart, openFile }: FileExplorerProps) {
   const storageKey = `file-explorer:${runnerId}:${cwd}`;
   const git = useGitService(cwd);
   const canBlame = Boolean(git.available && git.status);
@@ -146,6 +146,12 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [viewingFile, setViewingFile] = React.useState<string | null>(null);
+
+  // Externally-requested file open (e.g. clicking a [[file:...]] sigil).
+  // Object identity re-triggers even when the same path is clicked twice.
+  React.useEffect(() => {
+    if (openFile?.path) setViewingFile(openFile.path);
+  }, [openFile]);
 
   // Lifted tree state
   const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() => loadExpandedPaths(storageKey));
@@ -302,7 +308,7 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
 
   // File viewer routing
   if (viewingFile) {
-    const viewingFileName = viewingFile.split("/").pop() ?? viewingFile;
+    const viewingFileName = viewingFile.split(/[\\/]/).pop() ?? viewingFile;
     const isImage = isImageFile(viewingFileName);
     const isMarkdown = isMarkdownFile(viewingFileName);
 

--- a/packages/ui/src/components/file-explorer/types.ts
+++ b/packages/ui/src/components/file-explorer/types.ts
@@ -35,4 +35,6 @@ export interface FileExplorerProps {
   onPositionChange?: (pos: "left" | "right" | "bottom") => void;
   /** Called when the user starts dragging the panel grip to reposition it. */
   onDragStart?: (e: React.PointerEvent) => void;
+  /** When set, opens this file in the viewer. New object identity re-triggers open. */
+  openFile?: { path: string } | null;
 }

--- a/packages/ui/src/components/file-explorer/utils.test.ts
+++ b/packages/ui/src/components/file-explorer/utils.test.ts
@@ -1,20 +1,35 @@
-import { describe, expect, test } from "bun:test";
-import { repoRelativePath } from "./utils";
+import { describe, test, expect } from "bun:test";
+import { resolveFilePath, repoRelativePath } from "./utils";
 
-describe("repoRelativePath", () => {
-  test("strips cwd prefix", () => {
-    expect(repoRelativePath("/repo", "/repo/src/foo.ts")).toBe("src/foo.ts");
+describe("resolveFilePath", () => {
+  test("POSIX absolute passes through", () => {
+    expect(resolveFilePath("/home/j/proj", "/etc/hosts")).toBe("/etc/hosts");
   });
 
-  test("handles cwd with trailing slash", () => {
-    expect(repoRelativePath("/repo/", "/repo/src/foo.ts")).toBe("src/foo.ts");
+  test("POSIX relative joins with cwd", () => {
+    expect(resolveFilePath("/home/j/proj/", "src/app.ts")).toBe("/home/j/proj/src/app.ts");
   });
 
-  test("returns the original path when already relative", () => {
-    expect(repoRelativePath("/repo", "src/foo.ts")).toBe("src/foo.ts");
+  test("Windows drive absolute passes through (both slash styles)", () => {
+    expect(resolveFilePath("C:\\proj", "C:\\Users\\j\\a.ts")).toBe("C:\\Users\\j\\a.ts");
+    expect(resolveFilePath("C:\\proj", "D:/data/b.ts")).toBe("D:/data/b.ts");
   });
 
-  test("returns empty string when filePath equals cwd", () => {
-    expect(repoRelativePath("/repo", "/repo")).toBe("");
+  test("UNC absolute passes through", () => {
+    expect(resolveFilePath("C:\\proj", "\\\\server\\share\\f.ts")).toBe("\\\\server\\share\\f.ts");
+  });
+
+  test("relative joins with Windows cwd using backslash", () => {
+    expect(resolveFilePath("C:\\Users\\j\\proj\\", "src/app.ts")).toBe("C:\\Users\\j\\proj\\src/app.ts");
+  });
+});
+
+describe("repoRelativePath (Windows)", () => {
+  test("strips Windows cwd prefix", () => {
+    expect(repoRelativePath("C:\\proj", "C:\\proj\\src\\a.ts")).toBe("src\\a.ts");
+  });
+
+  test("still strips POSIX cwd prefix", () => {
+    expect(repoRelativePath("/home/j/proj", "/home/j/proj/src/a.ts")).toBe("src/a.ts");
   });
 });

--- a/packages/ui/src/components/file-explorer/utils.ts
+++ b/packages/ui/src/components/file-explorer/utils.ts
@@ -128,10 +128,22 @@ export function gitStatusLabel(status: string): { label: string; color: string; 
  *  sits under the current working directory. Falls back to the original path
  *  if it is already relative or outside the cwd.
  */
+/**
+ * Resolve a possibly-relative file path against a runner cwd.
+ * Handles POSIX and Windows (drive-letter, UNC) absolute paths and separators.
+ */
+export function resolveFilePath(cwd: string, path: string): string {
+  // Absolute: POSIX (/x), Windows drive (C:\x or C:/x), or UNC (\\host\x)
+  if (/^(\/|[A-Za-z]:[\\/]|\\\\)/.test(path)) return path;
+  const sep = cwd.includes("\\") ? "\\" : "/";
+  return `${cwd.replace(/[\\/]+$/, "")}${sep}${path.replace(/^[\\/]+/, "")}`;
+}
+
 export function repoRelativePath(cwd: string, filePath: string): string {
   if (!cwd || !filePath) return filePath;
-  const withSlash = cwd.endsWith("/") ? cwd : `${cwd}/`;
   if (filePath === cwd) return "";
+  const sep = cwd.includes("\\") ? "\\" : "/";
+  const withSlash = /[\\/]$/.test(cwd) ? cwd : `${cwd}${sep}`;
   if (filePath.startsWith(withSlash)) {
     return filePath.slice(withSlash.length);
   }

--- a/packages/ui/src/components/sigils/PizzaPiNavContext.test.ts
+++ b/packages/ui/src/components/sigils/PizzaPiNavContext.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "bun:test";
+import { parsePizzaPiUrl } from "./PizzaPiNavContext";
+
+describe("parsePizzaPiUrl file URLs", () => {
+  test("round-trips an encoded absolute path as a single segment", () => {
+    const path = "/Users/jordan/Documents/Projects/PizzaPi/README.md";
+    const url = `pizzapi://file/${encodeURIComponent(path)}`;
+    const parsed = parsePizzaPiUrl(url);
+    expect(parsed).not.toBeNull();
+    const segments = parsed!.path.split("/").filter(Boolean);
+    expect(segments[0]).toBe("file");
+    expect(decodeURIComponent(segments.slice(1).join("/"))).toBe(path);
+  });
+
+  test("round-trips a relative path", () => {
+    const path = "packages/ui/src/App.tsx";
+    const parsed = parsePizzaPiUrl(`pizzapi://file/${encodeURIComponent(path)}`);
+    const segments = parsed!.path.split("/").filter(Boolean);
+    expect(decodeURIComponent(segments.slice(1).join("/"))).toBe(path);
+  });
+
+  test("rejects non-pizzapi URLs", () => {
+    expect(parsePizzaPiUrl("https://example.com")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/sigils/PizzaPiNavContext.tsx
+++ b/packages/ui/src/components/sigils/PizzaPiNavContext.tsx
@@ -6,6 +6,7 @@
  * - pizzapi://panel/{serviceId}?key=val#frag       — open panel, forward query + hash to iframe
  * - pizzapi://session/{sessionId}                  — navigate to a session
  * - pizzapi://session/{sessionId}?tab=triggers     — navigate with query params
+ * - pizzapi://file/{encodedPath}                    — open a file in the file explorer
  *
  * Query parameters and hash fragments are preserved and passed to the
  * action handlers so they can forward them downstream (e.g. to panel iframes).
@@ -17,6 +18,8 @@ const SCHEME = "pizzapi://";
 export interface PizzaPiNavActions {
   toggleServicePanel: (serviceId: string, query?: string, fragment?: string) => void;
   setActiveSessionId: (sessionId: string, query?: string, fragment?: string) => void;
+  /** Open a file in the file explorer panel. Path is decoded before this is called. */
+  openFile?: (path: string) => void;
 }
 
 type NavigateFn = (url: string) => boolean;
@@ -96,6 +99,17 @@ export function PizzaPiNavProvider({ actions, children }: PizzaPiNavProviderProp
         case "session":
           if (id) {
             actions.setActiveSessionId(id, query, fragment);
+            return true;
+          }
+          return false;
+
+        case "file":
+          if (id && actions.openFile) {
+            try {
+              actions.openFile(decodeURIComponent(id));
+            } catch {
+              actions.openFile(id);
+            }
             return true;
           }
           return false;

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -77,7 +77,9 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const displayText = resolved.data?.title ?? params.label ?? (id || canonicalType);
   const statusParam = resolved.data?.status ?? params.status ?? params.conclusion;
   const statusColor = statusParam ? getStatusColor(statusParam) : undefined;
-  const rawHref = params.link ?? params.href ?? (resolved.data?.url ? String(resolved.data.url) : undefined);
+  // File sigils get an in-app link that opens the file in the file explorer.
+  const fileHref = canonicalType === "file" && id ? `pizzapi://file/${encodeURIComponent(id)}` : undefined;
+  const rawHref = params.link ?? params.href ?? (resolved.data?.url ? String(resolved.data.url) : undefined) ?? fileHref;
   const href = rawHref && isSafeUrl(rawHref) ? rawHref : undefined;
   const author = resolved.data?.author ? String(resolved.data.author) : undefined;
   const description = resolved.data?.description


### PR DESCRIPTION
## What

Clicking a `[[file:path]]` sigil in the web UI now opens that file in the file explorer panel.

## How

- **`SigilPill.tsx`** — file sigils with no explicit link synthesize `pizzapi://file/<encoded-path>`, making the pill clickable (and the hover-card "Open in app" button appear).
- **`PizzaPiNavContext.tsx`** — new `pizzapi://file/{encodedPath}` route → `actions.openFile(path)`.
- **`App.tsx`** — `openFile` action resolves the path against the active session's cwd, opens/focuses the Files panel, and passes `openFile` down to the explorer.
- **`FileExplorer.tsx` / `types.ts`** — new optional `openFile` prop; object identity re-triggers so clicking the same sigil twice reopens the viewer.

## Windows support

- `resolveFilePath(cwd, path)` recognizes POSIX, drive-letter (`C:\` / `C:/`), and UNC (`\\server\...`) absolutes; relative paths join with the cwd's own separator.
- Viewer filename extraction splits on both `\` and `/` (image/markdown routing).
- `repoRelativePath` strips Windows cwd prefixes too (git blame path).

## Tests

- `PizzaPiNavContext.test.ts` — pizzapi://file encode/decode round-trip (3 tests).
- `utils.test.ts` — `resolveFilePath` + `repoRelativePath` POSIX/Windows/UNC cases (added).
- Full repo `bun run typecheck` clean.

skipped: scroll-to/reveal the file within the tree — add when tree highlighting is requested.
