### PR TITLE
feat(cli): scope tunnels to session with refcounted cleanup

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -442,11 +442,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         } else {
             registry.register(new ProcessService((sessionId) => runningSessions.get(sessionId)?.child?.pid ?? null));
         }
-        const cleanupGitSessionState = (sessionId: string) => {
-            const gitService = registry.get("git");
-            if (!gitService) return;
-            const maybeGitService = gitService as GitService & { handleSessionEnded?: (id: string) => void };
-            maybeGitService.handleSessionEnded?.(sessionId);
+        const cleanupSessionServices = (sessionId: string) => {
+            for (const handler of registry.getAll()) {
+                handler.handleSessionEnded?.(sessionId);
+            }
         };
         const sessionCloseMetadata = new Map<string, SessionCloseMetadata>();
         const setSessionCloseMetadata = (sessionId: string, metadata: Omit<SessionCloseMetadata, "updatedAt">) => {
@@ -1400,7 +1399,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 runningSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
                 await notifyProviderSessionClose(sessionId, "close", entry.sessionFile);
-                cleanupGitSessionState(sessionId);
+                cleanupSessionServices(sessionId);
                 sessionCloseMetadata.delete(sessionId);
                 logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
                 socket.emit("session_killed", { sessionId });
@@ -1467,7 +1466,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 );
             }
 
