### PR TITLE
refactor(cli): route remote input through SessionHost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,10 @@ PizzaPi patches four upstream pi packages via `patchedDependencies` in the root 
 
 - **Version check removal:** Disables the npm registry version check and "Update Available" notification (irrelevant for PizzaPi's headless runner).
 - **Auth path display:** Shows the actual auth file path instead of hardcoded default.
-- **`sendUserMessage({ expandPromptTemplates })` opt-in:** lets the web UI input path run slash-command/template expansion.
 
 **Removed in Phase 1 (SessionHost):** the patch no longer copies session-control onto `ExtensionAPI` (`newSession`/`switchSession`/`fork`, `getQueuedMessages`/`replaceQueuedMessages`). Those were surface-widening — already native on `AgentSessionRuntime`/`AgentSession`. PizzaPi's remote extension now drives control through a host-owned `SessionHost` (`packages/cli/src/runner/session-host.ts`), threaded in via `extensions/remote/session-host-ref.ts`. `patches.test.ts` guards against the hunks silently returning on a version bump.
+
+**Removed in Phase 2 (SessionHost.sendUserMessage):** the `sendUserMessage({ expandPromptTemplates })` opt-in hunk (`dist/core/agent-session.js` + both `dist/core/extensions/types.d.ts` hunks) is gone too. `connection-handlers-factory.ts`'s `ConnectionHandlers.sendUserMessage` now calls `rctx.sessionHost.sendUserMessage()` directly instead of `(pi as any).sendUserMessage()`; `SessionHost.sendUserMessage` already drove `session.prompt({ expandPromptTemplates })` via pi's native (unpatched) `PromptOptions` field, so the patched ExtensionAPI wrapper had nothing left calling it.
 
 ### @earendil-works/pi-ai
 

--- a/packages/cli/src/extensions/remote/connection-handlers-factory.test.ts
+++ b/packages/cli/src/extensions/remote/connection-handlers-factory.test.ts
@@ -90,3 +90,38 @@ describe("createConnectionHandlers flushDeferredDelinks", () => {
         expect(fireSessionComplete).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("createConnectionHandlers sendUserMessage", () => {
+    function makeBaseDeps(sessionHost: unknown) {
+        return {
+            pi: { sendUserMessage: () => { throw new Error("pi.sendUserMessage must never be called"); } },
+            rctx: { sessionHost } as any,
+            state: {} as any,
+            triggerWaits: {} as any,
+            delinkManager: {} as any,
+            cancellationManager: {} as any,
+            followUpGrace: {} as any,
+            setModelFromWeb: async () => {},
+        };
+    }
+
+    test("delegates to rctx.sessionHost.sendUserMessage and awaits the result", async () => {
+        const calls: Array<[unknown, unknown]> = [];
+        const sessionHost = {
+            sendUserMessage: async (msg: unknown, opts?: unknown) => {
+                calls.push([msg, opts]);
+            },
+        };
+        const { connectionHandlers } = createConnectionHandlers(makeBaseDeps(sessionHost) as any);
+
+        await connectionHandlers.sendUserMessage("hello", { expandPromptTemplates: true });
+
+        expect(calls).toEqual([["hello", { expandPromptTemplates: true }]]);
+    });
+
+    test("throws clearly when no SessionHost is available — never falls back to pi.sendUserMessage", async () => {
+        const { connectionHandlers } = createConnectionHandlers(makeBaseDeps(null) as any);
+
+        await expect(connectionHandlers.sendUserMessage("hello")).rejects.toThrow(/SessionHost/);
+    });
+});

--- a/packages/cli/src/extensions/remote/connection-handlers-factory.ts
+++ b/packages/cli/src/extensions/remote/connection-handlers-factory.ts
@@ -12,6 +12,7 @@
 import { createLogger } from "@pizzapi/tools";
 import type { RelayContext } from "../remote-types.js";
 import type { TriggerWaitManager } from "../trigger-wait-manager.js";
+import type { SendUserMessageOptions, UserMessageContent } from "../../runner/session-host.js";
 import { connect, disconnect, type ConnectionHandlers } from "./connection.js";
 import type { DelinkManager } from "./delink-management.js";
 import type { CancellationManager } from "./trigger-cancellation.js";
@@ -43,7 +44,6 @@ export interface ConnectionHandlerState {
 }
 
 export interface ConnectionHandlersDeps {
-    pi: any;
     rctx: RelayContext;
     state: ConnectionHandlerState;
     triggerWaits: TriggerWaitManager;
@@ -57,15 +57,23 @@ export interface ConnectionHandlersDeps {
  * Build ConnectionHandlers + doConnect/doDisconnect from the provided deps.
  */
 export function createConnectionHandlers(deps: ConnectionHandlersDeps) {
-    const { pi, rctx, state, triggerWaits, delinkManager, cancellationManager, followUpGrace, setModelFromWeb } = deps;
+    const { rctx, state, triggerWaits, delinkManager, cancellationManager, followUpGrace, setModelFromWeb } = deps;
 
     const connectionHandlers: ConnectionHandlers = {
         clearFollowUpGrace: followUpGrace.clearFollowUpGrace,
 
         setModelFromWeb,
 
-        sendUserMessage: (msg: unknown, opts?: { deliverAs?: "followUp" | "steer"; expandPromptTemplates?: boolean }) =>
-            (pi as any).sendUserMessage(msg, opts),
+        // Routed through the host-owned SessionHost — never falls back to the
+        // (now-unpatched) ExtensionAPI.sendUserMessage. If no host was ever
+        // published (see remote-types.ts RelayContext.sessionHost), fail loudly
+        // instead of silently dropping the message.
+        sendUserMessage: async (msg: unknown, opts?: SendUserMessageOptions): Promise<void> => {
+            if (!rctx.sessionHost) {
+                throw new Error("pizzapi: no SessionHost available — cannot deliver user message");
+            }
+            await rctx.sessionHost.sendUserMessage(msg as UserMessageContent, opts);
+        },
 
         // ── Delink handlers ───────────────────────────────────────────────
 

--- a/packages/cli/src/extensions/remote/connection-session-host.integration.test.ts
+++ b/packages/cli/src/extensions/remote/connection-session-host.integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Integration regression: connection.ts (relay socket handlers) →
+ * connection-handlers-factory.ts (ConnectionHandlers.sendUserMessage) →
+ * SessionHost.sendUserMessage → AgentSession.prompt().
+ *
+ * Proves the two live call sites (web input, trigger batch) route through the
+ * real SessionHost with the correct PromptOptions, and that the retired
+ * ExtensionAPI fallback (`pi.sendUserMessage`) is never invoked — it isn't
+ * even part of ConnectionHandlersDeps anymore (see connection-handlers-factory.ts).
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { SessionHost } from "../../runner/session-host.js";
+
+class FakeSocket {
+    handlers = new Map<string, Array<(data: any) => void>>();
+    connected = true;
+    emit = mock((_event: string, _data?: any) => {});
+    removeAllListeners = mock(() => this.handlers.clear());
+    disconnect = mock(() => { this.connected = false; });
+    on(event: string, handler: (data: any) => void) {
+        const list = this.handlers.get(event) ?? [];
+        list.push(handler);
+        this.handlers.set(event, list);
+        return this;
+    }
+    off() { return this; }
+    trigger(event: string, data?: any) {
+        for (const handler of this.handlers.get(event) ?? []) handler(data);
+    }
+    io = { on: () => this.io };
+}
+
+let lastSocket: FakeSocket | null = null;
+
+mock.module("socket.io-client", () => ({
+    io: mock(() => { lastSocket = new FakeSocket(); return lastSocket; }),
+}));
+mock.module("../../config.js", () => ({ loadConfig: mock(() => ({ relayUrl: "ws://relay.test" })) }));
+mock.module("../../backoff.js", () => ({
+    RELAY_BACKOFF_DEFAULTS: { baseMs: 1000, maxMs: 30000, jitterFactor: 0.25 },
+    computeBackoffDelay: mock(() => 1000),
+}));
+mock.module("../mcp-bridge.js", () => ({ getMcpBridge: mock(() => null) }));
+mock.module("../session-message-bus.js", () => ({
+    messageBus: { setOwnSessionId: mock(() => {}), setSendFn: mock(() => {}), receive: mock(() => {}) },
+}));
+mock.module("../remote-provider-usage.js", () => ({
+    getOAuthToken: mock(() => null),
+    refreshAllUsage: mock(async () => {}),
+    buildProviderUsage: mock(() => ({})),
+}));
+mock.module("../remote-heartbeat.js", () => ({
+    startHeartbeat: mock(() => {}),
+    stopHeartbeat: mock(() => {}),
+    buildHeartbeat: mock(() => ({ type: "heartbeat" })),
+    buildTokenUsage: mock(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: null })),
+}));
+mock.module("../remote-meta-events.js", () => ({
+    emitTodoUpdated: mock(() => {}), emitQuestionPending: mock(() => {}), emitQuestionCleared: mock(() => {}),
+    emitPlanPending: mock(() => {}), emitPlanCleared: mock(() => {}), emitPlanModeToggled: mock(() => {}),
+    emitCompactStarted: mock(() => {}), emitCompactEnded: mock(() => {}), emitRetryStateChanged: mock(() => {}),
+    emitPluginTrustRequired: mock(() => {}), emitPluginTrustResolved: mock(() => {}), emitMcpStartupReport: mock(() => {}),
+    emitTokenUsageUpdated: mock(() => {}), emitThinkingLevelChanged: mock(() => {}), emitAuthSourceChanged: mock(() => {}),
+    emitModelChanged: mock(() => {}), emitGoalUpdated: mock(() => {}),
+}));
+mock.module("../remote-auth-source.js", () => ({ getAuthSource: mock(() => null), authSourceLabel: mock(() => "") }));
+mock.module("../remote-ask-user.js", () => ({
+    cancelPendingAskUserQuestion: mock(() => {}),
+    consumePendingAskUserQuestionFromWeb: mock(() => false),
+    registerAskUserTool: mock(() => {}),
+}));
+mock.module("../remote-plan-mode.js", () => ({
+    cancelPendingPlanMode: mock(() => {}),
+    consumePendingPlanModeFromWeb: mock(() => false),
+    registerPlanModeTool: mock(() => {}),
+}));
+mock.module("../remote-input.js", () => ({
+    normalizeRemoteInputAttachments: mock(() => []),
+    buildUserMessageFromRemoteInput: mock(async (text: string) => text),
+}));
+mock.module("../remote-exec-handler.js", () => ({ handleExecFromWeb: mock(async () => {}) }));
+mock.module("./registration-gate.js", () => ({
+    resetRelayRegistrationGate: mock(() => {}),
+    signalRelayRegistered: mock(() => {}),
+    waitForRelayRegistrationGated: mock(async () => {}),
+}));
+mock.module("../remote-registered-parent-state.js", () => ({
+    decideRegisteredParentState: mock(() => ({ kind: "no_change" })),
+}));
+
+const { connect } = await import("./connection.js");
+const { createConnectionHandlers } = await import("./connection-handlers-factory.js");
+const { _resetWorkerStartupGateForTesting } = await import("../worker-startup-gate.js");
+
+mock.restore();
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeRctx(sessionHost: SessionHost) {
+    const forwardEvent = mock((_e: unknown) => {});
+    return {
+        rctx: {
+            shuttingDown: false,
+            sioSocket: null,
+            relay: null,
+            relaySessionId: null,
+            isAgentActive: false,
+            sessionHost,
+            apiKey: () => "test-key",
+            relayUrl: () => "ws://relay.test",
+            disconnectedStatusText: () => "Disconnected",
+            setRelayStatus: mock(() => {}),
+            getCurrentSessionName: () => null,
+            getCurrentThinkingLevel: () => null,
+            forwardEvent,
+            buildCapabilitiesState: () => ({ type: "capabilities" }),
+            buildHeartbeat: () => ({ type: "heartbeat" }),
+            relayHttpBaseUrl: () => "http://relay.test",
+        } as any,
+        forwardEvent,
+    };
+}
+
+function makeState() {
+    return {
+        pendingDelinkOwnParent: false,
+        serverClockOffset: 0,
+        staleChildIds: new Set<string>(),
+        stalePrimaryParentId: null,
+        pendingDelink: false,
+        pendingDelinkEpoch: null,
+        pendingCancellations: [],
+        sessionCompleteFired: false,
+        sessionCompleteTransportGeneration: 0,
+        pendingSessionCompleteDelivery: null,
+        pendingSessionCompleteSocket: null,
+        pendingSessionCompleteTransportGeneration: null,
+        sessionCompleteRetryTimer: null,
+        lastSessionCompletePayload: null,
+    };
+}
+
+describe("connection handler -> SessionHost -> AgentSession.prompt integration", () => {
+    beforeEach(() => {
+        lastSocket = null;
+        _resetWorkerStartupGateForTesting();
+    });
+    afterEach(() => {
+        _resetWorkerStartupGateForTesting();
+    });
+
+    test("web input carries expandPromptTemplates:true, source:extension, and resolved streaming behavior", async () => {
+        const promptCalls: Array<{ text: string; options: any }> = [];
+        const fakeSession = {
+            prompt: async (text: string, options: any) => { promptCalls.push({ text, options }); },
+        } as any;
+        const host = new SessionHost(() => fakeSession, {
+            newSession: async () => ({ cancelled: false }),
+            switchSession: async () => ({ cancelled: false }),
+            fork: async () => ({ cancelled: false }),
+        });
+        const { rctx } = makeRctx(host);
+        const { connectionHandlers } = createConnectionHandlers({
+            rctx,
+            state: makeState() as any,
+            triggerWaits: { cancelAll: () => 0 } as any,
+            delinkManager: {} as any,
+            cancellationManager: {} as any,
+            followUpGrace: { clearFollowUpGrace: () => {} } as any,
+            setModelFromWeb: async () => {},
+        });
+
+        connect(rctx, connectionHandlers);
+        expect(lastSocket).toBeTruthy();
+
+        lastSocket!.trigger("input", { text: "fix the flaky test please" });
+        await sleep(30);
+
+        expect(promptCalls).toHaveLength(1);
+        expect(promptCalls[0].text).toBe("fix the flaky test please");
+        expect(promptCalls[0].options).toEqual({
+            expandPromptTemplates: true,
+            streamingBehavior: undefined,
+            images: undefined,
+            source: "extension",
+        });
+    });
+
+    test("trigger batch does NOT opt into prompt-template expansion and uses steer streaming", async () => {
+        const promptCalls: Array<{ text: string; options: any }> = [];
+        const fakeSession = {
+            prompt: async (text: string, options: any) => { promptCalls.push({ text, options }); },
+        } as any;
+        const host = new SessionHost(() => fakeSession, {
+            newSession: async () => ({ cancelled: false }),
+            switchSession: async () => ({ cancelled: false }),
+            fork: async () => ({ cancelled: false }),
+        });
+        const { rctx } = makeRctx(host);
+        const { connectionHandlers } = createConnectionHandlers({
+            rctx,
+            state: makeState() as any,
+            triggerWaits: { cancelAll: () => 0 } as any,
+            delinkManager: {} as any,
+            cancellationManager: {} as any,
+            followUpGrace: { clearFollowUpGrace: () => {} } as any,
+            setModelFromWeb: async () => {},
+        });
+
+        connect(rctx, connectionHandlers);
+        expect(lastSocket).toBeTruthy();
+
+        lastSocket!.trigger("session_trigger", {
+            trigger: {
+                type: "github:pr_comment",
+                sourceSessionId: "external:github",
+                sourceSessionName: "GitHub",
+                triggerId: "trig_integration_1",
+                payload: { body: "please fix this" },
+                deliverAs: "steer",
+                ts: new Date().toISOString(),
+            },
+        });
+
+        await sleep(120);
+
+        expect(promptCalls).toHaveLength(1);
+        expect(promptCalls[0].options).toEqual({
+            expandPromptTemplates: false,
+            streamingBehavior: "steer",
+            images: undefined,
+            source: "extension",
+        });
+    });
+
+    test("throws (and surfaces a relay-visible cli_error) instead of falling back to pi.sendUserMessage when no SessionHost is set", async () => {
+        // createConnectionHandlers no longer accepts a `pi` fallback at all —
+        // this is the structural proof the old ExtensionAPI path is unused.
+        const { rctx, forwardEvent } = makeRctx(null as any);
+        const { connectionHandlers } = createConnectionHandlers({
+            rctx,
+            state: makeState() as any,
+            triggerWaits: { cancelAll: () => 0 } as any,
+            delinkManager: {} as any,
+            cancellationManager: {} as any,
+            followUpGrace: { clearFollowUpGrace: () => {} } as any,
+            setModelFromWeb: async () => {},
+        });
+
+        connect(rctx, connectionHandlers);
+        expect(lastSocket).toBeTruthy();
+
+        lastSocket!.trigger("input", { text: "hello" });
+        await sleep(30);
+
+        expect(forwardEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "cli_error", source: "remote" }),
+        );
+    });
+});

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -53,7 +53,7 @@ export interface ConnectionHandlers {
     /** Change the active model (called from exec and model_set handlers). */
     setModelFromWeb: (provider: string, modelId: string) => Promise<void>;
     /** Deliver a user message to the agent (called from input and session_trigger handlers). */
-    sendUserMessage: (message: unknown, options?: { deliverAs?: "followUp" | "steer"; expandPromptTemplates?: boolean }) => void;
+    sendUserMessage: (message: unknown, options?: { deliverAs?: "followUp" | "steer"; expandPromptTemplates?: boolean }) => Promise<void>;
 
     // ── Delink handlers (PR #176) ─────────────────────────────────────────
     /** Whether a delink_own_parent is pending (child did /new). */
@@ -228,9 +228,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         void (async () => {
             try {
                 await waitForWorkerStartupComplete();
-                handlers.sendUserMessage(rendered, { deliverAs });
+                await handlers.sendUserMessage(rendered, { deliverAs });
             } catch (err) {
-                log.error(`pizzapi: failed to deliver trigger batch: ${err instanceof Error ? err.message : String(err)}`);
+                const message = err instanceof Error ? err.message : String(err);
+                log.error(`pizzapi: failed to deliver trigger batch: ${message}`);
+                rctx.forwardEvent({ type: "cli_error", message: `Failed to deliver trigger batch: ${message}`, source: "remote", ts: Date.now() });
             }
         })();
     };
@@ -406,9 +408,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 // started streaming by the time we resume here. See
                 // resolveInputDeliverAs for the rationale.
                 const effectiveDeliverAs = resolveInputDeliverAs(deliverAs, rctx.isAgentActive === true);
-                handlers.sendUserMessage(message, { expandPromptTemplates: true, ...(effectiveDeliverAs ? { deliverAs: effectiveDeliverAs } : {}) });
+                await handlers.sendUserMessage(message, { expandPromptTemplates: true, ...(effectiveDeliverAs ? { deliverAs: effectiveDeliverAs } : {}) });
             } catch (err) {
-                log.error(`pizzapi: failed to deliver remote input: ${err instanceof Error ? err.message : String(err)}`);
+                const errMessage = err instanceof Error ? err.message : String(err);
+                log.error(`pizzapi: failed to deliver remote input: ${errMessage}`);
+                rctx.forwardEvent({ type: "cli_error", message: `Failed to deliver remote input: ${errMessage}`, source: "remote", ts: Date.now() });
             }
         })();
     });

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -141,7 +141,6 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     const followUpGrace = createFollowUpGrace(rctx, st);
 
     const { doConnect, doDisconnect } = createConnectionHandlers({
-        pi,
         rctx,
         state: st,
         triggerWaits,

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -63,14 +63,30 @@ function piTuiPath(subpath: string): string {
 // ---------------------------------------------------------------------------
 
 describe("pi-coding-agent patch application", () => {
-    test("agent-session.js: extension sendUserMessage accepts expandPromptTemplates opt-in", async () => {
+    // Phase 2 (SessionHost sendUserMessage routing): the expandPromptTemplates
+    // opt-in hunk was removed. PizzaPi's remote extension no longer calls the
+    // patched ExtensionAPI.sendUserMessage at all — connection-handlers-factory.ts
+    // drives SessionHost.sendUserMessage, which calls session.prompt() directly
+    // (packages/cli/src/runner/session-host.ts). These guards prevent the hunk
+    // from silently reappearing on a version bump.
+    test("agent-session.js: extension sendUserMessage does NOT special-case expandPromptTemplates (removed — PizzaPi routes through SessionHost)", async () => {
         const source = await Bun.file(
             piCodingAgentPath("dist/core/agent-session.js"),
         ).text();
 
-        // The patch lets callers opt into command/template expansion (default false)
-        expect(source).toContain("PATCH(pizzapi): allow callers to opt into command/template expansion");
-        expect(source).toContain("options?.expandPromptTemplates ?? false");
+        expect(source).not.toContain("PATCH(pizzapi): allow callers to opt into command/template expansion");
+        expect(source).not.toContain("options?.expandPromptTemplates ?? false");
+        // Upstream's original hardcoded false is back in place.
+        expect(source).toContain("expandPromptTemplates: false,");
+    });
+
+    test("types.d.ts: ExtensionAPI.sendUserMessage does NOT carry the expandPromptTemplates PATCH (removed — SessionHost owns expansion)", async () => {
+        const source = await Bun.file(
+            piCodingAgentPath("dist/core/extensions/types.d.ts"),
+        ).text();
+
+        expect(source).not.toContain("expandPromptTemplates");
+        expect(source).not.toContain("PATCH(pizzapi): opt into slash-command and template expansion");
     });
 
     // Phase 1: the ExtensionAPI control-plane exposure (newSession/switchSession/

--- a/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
@@ -35,45 +35,6 @@ index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed0
  }
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
-diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index c99a78f31ce2d58973ab1809bd72deb8a1f4135b..abac9c0ddf96e7f41b6de12fd82d8ba567e270a4 100644
---- a/dist/core/agent-session.js
-+++ b/dist/core/agent-session.js
-@@ -1122,9 +1122,10 @@ export class AgentSession {
-             if (images.length === 0)
-                 images = undefined;
-         }
--        // Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
-+        // Use prompt() with expandPromptTemplates: false by default to skip command handling and template expansion.
-+        // PATCH(pizzapi): allow callers to opt into command/template expansion (e.g. web UI input).
-         await this.prompt(text, {
--            expandPromptTemplates: false,
-+            expandPromptTemplates: options?.expandPromptTemplates ?? false,
-             streamingBehavior: options?.deliverAs,
-             images,
-             source: "extension",
-diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
-index a7d5547e62e36d252b90ae083bc847ce97a5bf6d..6b77da4e2b4c342c9f541d0d68ee7755bdfa80ae 100644
---- a/dist/core/extensions/types.d.ts
-+++ b/dist/core/extensions/types.d.ts
-@@ -912,6 +912,8 @@ export interface ExtensionAPI {
-      */
-     sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
-         deliverAs?: "steer" | "followUp";
-+        /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
-+        expandPromptTemplates?: boolean;
-     }): void;
-     /** Append a custom entry to the session for state persistence (not sent to LLM). */
-     appendEntry<T = unknown>(customType: string, data?: T): void;
-@@ -1107,6 +1109,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
- }) => void;
- export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
-     deliverAs?: "steer" | "followUp";
-+    /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
-+    expandPromptTemplates?: boolean;
- }) => void;
- export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
- export type SetSessionNameHandler = (name: string) => void;
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
 index 4cd51566b17e362a4c9c149fa3a339458abc30f6..6f41d5c16b9e476dfe01c312cf86fe0bdce96dac 100644
 --- a/dist/core/model-resolver.js

--- a/patches/README.md
+++ b/patches/README.md
@@ -95,13 +95,11 @@ removals absorbed elsewhere rather than restored:
 | File | Change |
 |------|--------|
 | `dist/config.js` | Same `.pizzapi` config-dir / flat-directory / `PIZZAPI_CHANGELOG_PATH` overrides as 0.80.6 |
-| `dist/core/agent-session.js` | `sendUserMessage({ expandPromptTemplates })` opt-in (web UI input path). **The `getQueuedMessages`/`replaceQueuedMessages` runtime getters were removed in Phase 1** — see below. |
-| `dist/core/extensions/types.d.ts` | `ExtensionAPI.sendUserMessage` `expandPromptTemplates` typing only. |
 | `dist/core/model-resolver.js` | Same `ollama-cloud` default model (`glm-5.1`) as 0.80.6 |
 | `dist/modes/interactive/interactive-mode.js` | Same version-notification-UI removal as 0.80.6 (upstream shifted a few lines; hunk re-applied manually) |
 | `dist/index.js` / `dist/index.d.ts` | Same `handlePackageCommand`/`handleConfigCommand` re-export as 0.80.6 |
 
-**No longer present (see above for why):** `dist/core/provider-display-names.js`.
+**No longer present (see above for why):** `dist/core/provider-display-names.js`. **Also no longer present (Phase 2, below):** `dist/core/agent-session.js`'s `sendUserMessage({ expandPromptTemplates })` opt-in and both `dist/core/extensions/types.d.ts` hunks that typed it.
 
 ### Phase 1: control-plane exposure removed (was `loader.js` / `runner.js` / `types.d.ts`)
 
@@ -120,10 +118,24 @@ host with its existing headless in-place lifecycle actions; the local TUI backs
 it with the runtime. `replaceQueuedMessages` has no clean public native path (it
 needs pi's private raw-enqueue to avoid double-expanding already-expanded queued
 text), so the worker's SessionHost reaches those private methods directly — as
-it already does for queue clearing — rather than via a patch. The
-`sendUserMessage({ expandPromptTemplates })` hunk stays (the primary input path
-still uses it). `patches.test.ts` has regression guards asserting the removed
-hunks do not silently return on a version bump.
+it already does for queue clearing — rather than via a patch. `patches.test.ts`
+has regression guards asserting the removed hunks do not silently return on a
+version bump.
+
+### Phase 2: `sendUserMessage({ expandPromptTemplates })` hunk removed
+
+The last remaining reason for the patch's `ExtensionAPI.sendUserMessage`
+surface — the `expandPromptTemplates` opt-in used by the web UI input path —
+was removed once `connection-handlers-factory.ts`'s `ConnectionHandlers.sendUserMessage`
+was rewired to call `rctx.sessionHost.sendUserMessage()` directly instead of
+`(pi as any).sendUserMessage()`. `SessionHost.sendUserMessage` already called
+`session.prompt()` with `expandPromptTemplates` natively supported (unpatched
+`PromptOptions` field) — the patched `AgentSession.sendUserMessage()` method
+and its `ExtensionAPI`/`SendUserMessageHandler` typings in `types.d.ts` were
+never reached anymore. Both hunks (`dist/core/agent-session.js` and the two
+`dist/core/extensions/types.d.ts` hunks) were dropped from the patch.
+`patches.test.ts` has negative-guard tests asserting they do not silently
+reappear on a version bump.
 
 ### packages/cli auth call-site migration (not a patch — our own source)
 


### PR DESCRIPTION
## Summary

Routes the remote extension's last two `sendUserMessage` call sites (trigger-batch flush, web input) through the host-owned `SessionHost` instead of the patched `ExtensionAPI.sendUserMessage`, and removes the two now-fully-dead pi-coding-agent patch hunks that existed only to support that call.

## Changes

- **`connection-handlers-factory.ts`**: `ConnectionHandlers.sendUserMessage` now returns `Promise<void>` and is implemented as `rctx.sessionHost.sendUserMessage(msg, opts)`. No fallback to `(pi as any).sendUserMessage` — throws clearly (`"pizzapi: no SessionHost available — cannot deliver user message"`) if no host was ever published. The now-unused `pi` field was removed from `ConnectionHandlersDeps` entirely (not just unreferenced — structurally gone).
- **`connection.ts`**: both call sites (trigger-batch flush, web input) `await` the promise inside their existing guarded async IIFEs. On failure they still `log.error(...)` **and** now also forward a relay-visible `{ type: "cli_error", ... }` event via `rctx.forwardEvent`, matching what the old `ExtensionAPI.sendUserMessage` path surfaced (`AgentSession`'s internal `.catch(err => runner.emitError({event:"send_user_message",...}))` → `worker.ts`'s `onError` binding → `forwardCliError`). Failures are never silently downgraded to logs-only.
- **`index.ts`**: stopped passing `pi` into `createConnectionHandlers`.
- **Patch (`patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch`)**: removed the `dist/core/agent-session.js` `expandPromptTemplates` hunk and both `dist/core/extensions/types.d.ts` hunks (`ExtensionAPI.sendUserMessage` + `SendUserMessageHandler` typings). All other hunks (config, model-resolver, index, interactive-mode) are untouched.
- **`patches.test.ts`**: converted the old positive "patch is present" assertion into two negative guards (agent-session.js no longer special-cases `expandPromptTemplates`; types.d.ts no longer mentions it at all), so a version bump can't silently reintroduce the hunks.
- **`patches/README.md` / `AGENTS.md`**: updated to describe the removal ("Phase 2").
- **Tests**: added unit coverage in `connection-handlers-factory.test.ts` (delegates to `sessionHost.sendUserMessage`; throws when no host, never calling `pi.sendUserMessage`) and a new integration test file `connection-session-host.integration.test.ts` that wires the *real* `connect()` + `createConnectionHandlers()` + a real `SessionHost` to a fake `AgentSession.prompt`, proving:
  - web input → `prompt(text, { expandPromptTemplates: true, streamingBehavior: undefined, images: undefined, source: "extension" })`
  - trigger batch → `prompt(text, { expandPromptTemplates: false, streamingBehavior: "steer", ... })` (no expansion opt-in)
  - no `SessionHost` → throws and forwards a `cli_error` relay event instead of silently dropping the message

## Investigation note (acceptance #4)

The old `ExtensionAPI.sendUserMessage` path had a `runtime.assertActive()` guard that throws if the extension's captured `pi` context went stale after `ctx.newSession()`/`fork()`/`switchSession()`/`reload()`. `SessionHost` has no equivalent need: it reads the live session through a `getSession()` accessor on every call (see its class doc-comment) rather than holding a snapshot, so the whole class of "stale captured ctx" bug the assertion guarded against doesn't exist here. No code needed for that half; the `send_user_message` error-emission half is preserved via the new `cli_error` `rctx.forwardEvent` call described above.

## Mutation check (acceptance #5)

Temporarily changed the web-input call site's `expandPromptTemplates: true` → `false`, ran the new integration test — the "web input carries expandPromptTemplates:true..." test failed with a clear diff (`expandPromptTemplates: false` vs expected `true`), other two tests still passed. Reverted; full suite green again.

## Verification

| Command | Exit code |
|---|---|
| `bun test packages/cli/src/extensions/remote` | `0` (323 pass, 0 fail) |
| `bun test packages/cli/src/runner/session-host.test.ts packages/cli/src/patches.test.ts` | `0` (57 pass, 0 fail) |
| `bun test packages/cli/src` | `1` — 2500 pass, 2 skip, **2 pre-existing fail** (see below) |
| `bun run typecheck` | `0` |
| `git status --short` (post-commit) | empty — clean tree |

`bun install` after trimming the patch re-applied cleanly (verified `dist/core/agent-session.js` reverted to upstream's hardcoded `expandPromptTemplates: false,` and `dist/core/extensions/types.d.ts` no longer mentions `expandPromptTemplates` at all; config/model-resolver/index/interactive-mode hunks unchanged). `bun.lock` has no diff — not touched, per the task's "only if truly required."

### Pre-existing failure (not caused by this change)

`packages/cli/src/__tests__/models-command.test.ts` — 2 tests (`does not attempt a live fetch or surface ollama-cloud models with no credentials configured`, `falls back to the static offline catalog when the live fetch fails`) fail with `SyntaxError: JSON Parse error: Unexpected EOF` **only** when run as part of the full 135-file `bun test packages/cli/src` suite. They pass reliably in isolation and in combination with the new test files from this PR. Confirmed via `git stash` that this reproduces identically on the pre-change `ns/p23-c-provider-adapter` tip — same failure, same 2 tests, before any of this PR's source changes. Almost certainly the same class of Bun full-process `console.log` monkey-patch race documented in existing Godmother ideas `ltl2EKmU`/`YiJdtVwz`. Captured as Godmother idea `f5ohlCyG` for follow-up; not addressed here per scope.

## New bugs found

None in-scope beyond the pre-existing flaky test above (captured, not fixed, per instructions not to chase unrelated failures).

Branch: `ns/0730-session-input`. Base: `ns/p23-c-provider-adapter` (not `main`). Not merged.
