### PR TITLE
fix(cli): stop stranded messages from stalling sessions

### DIFF
--- a/packages/cli/src/extensions/background-bash.test.ts
+++ b/packages/cli/src/extensions/background-bash.test.ts
@@ -10,16 +10,18 @@ function mockPi() {
     const tools = new Map<string, any>();
     const shortcuts = new Map<string, any>();
     const commands = new Map<string, any>();
+    const handlers = new Map<string, any[]>();
     return {
         messages,
         tools,
         shortcuts,
         commands,
+        emit(event: string, payload?: any) { for (const h of handlers.get(event) ?? []) h(payload); },
         registerTool(tool: any) { tools.set(tool.name, tool); },
         registerShortcut(key: string, opts: any) { shortcuts.set(key, opts); },
         registerCommand(name: string, opts: any) { commands.set(name, opts); },
         sendMessage(msg: any, opts: any) { messages.push({ msg, opts }); },
-        on: () => {},
+        on(event: string, handler: any) { handlers.set(event, [...(handlers.get(event) ?? []), handler]); },
     };
 }
 
@@ -95,7 +97,26 @@ describe("bash override with backgrounding", () => {
         expect(pi.messages[0].msg.content).toContain("Late job exited with code 7");
         expect(pi.messages[0].msg.content).toContain("See full stdout/stderr in ");
         expect(pi.messages[0].msg.details.exitCode).toBe(7);
-        expect(pi.messages[0].opts.deliverAs).toBe("followUp");
+        expect(pi.messages[0].opts.triggerTurn).toBe(true); // idle → must start a turn
+    });
+
+    test("a completion stranded in a drained queue is re-sent, then confirmed", async () => {
+        const { pi, tool } = getTool();
+        pi.emit("agent_start");
+        await run(tool, { command: "exit 0", title: "Racy job", run_in_background: true });
+        await Bun.sleep(200);
+        expect(pi.messages.length).toBe(1);
+        expect(pi.messages[0].opts.deliverAs).toBe("steer"); // streaming → interrupt the turn
+
+        // Turn ended without the queued message ever being processed.
+        pi.emit("agent_settled");
+        expect(pi.messages.length).toBe(2);
+        expect(pi.messages[1].opts.triggerTurn).toBe(true);
+
+        // The re-send lands: no further attempts.
+        pi.emit("message_start", { message: pi.messages[1].msg });
+        pi.emit("agent_settled");
+        expect(pi.messages.length).toBe(2);
     });
 
     test("manual background (TUI shortcut / web exec) detaches a running foreground command", async () => {

--- a/packages/cli/src/extensions/background-bash.ts
+++ b/packages/cli/src/extensions/background-bash.ts
@@ -28,6 +28,8 @@ import { loadConfig } from "../config.js";
 
 const TAIL_BYTES = 4000;
 const DEFAULT_BACKGROUND_AFTER_SECONDS = 15;
+const DELIVERY_RETRY_MS = 10_000;
+const MAX_DELIVERY_ATTEMPTS = 3;
 
 /** Seconds a bash call streams in the foreground before it auto-backgrounds. 0 = immediate. */
 export function backgroundAfterSeconds(): number {
@@ -163,16 +165,59 @@ let nextRunInBackground = false;
 let nextTitle = "";
 
 export const backgroundBashExtension: ExtensionFactory = (pi) => {
+    // Exit notifications that were sent but haven't shown up in the transcript.
+    // Two ways a completion silently vanishes and leaves the session waiting
+    // forever: queued microseconds after the agent loop drained its queues, or
+    // sendMessage (fire-and-forget) throwing while the agent is
+    // between runs. Both are invisible to us, so re-send until a message_start
+    // proves it landed.
+    const undelivered = new Map<string, { message: any; attempts: number }>();
+    let streaming = false;
+    let sweeper: ReturnType<typeof setInterval> | undefined;
+
+    const send = (deliveryId: string, entry: { message: any; attempts: number }) => {
+        entry.attempts += 1;
+        undelivered.set(deliveryId, entry);
+        if (!sweeper) {
+            sweeper = setInterval(sweep, DELIVERY_RETRY_MS);
+            sweeper.unref?.();
+        }
+        // Steer while streaming so a long turn hears about the exit now instead of
+        // at the end of it; when idle the message has to start a turn itself.
+        pi.sendMessage(entry.message, (streaming ? { deliverAs: "steer" } : { triggerTurn: true }) as any);
+    };
+
+    function sweep(): void {
+        if (streaming) return;
+        for (const [deliveryId, entry] of undelivered) {
+            // ponytail: give up after MAX_DELIVERY_ATTEMPTS rather than risk a resend loop.
+            if (entry.attempts >= MAX_DELIVERY_ATTEMPTS) undelivered.delete(deliveryId);
+            else send(deliveryId, entry);
+        }
+        if (undelivered.size === 0 && sweeper) {
+            clearInterval(sweeper);
+            sweeper = undefined;
+        }
+    }
+
+    pi.on("agent_start" as any, () => { streaming = true; });
+    pi.on("agent_settled" as any, () => { streaming = false; sweep(); });
+    pi.on("message_start" as any, (event: any) => {
+        const deliveryId = event?.message?.details?.deliveryId;
+        if (deliveryId) undelivered.delete(deliveryId);
+    });
+
     const notifyExit = (title: string, command: string, code: number | null, sig: string | null, ms: number, logPath: string, pid: number | undefined) => {
-        pi.sendMessage(
-            {
+        const deliveryId = `bg-${pid}-${Date.now()}`;
+        send(deliveryId, {
+            attempts: 0,
+            message: {
                 customType: "background-bash",
                 content: formatCompletion(title, code, sig, ms, logPath),
                 display: true,
-                details: { title, command, pid, exitCode: code, signal: sig, logPath },
-            } as any,
-            { deliverAs: "followUp", triggerTurn: true } as any,
-        );
+                details: { title, command, pid, exitCode: code, signal: sig, logPath, deliveryId },
+            },
+        });
     };
 
     const exec = async (

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -30,6 +30,7 @@ import { sessionAnalysisExtension } from "./session-analysis.js";
 import { providerRequestLogExtension } from "./provider-request-log.js";
 import { sessionProcessesExtension } from "./session-processes.js";
 import { backgroundBashExtension } from "./background-bash.js";
+import { queueFlushExtension } from "./queue-flush.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     providerRequestLogExtension,
@@ -45,6 +46,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     setSessionNameExtension,
     currentTimeExtension,
     backgroundBashExtension,
+    queueFlushExtension,
     updateTodoExtension,
     memoryExtension,
     spawnSessionExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -10,6 +10,7 @@ import { sessionProcessesExtension } from "./session-processes.js";
 import { setSessionNameExtension } from "./set-session-name.js";
 import { currentTimeExtension } from "./current-time.js";
 import { backgroundBashExtension } from "./background-bash.js";
+import { queueFlushExtension } from "./queue-flush.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { memoryExtension } from "./memory/index.js";
@@ -82,6 +83,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(setSessionNameExtension, "session-name"),
         named(currentTimeExtension, "current-time"),
         named(backgroundBashExtension, "background-bash"),
+        named(queueFlushExtension, "queue-flush"),
         named(updateTodoExtension, "todo"),
         named(memoryExtension, "memory"),
         named(spawnSessionExtension, "spawn-session"),

--- a/packages/cli/src/extensions/queue-flush.test.ts
+++ b/packages/cli/src/extensions/queue-flush.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test";
+import { queueFlushExtension } from "./queue-flush.js";
+
+function mockPi(pending: () => boolean) {
+    const messages: any[] = [];
+    let settled: any;
+    return {
+        messages,
+        settle: () => settled({}, { hasPendingMessages: pending }),
+        on(event: string, handler: any) { if (event === "agent_settled") settled = handler; },
+        sendMessage(msg: any, opts: any) { messages.push({ msg, opts }); },
+    };
+}
+
+const tick = () => Bun.sleep(5);
+
+describe("queue-flush", () => {
+    test("kicks a turn when the session settles with messages still queued", async () => {
+        const pi = mockPi(() => true);
+        queueFlushExtension(pi as any);
+        pi.settle();
+        await tick();
+        expect(pi.messages.length).toBe(1);
+        expect(pi.messages[0].opts.triggerTurn).toBe(true);
+        expect(pi.messages[0].msg.display).toBe(false);
+    });
+
+    test("does nothing when the queue is empty", async () => {
+        const pi = mockPi(() => false);
+        queueFlushExtension(pi as any);
+        pi.settle();
+        await tick();
+        expect(pi.messages.length).toBe(0);
+    });
+
+    test("stops kicking after 3 consecutive attempts, resets once drained", async () => {
+        let pending = true;
+        const pi = mockPi(() => pending);
+        queueFlushExtension(pi as any);
+        for (let i = 0; i < 5; i++) pi.settle();
+        await tick();
+        expect(pi.messages.length).toBe(3);
+
+        pending = false;
+        pi.settle();
+        pending = true;
+        pi.settle();
+        await tick();
+        expect(pi.messages.length).toBe(4);
+    });
+});

--- a/packages/cli/src/extensions/queue-flush.ts
+++ b/packages/cli/src/extensions/queue-flush.ts
@@ -1,0 +1,44 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Rescue for stranded queued messages.
+ *
+ * pi's agent loop drains the steering/follow-up queues once, just before it
+ * emits agent_end — but the session keeps reporting `isStreaming` until
+ * agent_settled. Anything queued in that window (relay triggers, web UI input,
+ * subagent results) lands in a queue nothing will ever drain again: queues are
+ * only pulled from inside a run, and no run is starting. The session looks
+ * finished while a message sits waiting — the conversation stalls.
+ *
+ * If we settle with messages still queued, kick one turn. Steering drains at
+ * the start of that run, follow-ups at the end, so the stranded content lands
+ * either way.
+ */
+
+const MAX_CONSECUTIVE_KICKS = 3;
+
+export const queueFlushExtension: ExtensionFactory = (pi) => {
+    let kicks = 0;
+
+    pi.on("agent_settled", (_event: any, ctx: any) => {
+        if (!ctx?.hasPendingMessages?.()) {
+            kicks = 0;
+            return;
+        }
+        // ponytail: cap the kicks — if a queue somehow never drains, stall beats spin.
+        if (kicks >= MAX_CONSECUTIVE_KICKS) return;
+        kicks += 1;
+        // Deferred: agent_settled handlers are still running, and starting a run
+        // from inside one re-enters the session's run state.
+        setTimeout(() => {
+            pi.sendMessage(
+                {
+                    customType: "queue-flush",
+                    content: "(resuming: messages were queued after the turn ended)",
+                    display: false,
+                } as any,
+                { triggerTurn: true } as any,
+            );
+        }, 0);
+    });
+};


### PR DESCRIPTION
Background bash could make a conversation stall: the agent backgrounds a command, ends its turn, and the completion message never arrives. Same root cause hits relay triggers and web UI input.

## Root cause

pi's agent loop drains the steering/follow-up queues **once**, just before it emits `agent_end` — but `AgentSession` keeps reporting `isStreaming` until `agent_settled` (`_isAgentRunActive` flips false in `_emitAgentSettled`). Anything queued in that window is never drained: queues are only pulled from inside a run, and no run is starting.

`ExtensionAPI.sendMessage` returns `void`, so the second loss path is invisible too — when idle it takes the `triggerTurn` branch into `_runAgentPrompt`, which throws `"Agent is already processing a prompt"` if a run is starting, and the rejection is swallowed.

Compounding it: `remote/lifecycle-handlers.ts` only fires `session_complete` when `!ctx.hasPendingMessages()`, so a stranded queue means a child session **neither completes nor continues** — the parent waits forever.

## Changes

**`background-bash.ts`**
- Exit notifications now `deliverAs: "steer"` while streaming, so a long turn hears about the exit immediately instead of at the end.
- Each notification carries a `deliveryId`; delivery is confirmed by watching `message_start`.
- Unconfirmed notifications are re-sent (with `triggerTurn` when idle) on `agent_settled` and via a 10s unref'd sweep, capped at 3 attempts.

**`queue-flush.ts` (new, registered in `factories.ts` for TUI + worker)**
- On `agent_settled`, if `ctx.hasPendingMessages()`, kick one turn with a hidden custom message. Steering drains at run start, follow-ups at run end, so stranded content lands either way.
- Deferred with `setTimeout(0)` (settle handlers are still running), capped at 3 consecutive kicks, reset when the queue drains.

## Not covered

`hasPendingMessages()` counts only user text, so custom messages queued by *other* extensions still aren't rescued generically — background-bash handles its own. Add when one shows up stranded.

## Testing

- `bun test packages/cli/src/extensions/` — 1362 pass, 0 fail (new: stranded-then-confirmed re-send, queue-flush kick/no-op/cap)
- `bun run typecheck` — clean

Godmother: `CK41cPVI`, `OgmB5U8D`