-            cleanupGitSessionState(sessionId);
+            cleanupSessionServices(sessionId);
             if (shouldNotifyProviderClose) sessionCloseMetadata.delete(sessionId);
 
             // Clean up persisted attachments.  For spawned sessions child.on("exit")

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -24,6 +24,12 @@ export interface ServiceHandler {
     dispose(): void;
 
     /**
+     * Clean up any state tied to a specific session when that session ends.
+     * Optional — services that don't manage per-session runtime state can skip it.
+     */
+    handleSessionEnded?(sessionId: string): void;
+
+    /**
      * Reconcile in-memory subscription state against a full snapshot from the server.
      * Called after runner reconnection with the subset of subscriptions relevant to
      * this service's trigger types. Services that manage runtime state per subscription

--- a/packages/cli/src/runner/services/tunnel-service.test.ts
+++ b/packages/cli/src/runner/services/tunnel-service.test.ts
@@ -33,13 +33,35 @@ function getServiceMessageHandler(socket: ReturnType<typeof createMockSocket>): 
     return handlers[0]!;
 }
 
+function exposeViaMessage(socket: ReturnType<typeof createMockSocket>, sessionId: string, port: number, name?: string) {
+    getServiceMessageHandler(socket)({
+        serviceId: "tunnel",
+        type: "tunnel_expose",
+        sessionId,
+        requestId: `req-expose-${sessionId}-${port}`,
+        payload: { port, name },
+    });
+}
+
+function unexposeViaMessage(socket: ReturnType<typeof createMockSocket>, sessionId: string, port: number) {
+    getServiceMessageHandler(socket)({
+        serviceId: "tunnel",
+        type: "tunnel_unexpose",
+        sessionId,
+        requestId: `req-unexpose-${sessionId}-${port}`,
+        payload: { port },
+    });
+}
+
 describe("TunnelService", () => {
     test("setTunnelClient re-exposes already known ports", () => {
         const service = new TunnelService();
+        const socket = createMockSocket();
         const tunnelClient = createMockTunnelClient();
 
+        service.init(socket as any, { isShuttingDown: () => false });
         service.registerPort(3000, "Panel");
-        service.registerPort(5173, "Vite");
+        exposeViaMessage(socket, "sess-a", 5173, "Vite");
         service.setTunnelClient(tunnelClient as any);
 
         expect(tunnelClient.exposePort).toHaveBeenCalledTimes(2);
@@ -82,18 +104,8 @@ describe("TunnelService", () => {
         service.setTunnelClient(tunnelClient as any);
         service.init(socket as any, { isShuttingDown: () => false });
 
-        const onServiceMessage = getServiceMessageHandler(socket);
-        onServiceMessage({
-            serviceId: "tunnel",
-            type: "tunnel_expose",
-            requestId: "req-1",
-            payload: { port: 8080, name: "App" },
-        });
-        onServiceMessage({
-            serviceId: "tunnel",
-            type: "tunnel_unexpose",
-            payload: { port: 8080 },
-        });
+        exposeViaMessage(socket, "sess-1", 8080, "App");
+        unexposeViaMessage(socket, "sess-1", 8080);
 
         expect(tunnelClient.exposePort).toHaveBeenCalledWith(8080);
         expect(tunnelClient.unexposePort).toHaveBeenCalledWith(8080);
@@ -103,7 +115,8 @@ describe("TunnelService", () => {
                 {
                     serviceId: "tunnel",
                     type: "tunnel_registered",
-                    requestId: "req-1",
+                    sessionId: "sess-1",
+                    requestId: "req-expose-sess-1-8080",
                     payload: {
                         port: 8080,
                         name: "App",
@@ -127,9 +140,10 @@ describe("TunnelService", () => {
         const firstSocket = createMockSocket();
         const secondSocket = createMockSocket();
 
-        service.registerPort(3000, "Panel");
-
         service.init(firstSocket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+        exposeViaMessage(firstSocket, "sess-a", 4000);
+
         service.dispose();
         service.init(secondSocket as any, { isShuttingDown: () => false });
 
@@ -147,8 +161,47 @@ describe("TunnelService", () => {
                     },
                 },
             ],
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    sessionId: "sess-a",
+                    requestId: "req-expose-sess-a-4000",
+                    payload: {
+                        port: 4000,
+                        url: "/tunnel/4000",
+                    },
+                },
+            ],
         ]);
-        expect(secondSocket.emitted).toEqual(firstSocket.emitted);
+        expect(secondSocket.emitted).toEqual([
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    payload: {
+                        port: 3000,
+                        name: "Panel",
+                        url: "/tunnel/3000",
+                        pinned: true,
+                    },
+                },
+            ],
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    sessionId: "sess-a",
+                    payload: {
+                        port: 4000,
+                        url: "/tunnel/4000",
+                    },
+                },
+            ],
+        ]);
     });
 
     test("invalid ports return tunnel_error without exposing", () => {
@@ -163,6 +216,7 @@ describe("TunnelService", () => {
         onServiceMessage({
             serviceId: "tunnel",
             type: "tunnel_expose",
+            sessionId: "sess-1",
             requestId: "req-bad",
             payload: { port: 0 },
         });
@@ -174,10 +228,169 @@ describe("TunnelService", () => {
                 {
                     serviceId: "tunnel",
                     type: "tunnel_error",
+                    sessionId: "sess-1",
                     requestId: "req-bad",
                     payload: { error: "Invalid port: 0" },
                 },
             ],
         ]);
+    });
+
+    test("tunnel_expose without sessionId returns error", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        const onServiceMessage = getServiceMessageHandler(socket);
+        onServiceMessage({
+            serviceId: "tunnel",
+            type: "tunnel_expose",
+            requestId: "req-nosess",
+            payload: { port: 8080 },
+        });
+
+        expect(tunnelClient.exposePort).not.toHaveBeenCalled();
+        expect(socket.emitted).toEqual([
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_error",
+                    requestId: "req-nosess",
+                    payload: { error: "Missing sessionId: tunnel_expose must be session-scoped" },
+                },
+            ],
+        ]);
+    });
+
+    test("tunnel_list only returns pinned and requesting session's tunnels", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+
+        service.init(socket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+        exposeViaMessage(socket, "sess-a", 8080, "A");
+        exposeViaMessage(socket, "sess-b", 9090, "B");
+
+        socket.emitted.length = 0;
+        getServiceMessageHandler(socket)({
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            sessionId: "sess-a",
+            requestId: "req-list",
+            payload: {},
+        });
+
+        expect(socket.emitted).toEqual([
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_list_result",
+                    sessionId: "sess-a",
+                    requestId: "req-list",
+                    payload: {
+                        tunnels: [
+                            { port: 3000, name: "Panel", url: "/tunnel/3000", pinned: true },
+                            { port: 8080, name: "A", url: "/tunnel/8080" },
+                        ],
+                    },
+                },
+            ],
+        ]);
+    });
+
+    test("one session cannot close another session's tunnel", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+        exposeViaMessage(socket, "sess-a", 8080);
+
+        expect(tunnelClient.exposePort).toHaveBeenCalledTimes(1);
+        socket.emitted.length = 0;
+
+        unexposeViaMessage(socket, "sess-b", 8080);
+
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalled();
+        expect(socket.emitted).toEqual([
+            [
+                "service_message",
+                {
+                    serviceId: "tunnel",
+                    type: "tunnel_error",
+                    sessionId: "sess-b",
+                    requestId: "req-unexpose-sess-b-8080",
+                    payload: { error: "Port 8080 is not exposed by this session" },
+                },
+            ],
+        ]);
+    });
+
+    test("same port exposed by two sessions is refcounted", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        exposeViaMessage(socket, "sess-a", 8080);
+        exposeViaMessage(socket, "sess-b", 8080);
+
+        expect(tunnelClient.exposePort).toHaveBeenCalledTimes(2);
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalled();
+
+        socket.emitted.length = 0;
+        unexposeViaMessage(socket, "sess-a", 8080);
+
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalled();
+        // sess-a got a session-scoped tunnel_removed response.
+        expect(socket.emitted.some(([event, envelope]: any) =>
+            event === "service_message" &&
+            envelope.type === "tunnel_removed" &&
+            envelope.sessionId === "sess-a" &&
+            envelope.payload.port === 8080,
+        )).toBe(true);
+
+        socket.emitted.length = 0;
+        unexposeViaMessage(socket, "sess-b", 8080);
+
+        expect(tunnelClient.unexposePort).toHaveBeenCalledTimes(1);
+        expect(tunnelClient.unexposePort).toHaveBeenCalledWith(8080);
+    });
+
+    test("handleSessionEnded cleans up only that session's tunnels", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        exposeViaMessage(socket, "sess-a", 8080);
+        exposeViaMessage(socket, "sess-b", 9090);
+
+        service.handleSessionEnded("sess-a");
+
+        expect(tunnelClient.unexposePort).toHaveBeenCalledWith(8080);
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalledWith(9090);
+
+        // sess-b's tunnel is still listable by sess-b.
+        socket.emitted.length = 0;
+        getServiceMessageHandler(socket)({
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            sessionId: "sess-b",
+            requestId: "req-list",
+            payload: {},
+        });
+        const listEnvelope = (socket.emitted[0] as any[])[1] as any;
+        expect(listEnvelope.payload.tunnels.map((t: any) => t.port)).toEqual([9090]);
     });
 });

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -15,7 +15,13 @@ interface TunnelInfo {
 export class TunnelService implements ServiceHandler {
     readonly id = "tunnel";
 
-    private tunnels = new Map<number, TunnelInfo>();
+    /** Runner-level pinned/auto-registered ports shared across all sessions. */
+    private pinnedTunnels = new Map<number, TunnelInfo>();
+    /** Session-scoped ports: sessionId -> port -> TunnelInfo. */
+    private sessionTunnels = new Map<string, Map<number, TunnelInfo>>();
+    /** Refcount of how many owners (sessions + pinned) currently want a port exposed. */
+    private portRefCount = new Map<number, number>();
+
     private socket: Socket | null = null;
     private tunnelClient: TunnelClient | null = null;
     private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
@@ -24,8 +30,8 @@ export class TunnelService implements ServiceHandler {
         this.tunnelClient = client;
         if (!client) return;
 
-        for (const port of this.tunnels.keys()) {
-            client.exposePort(port);
+        for (const [port, count] of this.portRefCount.entries()) {
+            if (count > 0) client.exposePort(port);
         }
     }
 
@@ -36,15 +42,16 @@ export class TunnelService implements ServiceHandler {
             if (isShuttingDown()) return;
             if (envelope.serviceId !== "tunnel") return;
 
+            const sessionId = envelope.sessionId;
             switch (envelope.type) {
                 case "tunnel_list":
-                    this.handleList(envelope.requestId);
+                    this.handleList(sessionId, envelope.requestId);
                     break;
                 case "tunnel_expose":
-                    this.handleExpose(envelope.requestId, envelope.payload as { port: number; name?: string });
+                    this.handleExpose(sessionId, envelope.requestId, envelope.payload as { port: number; name?: string });
                     break;
                 case "tunnel_unexpose":
-                    this.handleUnexpose(envelope.payload as { port: number });
+                    this.handleUnexpose(sessionId, envelope.requestId, envelope.payload as { port: number });
                     break;
             }
         };
@@ -64,6 +71,7 @@ export class TunnelService implements ServiceHandler {
     /**
      * Register a port for HTTP proxying without a viewer-initiated tunnel_expose.
      * Used by the daemon to auto-expose panel ports from folder-based services.
+     * Pinned ports are runner-level and shared across all sessions.
      */
     registerPort(port: number, name?: string): void {
         const info: TunnelInfo = {
@@ -72,78 +80,195 @@ export class TunnelService implements ServiceHandler {
             url: `/tunnel/${port}`,
             pinned: true,
         };
-        this.tunnels.set(port, info);
+        this.pinnedTunnels.set(port, info);
+        this.incRef(port);
         this.tunnelClient?.exposePort(port);
         logInfo(`[tunnel] auto-registered panel port ${port}${name ? ` (${name})` : ""}`);
         this.emitTunnelRegistered(info);
     }
 
+    /**
+     * Close all tunnels owned by a session when the session ends.
+     */
+    handleSessionEnded(sessionId: string): void {
+        const sessionMap = this.sessionTunnels.get(sessionId);
+        if (!sessionMap || sessionMap.size === 0) return;
+
+        const ports = Array.from(sessionMap.keys());
+        for (const port of ports) {
+            this.removeSessionPort(sessionId, port);
+        }
+        this.sessionTunnels.delete(sessionId);
+        logInfo(`[tunnel] cleaned up ${ports.length} tunnel(s) for ended session ${sessionId}`);
+    }
+
     private syncSocketState(): void {
-        for (const info of this.tunnels.values()) {
+        for (const info of this.pinnedTunnels.values()) {
             this.emitTunnelRegistered(info);
+        }
+        for (const [sessionId, sessionMap] of this.sessionTunnels.entries()) {
+            for (const info of sessionMap.values()) {
+                this.emitTunnelRegistered(info, undefined, sessionId);
+            }
         }
     }
 
-    private emitTunnelRegistered(info: TunnelInfo, requestId?: string): void {
+    private getSessionMap(sessionId: string): Map<number, TunnelInfo> {
+        let map = this.sessionTunnels.get(sessionId);
+        if (!map) {
+            map = new Map<number, TunnelInfo>();
+            this.sessionTunnels.set(sessionId, map);
+        }
+        return map;
+    }
+
+    private incRef(port: number): void {
+        this.portRefCount.set(port, (this.portRefCount.get(port) ?? 0) + 1);
+    }
+
+    private decRef(port: number): void {
+        const count = (this.portRefCount.get(port) ?? 0) - 1;
+        if (count <= 0) {
+            this.portRefCount.delete(port);
+            this.tunnelClient?.unexposePort(port);
+            logInfo(`[tunnel] unexposed port ${port}`);
+            this.emitTunnelRemoved(port);
+        } else {
+            this.portRefCount.set(port, count);
+        }
+    }
+
+    private emitTunnelRegistered(info: TunnelInfo, requestId?: string, sessionId?: string): void {
         if (!this.socket) return;
         (this.socket as any).emit("service_message", {
             serviceId: "tunnel",
             type: "tunnel_registered",
             ...(requestId ? { requestId } : {}),
+            ...(sessionId ? { sessionId } : {}),
             payload: info,
         } satisfies ServiceEnvelope);
     }
 
-    private handleList(requestId?: string): void {
+    private emitTunnelRemoved(port: number): void {
         if (!this.socket) return;
-        const tunnels = Array.from(this.tunnels.values());
-        (this.socket as any).emit("service_message", {
-            serviceId: "tunnel",
-            type: "tunnel_list_result",
-            requestId,
-            payload: { tunnels },
-        } satisfies ServiceEnvelope);
-    }
-
-    private handleExpose(requestId: string | undefined, payload: { port: number; name?: string }): void {
-        if (!this.socket) return;
-        const { port, name } = payload;
-
-        if (!port || port < 1 || port > 65535) {
-            (this.socket as any).emit("service_message", {
-                serviceId: "tunnel",
-                type: "tunnel_error",
-                requestId,
-                payload: { error: `Invalid port: ${port}` },
-            } satisfies ServiceEnvelope);
-            return;
-        }
-
-        const existing = this.tunnels.get(port);
-        const info: TunnelInfo = {
-            port,
-            ...(name ? { name } : existing?.name ? { name: existing.name } : {}),
-            url: `/tunnel/${port}`,
-            ...(existing?.pinned ? { pinned: true } : {}),
-        };
-        this.tunnels.set(port, info);
-        this.tunnelClient?.exposePort(port);
-        logInfo(`[tunnel] exposed port ${port}${info.name ? ` (${info.name})` : ""}`);
-        this.emitTunnelRegistered(info, requestId);
-    }
-
-    private handleUnexpose(payload: { port: number }): void {
-        if (!this.socket) return;
-        const { port } = payload;
-
-        if (!this.tunnels.delete(port)) return;
-
-        this.tunnelClient?.unexposePort(port);
-        logInfo(`[tunnel] unexposed port ${port}`);
         (this.socket as any).emit("service_message", {
             serviceId: "tunnel",
             type: "tunnel_removed",
             payload: { port },
         } satisfies ServiceEnvelope);
+    }
+
+    private emitTunnelError(requestId: string | undefined, sessionId: string | undefined, error: string): void {
+        if (!this.socket) return;
+        (this.socket as any).emit("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_error",
+            ...(requestId ? { requestId } : {}),
+            ...(sessionId ? { sessionId } : {}),
+            payload: { error },
+        } satisfies ServiceEnvelope);
+    }
+
+    private handleList(sessionId: string | undefined, requestId?: string): void {
+        if (!this.socket) return;
+
+        const tunnels: TunnelInfo[] = [];
+        // Pinned runner-level ports are shared with all sessions.
+        tunnels.push(...this.pinnedTunnels.values());
+        // Session-scoped ports are private to the requesting session.
+        if (sessionId) {
+            const sessionMap = this.sessionTunnels.get(sessionId);
+            if (sessionMap) tunnels.push(...sessionMap.values());
+        }
+
+        (this.socket as any).emit("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list_result",
+            requestId,
+            ...(sessionId ? { sessionId } : {}),
+            payload: { tunnels },
+        } satisfies ServiceEnvelope);
+    }
+
+    private handleExpose(
+        sessionId: string | undefined,
+        requestId: string | undefined,
+        payload: { port: number; name?: string },
+    ): void {
+        if (!this.socket) return;
+        const { port, name } = payload;
+
+        if (!port || port < 1 || port > 65535) {
+            this.emitTunnelError(requestId, sessionId, `Invalid port: ${port}`);
+            return;
+        }
+        if (!sessionId) {
+            this.emitTunnelError(requestId, sessionId, "Missing sessionId: tunnel_expose must be session-scoped");
+            return;
+        }
+
+        const sessionMap = this.getSessionMap(sessionId);
+        const existing = sessionMap.get(port) ?? this.pinnedTunnels.get(port);
+        const info: TunnelInfo = {
+            port,
+            ...(name ? { name } : existing?.name ? { name: existing.name } : {}),
+            url: `/tunnel/${port}`,
+        };
+
+        const isNewOwner = !sessionMap.has(port);
+        sessionMap.set(port, info);
+        if (isNewOwner) this.incRef(port);
+
+        this.tunnelClient?.exposePort(port);
+        logInfo(`[tunnel] exposed port ${port}${info.name ? ` (${info.name})` : ""} for session ${sessionId}`);
+        this.emitTunnelRegistered(info, requestId, sessionId);
+    }
+
+    private handleUnexpose(
+        sessionId: string | undefined,
+        requestId: string | undefined,
+        payload: { port: number },
+    ): void {
+        if (!this.socket) return;
+        const { port } = payload;
+
+        if (!port || port < 1 || port > 65535) {
+            this.emitTunnelError(requestId, sessionId, `Invalid port: ${port}`);
+            return;
+        }
+        if (!sessionId) {
+            this.emitTunnelError(requestId, sessionId, "Missing sessionId: tunnel_unexpose must be session-scoped");
+            return;
+        }
+
+        const hadPort = this.sessionTunnels.get(sessionId)?.has(port) ?? false;
+        const removed = this.removeSessionPort(sessionId, port);
+        if (!removed) {
+            this.emitTunnelError(requestId, sessionId, `Port ${port} is not exposed by this session`);
+            return;
+        }
+
+        // If the port is still exposed by other sessions, only notify the
+        // requesting session. If it was fully unexposed, broadcast so every
+        // session drops it from its UI.
+        if (this.portRefCount.has(port)) {
+            (this.socket as any).emit("service_message", {
+                serviceId: "tunnel",
+                type: "tunnel_removed",
+                requestId,
+                sessionId,
+                payload: { port },
+            } satisfies ServiceEnvelope);
+        }
+    }
+
+    private removeSessionPort(sessionId: string, port: number): boolean {
+        const sessionMap = this.sessionTunnels.get(sessionId);
+        if (!sessionMap || !sessionMap.has(port)) return false;
+
+        sessionMap.delete(port);
+        if (sessionMap.size === 0) this.sessionTunnels.delete(sessionId);
+        this.decRef(port);
+        return true;
     }
 }


### PR DESCRIPTION
Scopes runner-side tunnels to the session that opened them and cleans them up when the session ends.

## Changes
- `TunnelService` now splits state into:
  - Runner-level pinned ports (panel ports, shared across sessions).
  - Session-scoped tunnels keyed by `sessionId`.
- `tunnel_expose`, `tunnel_list`, and `tunnel_unexpose` now require the `sessionId` already attached by the relay/viewer `service_message` forwarding.
- Ports are reference-counted: if two sessions expose the same port, one session closing it won't tear down the other's tunnel until the last reference is gone.
- Added `handleSessionEnded(sessionId)` to the `ServiceHandler` interface and wired it through `daemon.ts` so every service is notified on session end (replacing the git-only cleanup helper).

## Tests
- Updated `TunnelService` tests with new cases for scoping, cross-session isolation, refcounting, and session cleanup.
- Full CLI runner test suite passes (388 tests).

## Verification
- `bun test packages/cli/src/runner/services/tunnel-service.test.ts`
- `bun test packages/cli/src/runner`
- `bun test packages/cli/src/extensions/tunnel-tools.test.ts`
- `bun test packages/server/src/ws/namespaces/relay/service-message.test.ts`
- `bun run typecheck`
