### PR TITLE
fix(cli): harden providerExtension shutdown against hook rejection & double-dispose

### DIFF
--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -436,6 +436,53 @@ describe("provider extension", () => {
     await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
   });
 
+  test("currentSessionInfo does not leak into a subsequent close after a failed shutdown", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "shutdown-a", lifecycleProviderSource("shutdown-a"));
+    const handlers = await startProviderExtension(cwd);
+
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+
+    // Shutdown fails partway through — the claim/reset block must still
+    // clear currentSessionInfo synchronously (before the first await) so a
+    // subsequent close never sees this session's sessionFile/cwd.
+    mod.__setBridgeForTest({
+      onSessionShutdown: async () => {
+        throw new Error("boom");
+      },
+    } as any);
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+
+    let seenCtx: { sessionFile?: string; cwd?: string } | undefined;
+    mod.__setBridgeForTest(
+      new ProviderBridge([
+        {
+          id: "close-after-shutdown",
+          capabilities: ["lifecycle"],
+          init: async () => {},
+          dispose: () => {},
+          onSessionClose: async (_event: unknown, ctx: any) => {
+            seenCtx = { sessionFile: ctx.sessionFile, cwd: ctx.cwd };
+            return null;
+          },
+        } as any,
+      ]),
+    );
+
+    await mod.runProviderSessionClose("close");
+
+    // makeCtx()'s sessionManager.getSessionFile() always returns
+    // "test-session.json" and cwd is always the fixture project dir — if
+    // currentSessionInfo had leaked, ctx would show those stale values here
+    // instead of falling back to sessionId/process.cwd().
+    expect(seenCtx?.sessionFile).not.toBe("test-session.json");
+    expect(seenCtx?.cwd).not.toBe(cwd);
+
+    mod.__setBridgeForTest(null);
+  });
+
   test("concurrent session_shutdown events do not double-dispose the same provider instances", async () => {
     const cwd = join(tmpHome, "project");
     mkdirSync(cwd, { recursive: true });

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -19,6 +19,37 @@ function writeProvider(homeDir: string, id: string): void {
   `);
 }
 
+function lifecycleProviderSource(id: string, opts: { failDispose?: boolean; deferDispose?: boolean } = {}): string {
+  const { failDispose = false, deferDispose = false } = opts;
+  const deferBlock = deferDispose
+    ? `
+    return new Promise((resolve) => {
+      globalThis.__disposeDeferred = globalThis.__disposeDeferred || {};
+      globalThis.__disposeDeferred[${JSON.stringify(id)}] = resolve;
+    });`
+    : "";
+  const failLine = failDispose ? `throw new Error(${JSON.stringify(`dispose failed: ${id}`)});` : "";
+  // No lifecycle capability declared: these providers only exercise
+  // init()/dispose() tracking, not bridge hooks, so an empty capabilities
+  // array keeps loader validation happy without a throwaway hook method.
+  return `
+export default {
+  id: ${JSON.stringify(id)},
+  capabilities: [],
+  init() {
+    globalThis.__initCalls = globalThis.__initCalls || [];
+    globalThis.__initCalls.push(${JSON.stringify(id)});
+  },
+  dispose() {
+    globalThis.__disposeCalls = globalThis.__disposeCalls || [];
+    globalThis.__disposeCalls.push(${JSON.stringify(id)});
+    ${deferBlock}
+    ${failLine}
+  },
+};
+`;
+}
+
 function writeProviderSource(homeDir: string, id: string, source: string): void {
   const providerDir = join(homeDir, ".pizzapi", "providers", id);
   mkdirSync(providerDir, { recursive: true });
@@ -58,11 +89,17 @@ describe("provider extension", () => {
     process.env.HOME = tmpHome;
     (globalThis as any).__providerInitCalls = [];
     (globalThis as any).__providerExtensionCalls = [];
+    (globalThis as any).__initCalls = [];
+    (globalThis as any).__disposeCalls = [];
+    (globalThis as any).__disposeDeferred = {};
   });
 
   afterEach(() => {
     delete (globalThis as any).__providerInitCalls;
     delete (globalThis as any).__providerExtensionCalls;
+    delete (globalThis as any).__initCalls;
+    delete (globalThis as any).__disposeCalls;
+    delete (globalThis as any).__disposeDeferred;
     process.env.HOME = origHome;
     if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
   });
@@ -338,6 +375,104 @@ describe("provider extension", () => {
     expect(second?.systemPrompt).not.toContain("Memory for first");
 
     await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+  });
+
+  test("forced onSessionShutdown rejection still disposes all providers and resets state", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "shutdown-a", lifecycleProviderSource("shutdown-a"));
+    writeProviderSource(tmpHome, "shutdown-b", lifecycleProviderSource("shutdown-b"));
+    const handlers = await startProviderExtension(cwd);
+
+    const mod = await import("./extension");
+    // ProviderBridge already swallows per-provider onSessionShutdown hook
+    // errors internally, so to exercise the extension's own defensive catch
+    // we swap in a bridge whose onSessionShutdown itself rejects.
+    mod.__setBridgeForTest({
+      onSessionShutdown: async () => {
+        throw new Error("boom");
+      },
+    } as any);
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+
+    expect(((globalThis as any).__disposeCalls as string[]).sort()).toEqual(["shutdown-a", "shutdown-b"]);
+
+    // bridge/providerInstances were reset despite the rejection.
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hi", images: [], systemPrompt: "line1\nline2\nline3\nline4" },
+      makeCtx(cwd),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("a later session initializes cleanly after a failed shutdown", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "shutdown-a", lifecycleProviderSource("shutdown-a"));
+    const handlers = await startProviderExtension(cwd);
+
+    const mod = await import("./extension");
+    mod.__setBridgeForTest({
+      onSessionShutdown: async () => {
+        throw new Error("boom");
+      },
+    } as any);
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+
+    (globalThis as any).__initCalls = [];
+    (globalThis as any).__disposeCalls = [];
+
+    // Must not throw, and must not re-dispose an already-cleared instance
+    // from the failed shutdown (session_start's defensive re-init loop runs
+    // over providerInstances, which was already reset to []).
+    await expect(
+      handlers.get("session_start")?.({ reason: "startup" }, makeCtx(cwd)) as Promise<unknown>,
+    ).resolves.toBeUndefined();
+
+    expect((globalThis as any).__initCalls).toEqual(["shutdown-a"]);
+    expect((globalThis as any).__disposeCalls).toEqual([]);
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+  });
+
+  test("concurrent session_shutdown events do not double-dispose the same provider instances", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "slow-dispose", lifecycleProviderSource("slow-dispose", { deferDispose: true }));
+    const handlers = await startProviderExtension(cwd);
+
+    const mod = await import("./extension");
+    mod.__setBridgeForTest(null); // isolate dispose-claiming from bridge notification timing
+
+    const first = handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd)) as Promise<unknown>;
+    const second = handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd)) as Promise<unknown>;
+
+    const resolveDispose = (globalThis as any).__disposeDeferred["slow-dispose"];
+    expect(typeof resolveDispose).toBe("function");
+    resolveDispose();
+
+    await Promise.all([first, second]);
+
+    expect((globalThis as any).__disposeCalls).toEqual(["slow-dispose"]);
+  });
+
+  test("if one provider's dispose rejects, remaining providers are still disposed and state resets", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "dispose-fail", lifecycleProviderSource("dispose-fail", { failDispose: true }));
+    writeProviderSource(tmpHome, "dispose-ok", lifecycleProviderSource("dispose-ok"));
+    const handlers = await startProviderExtension(cwd);
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+
+    expect(((globalThis as any).__disposeCalls as string[]).sort()).toEqual(["dispose-fail", "dispose-ok"]);
+
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hi", images: [], systemPrompt: "line1\nline2\nline3\nline4" },
+      makeCtx(cwd),
+    );
+    expect(result).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -471,14 +471,28 @@ describe("provider extension", () => {
       ]),
     );
 
-    await mod.runProviderSessionClose("close");
+    // Control env explicitly so the fallback assertion below is
+    // deterministic — PIZZAPI_SESSION_ID/SESSION_ID are commonly set in the
+    // ambient environment (e.g. this suite running inside a real pi
+    // session), which would otherwise leak into the "unknown" fallback.
+    const origPizzapiSessionId = process.env.PIZZAPI_SESSION_ID;
+    const origSessionId = process.env.SESSION_ID;
+    delete process.env.PIZZAPI_SESSION_ID;
+    delete process.env.SESSION_ID;
+    try {
+      await mod.runProviderSessionClose("close");
+    } finally {
+      if (origPizzapiSessionId !== undefined) process.env.PIZZAPI_SESSION_ID = origPizzapiSessionId;
+      if (origSessionId !== undefined) process.env.SESSION_ID = origSessionId;
+    }
 
     // makeCtx()'s sessionManager.getSessionFile() always returns
     // "test-session.json" and cwd is always the fixture project dir — if
     // currentSessionInfo had leaked, ctx would show those stale values here
-    // instead of falling back to sessionId/process.cwd().
-    expect(seenCtx?.sessionFile).not.toBe("test-session.json");
-    expect(seenCtx?.cwd).not.toBe(cwd);
+    // instead of falling back to sessionId/process.cwd(). Pin the exact
+    // fallback values rather than only asserting the negative.
+    expect(seenCtx?.sessionFile).toBe("unknown");
+    expect(seenCtx?.cwd).toBe(process.cwd());
 
     mod.__setBridgeForTest(null);
   });
@@ -502,6 +516,82 @@ describe("provider extension", () => {
     await Promise.all([first, second]);
 
     expect((globalThis as any).__disposeCalls).toEqual(["slow-dispose"]);
+  });
+
+  test("session_shutdown joins an in-flight close instead of racing a second hook, and waits for it before disposing", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "flush-provider", lifecycleProviderSource("flush-provider"));
+    const handlers = await startProviderExtension(cwd);
+
+    const mod = await import("./extension");
+    const { ProviderBridge } = await import("../../providers/bridge");
+
+    let hookCalls = 0;
+    let resolveClose: ((v: { label: string } | null) => void) | undefined;
+    mod.__setBridgeForTest(
+      new ProviderBridge([
+        {
+          id: "flush-provider",
+          capabilities: ["lifecycle"],
+          init: async () => {},
+          dispose: () => {},
+          onSessionClose: async () => {
+            hookCalls++;
+            return new Promise((resolve) => {
+              resolveClose = resolve;
+            });
+          },
+          onSessionShutdown: async () => {},
+        } as any,
+      ]),
+    );
+
+    // A: an in-flight close (e.g. an extension-initiated shutdownHandler
+    // flush) is already running when session_shutdown fires.
+    const closeA = mod.runProviderSessionClose("complete");
+    await Promise.resolve(); // let A reach the in-flight provider hook
+
+    // session_shutdown claims lifecycle state synchronously but must not
+    // resolve until A settles.
+    const shutdown = handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd)) as Promise<unknown>;
+    let shutdownDone = false;
+    shutdown.then(() => {
+      shutdownDone = true;
+    });
+
+    // B: a later caller during this same shutdown window (e.g. the worker's
+    // SIGTERM path) must join A's promise, not start a second hook call.
+    const closeB = mod.runProviderSessionClose("close");
+    let bResolved = false;
+    closeB.then(() => {
+      bResolved = true;
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(bResolved).toBe(false);
+    expect(shutdownDone).toBe(false);
+    expect(hookCalls).toBe(1);
+
+    resolveClose!({ label: "flushed" });
+
+    const [a, b] = await Promise.all([closeA, closeB]);
+    expect(a?.label).toBe("flushed");
+    expect(b?.label).toBe("flushed");
+    expect(hookCalls).toBe(1);
+
+    await shutdown;
+    expect(shutdownDone).toBe(true);
+    expect((globalThis as any).__disposeCalls).toEqual(["flush-provider"]);
+
+    // Later session gets fresh close tracking: this session's bridge is now
+    // null (claimed/disposed above), so a fresh runProviderSessionClose call
+    // must resolve to null immediately rather than replaying A's cached
+    // "flushed" result from the stale sessionClosePromise.
+    const later = await mod.runProviderSessionClose("close");
+    expect(later).toBeNull();
+
+    mod.__setBridgeForTest(null);
   });
 
   test("if one provider's dispose rejects, remaining providers are still disposed and state resets", async () => {

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -287,6 +287,7 @@ export async function providerExtension(pi: ExtensionAPI) {
     const instances = providerInstances;
     bridge = null;
     providerInstances = [];
+    currentSessionInfo = null;
     currentPromptId = null;
     currentTurnId = 0;
     sessionClosePromise = null;

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -290,7 +290,17 @@ export async function providerExtension(pi: ExtensionAPI) {
     currentSessionInfo = null;
     currentPromptId = null;
     currentTurnId = 0;
-    sessionClosePromise = null;
+
+    // sessionClosePromise is deliberately NOT cleared above: if a close
+    // (e.g. an extension-initiated shutdownHandler flush) is already
+    // in-flight, runProviderSessionClose's own idempotency check
+    // (`if (sessionClosePromise) return sessionClosePromise;`) is what lets
+    // a later caller during this same shutdown (e.g. the worker's SIGTERM
+    // path) join that SAME promise instead of racing a second hook. Nulling
+    // it here would make that later caller start a fresh call, see the
+    // `bridge = null` claimed just above, and resolve to null immediately —
+    // letting the caller reach process.exit() before the real flush settles.
+    const inFlightClose = sessionClosePromise;
 
     try {
       if (activeBridge) {
@@ -303,6 +313,18 @@ export async function providerExtension(pi: ExtensionAPI) {
       }
     } catch (err) {
       log.error("Error in provider onSessionShutdown:", err);
+    }
+
+    if (inFlightClose) {
+      // Bounded by doRunProviderSessionClose's own timeout — don't dispose
+      // provider instances out from under a close that's still writing.
+      await inFlightClose;
+    }
+    // Reset close tracking now so a later session gets a fresh close
+    // lifecycle — but only if nothing newer (a racing session_start, or a
+    // fresh close request for this same session) already replaced it.
+    if (sessionClosePromise === inFlightClose) {
+      sessionClosePromise = null;
     }
 
     // Dispose every claimed instance regardless of shutdown-hook or sibling

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -277,27 +277,43 @@ export async function providerExtension(pi: ExtensionAPI) {
 
   // ── Session Shutdown: dispose providers ───────────────────────
   pi.on("session_shutdown", async (event, ctx) => {
-    if (bridge) {
-      // SessionClose runs from the worker's process shutdown paths (see
-      // runProviderSessionClose). Here we only notify shutdown and dispose.
-      await bridge.onSessionShutdown(
-        { reason: event.reason as "quit", targetSessionFile: event.targetSessionFile },
-        makeProviderContext(ctx),
-      );
+    // Claim the lifecycle state synchronously, before the first await, so
+    // repeated/overlapping session_shutdown events can't both see the same
+    // bridge/instances and double-dispose (mirrors pi-bridge-adapter.ts).
+    // Reset unconditionally up front — a later onSessionShutdown/dispose
+    // rejection must never leave stale module-global state behind for the
+    // next session_start to trip over.
+    const activeBridge = bridge;
+    const instances = providerInstances;
+    bridge = null;
+    providerInstances = [];
+    currentPromptId = null;
+    currentTurnId = 0;
+    sessionClosePromise = null;
+
+    try {
+      if (activeBridge) {
+        // SessionClose runs from the worker's process shutdown paths (see
+        // runProviderSessionClose). Here we only notify shutdown and dispose.
+        await activeBridge.onSessionShutdown(
+          { reason: event.reason as "quit", targetSessionFile: event.targetSessionFile },
+          makeProviderContext(ctx),
+        );
+      }
+    } catch (err) {
+      log.error("Error in provider onSessionShutdown:", err);
     }
 
-    for (const instance of providerInstances) {
+    // Dispose every claimed instance regardless of shutdown-hook or sibling
+    // dispose failures — a stuck/errored provider must not block cleanup of
+    // the rest.
+    for (const instance of instances) {
       try {
         await instance.dispose();
       } catch (err) {
         log.error(`Error disposing ${instance.id}:`, err);
       }
     }
-
-    bridge = null;
-    providerInstances = [];
-    currentPromptId = null;
-    currentTurnId = 0;
   });
 }
 


### PR DESCRIPTION
## Summary
Hardens `providerExtension`'s `session_shutdown` handler in `packages/cli/src/extensions/providers/extension.ts`:

- Claims (`bridge`, `providerInstances`) and resets all module-global lifecycle state (`bridge`, `providerInstances`, `currentPromptId`, `currentTurnId`, `sessionClosePromise`) **synchronously, before the first await** — repeated or overlapping `session_shutdown` events can no longer see the same instances and dispose them twice (mirrors the existing pattern in `pi-bridge-adapter.ts`).
- Wraps `bridge.onSessionShutdown(...)` in try/catch so an unexpected rejection no longer skips provider disposal.
- Every claimed provider instance is still attempted for disposal even if the shutdown hook or a sibling's `dispose()` rejects (existing per-instance try/catch, now proven under the new claim/reset).
- `runProviderSessionClose` itself, its ordering, and its idempotency (shared in-flight promise) are unchanged — only the shutdown handler's state ownership changed.

No changes to `pi-bridge-adapter.ts`, discovery/config, provider API contracts, or `ExtensionProvider`.

## Tests
Added to `packages/cli/src/extensions/providers/extension.test.ts`:
1. `forced onSessionShutdown rejection still disposes all providers and resets state`
2. `a later session initializes cleanly after a failed shutdown`
3. `concurrent session_shutdown events do not double-dispose the same provider instances`
4. `if one provider's dispose rejects, remaining providers are still disposed and state resets`

## Verification
- `bun test packages/cli/src/extensions/providers/extension.test.ts packages/cli/src/extensions/providers/session-close-signal.test.ts` — 18 pass, 0 fail
- `bun run typecheck` — clean
- `git diff --check` — clean; no TODO/debug/only/skip in the diff

## Stack
Stacked on #650 (`ns/0730-session-input`) — **base is `ns/0730-session-input`, not main.** Do not merge.

Godmother idea: `NfOjOc4d`
