### PR TITLE
fix(cli): stop agent_end from truncating the web transcript

### DIFF
--- a/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
@@ -144,3 +144,26 @@ describe("agent_end — session_error / session_complete ordering", () => {
         expect(emitted).toEqual(["session_complete"]);
     });
 });
+
+describe("agent_end — forwarded event must not carry run-scoped messages", () => {
+    // pi's agent_end.messages contains only the current run's messages. The web
+    // UI and server snapshot cache treat agent_end.messages as a full-transcript
+    // snapshot, so forwarding them truncates the visible transcript to the last
+    // run. The handler must strip messages before forwarding.
+    test("forwards agent_end without messages, keeps them for the settled summary", () => {
+        const { agentEnd, agentSettled, emitted, rctx } = setup(null);
+        const runMessages = [{ role: "assistant", content: [{ type: "text", text: "turn 2 only" }] }];
+
+        agentEnd({ type: "agent_end", messages: runMessages }, agentEndCtx);
+
+        const forwarded = (rctx.forwardEvent as any).mock.calls
+            .map((c: any[]) => c[0])
+            .find((e: any) => e?.type === "agent_end");
+        expect(forwarded).toBeDefined();
+        expect("messages" in forwarded).toBe(false);
+
+        // Summary reporting still sees the run messages via agent_settled.
+        agentSettled({}, agentEndCtx);
+        expect(emitted).toEqual(["session_complete"]);
+    });
+});

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -368,12 +368,20 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     pi.on("agent_end", (event: any, ctx: any) => {
         rctx.isAgentActive = false;
-        rctx.forwardEvent(event);
+        // pi's agent_end.messages contains only THIS run's messages (prompts +
+        // new assistant/tool messages), not the full transcript. The web UI and
+        // the server's snapshot cache both treat agent_end.messages as a full
+        // snapshot, so forwarding it wholesale truncates the visible transcript
+        // to the latest run. Strip messages and emit a real full snapshot
+        // (chunk-aware) instead — both consumers skip message-less agent_end.
+        const { messages: runMessages, ...eventWithoutMessages } = event;
+        rctx.forwardEvent(eventWithoutMessages);
+        emitSessionActive(rctx);
         rctx.forwardEvent(rctx.buildHeartbeat());
         // Defer completion/error reporting to agent_settled: pi fires agent_end
         // after every attempt, including ones it will auto-retry. agent_settled
         // fires once, only after retries/compaction/continuations are exhausted.
-        settledMessages = (event as any).messages ?? [];
+        settledMessages = runMessages ?? [];
     });
 
     pi.on("agent_settled", (_event: any, ctx: any) => {


### PR DESCRIPTION
## Problem

After the second user message in a session, the web UI transcript collapses to just the latest turn — all earlier messages disappear.

## Root cause

pi's `agent_end.messages` is **run-scoped**: `newMessages = [...prompts, ...this run's assistant/tool messages]` (pi-agent-core `agent-loop.js`), not the full transcript. But PizzaPi treats it as a full snapshot in two places:

- **Web UI** (`App.tsx` agent_end handler): wholesale `setMessages(evt.messages)` + `patchSessionCache` — replaces the entire transcript with the last run and poisons the local session cache.
- **Server** (`redis.ts` `isSnapshotEvent`): caches `agent_end` as the "latest full snapshot", so reconnect/switch hydration replays the truncated transcript.

The first run in a fresh session masks the bug (run 1's messages == whole transcript); from run 2 onward the replacement wipes history. The 10s heartbeat's full `session_active` sometimes repairs live viewers, which is why messages occasionally "came back".

## Fix

One file — the runner's `agent_end` lifecycle handler now:

1. Strips `messages` from the forwarded `agent_end` event (kept locally for the `agent_settled` completion summary).
2. Emits a real full snapshot via `emitSessionActive(rctx)` (already chunk-aware for large sessions).

Both downstream consumers naturally skip a message-less `agent_end` (`Array.isArray(evt.messages)` guard in the UI, `isSnapshotEvent` on the server), so the follow-up `session_active` becomes the authoritative snapshot with zero UI/server changes.

## Testing

- New regression test: forwarded `agent_end` must not carry `messages`; settled summary path unaffected.
- `bun test packages/cli/src/extensions/remote` — 316 pass.
- Server snapshot/viewer suites (`redis.snapshot`, `snapshot-provider`, `viewer`) — 102 pass.
- Full workspace typecheck passes.
