### PR TITLE
feat(extension-sdk): add public overlay authoring contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.6",
+      "version": "0.5.61",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -49,6 +49,7 @@
         "@earendil-works/pi-ai": "^0.82.1",
         "@earendil-works/pi-coding-agent": "^0.82.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@pizzapi/extension-sdk": "workspace:*",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -70,6 +71,21 @@
         "@astrojs/starlight": "^0.40.0",
         "astro": "^6.4.6",
         "sharp": "^0.33.5",
+      },
+    },
+    "packages/extension-sdk": {
+      "name": "@pizzapi/extension-sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "@pizzapi/protocol": "workspace:*",
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.82.1",
+        "@types/bun": "^1.3.9",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*",
       },
     },
     "packages/protocol": {
@@ -844,6 +860,8 @@
     "@pizzapi/cli": ["@pizzapi/cli@workspace:packages/cli"],
 
     "@pizzapi/docs": ["@pizzapi/docs@workspace:packages/docs"],
+
+    "@pizzapi/extension-sdk": ["@pizzapi/extension-sdk@workspace:packages/extension-sdk"],
 
     "@pizzapi/mobile": ["@pizzapi/mobile@workspace:mobile"],
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": [
     "packages/protocol",
+    "packages/extension-sdk",
     "packages/tunnel",
     "packages/tools",
     "packages/server",
@@ -12,10 +13,11 @@
     "mobile"
   ],
   "scripts": {
-    "build": "bun run build:protocol && bun run build:tunnel && bun run build:tools && bun run build:server && bun run build:ui && bun run build:cli",
+    "build": "bun run build:protocol && bun run build:extension-sdk && bun run build:tunnel && bun run build:tools && bun run build:server && bun run build:ui && bun run build:cli",
     "build:docs": "cd packages/docs && bun run build",
     "dev:docs": "cd packages/docs && bun run dev",
     "build:protocol": "cd packages/protocol && bun run build",
+    "build:extension-sdk": "cd packages/extension-sdk && bun run build",
     "build:tunnel": "cd packages/tunnel && bun run build",
     "build:tools": "cd packages/tools && bun run build",
     "build:server": "cd packages/server && bun run build",
@@ -39,10 +41,10 @@
     "dev:redis:stop": "bash scripts/stop-redis.sh",
     "dev:cli": "bun packages/cli/src/index.ts",
     "dev:runner": "bun packages/cli/src/index.ts runner",
-    "test": "bun test --max-concurrency=1 scripts/start-redis.test.ts packages/protocol/src packages/tunnel/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/server/tests/mobile-ota.test.ts packages/tools/src && bun scripts/test-isolated.ts packages/server/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun scripts/test-isolated.ts packages/server/tests/harness && bun test --max-concurrency=1 packages/server/tests/browser-smoke.test.ts && bun scripts/test-isolated.ts packages/cli/src && cd packages/ui && bun test src && cd ../.. && bun test mobile",
-    "typecheck": "bun packages/cli/scripts/compile-prompt.ts && tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
+    "test": "bun test --max-concurrency=1 scripts/start-redis.test.ts packages/protocol/src packages/extension-sdk/src packages/tunnel/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/server/tests/mobile-ota.test.ts packages/tools/src && bun scripts/test-isolated.ts packages/server/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun scripts/test-isolated.ts packages/server/tests/harness && bun test --max-concurrency=1 packages/server/tests/browser-smoke.test.ts && bun scripts/test-isolated.ts packages/cli/src && cd packages/ui && bun test src && cd ../.. && bun test mobile",
+    "typecheck": "bun packages/cli/scripts/compile-prompt.ts && tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/extension-sdk typecheck:tests && bun run --cwd packages/server typecheck:tests",
     "migrate": "cd packages/server && bun run migrate",
-    "clean": "bun -e \"['protocol','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",
+    "clean": "bun -e \"['protocol','extension-sdk','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",
     "postinstall": "bun scripts/link-workspaces.ts"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "@earendil-works/pi-ai": "^0.82.1",
     "@earendil-works/pi-coding-agent": "^0.82.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@pizzapi/extension-sdk": "workspace:*",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",
     "@pizzapi/tunnel": "workspace:*",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { existsSync, rmSync } from "node:fs";
 import { forceKillTree, isShutdownMessage, requestChildShutdown, STOP_FILE_NAME } from "./process-kill.js";
 import { ServiceRegistry, type ServiceHandler, type ServiceInitOptions } from "./service-handler.js";
+import type { PizzaPiSocket } from "@pizzapi/extension-sdk";
 import { TerminalService } from "./services/terminal-service.js";
 import { FileExplorerService } from "./services/file-explorer-service.js";
 import { GitService, GIT_SIGIL_DEFS } from "./services/git-service.js";
@@ -139,7 +140,7 @@ export function initServiceHandlers(
     for (const handler of handlers) {
         if (initializedIds.has(handler.id)) continue;
         try {
-            handler.init(socket, makeOpts(handler));
+            handler.init(socket as unknown as PizzaPiSocket, makeOpts(handler));
             initializedIds.add(handler.id);
             initialized.push(handler.id);
         } catch (err) {
@@ -1094,7 +1095,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                                 ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
                             });
                         }
-                        handler.init(socket, optsForInit(handler.id));
+                        handler.init(socket as unknown as PizzaPiSocket, optsForInit(handler.id));
                         initializedServiceIds.add(handler.id);
                         if (typeof handler.reconcileSubscriptions === "function") {
                             const subs = cachedTriggerSubscriptions.filter((sub) => sub.triggerType?.split(":")[0] === handler.id);

--- a/packages/cli/src/runner/service-handler.test.ts
+++ b/packages/cli/src/runner/service-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import { ServiceRegistry } from "./service-handler.js";
-import type { ServiceHandler, ServiceInitOptions } from "./service-handler.js";
+import type { ServiceHandler, ServiceInitOptions, PizzaPiSocket } from "./service-handler.js";
 import type { Socket } from "socket.io-client";
 
 function makeMockSocket(): Socket {
@@ -16,7 +16,7 @@ describe("ServiceRegistry", () => {
         const registry = new ServiceRegistry();
         const socket = makeMockSocket();
         const options: ServiceInitOptions = { isShuttingDown: () => false };
-        const initCalls: Array<{ id: string; socket: Socket; options: ServiceInitOptions }> = [];
+        const initCalls: Array<{ id: string; socket: PizzaPiSocket; options: ServiceInitOptions }> = [];
 
         const makeHandler = (id: string): ServiceHandler => ({
             id,

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -1,91 +1,23 @@
 import type { Socket } from "socket.io-client";
-import type { TriggerSubscriptionDelta, TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import type { PizzaPiSocket, ServiceHandler, ServiceInitOptions } from "@pizzapi/extension-sdk";
 import { logError } from "./logger.js";
 
-/**
- * Interface for runner-side service handlers.
- * Each service registers its socket event handlers in init() and cleans up in dispose().
- */
-export interface ServiceHandler {
-    /** Unique service identifier (e.g., "terminal", "file-explorer", "git") */
-    readonly id: string;
-
-    /**
-     * Initialize the service — register socket event listeners and perform setup.
-     * Called once during daemon startup. Socket.IO reconnects reuse the same
-     * Socket instance, so listeners remain attached across transient reconnects.
-     */
-    init(socket: Socket, options: ServiceInitOptions): void;
-
-    /**
-     * Clean up the service — kill processes, clear state, remove listeners.
-     * Called on daemon shutdown.
-     */
-    dispose(): void;
-
-    /**
-     * Clean up any state tied to a specific session when that session ends.
-     * Optional — services that don't manage per-session runtime state can skip it.
-     */
-    handleSessionEnded?(sessionId: string): void;
-
-    /**
-     * Reconcile in-memory subscription state against a full snapshot from the server.
-     * Called after runner reconnection with the subset of subscriptions relevant to
-     * this service's trigger types. Services that manage runtime state per subscription
-     * (e.g. timers, watchers) should implement this to rebuild that state.
-     *
-     * Optional — services that don't manage per-subscription state can skip this.
-     */
-    reconcileSubscriptions?(subscriptions: TriggerSubscriptionEntry[], options?: ReconcileOptions): ReconcileResult;
-}
-
-/**
- * Result of a reconcileSubscriptions call.
- */
-export interface ReconcileResult {
-    /** Number of subscriptions successfully reconciled. */
-    applied: number;
-    /** Optional error messages for subscriptions that failed. */
-    errors?: string[];
-}
-
-export interface ReconcileOptions {
-    /** Full snapshot rebuild vs. single live delta application. */
-    mode?: "snapshot" | "delta";
-    /** Delta action when mode === "delta". */
-    action?: TriggerSubscriptionDelta["action"];
-}
-
-export interface ServiceInitOptions {
-    isShuttingDown: () => boolean;
-    /** Call to announce a panel HTTP server port. Only provided to services with a panel manifest. */
-    announcePanel?: (port: number) => void;
-    /**
-     * Call to announce an HTTP server that handles sigil resolve calls but has no UI panel.
-     * The port is registered with the tunnel proxy for routing and stamped onto the service's
-     * sigil definitions so the UI can reach it — but the service does NOT appear in the
-     * panels list and is not shown in the services grid.
-     */
-    announceSigilServer?: (port: number) => void;
-}
-
-/**
- * Generic relay protocol envelope.
- * All service messages conceptually flow through this shape, even though
- * the actual socket events don't change in Phase 1 (relay unchanged).
- */
-export interface ServiceEnvelope {
-    serviceId: string;
-    type: string;
-    requestId?: string;
-    /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
-    sessionId?: string;
-    payload: unknown;
-}
+// Canonical public contract lives in @pizzapi/extension-sdk. Re-exported here
+// so existing internal `./service-handler.js` imports keep working unchanged.
+export type {
+  PizzaPiSocket,
+  ServiceHandler,
+  ServiceInitOptions,
+  ServiceEnvelope,
+  ReconcileResult,
+  ReconcileOptions,
+  TriggerSubscriptionEntry,
+  TriggerSubscriptionDelta,
+} from "@pizzapi/extension-sdk";
 
 /**
  * Registry of service handlers. The daemon uses this to register and dispose services.
+ * Host-side only — not part of the public extension-sdk contract.
  */
 export class ServiceRegistry {
     private readonly handlers = new Map<string, ServiceHandler>();
@@ -113,10 +45,16 @@ export class ServiceRegistry {
         return Array.from(this.handlers.values());
     }
 
-    /** Initialize all registered services against the given socket. */
+    /**
+     * Initialize all registered services against the given socket.
+     * The real runner socket is typed against the strict runner namespace
+     * event maps; service handlers use the narrower @pizzapi/extension-sdk
+     * `PizzaPiSocket` contract, so the widening happens once here.
+     */
     initAll(socket: Socket, options: ServiceInitOptions): void {
+        const pizzapiSocket = socket as unknown as PizzaPiSocket;
         for (const handler of this.handlers.values()) {
-            handler.init(socket, options);
+            handler.init(pizzapiSocket, options);
         }
     }
 

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@pizzapi/extension-sdk",
+  "version": "0.1.0",
+  "description": "Public authoring contract for PizzaPi overlay packages",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Pizzaface/PizzaPi.git",
+    "directory": "packages/extension-sdk"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.test.json --noEmit"
+  },
+  "dependencies": {
+    "@pizzapi/protocol": "workspace:*"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.82.1",
+    "@types/bun": "^1.3.9",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/extension-sdk/src/host.test.ts
+++ b/packages/extension-sdk/src/host.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { createEventBus } from "@earendil-works/pi-coding-agent";
+import type { PizzaPiHostAPI, PizzaPiHostInfo } from "./host.js";
+import { detectPizzaPiHost, isPizzaPiHostInfo, onPizzaPiHost } from "./host.js";
+
+const fakePi = (events: ReturnType<typeof createEventBus>): PizzaPiHostAPI => ({ events });
+
+function respond(data: unknown, value: unknown): void {
+  if (!data || typeof data !== "object" || !("respond" in data)) return;
+  const callback = (data as { respond?: unknown }).respond;
+  if (typeof callback === "function") callback(value);
+}
+
+describe("isPizzaPiHostInfo", () => {
+  test("accepts a valid host info payload", () => {
+    expect(isPizzaPiHostInfo({ apiVersion: 1, capabilities: ["panels", "triggers"] })).toBe(true);
+  });
+
+  test("rejects malformed payloads", () => {
+    expect(isPizzaPiHostInfo(undefined)).toBe(false);
+    expect(isPizzaPiHostInfo(null)).toBe(false);
+    expect(isPizzaPiHostInfo({ apiVersion: 2, capabilities: [] })).toBe(false);
+    expect(isPizzaPiHostInfo({ apiVersion: 1, capabilities: ["ok", 1] })).toBe(false);
+    expect(isPizzaPiHostInfo({ apiVersion: 1 })).toBe(false);
+  });
+});
+
+describe("detectPizzaPiHost", () => {
+  test("returns undefined when no host responds (vanilla pi)", () => {
+    expect(detectPizzaPiHost(fakePi(createEventBus()))).toBeUndefined();
+  });
+
+  test("pins pi's real event bus synchronous first-tick dispatch", () => {
+    const bus = createEventBus();
+    const info: PizzaPiHostInfo = { apiVersion: 1, capabilities: ["panels"] };
+    bus.on("pizzapi:host:probe", (data) => respond(data, info));
+    expect(detectPizzaPiHost(fakePi(bus))).toEqual(info);
+  });
+
+  test("does not accept a response deferred past emit", async () => {
+    const bus = createEventBus();
+    const info: PizzaPiHostInfo = { apiVersion: 1, capabilities: ["panels"] };
+    bus.on("pizzapi:host:probe", async (data) => {
+      await Promise.resolve();
+      respond(data, info);
+    });
+    expect(detectPizzaPiHost(fakePi(bus))).toBeUndefined();
+    await Promise.resolve();
+  });
+
+  test("ignores an invalid synchronous response", () => {
+    const bus = createEventBus();
+    bus.on("pizzapi:host:probe", (data) => respond(data, { bogus: true }));
+    expect(detectPizzaPiHost(fakePi(bus))).toBeUndefined();
+  });
+});
+
+describe("onPizzaPiHost", () => {
+  test("delivers immediately when the probe succeeds synchronously", () => {
+    const bus = createEventBus();
+    const info: PizzaPiHostInfo = { apiVersion: 1, capabilities: [] };
+    bus.on("pizzapi:host:probe", (data) => respond(data, info));
+    let delivered: unknown;
+    onPizzaPiHost(fakePi(bus), (host) => (delivered = host));
+    expect(delivered).toEqual(info);
+  });
+
+  test("delivers once from a real-bus ready event", () => {
+    const bus = createEventBus();
+    const calls: PizzaPiHostInfo[] = [];
+    onPizzaPiHost(fakePi(bus), (host) => calls.push(host));
+
+    const info: PizzaPiHostInfo = { apiVersion: 1, capabilities: ["panels"] };
+    bus.emit("pizzapi:host:ready", info);
+    bus.emit("pizzapi:host:ready", { apiVersion: 1, capabilities: ["should-not-redeliver"] });
+
+    expect(calls).toEqual([info]);
+  });
+
+  test("unsubscribe stops delivery", () => {
+    const bus = createEventBus();
+    const calls: PizzaPiHostInfo[] = [];
+    const unsubscribe = onPizzaPiHost(fakePi(bus), (host) => calls.push(host));
+    unsubscribe();
+    bus.emit("pizzapi:host:ready", { apiVersion: 1, capabilities: [] });
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/extension-sdk/src/host.ts
+++ b/packages/extension-sdk/src/host.ts
@@ -1,0 +1,56 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export interface PizzaPiHostInfo {
+  apiVersion: 1;
+  capabilities: readonly string[];
+}
+
+export type PizzaPiHostAPI = Pick<ExtensionAPI, "events">;
+
+export function isPizzaPiHostInfo(value: unknown): value is PizzaPiHostInfo {
+  if (!value || typeof value !== "object") return false;
+  const host = value as Record<string, unknown>;
+  return (
+    host.apiVersion === 1 &&
+    Array.isArray(host.capabilities) &&
+    host.capabilities.every((item) => typeof item === "string")
+  );
+}
+
+/**
+ * Synchronous host probe. The PizzaPi host's `pizzapi:host:probe` listener
+ * (if present) must respond synchronously — pi's event bus dispatches
+ * listeners synchronously before `emit()` returns, but only the first
+ * synchronous tick of an async listener runs before then.
+ */
+export function detectPizzaPiHost(pi: PizzaPiHostAPI): PizzaPiHostInfo | undefined {
+  let host: PizzaPiHostInfo | undefined;
+  pi.events.emit("pizzapi:host:probe", {
+    respond(value: unknown) {
+      if (!host && isPizzaPiHostInfo(value)) host = value;
+    },
+  });
+  return host;
+}
+
+/**
+ * Subscribes to host readiness. Delivers immediately if the host already
+ * responded to a synchronous probe, otherwise waits for the host's
+ * `pizzapi:host:ready` announcement. Delivers at most once.
+ */
+export function onPizzaPiHost(pi: PizzaPiHostAPI, callback: (host: PizzaPiHostInfo) => void): () => void {
+  let delivered = false;
+  let unsubscribe = () => {};
+  const deliver = (host: PizzaPiHostInfo) => {
+    if (delivered) return;
+    delivered = true;
+    unsubscribe();
+    callback(host);
+  };
+  unsubscribe = pi.events.on("pizzapi:host:ready", (data: unknown) => {
+    if (isPizzaPiHostInfo(data)) deliver(data);
+  });
+  const current = detectPizzaPiHost(pi);
+  if (current) deliver(current);
+  return unsubscribe;
+}

--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -1,0 +1,21 @@
+// @pizzapi/extension-sdk — public authoring contract for PizzaPi overlay packages.
+// See docs/specs/pi-pizzapi-overlay.md for the normative spec.
+
+export type {
+  PizzaPiSocket,
+  ServiceHandler,
+  ServiceInitOptions,
+  ServiceEnvelope,
+  ReconcileResult,
+  ReconcileOptions,
+  TriggerSubscriptionEntry,
+  TriggerSubscriptionDelta,
+} from "./service.js";
+
+export type { PizzaPiOverlayV1, PizzaPiServiceDeclaration, PanelVariable } from "./overlay.js";
+
+export type { PizzaPiHostInfo, PizzaPiHostAPI } from "./host.js";
+export { isPizzaPiHostInfo, detectPizzaPiHost, onPizzaPiHost } from "./host.js";
+
+// Re-exported protocol declaration types required by the public service contract.
+export type { ServiceTriggerDef, ServiceSigilDef, ServicePanelInfo, ServiceTriggerParamDef } from "@pizzapi/protocol";

--- a/packages/extension-sdk/src/overlay.ts
+++ b/packages/extension-sdk/src/overlay.ts
@@ -1,0 +1,28 @@
+import type { ServiceSigilDef, ServiceTriggerDef } from "@pizzapi/protocol";
+
+/**
+ * `pi.pizzapi` package manifest overlay — schema version 1.
+ * See docs/specs/pi-pizzapi-overlay.md for the normative spec.
+ */
+export interface PizzaPiOverlayV1 {
+  schemaVersion: 1;
+  services?: PizzaPiServiceDeclaration[];
+  agents?: string[];
+  rules?: string[];
+  mcp?: string;
+}
+
+export interface PizzaPiServiceDeclaration {
+  id: string;
+  label: string;
+  entry: string;
+  icon?: string;
+  panel?: {
+    dir: string;
+    requires?: PanelVariable[];
+  };
+  triggers?: string | ServiceTriggerDef[];
+  sigils?: string | ServiceSigilDef[];
+}
+
+export type PanelVariable = "PWD" | "SESSION_ID" | "HOME" | "USER" | "PROJECT_DIR";

--- a/packages/extension-sdk/src/service.test.ts
+++ b/packages/extension-sdk/src/service.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { PizzaPiSocket, ServiceHandler, ServiceInitOptions } from "./service.js";
+
+describe("public service contract", () => {
+  test("a typed handler works against a plain event-emitter socket", () => {
+    const listeners = new Map<string, (args: unknown[]) => void>();
+    const socket: PizzaPiSocket = {
+      on<Args extends unknown[]>(event: string, listener: (...args: Args) => void) {
+        listeners.set(event, (args) => listener(...(args as Args)));
+        return socket;
+      },
+      off(event) {
+        listeners.delete(event);
+        return socket;
+      },
+      emit(event, ...args) {
+        listeners.get(event)?.(args);
+        return true;
+      },
+    };
+
+    let initialized = false;
+    let disposed = false;
+    let endedSession: string | undefined;
+    const handler: ServiceHandler = {
+      id: "example",
+      init(sock, options: ServiceInitOptions) {
+        initialized = true;
+        sock.on("ping", (message: string) => sock.emit("pong", message.length));
+        expect(options.isShuttingDown()).toBe(false);
+      },
+      dispose() {
+        disposed = true;
+      },
+      handleSessionEnded(sessionId) {
+        endedSession = sessionId;
+      },
+    };
+
+    handler.init(socket, { isShuttingDown: () => false });
+    expect(initialized).toBe(true);
+
+    let pong = 0;
+    socket.on("pong", (length: number) => (pong = length));
+    socket.emit("ping", "hello");
+    expect(pong).toBe(5);
+
+    handler.handleSessionEnded?.("session-1");
+    expect(endedSession).toBe("session-1");
+
+    handler.dispose();
+    expect(disposed).toBe(true);
+  });
+});

--- a/packages/extension-sdk/src/service.ts
+++ b/packages/extension-sdk/src/service.ts
@@ -1,0 +1,96 @@
+import type { TriggerSubscriptionDelta, TriggerSubscriptionEntry } from "@pizzapi/protocol";
+
+/**
+ * Narrow socket shape actually used by service handlers. Structurally
+ * compatible with a socket.io-client `Socket`, but this package does not
+ * depend on socket.io-client — hosts pass their real socket instance in.
+ */
+export interface PizzaPiSocket {
+  on<Args extends unknown[]>(event: string, listener: (...args: Args) => void): unknown;
+  off<Args extends unknown[]>(event: string, listener: (...args: Args) => void): unknown;
+  emit<Args extends unknown[]>(event: string, ...args: Args): unknown;
+}
+
+/**
+ * Interface for runner-side service handlers.
+ * Each service registers its socket event handlers in init() and cleans up in dispose().
+ */
+export interface ServiceHandler {
+  /** Unique service identifier (e.g., "terminal", "file-explorer", "git") */
+  readonly id: string;
+
+  /**
+   * Initialize the service — register socket event listeners and perform setup.
+   * Called once during daemon startup. Socket.IO reconnects reuse the same
+   * Socket instance, so listeners remain attached across transient reconnects.
+   */
+  init(socket: PizzaPiSocket, options: ServiceInitOptions): void;
+
+  /**
+   * Clean up the service — kill processes, clear state, remove listeners.
+   * Called on daemon shutdown.
+   */
+  dispose(): void;
+
+  /**
+   * Clean up any state tied to a specific session when that session ends.
+   * Optional — services that don't manage per-session runtime state can skip it.
+   */
+  handleSessionEnded?(sessionId: string): void;
+
+  /**
+   * Reconcile in-memory subscription state against a full snapshot from the server.
+   * Called after runner reconnection with the subset of subscriptions relevant to
+   * this service's trigger types. Services that manage runtime state per subscription
+   * (e.g. timers, watchers) should implement this to rebuild that state.
+   *
+   * Optional — services that don't manage per-subscription state can skip this.
+   */
+  reconcileSubscriptions?(subscriptions: TriggerSubscriptionEntry[], options?: ReconcileOptions): ReconcileResult;
+}
+
+/**
+ * Result of a reconcileSubscriptions call.
+ */
+export interface ReconcileResult {
+  /** Number of subscriptions successfully reconciled. */
+  applied: number;
+  /** Optional error messages for subscriptions that failed. */
+  errors?: string[];
+}
+
+export interface ReconcileOptions {
+  /** Full snapshot rebuild vs. single live delta application. */
+  mode?: "snapshot" | "delta";
+  /** Delta action when mode === "delta". */
+  action?: TriggerSubscriptionDelta["action"];
+}
+
+export interface ServiceInitOptions {
+  isShuttingDown: () => boolean;
+  /** Call to announce a panel HTTP server port. Only provided to services with a panel manifest. */
+  announcePanel?: (port: number) => void;
+  /**
+   * Call to announce an HTTP server that handles sigil resolve calls but has no UI panel.
+   * The port is registered with the tunnel proxy for routing and stamped onto the service's
+   * sigil definitions so the UI can reach it — but the service does NOT appear in the
+   * panels list and is not shown in the services grid.
+   */
+  announceSigilServer?: (port: number) => void;
+}
+
+/**
+ * Generic relay protocol envelope.
+ * All service messages conceptually flow through this shape, even though
+ * the actual socket events don't change in Phase 1 (relay unchanged).
+ */
+export interface ServiceEnvelope {
+  serviceId: string;
+  type: string;
+  requestId?: string;
+  /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
+  sessionId?: string;
+  payload: unknown;
+}
+
+export type { TriggerSubscriptionEntry, TriggerSubscriptionDelta };

--- a/packages/extension-sdk/tsconfig.json
+++ b/packages/extension-sdk/tsconfig.json
@@ -5,8 +5,8 @@
         "rootDir": "src"
     },
     "include": ["src"],
+    "exclude": ["src/**/*.test.ts"],
     "references": [
-        { "path": "../protocol" },
-        { "path": "../extension-sdk" }
+        { "path": "../protocol" }
     ]
 }

--- a/packages/extension-sdk/tsconfig.test.json
+++ b/packages/extension-sdk/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/scripts/link-workspaces.ts
+++ b/scripts/link-workspaces.ts
@@ -8,7 +8,7 @@ import { join, resolve } from "path";
 
 const root = resolve(import.meta.dirname, "..");
 const scope = join(root, "node_modules", "@pizzapi");
-const packages = ["cli", "docs", "protocol", "server", "tools", "tunnel", "ui"];
+const packages = ["cli", "docs", "extension-sdk", "protocol", "server", "tools", "tunnel", "ui"];
 
 mkdirSync(scope, { recursive: true });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "files": [],
     "references": [
         { "path": "packages/protocol" },
+        { "path": "packages/extension-sdk" },
         { "path": "packages/tunnel" },
         { "path": "packages/tools" },
         { "path": "packages/server" },


### PR DESCRIPTION
## Summary

- add the publishable `@pizzapi/extension-sdk` workspace package
- extract the canonical runner-service contract behind a minimal typed socket interface
- publish overlay manifest and PizzaPi host-detection types/helpers
- re-export the required `@pizzapi/protocol` declaration types
- keep CLI imports compatible through a thin re-export

## Validation

- `bun test packages/extension-sdk/src packages/cli/src/runner/service-handler.test.ts` — 12 passed
- `bun run --cwd packages/extension-sdk typecheck:tests` — passed
- `bun run typecheck` — passed
- `bun run --cwd packages/extension-sdk build` — passed
- `bun pm pack --destination /tmp/pizzapi-sdk-pack` — dist-only artifact verified
- independent Fable re-review — LGTM, no P0–P2 findings

## Follow-up

- Godmother `5x1fgxyr` tracks publishing `@pizzapi/protocol` before the SDK's first npm release.

## Stack

- base: #652 (`feat/pi-pizzapi-overlay-spec`)
- no merge performed
