### PR TITLE
feat(cli): add pi.pizzapi validation and daemon grants

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -331,6 +331,20 @@ export interface ProviderConfig {
   [key: string]: unknown;
 }
 
+/**
+ * A daemon-service trust grant for one `pi.pizzapi` overlay package.
+ *
+ * Distinct from pi's project trust, `trustedPlugins` (legacy plugin-path
+ * allowlist), and `disabledRunnerServices` (on/off switch *after* trust).
+ * See docs/specs/pi-pizzapi-overlay.md §7.2.
+ */
+export interface OverlayServiceGrant {
+    /** Normalized package identity, e.g. "npm:@acme/pi-github", "local:/abs/path". */
+    package: string;
+    /** Exact granted service IDs. A package update that adds a service does not auto-grant it. */
+    services: string[];
+}
+
 export interface PizzaPiConfig {
     /** Override the default system prompt */
     systemPrompt?: string;
@@ -560,4 +574,15 @@ export interface PizzaPiConfig {
 
     /** Extension provider configurations, keyed by provider ID. */
     providers?: Record<string, ProviderConfig>;
+
+    /**
+     * Explicit per-package, per-service daemon trust grants for `pi.pizzapi`
+     * overlay packages. Keyed by normalized package identity — separate from
+     * pi project trust, `trustedPlugins`, and `disabledRunnerServices`.
+     *
+     * Always stored in the GLOBAL ~/.pizzapi/config.json. Project packages
+     * never receive grants here in schema v1 (see docs/specs/pi-pizzapi-overlay.md §6.3).
+     * Managed via `pizza install --allow-daemon-services` / `pizza config grant|revoke`.
+     */
+    overlayServiceGrants?: OverlayServiceGrant[];
 }

--- a/packages/cli/src/overlay/cli-support.ts
+++ b/packages/cli/src/overlay/cli-support.ts
@@ -1,0 +1,256 @@
+/**
+ * `pizza install|list|config` overlay trust UX — flag stripping, install-time
+ * grant prompts, and list/config grant-state rendering.
+ *
+ * All overlay reading goes through readOverlayManifest() (manifest.ts); this
+ * module only adds the CLI-facing prompt/print/grant plumbing described in
+ * docs/specs/pi-pizzapi-overlay.md §7.3.
+ */
+import { createInterface } from "node:readline";
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { c } from "../cli-colors.js";
+import { loadGlobalConfig } from "../config/io.js";
+import { computePackageIdentity } from "./identity.js";
+import { formatOverlayIssue, readOverlayManifest, type OverlayReadResult, type PackageProvenance } from "./manifest.js";
+import { getGrantedServiceIds, grantServices, resolveServiceGrantState } from "./grants.js";
+import { defaultStatePath, isPidRunning, type RunnerState } from "../runner/runner-state.js";
+import { existsSync, readFileSync } from "node:fs";
+
+export interface DaemonServiceFlagResult {
+    args: string[];
+    /** true = --allow-daemon-services, false = --no-allow-daemon-services, undefined = neither given. */
+    allowDaemonServices: boolean | undefined;
+}
+
+/** Pre-parse and strip --allow-daemon-services / --no-allow-daemon-services, mirroring stripCwdFlag(). */
+export function stripDaemonServiceFlags(args: string[]): DaemonServiceFlagResult {
+    let allowDaemonServices: boolean | undefined;
+    const out: string[] = [];
+    for (const arg of args) {
+        if (arg === "--allow-daemon-services") {
+            allowDaemonServices = true;
+            continue;
+        }
+        if (arg === "--no-allow-daemon-services") {
+            allowDaemonServices = false;
+            continue;
+        }
+        out.push(arg);
+    }
+    return { args: out, allowDaemonServices };
+}
+
+function firstPositional(args: string[]): string | undefined {
+    return args.slice(1).find((a) => !a.startsWith("-"));
+}
+
+function isLocalScopeInstall(args: string[]): boolean {
+    return args.includes("-l") || args.includes("--local");
+}
+
+/** Best-effort: is a runner daemon currently running? Informational only — no new IPC. */
+function describeRunningDaemon(): string {
+    try {
+        const path = defaultStatePath();
+        if (!existsSync(path)) return "Grant changes will take effect the next time the daemon starts.";
+        const state = JSON.parse(readFileSync(path, "utf-8")) as Partial<RunnerState>;
+        const pid = typeof state.pid === "number" ? state.pid : 0;
+        if (pid > 0 && isPidRunning(pid)) {
+            return "A runner daemon is currently running — restart it (or wait for the next scheduled restart) to apply this grant change; automatic reconciliation lands with daemon package-service discovery.";
+        }
+    } catch {
+        // best-effort only
+    }
+    return "Grant changes will take effect the next time the daemon starts.";
+}
+
+function askYesNo(question: string): Promise<boolean> {
+    const iface = createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => {
+        iface.question(question, (answer) => {
+            iface.close();
+            resolve(/^y(es)?$/i.test(answer.trim()));
+        });
+    });
+}
+
+function packageManagerFor(cwd: string, agentDir: string): DefaultPackageManager {
+    const settingsManager = SettingsManager.create(cwd, agentDir);
+    return new DefaultPackageManager({ cwd, agentDir, settingsManager });
+}
+
+function readOverlayFor(cwd: string, agentDir: string, source: string, scope: "user" | "project"): { provenance: PackageProvenance; result: OverlayReadResult } | undefined {
+    const pm = packageManagerFor(cwd, agentDir);
+    const installedPath = pm.getInstalledPath(source, scope);
+    if (!installedPath) return undefined;
+    const identity = computePackageIdentity(source, agentDir).identity;
+    const provenance: PackageProvenance = { identity, source, scope };
+    return { provenance, result: readOverlayManifest(installedPath, provenance) };
+}
+
+/**
+ * Run after a successful upstream `pizza install <source>`. Validates the
+ * overlay and, for user-scoped packages that declare services, grants or
+ * warns per §7.3. Returns the exit code the CLI should use (0 unless the
+ * overlay is malformed).
+ */
+export async function handlePostInstallOverlay(args: string[], cwd: string, agentDir: string, allowDaemonServices: boolean | undefined): Promise<number> {
+    const source = firstPositional(args);
+    if (!source) return 0;
+    const scope: "user" | "project" = isLocalScopeInstall(args) ? "project" : "user";
+
+    const found = readOverlayFor(cwd, agentDir, source, scope);
+    if (!found) return 0; // not resolvable (e.g. install itself failed) — nothing to validate
+    const { provenance, result } = found;
+
+    if (result.present && result.overlay === null) {
+        console.error(`\n${c.error("✗")} pi.pizzapi overlay is invalid for ${c.cmd(provenance.identity)}:\n`);
+        for (const iss of result.issues) {
+            console.error(`  ${c.error("•")} ${formatOverlayIssue(iss)}`);
+        }
+        console.error(
+            `\n${c.warning("Note:")} the pi-native package install may remain in place (upstream install is not transactional).\n` +
+            `No daemon service grant was created. Run ${c.cmd(`pizza remove ${source}`)} to undo the install.\n`,
+        );
+        return 1;
+    }
+
+    if (!result.overlay || !result.overlay.services || result.overlay.services.length === 0) {
+        return 0;
+    }
+
+    const declaredIds = result.overlay.services.map((s) => s.id);
+
+    if (scope === "project") {
+        console.log(
+            `\n${c.warning("Note:")} ${c.cmd(provenance.identity)} declares runner service(s) [${declaredIds.join(", ")}], ` +
+            `but project-scoped packages do not mount daemon services in schema v1. The session-side surface (extensions/skills/agents/rules/mcp) still loads after project trust.\n`,
+        );
+        return 0;
+    }
+
+    if (allowDaemonServices === true) {
+        grantServices(provenance.identity, declaredIds);
+        console.log(`\n${c.success("✓")} Granted daemon service(s) [${declaredIds.join(", ")}] for ${c.cmd(provenance.identity)}.`);
+        console.log(`  ${describeRunningDaemon()}\n`);
+        return 0;
+    }
+
+    if (allowDaemonServices === false) {
+        console.log(
+            `\n${c.warning("Note:")} ${c.cmd(provenance.identity)} declares runner service(s) [${declaredIds.join(", ")}] — left ${c.warning("untrusted")} (--no-allow-daemon-services). ` +
+            `Run ${c.cmd(`pizza config grant ${source}`)} to trust them later.\n`,
+        );
+        return 0;
+    }
+
+    const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
+    if (interactive) {
+        console.log(`\n${c.cmd(provenance.identity)} declares runner service(s):`);
+        for (const svc of result.overlay.services) console.log(`  - ${svc.id} (${svc.label})`);
+        const grant = await askYesNo(`Grant daemon access to these service(s) now? [y/N] `);
+        if (grant) {
+            grantServices(provenance.identity, declaredIds);
+            console.log(`${c.success("✓")} Granted. ${describeRunningDaemon()}\n`);
+        } else {
+            console.log(`Left untrusted. Run ${c.cmd(`pizza config grant ${source}`)} to trust them later.\n`);
+        }
+        return 0;
+    }
+
+    console.log(
+        `\n${c.warning("Note:")} ${c.cmd(provenance.identity)} declares runner service(s) [${declaredIds.join(", ")}] — installed but left ${c.warning("untrusted")} ` +
+        `(non-interactive install with no --allow-daemon-services/--no-allow-daemon-services flag). Run ${c.cmd(`pizza config grant ${source}`)} to trust them.\n`,
+    );
+    return 0;
+}
+
+/** Render the overlay/service-trust section appended to `pizza list` output. */
+export function renderOverlaySummary(cwd: string, agentDir: string): void {
+    const pm = packageManagerFor(cwd, agentDir);
+    const configured = pm.listConfiguredPackages();
+    if (configured.length === 0) return;
+
+    const disabledRunnerServices = loadGlobalConfig().disabledRunnerServices ?? [];
+    const lines: string[] = [];
+
+    for (const pkg of configured) {
+        if (!pkg.installedPath) continue;
+        const identity = computePackageIdentity(pkg.source, agentDir).identity;
+        const provenance: PackageProvenance = { identity, source: pkg.source, scope: pkg.scope };
+        const { overlay, present, issues } = readOverlayManifest(pkg.installedPath, provenance);
+
+        if (present && !overlay) {
+            lines.push(`${c.warning("⚠")} ${identity} — invalid pi.pizzapi overlay (${issues.length} issue(s); run \`pizza install ${pkg.source}\` again to see details)`);
+            continue;
+        }
+        if (!overlay) continue;
+
+        const parts: string[] = [];
+        if (overlay.agents?.length) parts.push(`agents:${overlay.agents.length}`);
+        if (overlay.rules?.length) parts.push(`rules:${overlay.rules.length}`);
+        if (overlay.mcp) parts.push("mcp");
+        if (overlay.services?.length) {
+            const svcStates = overlay.services
+                .map((s) => {
+                    const state = pkg.scope === "project" ? "untrusted (project, v1)" : resolveServiceGrantState(identity, s.id, disabledRunnerServices);
+                    return `${s.id}:${state}`;
+                })
+                .join(", ");
+            parts.push(`services:[${svcStates}]`);
+        }
+        if (parts.length > 0) {
+            lines.push(`${c.accent("●")} ${identity} (${pkg.scope}) — ${parts.join("  ")}`);
+        }
+    }
+
+    if (lines.length > 0) {
+        console.log(`\n${c.label("PizzaPi overlay:")}`);
+        for (const line of lines) console.log(`  ${line}`);
+        console.log();
+    }
+}
+
+/** `pizza config grant|revoke <source> [serviceId...]`. Returns undefined if args aren't a grant/revoke subcommand. */
+export async function runOverlayConfigSubcommand(args: string[], cwd: string, agentDir: string): Promise<number | undefined> {
+    const sub = args[1];
+    if (sub !== "grant" && sub !== "revoke") return undefined;
+
+    const source = args[2];
+    if (!source) {
+        console.error(`pizza config ${sub}: missing <source>. Usage: pizza config ${sub} <source> [serviceId...]`);
+        return 1;
+    }
+
+    const found = readOverlayFor(cwd, agentDir, source, "user");
+    if (!found || !found.result.overlay) {
+        console.error(`pizza config ${sub}: no valid pi.pizzapi overlay found for "${source}" (must be a configured user-scope package).`);
+        return 1;
+    }
+    const { provenance, result } = found;
+    const declared = result.overlay!.services?.map((s) => s.id) ?? [];
+    if (declared.length === 0) {
+        console.error(`pizza config ${sub}: ${provenance.identity} declares no runner services.`);
+        return 1;
+    }
+
+    const requestedIds = args.slice(3).filter((a) => !a.startsWith("-"));
+    const ids = requestedIds.length > 0 ? requestedIds : declared;
+    const unknown = ids.filter((id) => !declared.includes(id));
+    if (unknown.length > 0) {
+        console.error(`pizza config ${sub}: unknown service id(s) [${unknown.join(", ")}] for ${provenance.identity}. Declared: [${declared.join(", ")}]`);
+        return 1;
+    }
+
+    if (sub === "grant") {
+        grantServices(provenance.identity, ids);
+        console.log(`${c.success("✓")} Granted [${ids.join(", ")}] for ${c.cmd(provenance.identity)}. ${describeRunningDaemon()}`);
+    } else {
+        const { revokeServices } = await import("./grants.js");
+        revokeServices(provenance.identity, ids);
+        console.log(`${c.success("✓")} Revoked [${ids.join(", ")}] for ${c.cmd(provenance.identity)}. ${describeRunningDaemon()}`);
+    }
+    return 0;
+}
+
+export { getGrantedServiceIds };

--- a/packages/cli/src/overlay/cli-support.ts
+++ b/packages/cli/src/overlay/cli-support.ts
@@ -10,9 +10,9 @@ import { createInterface } from "node:readline";
 import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { c } from "../cli-colors.js";
 import { loadGlobalConfig } from "../config/io.js";
-import { computePackageIdentity } from "./identity.js";
+import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
 import { formatOverlayIssue, readOverlayManifest, type OverlayReadResult, type PackageProvenance } from "./manifest.js";
-import { getGrantedServiceIds, grantServices, resolveServiceGrantState } from "./grants.js";
+import { getGrantedServiceIds, grantServices, revokeServices, resolveServiceGrantState } from "./grants.js";
 import { defaultStatePath, isPidRunning, type RunnerState } from "../runner/runner-state.js";
 import { existsSync, readFileSync } from "node:fs";
 
@@ -79,13 +79,83 @@ function packageManagerFor(cwd: string, agentDir: string): DefaultPackageManager
     return new DefaultPackageManager({ cwd, agentDir, settingsManager });
 }
 
+/** `ConfiguredPackage` isn't re-exported from the package root; derive it structurally. */
+type ConfiguredPkg = ReturnType<DefaultPackageManager["listConfiguredPackages"]>[number];
+
+interface ConfiguredMatch {
+    provenance: PackageProvenance;
+    installedPath: string;
+}
+
+/**
+ * Resolve `source` to a package pi actually has *configured* at `scope` —
+ * matched by normalized identity, using the scope-aware base dir pi itself
+ * resolves relative local paths against (agent dir for user, `<cwd>/.pizzapi`
+ * for project; see identity.ts `packageScopeBaseDir`).
+ *
+ * P1: `DefaultPackageManager.getInstalledPath()` alone does NOT check
+ * configuration for local sources — it just resolves the path and checks
+ * `existsSync`. Reading an overlay (and especially granting daemon service
+ * trust) must never be reachable for an arbitrary local directory that
+ * merely exists on disk; it must be a package the user actually installed
+ * via `pi install`/`pizza install` (i.e. present in
+ * `listConfiguredPackages()`). This is the single choke point every
+ * overlay-reading CLI path (install, list, config grant/revoke, update)
+ * goes through.
+ */
+function findConfiguredOverlaySource(
+    pm: DefaultPackageManager,
+    source: string,
+    scope: "user" | "project",
+    cwd: string,
+    agentDir: string,
+): ConfiguredMatch | undefined {
+    const baseDir = packageScopeBaseDir(scope, cwd, agentDir);
+    const identity = computePackageIdentity(source, baseDir).identity;
+    for (const pkg of pm.listConfiguredPackages()) {
+        if (pkg.scope !== scope || !pkg.installedPath) continue;
+        const pkgBaseDir = packageScopeBaseDir(pkg.scope, cwd, agentDir);
+        if (computePackageIdentity(pkg.source, pkgBaseDir).identity !== identity) continue;
+        return { provenance: { identity, source: pkg.source, scope }, installedPath: pkg.installedPath };
+    }
+    return undefined;
+}
+
 function readOverlayFor(cwd: string, agentDir: string, source: string, scope: "user" | "project"): { provenance: PackageProvenance; result: OverlayReadResult } | undefined {
     const pm = packageManagerFor(cwd, agentDir);
-    const installedPath = pm.getInstalledPath(source, scope);
-    if (!installedPath) return undefined;
-    const identity = computePackageIdentity(source, agentDir).identity;
-    const provenance: PackageProvenance = { identity, source, scope };
-    return { provenance, result: readOverlayManifest(installedPath, provenance) };
+    const match = findConfiguredOverlaySource(pm, source, scope, cwd, agentDir);
+    if (!match) return undefined;
+    return { provenance: match.provenance, result: readOverlayManifest(match.installedPath, match.provenance) };
+}
+
+/**
+ * Dedupe configured packages by normalized identity before display —
+ * project entries override user entries for the same identity, matching
+ * pi's own scope/dedup rule (docs/packages.md "Scope and Deduplication").
+ * Preserves stable order: the winning entry keeps the position of its first
+ * occurrence, only its content (source/scope) is replaced.
+ */
+function dedupeConfiguredPackages(
+    configured: ConfiguredPkg[],
+    cwd: string,
+    agentDir: string,
+): Array<{ identity: string; pkg: ConfiguredPkg }> {
+    const order: string[] = [];
+    const byIdentity = new Map<string, { identity: string; pkg: ConfiguredPkg }>();
+    for (const pkg of configured) {
+        const baseDir = packageScopeBaseDir(pkg.scope, cwd, agentDir);
+        const identity = computePackageIdentity(pkg.source, baseDir).identity;
+        const existing = byIdentity.get(identity);
+        if (!existing) {
+            byIdentity.set(identity, { identity, pkg });
+            order.push(identity);
+            continue;
+        }
+        if (pkg.scope === "project" && existing.pkg.scope === "user") {
+            byIdentity.set(identity, { identity, pkg });
+        }
+    }
+    return order.map((identity) => byIdentity.get(identity)!);
 }
 
 /**
@@ -171,12 +241,12 @@ export function renderOverlaySummary(cwd: string, agentDir: string): void {
     const configured = pm.listConfiguredPackages();
     if (configured.length === 0) return;
 
+    const deduped = dedupeConfiguredPackages(configured, cwd, agentDir);
     const disabledRunnerServices = loadGlobalConfig().disabledRunnerServices ?? [];
     const lines: string[] = [];
 
-    for (const pkg of configured) {
+    for (const { identity, pkg } of deduped) {
         if (!pkg.installedPath) continue;
-        const identity = computePackageIdentity(pkg.source, agentDir).identity;
         const provenance: PackageProvenance = { identity, source: pkg.source, scope: pkg.scope };
         const { overlay, present, issues } = readOverlayManifest(pkg.installedPath, provenance);
 
@@ -246,11 +316,91 @@ export async function runOverlayConfigSubcommand(args: string[], cwd: string, ag
         grantServices(provenance.identity, ids);
         console.log(`${c.success("✓")} Granted [${ids.join(", ")}] for ${c.cmd(provenance.identity)}. ${describeRunningDaemon()}`);
     } else {
-        const { revokeServices } = await import("./grants.js");
         revokeServices(provenance.identity, ids);
         console.log(`${c.success("✓")} Revoked [${ids.join(", ")}] for ${c.cmd(provenance.identity)}. ${describeRunningDaemon()}`);
     }
     return 0;
 }
 
-export { getGrantedServiceIds };
+export interface OverlaySnapshotEntry {
+    identity: string;
+    source: string;
+    overlayPresent: boolean;
+    overlayValid: boolean;
+    serviceIds: string[];
+}
+
+/**
+ * Snapshot each configured user-scope package's declared overlay service ids
+ * (plus overlay validity), keyed by normalized identity.
+ *
+ * P2: `pizza update` doesn't change `packages[]` in settings.json (the
+ * identity is unchanged before/after), so a literal settings diff can't
+ * detect that an update changed a package's *content*. We snapshot the
+ * overlay content itself before and after the upstream update instead, so
+ * `handlePostUpdateOverlay()` can diff declared service ids and catch a
+ * newly-malformed overlay.
+ */
+export function snapshotOverlayServiceIds(cwd: string, agentDir: string): Map<string, OverlaySnapshotEntry> {
+    const pm = packageManagerFor(cwd, agentDir);
+    const configured = pm.listConfiguredPackages().filter((p) => p.scope === "user");
+    const deduped = dedupeConfiguredPackages(configured, cwd, agentDir);
+    const snapshot = new Map<string, OverlaySnapshotEntry>();
+    for (const { identity, pkg } of deduped) {
+        if (!pkg.installedPath) continue;
+        const provenance: PackageProvenance = { identity, source: pkg.source, scope: "user" };
+        const { overlay, present } = readOverlayManifest(pkg.installedPath, provenance);
+        snapshot.set(identity, {
+            identity,
+            source: pkg.source,
+            overlayPresent: present,
+            overlayValid: present ? overlay !== null : true,
+            serviceIds: overlay?.services?.map((s) => s.id) ?? [],
+        });
+    }
+    return snapshot;
+}
+
+/**
+ * Run after a successful upstream `pizza update`. Compares the pre-update
+ * overlay snapshot (from `snapshotOverlayServiceIds`) against the current
+ * one: a newly-malformed overlay fails the command (partial-update
+ * remediation); newly-declared service ids are surfaced as untrusted but
+ * never auto-granted; ids that were already granted stay granted (grants
+ * are keyed by exact service id and untouched here). Returns the exit code
+ * the CLI should use (0 unless an overlay became malformed).
+ */
+export function handlePostUpdateOverlay(cwd: string, agentDir: string, before: Map<string, OverlaySnapshotEntry>): number {
+    const after = snapshotOverlayServiceIds(cwd, agentDir);
+    let sawMalformed = false;
+    const newlyDeclared: Array<{ identity: string; ids: string[] }> = [];
+
+    for (const snap of after.values()) {
+        if (snap.overlayPresent && !snap.overlayValid) {
+            console.error(`\n${c.error("✗")} pi.pizzapi overlay is invalid for ${c.cmd(snap.identity)} after update:\n`);
+            console.error(
+                `  ${c.warning("Note:")} the pi-native package update may have completed (upstream update is not transactional); ` +
+                `its daemon services remain unmounted. Run ${c.cmd(`pizza install ${snap.source}`)} to see full errors, or ${c.cmd(`pizza remove ${snap.source}`)} to undo.\n`,
+            );
+            sawMalformed = true;
+            continue;
+        }
+
+        const prior = before.get(snap.identity);
+        const priorIds = new Set(prior?.serviceIds ?? []);
+        const granted = getGrantedServiceIds(snap.identity);
+        const newUngranted = snap.serviceIds.filter((id) => !priorIds.has(id) && !granted.has(id));
+        if (newUngranted.length > 0) {
+            newlyDeclared.push({ identity: snap.identity, ids: newUngranted });
+        }
+    }
+
+    for (const { identity, ids } of newlyDeclared) {
+        console.log(
+            `\n${c.warning("Note:")} ${c.cmd(identity)} now declares new runner service(s) [${ids.join(", ")}] — left ${c.warning("untrusted")}. ` +
+            `Run ${c.cmd(`pizza config grant <source> ${ids.join(" ")}`)} to trust them.\n`,
+        );
+    }
+
+    return sawMalformed ? 1 : 0;
+}

--- a/packages/cli/src/overlay/grants.test.ts
+++ b/packages/cli/src/overlay/grants.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _setGlobalConfigDir } from "../config/io.js";
@@ -8,8 +8,9 @@ import {
     getGrantedServiceIds,
     grantServices,
     revokeServices,
-    pruneOrphanGrants,
+    reconcileGrants,
     resolveServiceGrantState,
+    type ConfiguredPackageGrantInfo,
 } from "./grants.js";
 
 describe("overlay grants", () => {
@@ -53,15 +54,40 @@ describe("overlay grants", () => {
         expect(getOverlayServiceGrants()).toHaveLength(0);
     });
 
-    test("pruneOrphanGrants removes grants whose identity is no longer configured", () => {
+    test("no-op revoke does not write to disk", () => {
         grantServices("npm:@acme/pkg", ["github"]);
-        grantServices("local:/old/path", ["svc"]);
+        const configPath = join(dir, "config.json");
+        const before = readFileSync(configPath, "utf-8");
 
-        const removed = pruneOrphanGrants(new Set(["npm:@acme/pkg"]));
-        expect(removed).toHaveLength(1);
-        expect(removed[0]?.package).toBe("local:/old/path");
-        expect(getGrantedServiceIds("local:/old/path").size).toBe(0);
+        // Revoking a service that was never granted, and revoking on an
+        // identity with no grant at all — neither changes anything.
+        const resultA = revokeServices("npm:@acme/pkg", ["gitlab"]);
+        const resultB = revokeServices("npm:@other/pkg", ["github"]);
+
+        expect(readFileSync(configPath, "utf-8")).toBe(before);
+        expect(resultA).toEqual(getOverlayServiceGrants());
+        expect(resultB).toEqual(getOverlayServiceGrants());
         expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github"]));
+    });
+
+    test("malformed grant entries in the raw config are ignored on read", () => {
+        const configPath = join(dir, "config.json");
+        writeFileSync(
+            configPath,
+            JSON.stringify({
+                overlayServiceGrants: [
+                    { package: "npm:@acme/good", services: ["github"] },
+                    { package: "", services: ["github"] }, // empty package string
+                    { package: "npm:@acme/bad-services", services: ["github", ""] }, // empty service id
+                    { package: "npm:@acme/bad-services", services: ["github", 42] }, // non-string service id
+                    { package: 7, services: ["github"] }, // non-string package
+                    { services: ["github"] }, // missing package
+                    "not-an-object",
+                ],
+            }),
+        );
+
+        expect(getOverlayServiceGrants()).toEqual([{ package: "npm:@acme/good", services: ["github"] }]);
     });
 
     test("resolveServiceGrantState: untrusted -> granted -> disabled", () => {
@@ -69,5 +95,87 @@ describe("overlay grants", () => {
         grantServices("npm:@acme/pkg", ["github"]);
         expect(resolveServiceGrantState("npm:@acme/pkg", "github")).toBe("granted");
         expect(resolveServiceGrantState("npm:@acme/pkg", "github", ["github"])).toBe("disabled");
+    });
+
+    describe("corrupt global config", () => {
+        function corruptConfig(): { path: string; bytes: string } {
+            const path = join(dir, "config.json");
+            const bytes = "{ this is not valid json !! ";
+            writeFileSync(path, bytes, "utf-8");
+            return { path, bytes };
+        }
+
+        test("grantServices refuses to write and preserves bytes exactly", () => {
+            const { path, bytes } = corruptConfig();
+            expect(() => grantServices("npm:@acme/pkg", ["github"])).toThrow(/malformed global config/);
+            expect(readFileSync(path, "utf-8")).toBe(bytes);
+        });
+
+        test("revokeServices (non-no-op) refuses to write and preserves bytes exactly", () => {
+            // Seed a grant while the config is still valid, then corrupt it.
+            grantServices("npm:@acme/pkg", ["github"]);
+            const path = join(dir, "config.json");
+            const bytes = "{ still not json ]]] ";
+            writeFileSync(path, bytes, "utf-8");
+
+            expect(() => revokeServices("npm:@acme/pkg", ["github"])).toThrow(/malformed global config/);
+            expect(readFileSync(path, "utf-8")).toBe(bytes);
+        });
+    });
+
+    describe("reconcileGrants", () => {
+        function info(ids: string[] | null): ConfiguredPackageGrantInfo {
+            return { declaredServiceIds: ids === null ? null : new Set(ids) };
+        }
+
+        test("removes grants whose identity is no longer configured at all", () => {
+            grantServices("npm:@acme/pkg", ["github"]);
+            grantServices("local:/old/path", ["svc"]);
+
+            const removed = reconcileGrants(new Map([["npm:@acme/pkg", info(["github"])]]));
+
+            expect(removed).toHaveLength(1);
+            expect(removed[0]).toEqual({ package: "local:/old/path", removedServiceIds: ["svc"], fullyRemoved: true });
+            expect(getGrantedServiceIds("local:/old/path").size).toBe(0);
+            expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github"]));
+        });
+
+        test("keeps a configured-but-missing package's grant untouched (fail-closed)", () => {
+            grantServices("npm:@acme/pkg", ["github", "gitlab"]);
+
+            const removed = reconcileGrants(new Map([["npm:@acme/pkg", info(null)]]));
+
+            expect(removed).toHaveLength(0);
+            expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github", "gitlab"]));
+        });
+
+        test("trims a granted service id no longer declared, keeping the rest", () => {
+            grantServices("npm:@acme/pkg", ["github", "gitlab"]);
+
+            const removed = reconcileGrants(new Map([["npm:@acme/pkg", info(["github"])]]));
+
+            expect(removed).toEqual([{ package: "npm:@acme/pkg", removedServiceIds: ["gitlab"], fullyRemoved: false }]);
+            expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github"]));
+        });
+
+        test("drops the entry entirely when no declared ids remain", () => {
+            grantServices("npm:@acme/pkg", ["github"]);
+
+            const removed = reconcileGrants(new Map([["npm:@acme/pkg", info([])]]));
+
+            expect(removed).toEqual([{ package: "npm:@acme/pkg", removedServiceIds: ["github"], fullyRemoved: true }]);
+            expect(getOverlayServiceGrants()).toHaveLength(0);
+        });
+
+        test("no-op reconciliation does not write to disk", () => {
+            grantServices("npm:@acme/pkg", ["github"]);
+            const configPath = join(dir, "config.json");
+            const before = readFileSync(configPath, "utf-8");
+
+            const removed = reconcileGrants(new Map([["npm:@acme/pkg", info(["github", "gitlab"])]]));
+
+            expect(removed).toHaveLength(0);
+            expect(readFileSync(configPath, "utf-8")).toBe(before);
+        });
     });
 });

--- a/packages/cli/src/overlay/grants.test.ts
+++ b/packages/cli/src/overlay/grants.test.ts
@@ -121,6 +121,14 @@ describe("overlay grants", () => {
             expect(() => revokeServices("npm:@acme/pkg", ["github"])).toThrow(/malformed global config/);
             expect(readFileSync(path, "utf-8")).toBe(bytes);
         });
+
+        test("valid JSON with a non-object top level is also refused", () => {
+            const path = join(dir, "config.json");
+            const bytes = "[]\n";
+            writeFileSync(path, bytes, "utf-8");
+            expect(() => grantServices("npm:@acme/pkg", ["github"])).toThrow(/malformed global config/);
+            expect(readFileSync(path, "utf-8")).toBe(bytes);
+        });
     });
 
     describe("reconcileGrants", () => {

--- a/packages/cli/src/overlay/grants.test.ts
+++ b/packages/cli/src/overlay/grants.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setGlobalConfigDir } from "../config/io.js";
+import {
+    getOverlayServiceGrants,
+    getGrantedServiceIds,
+    grantServices,
+    revokeServices,
+    pruneOrphanGrants,
+    resolveServiceGrantState,
+} from "./grants.js";
+
+describe("overlay grants", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "pizzapi-grants-"));
+        _setGlobalConfigDir(dir);
+    });
+
+    afterEach(() => {
+        _setGlobalConfigDir(null);
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("grant is exact — only listed service ids are granted", () => {
+        grantServices("npm:@acme/pkg", ["github", "gitlab"]);
+        expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github", "gitlab"]));
+        expect(getGrantedServiceIds("npm:@acme/pkg").has("bitbucket")).toBe(false);
+    });
+
+    test("granting again unions rather than replacing", () => {
+        grantServices("npm:@acme/pkg", ["github"]);
+        grantServices("npm:@acme/pkg", ["gitlab"]);
+        expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github", "gitlab"]));
+    });
+
+    test("added service ids after an update remain untrusted (no grant call = no grant)", () => {
+        grantServices("npm:@acme/pkg", ["github"]);
+        // Simulates a package update that adds a new declared id "gitlab" —
+        // nothing calls grantServices for it, so it must stay ungranted.
+        expect(getGrantedServiceIds("npm:@acme/pkg").has("gitlab")).toBe(false);
+    });
+
+    test("revoke removes only the listed ids, and clears the entry when empty", () => {
+        grantServices("npm:@acme/pkg", ["github", "gitlab"]);
+        revokeServices("npm:@acme/pkg", ["github"]);
+        expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["gitlab"]));
+
+        revokeServices("npm:@acme/pkg", ["gitlab"]);
+        expect(getOverlayServiceGrants()).toHaveLength(0);
+    });
+
+    test("pruneOrphanGrants removes grants whose identity is no longer configured", () => {
+        grantServices("npm:@acme/pkg", ["github"]);
+        grantServices("local:/old/path", ["svc"]);
+
+        const removed = pruneOrphanGrants(new Set(["npm:@acme/pkg"]));
+        expect(removed).toHaveLength(1);
+        expect(removed[0]?.package).toBe("local:/old/path");
+        expect(getGrantedServiceIds("local:/old/path").size).toBe(0);
+        expect(getGrantedServiceIds("npm:@acme/pkg")).toEqual(new Set(["github"]));
+    });
+
+    test("resolveServiceGrantState: untrusted -> granted -> disabled", () => {
+        expect(resolveServiceGrantState("npm:@acme/pkg", "github")).toBe("untrusted");
+        grantServices("npm:@acme/pkg", ["github"]);
+        expect(resolveServiceGrantState("npm:@acme/pkg", "github")).toBe("granted");
+        expect(resolveServiceGrantState("npm:@acme/pkg", "github", ["github"])).toBe("disabled");
+    });
+});

--- a/packages/cli/src/overlay/grants.ts
+++ b/packages/cli/src/overlay/grants.ts
@@ -114,9 +114,13 @@ export function buildConfiguredGrantIdentities(cwd: string, agentDir: string): M
         let declaredServiceIds: Set<string> | null;
         try {
             const provenance: PackageProvenance = { identity, source: pkg.source, scope: pkg.scope };
-            const { overlay, present } = readOverlayManifest(pkg.installedPath, provenance);
-            if (!present) {
-                // No pi.pizzapi key at all — the package declares no services.
+            const { overlay, present, issues } = readOverlayManifest(pkg.installedPath, provenance);
+            if (issues.length > 0 || !existsSync(join(pkg.installedPath, "package.json"))) {
+                // The configured install exists but its package manifest cannot
+                // be read cleanly. Preserve grants fail-closed until repaired.
+                declaredServiceIds = null;
+            } else if (!present) {
+                // Readable package.json with no pi.pizzapi key: no services.
                 declaredServiceIds = new Set();
             } else if (overlay) {
                 declaredServiceIds = new Set(overlay.services?.map((s) => s.id) ?? []);
@@ -158,6 +162,7 @@ export interface GrantReconciliationRemoval {
  *   fresh grant); the entry is dropped entirely if nothing remains.
  */
 export function reconcileGrants(configured: ReadonlyMap<string, ConfiguredPackageGrantInfo>): GrantReconciliationRemoval[] {
+    assertGlobalConfigParsable();
     const grants = getOverlayServiceGrants();
     const kept: OverlayServiceGrant[] = [];
     const removals: GrantReconciliationRemoval[] = [];
@@ -208,7 +213,8 @@ function assertGlobalConfigParsable(): void {
         throw new Error(`overlay grants: cannot read global config at ${path}: ${err instanceof Error ? err.message : String(err)}`);
     }
     try {
-        JSON.parse(text);
+        const parsed: unknown = JSON.parse(text);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("top-level value must be an object");
     } catch {
         throw new Error(
             `overlay grants: refusing to modify malformed global config at ${path} — ` +

--- a/packages/cli/src/overlay/grants.ts
+++ b/packages/cli/src/overlay/grants.ts
@@ -4,10 +4,13 @@
  * Grants live only in ~/.pizzapi/config.json (global) — project packages
  * never receive daemon grants in schema v1 (docs/specs/pi-pizzapi-overlay.md §6.3).
  */
-import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 import type { OverlayServiceGrant } from "../config/types.js";
 import { globalConfigDir, loadGlobalConfig, saveGlobalConfig } from "../config/io.js";
+import { computePackageIdentity } from "./identity.js";
+import { readOverlayManifest, type PackageProvenance } from "./manifest.js";
 
 export type ServiceGrantState = "granted" | "disabled" | "untrusted";
 
@@ -17,11 +20,14 @@ export function getOverlayServiceGrants(): OverlayServiceGrant[] {
 }
 
 function isValidGrant(g: unknown): g is OverlayServiceGrant {
+    if (!g || typeof g !== "object") return false;
+    const pkg = (g as OverlayServiceGrant).package;
+    const services = (g as OverlayServiceGrant).services;
     return (
-        !!g &&
-        typeof g === "object" &&
-        typeof (g as OverlayServiceGrant).package === "string" &&
-        Array.isArray((g as OverlayServiceGrant).services)
+        typeof pkg === "string" &&
+        pkg.length > 0 &&
+        Array.isArray(services) &&
+        services.every((s) => typeof s === "string" && s.length > 0)
     );
 }
 
@@ -32,6 +38,11 @@ export function getGrantedServiceIds(identity: string): Set<string> {
 
 /** Grant the given service IDs for a package identity (union with any existing grant). */
 export function grantServices(identity: string, serviceIds: string[]): OverlayServiceGrant[] {
+    // Check parsability up front, before reading: once the config is
+    // corrupt, reads silently degrade to "no grants" (see
+    // assertGlobalConfigParsable()'s docstring), which would otherwise make
+    // this look like a fresh grant instead of a refused write.
+    assertGlobalConfigParsable();
     const grants = getOverlayServiceGrants();
     const existing = grants.find((g) => g.package === identity);
     if (existing) {
@@ -45,28 +56,169 @@ export function grantServices(identity: string, serviceIds: string[]): OverlaySe
 
 /** Revoke the given service IDs for a package identity. Removes the entry entirely once empty. */
 export function revokeServices(identity: string, serviceIds: string[]): OverlayServiceGrant[] {
+    // Same reasoning as grantServices(): a corrupt config reads back as "no
+    // grants", which would otherwise be indistinguishable from a genuine
+    // no-op revoke. Check parsability first so a real (unreadable) grant
+    // isn't silently treated as absent.
+    assertGlobalConfigParsable();
     const revokeSet = new Set(serviceIds);
-    const grants = getOverlayServiceGrants()
+    const grants = getOverlayServiceGrants();
+    const target = grants.find((g) => g.package === identity);
+    // No-op: nothing would actually change, so don't touch disk (and don't
+    // trip the malformed-config guard for a write that was never needed).
+    if (!target || !target.services.some((s) => revokeSet.has(s))) {
+        return grants;
+    }
+    const next = grants
         .map((g) => (g.package === identity ? { ...g, services: g.services.filter((s) => !revokeSet.has(s)) } : g))
         .filter((g) => g.services.length > 0);
-    persist(grants);
-    return grants;
+    persist(next);
+    return next;
+}
+
+/** Per-identity view of what the upstream package manager currently configures. */
+export interface ConfiguredPackageGrantInfo {
+    /**
+     * Service IDs currently declared by this package's valid `pi.pizzapi`
+     * overlay manifest. `null` means the identity is configured but its
+     * installed path is temporarily missing or its overlay could not be
+     * read cleanly — reconcileGrants() must treat that fail-closed and
+     * leave any existing grant untouched rather than deleting it.
+     */
+    declaredServiceIds: Set<string> | null;
 }
 
 /**
- * Remove grants whose package identity is absent from `validIdentities`.
- * Call at daemon start/reconfiguration (§7.2) — authoritative even when
- * `pi remove` bypassed the pizza wrapper.
+ * Build the configured-identity map reconcileGrants() needs from the
+ * upstream PackageManager's *user*-scope configured packages (grants are
+ * user-scope only in schema v1 — see module docstring) plus each package's
+ * manifest, read through the shared identity/manifest helpers.
  */
-export function pruneOrphanGrants(validIdentities: ReadonlySet<string>): OverlayServiceGrant[] {
+export function buildConfiguredGrantIdentities(cwd: string, agentDir: string): Map<string, ConfiguredPackageGrantInfo> {
+    const settingsManager = SettingsManager.create(cwd, agentDir);
+    const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+    const map = new Map<string, ConfiguredPackageGrantInfo>();
+
+    for (const pkg of packageManager.listConfiguredPackages()) {
+        if (pkg.scope !== "user") continue; // grants never apply to project-scoped packages (§6.3)
+        const identity = computePackageIdentity(pkg.source, agentDir).identity;
+
+        if (!pkg.installedPath) {
+            // Fail-closed: identity is configured but its install path is
+            // temporarily missing (e.g. npm store not yet warmed). Do not
+            // delete or trim its grant.
+            map.set(identity, { declaredServiceIds: null });
+            continue;
+        }
+
+        let declaredServiceIds: Set<string> | null;
+        try {
+            const provenance: PackageProvenance = { identity, source: pkg.source, scope: pkg.scope };
+            const { overlay, present } = readOverlayManifest(pkg.installedPath, provenance);
+            if (!present) {
+                // No pi.pizzapi key at all — the package declares no services.
+                declaredServiceIds = new Set();
+            } else if (overlay) {
+                declaredServiceIds = new Set(overlay.services?.map((s) => s.id) ?? []);
+            } else {
+                // Overlay present but invalid/unreadable as a unit — fail-closed.
+                declaredServiceIds = null;
+            }
+        } catch {
+            declaredServiceIds = null;
+        }
+        map.set(identity, { declaredServiceIds });
+    }
+
+    return map;
+}
+
+/** One removal or trim applied by reconcileGrants(), for daemon-side logging. */
+export interface GrantReconciliationRemoval {
+    package: string;
+    /** Service IDs revoked from this package's grant (all of them when fullyRemoved). */
+    removedServiceIds: string[];
+    /** True when the whole grant entry was dropped (unconfigured, or no declared IDs remain). */
+    fullyRemoved: boolean;
+}
+
+/**
+ * Reconcile grants against `configured` — the currently configured USER
+ * package identities and each valid manifest's currently declared service
+ * IDs (built via buildConfiguredGrantIdentities()). Call at daemon
+ * start/reconfiguration (§7.2) — authoritative even when `pi remove`
+ * bypassed the pizza wrapper.
+ *
+ * - Identity absent from `configured` (package no longer configured at
+ *   all): grant removed entirely.
+ * - Identity present with `declaredServiceIds: null` (install path
+ *   missing / overlay unreadable): grant left untouched, fail-closed.
+ * - Identity present with a real declared-IDs set: granted service IDs no
+ *   longer declared are trimmed (removing/re-adding a service requires a
+ *   fresh grant); the entry is dropped entirely if nothing remains.
+ */
+export function reconcileGrants(configured: ReadonlyMap<string, ConfiguredPackageGrantInfo>): GrantReconciliationRemoval[] {
     const grants = getOverlayServiceGrants();
-    const kept = grants.filter((g) => validIdentities.has(g.package));
-    const removed = grants.filter((g) => !validIdentities.has(g.package));
-    if (removed.length > 0) persist(kept);
-    return removed;
+    const kept: OverlayServiceGrant[] = [];
+    const removals: GrantReconciliationRemoval[] = [];
+
+    for (const g of grants) {
+        const info = configured.get(g.package);
+        if (!info) {
+            removals.push({ package: g.package, removedServiceIds: [...g.services], fullyRemoved: true });
+            continue;
+        }
+        if (info.declaredServiceIds === null) {
+            kept.push(g); // fail-closed: keep as-is
+            continue;
+        }
+        const declared = info.declaredServiceIds;
+        const remaining = g.services.filter((s) => declared.has(s));
+        const trimmedOut = g.services.filter((s) => !declared.has(s));
+        if (trimmedOut.length === 0) {
+            kept.push(g);
+            continue;
+        }
+        if (remaining.length > 0) {
+            kept.push({ package: g.package, services: remaining });
+        }
+        removals.push({ package: g.package, removedServiceIds: trimmedOut, fullyRemoved: remaining.length === 0 });
+    }
+
+    if (removals.length > 0) persist(kept);
+    return removals;
+}
+
+/**
+ * Refuse to write when ~/.pizzapi/config.json exists but is not valid
+ * JSON — every write path below (grant/revoke/reconcile) goes through
+ * persist(), so this guard is the single choke point that keeps a
+ * corrupt global config's bytes untouched instead of silently replacing
+ * it with `{ overlayServiceGrants: [...] }` (readJsonSafe() would
+ * otherwise swallow the parse error and return `{}`, discarding whatever
+ * else was in the file).
+ */
+function assertGlobalConfigParsable(): void {
+    const path = join(globalConfigDir(), "config.json");
+    if (!existsSync(path)) return;
+    let text: string;
+    try {
+        text = readFileSync(path, "utf-8");
+    } catch (err) {
+        throw new Error(`overlay grants: cannot read global config at ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    try {
+        JSON.parse(text);
+    } catch {
+        throw new Error(
+            `overlay grants: refusing to modify malformed global config at ${path} — ` +
+            "the file exists but is not valid JSON. Fix or remove it by hand before granting/revoking package trust.",
+        );
+    }
 }
 
 function persist(grants: OverlayServiceGrant[]): void {
+    assertGlobalConfigParsable();
     if (grants.length > 0) {
         saveGlobalConfig({ overlayServiceGrants: grants });
         return;

--- a/packages/cli/src/overlay/grants.ts
+++ b/packages/cli/src/overlay/grants.ts
@@ -96,6 +96,10 @@ export interface ConfiguredPackageGrantInfo {
  */
 export function buildConfiguredGrantIdentities(cwd: string, agentDir: string): Map<string, ConfiguredPackageGrantInfo> {
     const settingsManager = SettingsManager.create(cwd, agentDir);
+    const globalLoadErrors = settingsManager.drainErrors().filter((entry) => entry.scope === "global");
+    if (globalLoadErrors.length > 0) {
+        throw new Error(`cannot reconcile overlay grants: user package settings failed to load: ${globalLoadErrors.map((entry) => entry.error.message).join("; ")}`);
+    }
     const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
     const map = new Map<string, ConfiguredPackageGrantInfo>();
 

--- a/packages/cli/src/overlay/grants.ts
+++ b/packages/cli/src/overlay/grants.ts
@@ -1,0 +1,96 @@
+/**
+ * Global `overlayServiceGrants` CRUD + state resolution.
+ *
+ * Grants live only in ~/.pizzapi/config.json (global) — project packages
+ * never receive daemon grants in schema v1 (docs/specs/pi-pizzapi-overlay.md §6.3).
+ */
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { OverlayServiceGrant } from "../config/types.js";
+import { globalConfigDir, loadGlobalConfig, saveGlobalConfig } from "../config/io.js";
+
+export type ServiceGrantState = "granted" | "disabled" | "untrusted";
+
+export function getOverlayServiceGrants(): OverlayServiceGrant[] {
+    const grants = loadGlobalConfig().overlayServiceGrants;
+    return Array.isArray(grants) ? grants.filter((g): g is OverlayServiceGrant => isValidGrant(g)) : [];
+}
+
+function isValidGrant(g: unknown): g is OverlayServiceGrant {
+    return (
+        !!g &&
+        typeof g === "object" &&
+        typeof (g as OverlayServiceGrant).package === "string" &&
+        Array.isArray((g as OverlayServiceGrant).services)
+    );
+}
+
+export function getGrantedServiceIds(identity: string): Set<string> {
+    const grant = getOverlayServiceGrants().find((g) => g.package === identity);
+    return new Set(grant?.services ?? []);
+}
+
+/** Grant the given service IDs for a package identity (union with any existing grant). */
+export function grantServices(identity: string, serviceIds: string[]): OverlayServiceGrant[] {
+    const grants = getOverlayServiceGrants();
+    const existing = grants.find((g) => g.package === identity);
+    if (existing) {
+        existing.services = [...new Set([...existing.services, ...serviceIds])];
+    } else {
+        grants.push({ package: identity, services: [...new Set(serviceIds)] });
+    }
+    persist(grants);
+    return grants;
+}
+
+/** Revoke the given service IDs for a package identity. Removes the entry entirely once empty. */
+export function revokeServices(identity: string, serviceIds: string[]): OverlayServiceGrant[] {
+    const revokeSet = new Set(serviceIds);
+    const grants = getOverlayServiceGrants()
+        .map((g) => (g.package === identity ? { ...g, services: g.services.filter((s) => !revokeSet.has(s)) } : g))
+        .filter((g) => g.services.length > 0);
+    persist(grants);
+    return grants;
+}
+
+/**
+ * Remove grants whose package identity is absent from `validIdentities`.
+ * Call at daemon start/reconfiguration (§7.2) — authoritative even when
+ * `pi remove` bypassed the pizza wrapper.
+ */
+export function pruneOrphanGrants(validIdentities: ReadonlySet<string>): OverlayServiceGrant[] {
+    const grants = getOverlayServiceGrants();
+    const kept = grants.filter((g) => validIdentities.has(g.package));
+    const removed = grants.filter((g) => !validIdentities.has(g.package));
+    if (removed.length > 0) persist(kept);
+    return removed;
+}
+
+function persist(grants: OverlayServiceGrant[]): void {
+    if (grants.length > 0) {
+        saveGlobalConfig({ overlayServiceGrants: grants });
+        return;
+    }
+    // saveGlobalConfig only merges/overwrites keys — it cannot delete one.
+    // Write the full object directly, same pattern as toggleMcpServer().
+    const dir = globalConfigDir();
+    const path = join(dir, "config.json");
+    const rest = loadGlobalConfig();
+    delete rest.overlayServiceGrants;
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(path, JSON.stringify(rest, null, 2), { encoding: "utf-8", mode: 0o600 });
+    chmodSync(path, 0o600);
+}
+
+/**
+ * Resolve a service's trust state: `untrusted` (no grant), `disabled`
+ * (granted but operationally off via `disabledRunnerServices`), or `granted`.
+ */
+export function resolveServiceGrantState(
+    identity: string,
+    serviceId: string,
+    disabledRunnerServices: readonly string[] = [],
+): ServiceGrantState {
+    if (!getGrantedServiceIds(identity).has(serviceId)) return "untrusted";
+    return disabledRunnerServices.includes(serviceId) ? "disabled" : "granted";
+}

--- a/packages/cli/src/overlay/identity.test.ts
+++ b/packages/cli/src/overlay/identity.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computePackageIdentity } from "./identity.js";
+
+describe("computePackageIdentity", () => {
+    test("npm: strips version, keeps scope", () => {
+        expect(computePackageIdentity("npm:@foo/bar@1.2.3").identity).toBe("npm:@foo/bar");
+        expect(computePackageIdentity("npm:@foo/bar").identity).toBe("npm:@foo/bar");
+        expect(computePackageIdentity("npm:pkg@1.0.0").identity).toBe("npm:pkg");
+        expect(computePackageIdentity("npm:pkg").identity).toBe("npm:pkg");
+    });
+
+    test("git: normalizes all four documented source forms to the same identity", () => {
+        const forms = [
+            "git:github.com/user/repo@v1",
+            "git:git@github.com:user/repo@v1",
+            "https://github.com/user/repo@v1",
+            "ssh://git@github.com/user/repo@v1",
+        ];
+        const identities = forms.map((f) => computePackageIdentity(f).identity);
+        for (const id of identities) expect(id).toBe("git:github.com/user/repo");
+    });
+
+    test("local: resolves to canonical absolute path, symlinks included", () => {
+        const tmp = realpathSync(mkdtempSync(join(tmpdir(), "pizzapi-identity-")));
+        try {
+            const pkgDir = join(tmp, "pkg");
+            mkdirSync(pkgDir);
+            const id = computePackageIdentity(pkgDir, tmp);
+            expect(id.kind).toBe("local");
+            expect(id.identity).toBe(`local:${pkgDir}`);
+        } finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    test("local: relative path resolves against baseDir", () => {
+        const tmp = realpathSync(mkdtempSync(join(tmpdir(), "pizzapi-identity-")));
+        try {
+            const pkgDir = join(tmp, "pkg");
+            mkdirSync(pkgDir);
+            const id = computePackageIdentity("./pkg", tmp);
+            expect(id.identity).toBe(`local:${pkgDir}`);
+        } finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/cli/src/overlay/identity.test.ts
+++ b/packages/cli/src/overlay/identity.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { computePackageIdentity } from "./identity.js";
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
 
 describe("computePackageIdentity", () => {
     test("npm: strips version, keeps scope", () => {
@@ -21,6 +23,17 @@ describe("computePackageIdentity", () => {
         ];
         const identities = forms.map((f) => computePackageIdentity(f).identity);
         for (const id of identities) expect(id).toBe("git:github.com/user/repo");
+    });
+
+    test("git: preserves path case, normalizes host case only", () => {
+        expect(computePackageIdentity("git:GitHub.com/User/Repo").identity).toBe("git:github.com/User/Repo");
+        expect(computePackageIdentity("https://GitHub.COM/User/Repo").identity).toBe("git:github.com/User/Repo");
+    });
+
+    test("git: handles ssh port (port is dropped from identity, same as host)", () => {
+        expect(computePackageIdentity("ssh://git@github.com:2222/user/repo@v1").identity).toBe(
+            "git:github.com/user/repo",
+        );
     });
 
     test("local: resolves to canonical absolute path, symlinks included", () => {
@@ -43,6 +56,88 @@ describe("computePackageIdentity", () => {
             mkdirSync(pkgDir);
             const id = computePackageIdentity("./pkg", tmp);
             expect(id.identity).toBe(`local:${pkgDir}`);
+        } finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    test("local: expands a leading ~ against the home directory", () => {
+        // Use the real home directory (no filesystem writes needed — realpath
+        // falls back to the resolved path when the target doesn't exist).
+        const id = computePackageIdentity("~/pizzapi-identity-tilde-fixture-does-not-exist");
+        expect(id.identity).toBe(`local:${join(homedir(), "pizzapi-identity-tilde-fixture-does-not-exist")}`);
+    });
+});
+
+describe("packageScopeBaseDir", () => {
+    test("user scope uses the agent dir; project scope uses <cwd>/.pizzapi", () => {
+        expect(packageScopeBaseDir("user", "/cwd", "/agent")).toBe("/agent");
+        expect(packageScopeBaseDir("project", "/cwd", "/agent")).toBe(join("/cwd", ".pizzapi"));
+    });
+});
+
+/**
+ * Characterization tests pinning computePackageIdentity() against pi
+ * 0.82.1's own (private, test-only-cast) DefaultPackageManager.getPackageIdentity()
+ * for every documented source form plus tilde/case/port and both scopes.
+ * `getPackageIdentity` is intentionally not used in production code (it's
+ * private/unexported); this cast exists only so tests can assert parity.
+ */
+describe("computePackageIdentity matches upstream getPackageIdentity()", () => {
+    function makePm(cwd: string, agentDir: string): { getPackageIdentity(source: string, scope?: "user" | "project"): string } {
+        const settingsManager = SettingsManager.create(cwd, agentDir);
+        return new DefaultPackageManager({ cwd, agentDir, settingsManager }) as unknown as {
+            getPackageIdentity(source: string, scope?: "user" | "project"): string;
+        };
+    }
+
+    const gitForms = [
+        "git:github.com/user/repo@v1",
+        "git:git@github.com:user/repo@v1",
+        "https://github.com/user/repo@v1",
+        "ssh://git@github.com/user/repo@v1",
+        "git:GitHub.com/User/Repo",
+        "ssh://git@github.com:2222/user/repo@v1",
+        "npm:@foo/bar@1.2.3",
+        "npm:pkg",
+    ];
+
+    test("git/npm forms match upstream regardless of scope", () => {
+        const tmp = realpathSync(mkdtempSync(join(tmpdir(), "pizzapi-identity-parity-")));
+        try {
+            const agentDir = join(tmp, "agent");
+            const cwd = join(tmp, "project");
+            mkdirSync(agentDir, { recursive: true });
+            mkdirSync(cwd, { recursive: true });
+            const pm = makePm(cwd, agentDir);
+            for (const scope of ["user", "project"] as const) {
+                for (const source of gitForms) {
+                    expect(computePackageIdentity(source).identity).toBe(pm.getPackageIdentity(source, scope));
+                }
+            }
+        } finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    test("local paths match upstream per-scope base dir resolution (cwd and agentDir at different depths)", () => {
+        const tmp = realpathSync(mkdtempSync(join(tmpdir(), "pizzapi-identity-parity-")));
+        try {
+            // agentDir and cwd deliberately at different nesting depths.
+            const agentDir = join(tmp, "deep", "nested", "agent");
+            const cwd = join(tmp, "project");
+            mkdirSync(agentDir, { recursive: true });
+            mkdirSync(cwd, { recursive: true });
+            const pm = makePm(cwd, agentDir);
+
+            for (const scope of ["user", "project"] as const) {
+                const baseDir = packageScopeBaseDir(scope, cwd, agentDir);
+                for (const rel of ["./pkg", "~/pizzapi-identity-tilde-fixture-does-not-exist"]) {
+                    const ours = computePackageIdentity(rel, baseDir).identity;
+                    const upstream = pm.getPackageIdentity(rel, scope);
+                    expect(ours).toBe(upstream);
+                }
+            }
         } finally {
             rmSync(tmp, { recursive: true, force: true });
         }

--- a/packages/cli/src/overlay/identity.ts
+++ b/packages/cli/src/overlay/identity.ts
@@ -1,0 +1,87 @@
+/**
+ * Package identity normalization for the `pi.pizzapi` overlay.
+ *
+ * Mirrors the identity rules from docs/specs/pi-pizzapi-overlay.md §6.1 /
+ * pi 0.82.1 `docs/packages.md` ("Scope and Deduplication"):
+ *   - npm:  package name, version stripped
+ *   - git:  `host/path`, ref stripped, protocol/SSH forms normalized
+ *   - local: resolved canonical absolute path
+ *
+ * ponytail: pi's own git URL parsing goes through `hosted-git-info` (an
+ * upstream-only dependency we don't have access to and won't add). This is
+ * a small resolver covering the four documented source forms from
+ * docs/packages.md, characterized by identity.test.ts. It is not a full
+ * git URL parser — expand if an unsupported form surfaces in practice.
+ */
+import { realpathSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+
+export type PackageSourceKind = "npm" | "git" | "local";
+
+export interface PackageIdentity {
+    kind: PackageSourceKind;
+    /** Normalized identity string, e.g. "npm:@acme/pkg", "git:github.com/user/repo", "local:/abs/path". */
+    identity: string;
+}
+
+const GIT_PROTOCOL_RE = /^(https?|ssh|git):\/\//i;
+
+function stripVersionSuffix(spec: string): string {
+    const atIdx = spec.lastIndexOf("@");
+    return atIdx > 0 ? spec.slice(0, atIdx) : spec;
+}
+
+function normalizeGitSource(source: string): string {
+    let s = source;
+    if (s.startsWith("git:")) s = s.slice(4);
+    s = s.replace(/^(https?:\/\/|ssh:\/\/|git:\/\/)/i, "");
+    s = s.replace(/^git@/, "");
+    // scp-like shorthand "host:path" -> "host/path" (only the first colon
+    // separates host from path; version refs use "@", not ":").
+    s = s.replace(":", "/");
+    s = stripVersionSuffix(s);
+    s = s.replace(/\.git$/i, "");
+    s = s.replace(/\/+$/, "");
+    return s.toLowerCase();
+}
+
+/**
+ * Compute the normalized package identity for a configured source string.
+ *
+ * `baseDir` resolves relative local paths (matches pi: relative local paths
+ * resolve against the settings file's directory — the agent dir for user
+ * scope). Prefer `installedPath` from `PackageManager.listConfiguredPackages()`
+ * for local packages when available; it is already the upstream-resolved
+ * canonical path and avoids re-deriving this resolution ourselves.
+ */
+export function computePackageIdentity(source: string, baseDir: string = process.cwd()): PackageIdentity {
+    const trimmed = source.trim();
+    if (trimmed.startsWith("npm:")) {
+        return { kind: "npm", identity: `npm:${stripVersionSuffix(trimmed.slice(4).trim())}` };
+    }
+    if (trimmed.startsWith("git:") || GIT_PROTOCOL_RE.test(trimmed)) {
+        return { kind: "git", identity: `git:${normalizeGitSource(trimmed)}` };
+    }
+    return { kind: "local", identity: `local:${canonicalLocalPath(trimmed, baseDir)}` };
+}
+
+/** Resolve a local path to its canonical (symlink-resolved) absolute identity path. */
+export function canonicalLocalPath(path: string, baseDir: string = process.cwd()): string {
+    const abs = resolvePath(baseDir, path);
+    try {
+        return realpathSync(abs);
+    } catch {
+        // Target may not exist yet (or no longer exists) — fall back to the
+        // resolved absolute path so identity is still stable and comparable.
+        return abs;
+    }
+}
+
+/** Build a `local:<canonical-path>` identity directly from an already-resolved absolute path. */
+export function localIdentityFromResolvedPath(resolvedAbsolutePath: string): string {
+    try {
+        return `local:${realpathSync(resolvedAbsolutePath)}`;
+    } catch {
+        return `local:${resolvedAbsolutePath}`;
+    }
+}

--- a/packages/cli/src/overlay/identity.ts
+++ b/packages/cli/src/overlay/identity.ts
@@ -2,21 +2,30 @@
  * Package identity normalization for the `pi.pizzapi` overlay.
  *
  * Mirrors the identity rules from docs/specs/pi-pizzapi-overlay.md §6.1 /
- * pi 0.82.1 `docs/packages.md` ("Scope and Deduplication"):
+ * pi 0.82.1 `DefaultPackageManager.getPackageIdentity()` (a private method —
+ * pinned by identity.test.ts via a narrow test-only cast, not imported here):
  *   - npm:  package name, version stripped
- *   - git:  `host/path`, ref stripped, protocol/SSH forms normalized
- *   - local: resolved canonical absolute path
+ *   - git:  `host/path`, ref stripped, host lowercased, path case preserved
+ *   - local: resolved canonical absolute path, symlinks dereferenced
  *
  * ponytail: pi's own git URL parsing goes through `hosted-git-info` (an
  * upstream-only dependency we don't have access to and won't add). This is
- * a small resolver covering the four documented source forms from
- * docs/packages.md, characterized by identity.test.ts. It is not a full
- * git URL parser — expand if an unsupported form surfaces in practice.
+ * a small resolver covering the documented source forms from
+ * docs/packages.md (git:/https:/ssh: protocols plus the scp-like
+ * `git@host:path` shorthand), characterized against the real upstream
+ * `getPackageIdentity()` by identity.test.ts. It is not a full git URL
+ * parser — expand if an unsupported form surfaces in practice. Known
+ * divergence: upstream's `hosted-git-info` inconsistently skips host
+ * lowercasing for some non-documented ssh:// + mixed-case-host combinations;
+ * we always lowercase the host, which is the documented/intended behavior.
  */
 import { realpathSync } from "node:fs";
-import { resolve as resolvePath } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 
 export type PackageSourceKind = "npm" | "git" | "local";
+export type PackageScope = "user" | "project";
 
 export interface PackageIdentity {
     kind: PackageSourceKind;
@@ -31,28 +40,65 @@ function stripVersionSuffix(spec: string): string {
     return atIdx > 0 ? spec.slice(0, atIdx) : spec;
 }
 
+/** Expand a leading `~` or `~/...` to the user's home directory, matching pi's resolvePath(). */
+function expandTilde(input: string): string {
+    if (input === "~") return homedir();
+    if (input.startsWith("~/") || input.startsWith("~\\")) return join(homedir(), input.slice(2));
+    return input;
+}
+
+/**
+ * Split a non-protocol git source (after any `git:`/user-info prefix has
+ * been considered) into host/path at the first `:` (scp-like shorthand,
+ * e.g. "github.com:user/repo") or the first `/` (bare shorthand, e.g.
+ * "github.com/user/repo") — whichever comes first, matching pi's own
+ * scp-like-then-bare parsing order.
+ */
+function splitHostPath(rest: string): { host: string; path: string } {
+    const withoutUserInfo = rest.replace(/^[^@/:]+@/, "");
+    const colonIdx = withoutUserInfo.indexOf(":");
+    const slashIdx = withoutUserInfo.indexOf("/");
+    if (colonIdx >= 0 && (slashIdx < 0 || colonIdx < slashIdx)) {
+        return { host: withoutUserInfo.slice(0, colonIdx), path: withoutUserInfo.slice(colonIdx + 1) };
+    }
+    if (slashIdx >= 0) {
+        return { host: withoutUserInfo.slice(0, slashIdx), path: withoutUserInfo.slice(slashIdx + 1) };
+    }
+    return { host: withoutUserInfo, path: "" };
+}
+
 function normalizeGitSource(source: string): string {
-    let s = source;
-    if (s.startsWith("git:")) s = s.slice(4);
-    s = s.replace(/^(https?:\/\/|ssh:\/\/|git:\/\/)/i, "");
-    s = s.replace(/^git@/, "");
-    // scp-like shorthand "host:path" -> "host/path" (only the first colon
-    // separates host from path; version refs use "@", not ":").
-    s = s.replace(":", "/");
-    s = stripVersionSuffix(s);
-    s = s.replace(/\.git$/i, "");
-    s = s.replace(/\/+$/, "");
-    return s.toLowerCase();
+    let s = source.trim();
+    if (s.startsWith("git:")) s = s.slice(4).trim();
+
+    let host: string;
+    let path: string;
+    if (GIT_PROTOCOL_RE.test(s)) {
+        try {
+            const url = new URL(s);
+            host = url.hostname; // URL strips the port automatically — handles ssh://host:port/path.
+            path = url.pathname.replace(/^\/+/, "");
+        } catch {
+            ({ host, path } = splitHostPath(s));
+        }
+    } else {
+        ({ host, path } = splitHostPath(s));
+    }
+
+    path = stripVersionSuffix(path);
+    path = path.replace(/\.git$/i, "");
+    return `${host.toLowerCase()}/${path}`;
 }
 
 /**
  * Compute the normalized package identity for a configured source string.
  *
- * `baseDir` resolves relative local paths (matches pi: relative local paths
- * resolve against the settings file's directory — the agent dir for user
- * scope). Prefer `installedPath` from `PackageManager.listConfiguredPackages()`
- * for local packages when available; it is already the upstream-resolved
- * canonical path and avoids re-deriving this resolution ourselves.
+ * `baseDir` resolves relative local paths and must be the same scope-aware
+ * base pi itself uses: the agent dir for user-scope packages, or
+ * `<cwd>/.pizzapi` (pi's `CONFIG_DIR_NAME`) for project-scope packages. See
+ * `packageScopeBaseDir()`. Prefer `installedPath` from
+ * `PackageManager.listConfiguredPackages()` for local packages when
+ * available; it is already the upstream-resolved path.
  */
 export function computePackageIdentity(source: string, baseDir: string = process.cwd()): PackageIdentity {
     const trimmed = source.trim();
@@ -67,7 +113,7 @@ export function computePackageIdentity(source: string, baseDir: string = process
 
 /** Resolve a local path to its canonical (symlink-resolved) absolute identity path. */
 export function canonicalLocalPath(path: string, baseDir: string = process.cwd()): string {
-    const abs = resolvePath(baseDir, path);
+    const abs = resolvePath(baseDir, expandTilde(path.trim()));
     try {
         return realpathSync(abs);
     } catch {
@@ -77,11 +123,11 @@ export function canonicalLocalPath(path: string, baseDir: string = process.cwd()
     }
 }
 
-/** Build a `local:<canonical-path>` identity directly from an already-resolved absolute path. */
-export function localIdentityFromResolvedPath(resolvedAbsolutePath: string): string {
-    try {
-        return `local:${realpathSync(resolvedAbsolutePath)}`;
-    } catch {
-        return `local:${resolvedAbsolutePath}`;
-    }
+/**
+ * The base directory pi resolves relative local package paths against for a
+ * given scope — matches `DefaultPackageManager.getBaseDirForScope()`
+ * exactly: the agent dir for user scope, `<cwd>/.pizzapi` for project scope.
+ */
+export function packageScopeBaseDir(scope: PackageScope, cwd: string, agentDir: string): string {
+    return scope === "project" ? join(cwd, CONFIG_DIR_NAME) : agentDir;
 }

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -153,6 +153,245 @@ describe("readOverlayManifest", () => {
         expect(result.overlay).toBeNull();
         expect(result.issues.some((i) => i.field === "services[0].panel.dir")).toBe(true);
     });
+
+    // ── mcp sidecar shape/format ────────────────────────────────────────────
+
+    test("mcp sidecar with malformed JSON is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad.json" }, (d) => {
+            writeFileSync(join(d, "bad.json"), "{ not valid json,,,");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("not valid JSON"))).toBe(true);
+    });
+
+    test("mcp sidecar containing HTML is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad.json" }, (d) => {
+            writeFileSync(join(d, "bad.json"), "<html><body>nope</body></html>");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("not valid JSON"))).toBe(true);
+    });
+
+    test("mcp sidecar pointing at a directory is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./sidecar-dir.json" }, (d) => {
+            mkdirSync(join(d, "sidecar-dir.json"));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("regular file"))).toBe(true);
+    });
+
+    test("mcp sidecar with non-.json extension is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./config.txt" }, (d) => {
+            writeFileSync(join(d, "config.txt"), JSON.stringify({ mcpServers: { x: { command: "foo" } } }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes(".json extension"))).toBe(true);
+    });
+
+    test("mcp sidecar with invalid shape (neither mcp.servers nor mcpServers) is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./junk.json" }, (d) => {
+            writeFileSync(join(d, "junk.json"), JSON.stringify({ foo: "bar" }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("mcp.servers"))).toBe(true);
+    });
+
+    test("mcp sidecar entry missing both command and url is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad-entry.json" }, (d) => {
+            writeFileSync(join(d, "bad-entry.json"), JSON.stringify({ mcpServers: { x: { transport: "stdio" } } }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field.includes("mcpServers.x"))).toBe(true);
+    });
+
+    test("mcp sidecar with valid mcpServers object format is accepted", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./mcp.json" }, (d) => {
+            writeFileSync(join(d, "mcp.json"), JSON.stringify({ mcpServers: { playwright: { command: "npx", args: ["@playwright/mcp"] } } }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+        expect(result.overlay?.mcp).toBe("./mcp.json");
+    });
+
+    test("mcp sidecar with valid mcp.servers array format is accepted", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./mcp.json" }, (d) => {
+            writeFileSync(join(d, "mcp.json"), JSON.stringify({ mcp: { servers: [{ name: "gh", transport: "http", url: "https://api.example.com/mcp" }] } }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+    });
+
+    // ── triggers/sigils sidecar and inline validation ──────────────────────
+
+    test("triggers sidecar that isn't an array is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", triggers: "./triggers.json" }],
+        }, (d) => {
+            writeFileSync(join(d, "triggers.json"), JSON.stringify({ type: "x", label: "y" }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].triggers" && i.message.includes("array"))).toBe(true);
+    });
+
+    test("triggers sidecar with malformed JSON is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", triggers: "./triggers.json" }],
+        }, (d) => {
+            writeFileSync(join(d, "triggers.json"), "not json at all");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].triggers" && i.message.includes("not valid JSON"))).toBe(true);
+    });
+
+    test("triggers sidecar pointing at a directory is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", triggers: "./triggers-dir.json" }],
+        }, (d) => {
+            mkdirSync(join(d, "triggers-dir.json"));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].triggers" && i.message.includes("regular file"))).toBe(true);
+    });
+
+    test("inline junk sigil entry (missing type/label) is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", sigils: [{ icon: "bug" }] }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].sigils[0].type")).toBe(true);
+        expect(result.issues.some((i) => i.field === "services[0].sigils[0].label")).toBe(true);
+    });
+
+    test("inline junk trigger entry (unknown key, wrong description type) is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{
+                id: "svc",
+                label: "x",
+                entry: "./service.ts",
+                triggers: [{ type: "svc:event", label: "Event", description: 123, bogus: true }],
+            }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].triggers[0].description")).toBe(true);
+        expect(result.issues.some((i) => i.field === "services[0].triggers[0].bogus")).toBe(true);
+    });
+
+    test("malformed trigger params (bad type, multiselect without enum) is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{
+                id: "svc",
+                label: "x",
+                entry: "./service.ts",
+                triggers: [{
+                    type: "svc:event",
+                    label: "Event",
+                    params: [
+                        { name: "repo", label: "Repo", type: "stringly" },
+                        { name: "mode", label: "Mode", type: "string", multiselect: true },
+                    ],
+                }],
+            }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].triggers[0].params[0].type")).toBe(true);
+        expect(result.issues.some((i) => i.field === "services[0].triggers[0].params[1].multiselect")).toBe(true);
+    });
+
+    test("valid inline trigger and sigil definitions are accepted", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{
+                id: "svc",
+                label: "x",
+                entry: "./service.ts",
+                triggers: [{
+                    type: "svc:event",
+                    label: "Event",
+                    description: "fires on stuff",
+                    params: [{ name: "repo", label: "Repo", type: "string", required: true, enum: ["a", "b"], multiselect: true }],
+                }],
+                sigils: [{ type: "pr", label: "Pull Request", icon: "git-pull-request", aliases: ["mr"] }],
+            }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+        expect(result.overlay?.services?.[0]?.triggers).toBeDefined();
+    });
+
+    test("valid sidecar trigger/sigil JSON arrays are accepted", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", triggers: "./triggers.json", sigils: "./sigils.json" }],
+        }, (d) => {
+            writeFileSync(join(d, "triggers.json"), JSON.stringify([{ type: "svc:event", label: "Event" }]));
+            writeFileSync(join(d, "sigils.json"), JSON.stringify([{ type: "pr", label: "Pull Request" }]));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+    });
+
+    // ── agents/rules must resolve to a directory or a .md file ─────────────
+
+    test("agent entry pointing at a non-.md file is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, agents: ["./service.ts"] });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "agents[0]" && i.message.includes(".md"))).toBe(true);
+    });
+
+    test("rule entry pointing at a directory is accepted", () => {
+        const dir = fixturePkg({ schemaVersion: 1, rules: ["./rules-dir"] }, (d) => {
+            mkdirSync(join(d, "rules-dir"));
+            writeFileSync(join(d, "rules-dir", "a.md"), "# hi");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+    });
+
+    test("agent entry pointing at a .md file is accepted", () => {
+        const dir = fixturePkg({ schemaVersion: 1, agents: ["./agent.md"] }, (d) => {
+            writeFileSync(join(d, "agent.md"), "# agent");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+    });
 });
 
 describe("resolveConfinedPath", () => {

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readOverlayManifest, resolveConfinedPath, OVERLAY_SIDECAR_MAX_BYTES } from "./manifest.js";
+
+const provenance = { identity: "local:/pkg", source: "./pkg", scope: "user" as const };
+
+function fixturePkg(overlay: unknown, extra?: (dir: string) => void): string {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "pizzapi-overlay-")));
+    writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "fixture", version: "1.0.0", pi: { pizzapi: overlay } }),
+    );
+    writeFileSync(join(dir, "service.ts"), "export default {};");
+    if (extra) extra(dir);
+    return dir;
+}
+
+describe("readOverlayManifest", () => {
+    let dirs: string[] = [];
+    afterEach(() => {
+        for (const d of dirs) rmSync(d, { recursive: true, force: true });
+        dirs = [];
+    });
+
+    test("absent pi.pizzapi: overlay null, present false, no issues", () => {
+        const dir = mkdtempSync(join(tmpdir(), "pizzapi-overlay-"));
+        dirs.push(dir);
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+        const result = readOverlayManifest(dir, { ...provenance, identity: "local:x" });
+        expect(result.overlay).toBeNull();
+        expect(result.present).toBe(false);
+        expect(result.issues).toHaveLength(0);
+    });
+
+    test("valid minimal overlay with a service", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+        expect(result.overlay?.services?.[0]?.id).toBe("github");
+    });
+
+    test("unknown top-level key is rejected with all errors reported together", () => {
+        const dir = fixturePkg({ schemaVersion: 1, bogus: true, providers: {} });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.present).toBe(true);
+        const fields = result.issues.map((i) => i.field);
+        expect(fields).toContain("bogus");
+        expect(fields).toContain("providers");
+    });
+
+    test("unsupported schema version is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 2 });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues[0]?.field).toBe("schemaVersion");
+    });
+
+    test("duplicate service ids invalidate the overlay", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [
+                { id: "github", label: "GitHub", entry: "./service.ts" },
+                { id: "github", label: "GitHub 2", entry: "./service.ts" },
+            ],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.message.includes("duplicate service id"))).toBe(true);
+    });
+
+    test("invalid service id format is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, services: [{ id: "GitHub!", label: "x", entry: "./service.ts" }] });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].id")).toBe(true);
+    });
+
+    test("absolute entry path is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "/etc/passwd" }] });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.message.includes("absolute"))).toBe(true);
+    });
+
+    test("traversal (..) entry path is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "../outside.ts" }] });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.message.includes(".."))).toBe(true);
+    });
+
+    test("symlink escaping the package root is rejected", () => {
+        const outsideDir = mkdtempSync(join(tmpdir(), "pizzapi-outside-"));
+        dirs.push(outsideDir);
+        writeFileSync(join(outsideDir, "evil.ts"), "export default {};");
+        const dir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./link.ts" }] }, (d) => {
+            symlinkSync(join(outsideDir, "evil.ts"), join(d, "link.ts"));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.message.includes("symlink"))).toBe(true);
+    });
+
+    test("entry with disallowed extension is rejected without importing it", () => {
+        const dir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./service.json" }] }, (d) => {
+            writeFileSync(join(d, "service.json"), "{}");
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].entry")).toBe(true);
+    });
+
+    test("missing sidecar (mcp path) is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./missing.json" });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("does not exist"))).toBe(true);
+    });
+
+    test("oversized sidecar (>2 MiB) is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./big.json" }, (d) => {
+            writeFileSync(join(d, "big.json"), "x".repeat(OVERLAY_SIDECAR_MAX_BYTES + 1));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("exceeding"))).toBe(true);
+    });
+
+    test("panel.dir must resolve to a directory inside the package root", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", panel: { dir: "./service.ts" } }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].panel.dir")).toBe(true);
+    });
+});
+
+describe("resolveConfinedPath", () => {
+    test("accepts a clean relative path inside the root", () => {
+        const dir = mkdtempSync(join(tmpdir(), "pizzapi-confine-"));
+        try {
+            writeFileSync(join(dir, "a.ts"), "");
+            const result = resolveConfinedPath(dir, "./a.ts");
+            expect(result.ok).toBe(true);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -13,7 +13,7 @@
  * extension.
  */
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
+import { isAbsolute, join, resolve as resolvePath, sep } from "node:path";
 import type { PanelVariable, PizzaPiOverlayV1, PizzaPiServiceDeclaration } from "@pizzapi/extension-sdk";
 import { MAX_PLUGIN_FILE_SIZE } from "../plugins/types.js";
 
@@ -26,6 +26,14 @@ const PANEL_KEYS = new Set(["dir", "requires"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
 const SERVICE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const ENTRY_EXTENSIONS = [".ts", ".js", ".mts", ".mjs"];
+/** Value types allowed on a trigger param definition, mirrored from ServiceTriggerParamDef. */
+const TRIGGER_PARAM_TYPES = new Set(["string", "number", "boolean", "json"]);
+/** Allowed keys on a trigger param definition, mirrored from ServiceTriggerParamDef. */
+const TRIGGER_PARAM_KEYS = new Set(["name", "label", "type", "description", "required", "default", "enum", "multiselect"]);
+/** Allowed keys on a trigger definition, mirrored from ServiceTriggerDef. */
+const TRIGGER_KEYS = new Set(["type", "label", "description", "schema", "params"]);
+/** Allowed keys on a sigil definition, mirrored from ServiceSigilDef (excludes daemon-populated serviceId/resolvePort). */
+const SIGIL_KEYS = new Set(["type", "label", "description", "icon", "resolve", "schema", "aliases", "variants"]);
 
 export interface PackageProvenance {
     /** Normalized package identity, e.g. "npm:@acme/pi-github". */
@@ -128,6 +136,53 @@ function checkSidecarSize(absolutePath: string, relPath: string): string | null 
     return null;
 }
 
+/**
+ * Resolve, size-cap, and JSON-parse a sidecar file (mcp/triggers/sigils).
+ * Requires a REGULAR `.json` file inside the package root — rejects
+ * directories, non-`.json` extensions, oversized files, and content that
+ * doesn't parse as JSON (malformed JSON, HTML, etc). Returns the parsed
+ * value on success, or `undefined` after pushing an issue on failure.
+ */
+function readSidecarJson(packageRoot: string, relPath: string, field: string, push: PushFn): unknown | undefined {
+    const resolved = resolveConfinedPath(packageRoot, relPath);
+    if (!resolved.ok) {
+        push(field, resolved.message, `Point ${field} at a valid JSON file inside the package root.`);
+        return undefined;
+    }
+    if (!relPath.toLowerCase().endsWith(".json")) {
+        push(field, `sidecar file "${relPath}" must have a .json extension`, `Point ${field} at a .json file.`);
+        return undefined;
+    }
+    let isFile = false;
+    try {
+        isFile = statSync(resolved.absolutePath).isFile();
+    } catch {
+        isFile = false;
+    }
+    if (!isFile) {
+        push(field, `sidecar path "${relPath}" must resolve to a regular file, not a directory`, `Point ${field} at a JSON file inside the package root.`);
+        return undefined;
+    }
+    const sizeError = checkSidecarSize(resolved.absolutePath, relPath);
+    if (sizeError) {
+        push(field, sizeError, `Shrink the sidecar file below ${OVERLAY_SIDECAR_MAX_BYTES} bytes, or split it.`);
+        return undefined;
+    }
+    let text: string;
+    try {
+        text = readFileSync(resolved.absolutePath, "utf-8");
+    } catch {
+        push(field, `sidecar file "${relPath}" could not be read`, `Point ${field} at a readable JSON file.`);
+        return undefined;
+    }
+    try {
+        return JSON.parse(text);
+    } catch {
+        push(field, `sidecar file "${relPath}" is not valid JSON`, `Fix ${relPath} so it parses as JSON.`);
+        return undefined;
+    }
+}
+
 /** Read `package.json` and extract the raw (unvalidated) `pi.pizzapi` value, if present. */
 function readRawOverlay(packageRoot: string): { raw: unknown; present: boolean; error?: string } {
     const pkgJsonPath = join(packageRoot, "package.json");
@@ -212,18 +267,21 @@ export function readOverlayManifest(packageRoot: string, provenance: PackageProv
         return { overlay: null, present: true, issues };
     }
 
-    validateAgentsOrRules(raw.agents, "agents", packageRoot, provenance, push);
-    validateAgentsOrRules(raw.rules, "rules", packageRoot, provenance, push);
+    validateAgentsOrRules(raw.agents, "agents", packageRoot, push);
+    validateAgentsOrRules(raw.rules, "rules", packageRoot, push);
 
     if (raw.mcp !== undefined) {
         if (typeof raw.mcp !== "string") {
             push("mcp", "must be a package-relative JSON path string", "Set mcp to a single package-relative path, e.g. \"./.mcp.json\".");
         } else {
-            validateSidecarPath(packageRoot, raw.mcp, "mcp", provenance, push);
+            const parsed = readSidecarJson(packageRoot, raw.mcp, "mcp", push);
+            if (parsed !== undefined) {
+                validateMcpShape(parsed, "mcp", push);
+            }
         }
     }
 
-    const services = validateServices(raw.services, packageRoot, provenance, push);
+    const services = validateServices(raw.services, packageRoot, push);
 
     if (issues.length > 0) {
         return { overlay: null, present: true, issues };
@@ -244,7 +302,8 @@ function issue(provenance: PackageProvenance, field: string, message: string, re
 
 type PushFn = (field: string, message: string, remediation: string) => void;
 
-function validateAgentsOrRules(value: unknown, field: string, packageRoot: string, provenance: PackageProvenance, push: PushFn): void {
+/** Agent/rule entries must resolve to a directory, or a REGULAR `.md` file — never an arbitrary file. */
+function validateAgentsOrRules(value: unknown, field: string, packageRoot: string, push: PushFn): void {
     if (value === undefined) return;
     if (!Array.isArray(value)) {
         push(field, "must be an array of package-relative paths", `Set ${field} to an array of Markdown file/directory paths.`);
@@ -259,26 +318,226 @@ function validateAgentsOrRules(value: unknown, field: string, packageRoot: strin
         const resolved = resolveConfinedPath(packageRoot, entry);
         if (!resolved.ok) {
             push(entryField, resolved.message, `Point ${entryField} at a valid path inside the package root.`);
+            return;
         }
+        let st;
+        try {
+            st = statSync(resolved.absolutePath);
+        } catch {
+            push(entryField, `path "${entry}" could not be read`, `Point ${entryField} at a directory or .md file inside the package root.`);
+            return;
+        }
+        if (st.isDirectory()) return;
+        if (st.isFile() && resolved.absolutePath.toLowerCase().endsWith(".md")) return;
+        push(entryField, `must resolve to a directory or a .md file (got "${entry}")`, `Point ${entryField} at a directory or a Markdown (.md) file.`);
     });
 }
 
-function validateSidecarPath(packageRoot: string, relPath: string, field: string, provenance: PackageProvenance, push: PushFn): void {
-    const resolved = resolveConfinedPath(packageRoot, relPath);
-    if (!resolved.ok) {
-        push(field, resolved.message, `Point ${field} at a valid JSON file inside the package root.`);
+/**
+ * Shape-check a parsed `mcp` sidecar JSON value. Must contain at least one
+ * of the two formats PizzaPi's MCP loader already accepts: the preferred
+ * `mcp.servers` array or the compatibility `mcpServers` object (see
+ * extensions/mcp-extension.ts, extensions/mcp/registry.ts). Entries are
+ * shape-checked just enough to reject junk while staying compatible with
+ * every transport variant those loaders already support.
+ */
+function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(parsed)) {
+        push(field, "sidecar JSON must be a top-level object", "The mcp sidecar file must contain a JSON object with mcp.servers or mcpServers.");
         return;
     }
-    const sizeError = checkSidecarSize(resolved.absolutePath, relPath);
-    if (sizeError) {
-        push(field, sizeError, `Shrink the sidecar file below ${OVERLAY_SIDECAR_MAX_BYTES} bytes, or split it.`);
+
+    const mcpServersArray = isPlainObject(parsed.mcp) && Array.isArray((parsed.mcp as Record<string, unknown>).servers)
+        ? ((parsed.mcp as Record<string, unknown>).servers as unknown[])
+        : undefined;
+    const mcpServersObject = isPlainObject(parsed.mcpServers) ? (parsed.mcpServers as Record<string, unknown>) : undefined;
+
+    if (mcpServersArray === undefined && mcpServersObject === undefined) {
+        push(field, "must contain mcp.servers (array) or mcpServers (object)", "Use the preferred { mcp: { servers: [...] } } or compatibility { mcpServers: {...} } format.");
+        return;
     }
+
+    if (mcpServersArray !== undefined) {
+        mcpServersArray.forEach((entry, i) => {
+            const entryField = `${field}.servers[${i}]`;
+            if (!isPlainObject(entry)) {
+                push(entryField, "must be an object", "Fix this mcp.servers entry to a { name, command|url } object.");
+                return;
+            }
+            if (typeof entry.name !== "string" || entry.name.length === 0) {
+                push(`${entryField}.name`, "must be a non-empty string", "Set name to a unique server identifier.");
+            }
+            if (typeof entry.command !== "string" && typeof entry.url !== "string") {
+                push(entryField, "must have a string command (stdio) or url (http/streamable)", "Set command for a stdio server, or url for an http/streamable server.");
+            }
+        });
+    }
+
+    if (mcpServersObject !== undefined) {
+        for (const [name, value] of Object.entries(mcpServersObject)) {
+            const entryField = `${field}.mcpServers.${name}`;
+            if (!isPlainObject(value)) {
+                push(entryField, "must be an object", "Fix this mcpServers entry to a { command|url } object.");
+                continue;
+            }
+            if (typeof value.command !== "string" && typeof value.url !== "string") {
+                push(entryField, "must have a string command (stdio) or url (http/streamable)", "Set command for a stdio server, or url for an http/streamable server.");
+            }
+        }
+    }
+}
+
+function validateTriggerParamDef(entry: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a trigger param definition object.`);
+        return;
+    }
+    for (const key of Object.keys(entry)) {
+        if (!TRIGGER_PARAM_KEYS.has(key)) {
+            push(`${field}.${key}`, `unknown param key "${key}"`, `Remove "${key}" — allowed keys: ${[...TRIGGER_PARAM_KEYS].join(", ")}.`);
+        }
+    }
+    if (typeof entry.name !== "string" || entry.name.length === 0) {
+        push(`${field}.name`, "must be a non-empty string", "Set name to the parameter's identifier.");
+    }
+    if (typeof entry.label !== "string" || entry.label.length === 0) {
+        push(`${field}.label`, "must be a non-empty string", "Set label to a human-readable name.");
+    }
+    if (typeof entry.type !== "string" || !TRIGGER_PARAM_TYPES.has(entry.type)) {
+        push(`${field}.type`, `must be one of ${[...TRIGGER_PARAM_TYPES].join(", ")}`, `Set type to one of: ${[...TRIGGER_PARAM_TYPES].join(", ")}.`);
+    }
+    if (entry.description !== undefined && typeof entry.description !== "string") {
+        push(`${field}.description`, "must be a string", "Set description to a string, or omit it.");
+    }
+    if (entry.required !== undefined && typeof entry.required !== "boolean") {
+        push(`${field}.required`, "must be a boolean", "Set required to true/false, or omit it.");
+    }
+    let enumOk = true;
+    if (entry.enum !== undefined) {
+        enumOk = Array.isArray(entry.enum) && entry.enum.every((v) => typeof v === "string" || typeof v === "number" || typeof v === "boolean");
+        if (!enumOk) {
+            push(`${field}.enum`, "must be an array of strings/numbers/booleans", "Set enum to an array of allowed primitive values, or omit it.");
+        }
+    }
+    if (entry.multiselect !== undefined) {
+        if (typeof entry.multiselect !== "boolean") {
+            push(`${field}.multiselect`, "must be a boolean", "Set multiselect to true/false, or omit it.");
+        } else if (entry.multiselect && !(Array.isArray(entry.enum) && enumOk)) {
+            push(`${field}.multiselect`, "requires enum to be set", "Add an enum array, or remove multiselect.");
+        }
+    }
+    // `default` accepts any JsonValue — no further shape check needed.
+}
+
+function validateTriggerDef(entry: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a { type, label } trigger definition object.`);
+        return;
+    }
+    for (const key of Object.keys(entry)) {
+        if (!TRIGGER_KEYS.has(key)) {
+            push(`${field}.${key}`, `unknown trigger key "${key}"`, `Remove "${key}" — allowed keys: ${[...TRIGGER_KEYS].join(", ")}.`);
+        }
+    }
+    if (typeof entry.type !== "string" || entry.type.length === 0) {
+        push(`${field}.type`, "must be a non-empty string", 'Set type to a namespaced trigger type, e.g. "myservice:event".');
+    }
+    if (typeof entry.label !== "string" || entry.label.length === 0) {
+        push(`${field}.label`, "must be a non-empty string", "Set label to a human-readable trigger name.");
+    }
+    if (entry.description !== undefined && typeof entry.description !== "string") {
+        push(`${field}.description`, "must be a string", "Set description to a string, or omit it.");
+    }
+    if (entry.schema !== undefined && !isPlainObject(entry.schema)) {
+        push(`${field}.schema`, "must be an object (JSON Schema)", "Set schema to a JSON Schema object, or omit it.");
+    }
+    if (entry.params !== undefined) {
+        if (!Array.isArray(entry.params)) {
+            push(`${field}.params`, "must be an array of trigger param definitions", "Set params to an array, or omit it.");
+        } else {
+            entry.params.forEach((p, i) => validateTriggerParamDef(p, `${field}.params[${i}]`, push));
+        }
+    }
+}
+
+function validateSigilDef(entry: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a { type, label } sigil definition object.`);
+        return;
+    }
+    for (const key of Object.keys(entry)) {
+        if (!SIGIL_KEYS.has(key)) {
+            push(`${field}.${key}`, `unknown sigil key "${key}"`, `Remove "${key}" — allowed keys: ${[...SIGIL_KEYS].join(", ")}.`);
+        }
+    }
+    if (typeof entry.type !== "string" || entry.type.length === 0) {
+        push(`${field}.type`, "must be a non-empty string", 'Set type to a short sigil type name, e.g. "pr".');
+    }
+    if (typeof entry.label !== "string" || entry.label.length === 0) {
+        push(`${field}.label`, "must be a non-empty string", "Set label to a human-readable name.");
+    }
+    if (entry.description !== undefined && typeof entry.description !== "string") {
+        push(`${field}.description`, "must be a string", "Set description to a string, or omit it.");
+    }
+    if (entry.icon !== undefined && typeof entry.icon !== "string") {
+        push(`${field}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
+    }
+    if (entry.resolve !== undefined && typeof entry.resolve !== "string") {
+        push(`${field}.resolve`, "must be a string", "Set resolve to an endpoint path, or omit it.");
+    }
+    if (entry.schema !== undefined && !isPlainObject(entry.schema)) {
+        push(`${field}.schema`, "must be an object (JSON Schema)", "Set schema to a JSON Schema object, or omit it.");
+    }
+    if (entry.aliases !== undefined) {
+        if (!Array.isArray(entry.aliases) || !entry.aliases.every((v) => typeof v === "string")) {
+            push(`${field}.aliases`, "must be an array of strings", "Set aliases to an array of alternate type names, or omit it.");
+        }
+    }
+    if (entry.variants !== undefined) {
+        if (!Array.isArray(entry.variants) || !entry.variants.every((v) => isPlainObject(v) && typeof v.name === "string" && typeof v.description === "string")) {
+            push(`${field}.variants`, "must be an array of { name, description } objects", "Fix variants entries, or omit it.");
+        }
+    }
+}
+
+/**
+ * Validate a service's `triggers`/`sigils` field: either a package-relative
+ * JSON sidecar path (which must parse to an array) or an inline array. Every
+ * resulting entry is shape-checked against the trigger/sigil protocol
+ * declarations so junk (wrong types, missing type/label, malformed params)
+ * is rejected rather than silently forwarded.
+ */
+function validateTriggerOrSigilField(
+    sidecarValue: unknown,
+    field: string,
+    packageRoot: string,
+    kind: "triggers" | "sigils",
+    push: PushFn,
+): void {
+    const validateEntry = kind === "triggers" ? validateTriggerDef : validateSigilDef;
+
+    if (typeof sidecarValue === "string") {
+        const parsed = readSidecarJson(packageRoot, sidecarValue, field, push);
+        if (parsed === undefined) return;
+        if (!Array.isArray(parsed)) {
+            push(field, "sidecar JSON must be an array of definitions", `Fix the ${kind} sidecar file to contain a top-level JSON array.`);
+            return;
+        }
+        parsed.forEach((entry, i) => validateEntry(entry, `${field}[${i}]`, push));
+        return;
+    }
+
+    if (Array.isArray(sidecarValue)) {
+        sidecarValue.forEach((entry, i) => validateEntry(entry, `${field}[${i}]`, push));
+        return;
+    }
+
+    push(field, "must be a package-relative JSON path or an inline array", `Set ${field} to a string path or an array.`);
 }
 
 function validateServices(
     value: unknown,
     packageRoot: string,
-    provenance: PackageProvenance,
     push: PushFn,
 ): PizzaPiServiceDeclaration[] | undefined {
     if (value === undefined) return undefined;
@@ -393,20 +652,13 @@ function validateServices(
             }
         }
 
+        // Note: trigger/sigil shape issues push directly via `push`, which
+        // rejects the whole overlay in readOverlayManifest regardless of the
+        // `valid` flag below — no local bookkeeping needed here.
         for (const sidecarField of ["triggers", "sigils"] as const) {
             const sidecarValue = raw[sidecarField];
             if (sidecarValue === undefined) continue;
-            if (typeof sidecarValue === "string") {
-                validateSidecarPath(packageRoot, sidecarValue, `${field}.${sidecarField}`, provenance, push);
-            } else if (Array.isArray(sidecarValue)) {
-                if (!sidecarValue.every((v) => isPlainObject(v))) {
-                    push(`${field}.${sidecarField}`, "inline array entries must be objects", `Fix ${field}.${sidecarField} entries to protocol definition objects.`);
-                    valid = false;
-                }
-            } else {
-                push(`${field}.${sidecarField}`, "must be a package-relative JSON path or an inline array", `Set ${field}.${sidecarField} to a string path or an array.`);
-                valid = false;
-            }
+            validateTriggerOrSigilField(sidecarValue, `${field}.${sidecarField}`, packageRoot, sidecarField, push);
         }
 
         if (valid) {

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -1,0 +1,418 @@
+/**
+ * Shared `pi.pizzapi` overlay manifest reader and strict schema-v1 validator.
+ *
+ * This is the single source of truth for overlay parsing — package commands
+ * (install/list/config trust UX), daemon service discovery, and session-side
+ * agents/rules/MCP loading all read overlays through this module so the
+ * closed-schema and path-confinement rules never drift between call sites.
+ *
+ * Per docs/specs/pi-pizzapi-overlay.md §9.2: "Reading and validating
+ * declarative JSON is allowed before the grant; importing the service entry
+ * is not." This module never `import()`s or requires an `entry` file — it
+ * only checks that the path resolves, stays confined, and has an allowed
+ * extension.
+ */
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
+import type { PanelVariable, PizzaPiOverlayV1, PizzaPiServiceDeclaration } from "@pizzapi/extension-sdk";
+import { MAX_PLUGIN_FILE_SIZE } from "../plugins/types.js";
+
+/** Reuse the existing 2 MiB per-file cap already used for plugin sidecar files. */
+export const OVERLAY_SIDECAR_MAX_BYTES = MAX_PLUGIN_FILE_SIZE;
+
+const TOP_LEVEL_KEYS = new Set(["schemaVersion", "services", "agents", "rules", "mcp"]);
+const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils"]);
+const PANEL_KEYS = new Set(["dir", "requires"]);
+const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
+const SERVICE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+const ENTRY_EXTENSIONS = [".ts", ".js", ".mts", ".mjs"];
+
+export interface PackageProvenance {
+    /** Normalized package identity, e.g. "npm:@acme/pi-github". */
+    identity: string;
+    /** Raw configured source string, e.g. "npm:@acme/pi-github@1.2.0". */
+    source: string;
+    scope: "user" | "project";
+}
+
+export interface OverlayIssue {
+    identity: string;
+    source: string;
+    scope: "user" | "project";
+    /** Dotted field path within the overlay, e.g. "services[0].panel.dir". */
+    field: string;
+    message: string;
+    remediation: string;
+}
+
+export interface OverlayReadResult {
+    /** The validated overlay, or null if absent or invalid. */
+    overlay: PizzaPiOverlayV1 | null;
+    /** True when `pi.pizzapi` was present at all (even if invalid). */
+    present: boolean;
+    issues: OverlayIssue[];
+}
+
+/** One-line provenance-rich rendering of an issue, per spec §11. */
+export function formatOverlayIssue(issue: OverlayIssue): string {
+    return `[${issue.identity} (${issue.scope}: ${issue.source})] ${issue.field}: ${issue.message} — ${issue.remediation}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Resolve a package-relative path, rejecting absolute paths, `..` traversal,
+ * and symlinks that resolve outside the package root.
+ *
+ * Returns the resolved absolute path on success, or an error message on
+ * failure. Existence is the caller's responsibility (some callers need a
+ * distinct "missing" message).
+ */
+export function resolveConfinedPath(
+    packageRoot: string,
+    relPath: string,
+): { ok: true; absolutePath: string } | { ok: false; message: string } {
+    if (typeof relPath !== "string" || relPath.length === 0) {
+        return { ok: false, message: "path must be a non-empty string" };
+    }
+    if (isAbsolute(relPath)) {
+        return { ok: false, message: `path "${relPath}" must be package-relative, not absolute` };
+    }
+    const segments = relPath.split(/[\\/]/);
+    if (segments.some((seg) => seg === "..")) {
+        return { ok: false, message: `path "${relPath}" must not contain ".." traversal segments` };
+    }
+
+    let realRoot: string;
+    try {
+        realRoot = realpathSync(packageRoot);
+    } catch {
+        return { ok: false, message: `package root "${packageRoot}" does not exist` };
+    }
+
+    const absolutePath = resolvePath(realRoot, relPath);
+    if (absolutePath !== realRoot && !absolutePath.startsWith(realRoot + sep)) {
+        return { ok: false, message: `path "${relPath}" escapes the package root` };
+    }
+
+    if (!existsSync(absolutePath)) {
+        return { ok: false, message: `path "${relPath}" does not exist` };
+    }
+
+    // Symlink confinement: the fully resolved (real) path must also stay
+    // inside the package root, even if the declared path itself was clean.
+    let realTarget: string;
+    try {
+        realTarget = realpathSync(absolutePath);
+    } catch {
+        return { ok: false, message: `path "${relPath}" could not be resolved` };
+    }
+    if (realTarget !== realRoot && !realTarget.startsWith(realRoot + sep)) {
+        return { ok: false, message: `path "${relPath}" resolves (via symlink) outside the package root` };
+    }
+
+    return { ok: true, absolutePath: realTarget };
+}
+
+function checkSidecarSize(absolutePath: string, relPath: string): string | null {
+    try {
+        const size = statSync(absolutePath).size;
+        if (size > OVERLAY_SIDECAR_MAX_BYTES) {
+            return `sidecar file "${relPath}" is ${size} bytes, exceeding the ${OVERLAY_SIDECAR_MAX_BYTES}-byte cap`;
+        }
+    } catch {
+        return `sidecar file "${relPath}" could not be read`;
+    }
+    return null;
+}
+
+/** Read `package.json` and extract the raw (unvalidated) `pi.pizzapi` value, if present. */
+function readRawOverlay(packageRoot: string): { raw: unknown; present: boolean; error?: string } {
+    const pkgJsonPath = join(packageRoot, "package.json");
+    if (!existsSync(pkgJsonPath)) {
+        return { raw: undefined, present: false };
+    }
+    let stat;
+    try {
+        stat = lstatSync(pkgJsonPath);
+    } catch {
+        return { raw: undefined, present: false };
+    }
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+        return { raw: undefined, present: false };
+    }
+    let text: string;
+    try {
+        text = readFileSync(pkgJsonPath, "utf-8");
+    } catch {
+        return { raw: undefined, present: false, error: "package.json could not be read" };
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        return { raw: undefined, present: false, error: "package.json is not valid JSON" };
+    }
+    if (!isPlainObject(parsed)) return { raw: undefined, present: false };
+    const pi = parsed.pi;
+    if (!isPlainObject(pi)) return { raw: undefined, present: false };
+    if (!("pizzapi" in pi)) return { raw: undefined, present: false };
+    return { raw: pi.pizzapi, present: true };
+}
+
+/**
+ * Read and strictly validate a package's `pi.pizzapi` overlay.
+ *
+ * - Absent overlay (no `pi.pizzapi` key): `{ overlay: null, present: false, issues: [] }`.
+ * - Malformed overlay: `{ overlay: null, present: true, issues: [...] }` — the
+ *   whole overlay is rejected as a unit (no partial mount), matching §5.2.
+ * - Never imports `entry` — only validates that it resolves to an allowed
+ *   extension inside the package root.
+ */
+export function readOverlayManifest(packageRoot: string, provenance: PackageProvenance): OverlayReadResult {
+    const { raw, present, error } = readRawOverlay(packageRoot);
+    if (!present) {
+        if (error) {
+            return {
+                overlay: null,
+                present: false,
+                issues: [issue(provenance, "package.json", error, "Fix package.json so it can be parsed.")],
+            };
+        }
+        return { overlay: null, present: false, issues: [] };
+    }
+
+    const issues: OverlayIssue[] = [];
+    const push = (field: string, message: string, remediation: string) => {
+        issues.push(issue(provenance, field, message, remediation));
+    };
+
+    if (!isPlainObject(raw)) {
+        push("pi.pizzapi", "must be an object", "Declare pi.pizzapi as a JSON object matching schema version 1.");
+        return { overlay: null, present: true, issues };
+    }
+
+    for (const key of Object.keys(raw)) {
+        if (!TOP_LEVEL_KEYS.has(key)) {
+            push(key, `unknown top-level overlay key "${key}"`, `Remove "${key}" — schema v1 keys are: ${[...TOP_LEVEL_KEYS].join(", ")}.`);
+        }
+    }
+
+    if (raw.schemaVersion !== 1) {
+        const got = JSON.stringify(raw.schemaVersion);
+        push(
+            "schemaVersion",
+            `must be exactly 1 (got ${got})`,
+            "Set schemaVersion to 1, or update this package for the loader's supported schema version.",
+        );
+        // Unsupported/missing version invalidates the whole overlay — nothing
+        // downstream is safe to interpret without knowing the schema.
+        return { overlay: null, present: true, issues };
+    }
+
+    validateAgentsOrRules(raw.agents, "agents", packageRoot, provenance, push);
+    validateAgentsOrRules(raw.rules, "rules", packageRoot, provenance, push);
+
+    if (raw.mcp !== undefined) {
+        if (typeof raw.mcp !== "string") {
+            push("mcp", "must be a package-relative JSON path string", "Set mcp to a single package-relative path, e.g. \"./.mcp.json\".");
+        } else {
+            validateSidecarPath(packageRoot, raw.mcp, "mcp", provenance, push);
+        }
+    }
+
+    const services = validateServices(raw.services, packageRoot, provenance, push);
+
+    if (issues.length > 0) {
+        return { overlay: null, present: true, issues };
+    }
+
+    const overlay: PizzaPiOverlayV1 = { schemaVersion: 1 };
+    if (services) overlay.services = services;
+    if (Array.isArray(raw.agents)) overlay.agents = raw.agents as string[];
+    if (Array.isArray(raw.rules)) overlay.rules = raw.rules as string[];
+    if (typeof raw.mcp === "string") overlay.mcp = raw.mcp;
+
+    return { overlay, present: true, issues: [] };
+}
+
+function issue(provenance: PackageProvenance, field: string, message: string, remediation: string): OverlayIssue {
+    return { identity: provenance.identity, source: provenance.source, scope: provenance.scope, field, message, remediation };
+}
+
+type PushFn = (field: string, message: string, remediation: string) => void;
+
+function validateAgentsOrRules(value: unknown, field: string, packageRoot: string, provenance: PackageProvenance, push: PushFn): void {
+    if (value === undefined) return;
+    if (!Array.isArray(value)) {
+        push(field, "must be an array of package-relative paths", `Set ${field} to an array of Markdown file/directory paths.`);
+        return;
+    }
+    value.forEach((entry, i) => {
+        const entryField = `${field}[${i}]`;
+        if (typeof entry !== "string" || entry.length === 0) {
+            push(entryField, "must be a non-empty string path", `Fix ${entryField} to a package-relative path.`);
+            return;
+        }
+        const resolved = resolveConfinedPath(packageRoot, entry);
+        if (!resolved.ok) {
+            push(entryField, resolved.message, `Point ${entryField} at a valid path inside the package root.`);
+        }
+    });
+}
+
+function validateSidecarPath(packageRoot: string, relPath: string, field: string, provenance: PackageProvenance, push: PushFn): void {
+    const resolved = resolveConfinedPath(packageRoot, relPath);
+    if (!resolved.ok) {
+        push(field, resolved.message, `Point ${field} at a valid JSON file inside the package root.`);
+        return;
+    }
+    const sizeError = checkSidecarSize(resolved.absolutePath, relPath);
+    if (sizeError) {
+        push(field, sizeError, `Shrink the sidecar file below ${OVERLAY_SIDECAR_MAX_BYTES} bytes, or split it.`);
+    }
+}
+
+function validateServices(
+    value: unknown,
+    packageRoot: string,
+    provenance: PackageProvenance,
+    push: PushFn,
+): PizzaPiServiceDeclaration[] | undefined {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value)) {
+        push("services", "must be an array of service declarations", "Set services to an array of { id, label, entry } objects.");
+        return undefined;
+    }
+
+    const result: PizzaPiServiceDeclaration[] = [];
+    const seenIds = new Set<string>();
+
+    value.forEach((raw, i) => {
+        const field = `services[${i}]`;
+        if (!isPlainObject(raw)) {
+            push(field, "must be an object", `Fix ${field} to a { id, label, entry } object.`);
+            return;
+        }
+        for (const key of Object.keys(raw)) {
+            if (!SERVICE_KEYS.has(key)) {
+                push(`${field}.${key}`, `unknown service key "${key}"`, `Remove "${key}" — allowed keys: ${[...SERVICE_KEYS].join(", ")}.`);
+            }
+        }
+
+        let valid = true;
+
+        if (typeof raw.id !== "string" || !SERVICE_ID_RE.test(raw.id)) {
+            push(`${field}.id`, `must match ${SERVICE_ID_RE.source}`, "Use a lowercase id starting with a letter, e.g. \"github\".");
+            valid = false;
+        } else if (seenIds.has(raw.id)) {
+            push(`${field}.id`, `duplicate service id "${raw.id}" within this package`, "Give each service a unique id.");
+            valid = false;
+        } else {
+            seenIds.add(raw.id);
+        }
+
+        if (typeof raw.label !== "string" || raw.label.length === 0) {
+            push(`${field}.label`, "must be a non-empty string", "Set label to a short display name for the service.");
+            valid = false;
+        }
+
+        if (typeof raw.entry !== "string" || raw.entry.length === 0) {
+            push(`${field}.entry`, "must be a non-empty package-relative path", "Set entry to the service's implementation file.");
+            valid = false;
+        } else {
+            const resolved = resolveConfinedPath(packageRoot, raw.entry);
+            if (!resolved.ok) {
+                push(`${field}.entry`, resolved.message, "Point entry at a file inside the package root.");
+                valid = false;
+            } else {
+                const hasAllowedExt = ENTRY_EXTENSIONS.some((ext) => resolved.absolutePath.endsWith(ext));
+                let isFile = false;
+                try {
+                    isFile = statSync(resolved.absolutePath).isFile();
+                } catch {
+                    isFile = false;
+                }
+                if (!hasAllowedExt || !isFile) {
+                    push(`${field}.entry`, `must resolve to a file with extension ${ENTRY_EXTENSIONS.join("/")}`, "Point entry at a .ts/.js/.mts/.mjs file.");
+                    valid = false;
+                }
+                // NOTE: entry is never imported/required here — only checked
+                // for existence, type, and extension. See module docstring.
+            }
+        }
+
+        if (raw.icon !== undefined && typeof raw.icon !== "string") {
+            push(`${field}.icon`, "must be a string", "Set icon to a string identifier, or omit it.");
+            valid = false;
+        }
+
+        if (raw.panel !== undefined) {
+            if (!isPlainObject(raw.panel)) {
+                push(`${field}.panel`, "must be an object", "Set panel to { dir, requires? }, or omit it.");
+                valid = false;
+            } else {
+                for (const key of Object.keys(raw.panel)) {
+                    if (!PANEL_KEYS.has(key)) {
+                        push(`${field}.panel.${key}`, `unknown panel key "${key}"`, `Remove "${key}" — allowed keys: dir, requires.`);
+                    }
+                }
+                if (typeof raw.panel.dir !== "string" || raw.panel.dir.length === 0) {
+                    push(`${field}.panel.dir`, "must be a non-empty package-relative path", "Set panel.dir to the panel UI directory.");
+                    valid = false;
+                } else {
+                    const resolved = resolveConfinedPath(packageRoot, raw.panel.dir);
+                    if (!resolved.ok) {
+                        push(`${field}.panel.dir`, resolved.message, "Point panel.dir at a directory inside the package root.");
+                        valid = false;
+                    } else {
+                        let isDir = false;
+                        try {
+                            isDir = statSync(resolved.absolutePath).isDirectory();
+                        } catch {
+                            isDir = false;
+                        }
+                        if (!isDir) {
+                            push(`${field}.panel.dir`, "must resolve to a directory", "Point panel.dir at a directory, not a file.");
+                            valid = false;
+                        }
+                    }
+                }
+                if (raw.panel.requires !== undefined) {
+                    if (!Array.isArray(raw.panel.requires) || !raw.panel.requires.every((v: unknown) => typeof v === "string" && PANEL_VARIABLES.has(v as PanelVariable))) {
+                        push(
+                            `${field}.panel.requires`,
+                            "must be an array drawn from the five PanelVariable values",
+                            `Use only: ${[...PANEL_VARIABLES].join(", ")}.`,
+                        );
+                        valid = false;
+                    }
+                }
+            }
+        }
+
+        for (const sidecarField of ["triggers", "sigils"] as const) {
+            const sidecarValue = raw[sidecarField];
+            if (sidecarValue === undefined) continue;
+            if (typeof sidecarValue === "string") {
+                validateSidecarPath(packageRoot, sidecarValue, `${field}.${sidecarField}`, provenance, push);
+            } else if (Array.isArray(sidecarValue)) {
+                if (!sidecarValue.every((v) => isPlainObject(v))) {
+                    push(`${field}.${sidecarField}`, "inline array entries must be objects", `Fix ${field}.${sidecarField} entries to protocol definition objects.`);
+                    valid = false;
+                }
+            } else {
+                push(`${field}.${sidecarField}`, "must be a package-relative JSON path or an inline array", `Set ${field}.${sidecarField} to a string path or an array.`);
+                valid = false;
+            }
+        }
+
+        if (valid) {
+            result.push(raw as unknown as PizzaPiServiceDeclaration);
+        }
+    });
+
+    return result;
+}

--- a/packages/cli/src/package-commands.test.ts
+++ b/packages/cli/src/package-commands.test.ts
@@ -1,10 +1,11 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
 import { _setGlobalConfigDir } from "./config/io.js";
 import { getGrantedServiceIds } from "./overlay/grants.js";
+import { handlePostUpdateOverlay, snapshotOverlayServiceIds } from "./overlay/cli-support.js";
 
 describe("package command dispatch", () => {
     test("isPackageCommand recognizes package verbs", () => {
@@ -215,5 +216,175 @@ describe("overlay trust integration", () => {
         expect(errors.join("\n")).toContain("bogusKey");
         expect(errors.join("\n")).toContain("pi-native package install may remain");
         expect(getGrantedServiceIds("local:" + realpathSync(pkgDir)).size).toBe(0);
+    });
+
+    // P1: `pizza config grant` must require the normalized identity to exist
+    // in DefaultPackageManager.listConfiguredPackages() at USER scope —
+    // an arbitrary local directory that merely exists on disk (never
+    // installed/configured) must be rejected. Exact repro: fresh agentDir
+    // with no settings.json at all.
+    test("config grant rejects an arbitrary local directory that was never installed (no settings.json)", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        expect(existsSync(join(agentDir, "settings.json"))).toBe(false);
+
+        const outsideDir = join(tmpDir, "never-installed-pkg");
+        writeFixturePackage(outsideDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        const originalError = console.error;
+        const errors: string[] = [];
+        console.error = ((...a: unknown[]) => { errors.push(a.join(" ")); }) as typeof console.error;
+        let code: number;
+        try {
+            code = await runPackageCommand(["config", "grant", outsideDir], cwd, agentDir);
+        } finally {
+            console.error = originalError;
+        }
+
+        expect(code).not.toBe(0);
+        expect(errors.join("\n")).toContain("no valid pi.pizzapi overlay found");
+        expect(getGrantedServiceIds("local:" + realpathSync(outsideDir)).size).toBe(0);
+        // Still no settings.json — the rejected grant attempt didn't configure the package either.
+        expect(existsSync(join(agentDir, "settings.json"))).toBe(false);
+    });
+
+    // P2: `pizza list` must dedupe the same package identity across user and
+    // project scope (project wins), preserving stable order and using the
+    // correct per-scope base dir (agentDir for user, <cwd>/.pizzapi for
+    // project) to compute identity. Reaches the real `list` command path.
+    test("list dedupes the same package identity configured in both user and project scope (project wins, one line)", async () => {
+        const agentDir = join(tmpDir, "deeply", "nested", "agent");
+        const cwd = join(tmpDir, "project");
+        mkdirSync(agentDir, { recursive: true });
+        mkdirSync(cwd, { recursive: true });
+
+        const pkgDir = join(tmpDir, "shared-pkg");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        // Same absolute path configured at both scopes so identity matches
+        // regardless of each scope's base dir (agentDir vs <cwd>/.pizzapi).
+        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [pkgDir] }));
+        const projectPizzapiDir = join(cwd, ".pizzapi");
+        mkdirSync(projectPizzapiDir, { recursive: true });
+        writeFileSync(join(projectPizzapiDir, "settings.json"), JSON.stringify({ packages: [pkgDir] }));
+
+        const originalLog = console.log;
+        const logs: string[] = [];
+        console.log = ((...a: unknown[]) => { logs.push(a.join(" ")); }) as typeof console.log;
+        let code: number;
+        try {
+            code = await runPackageCommand(["list"], cwd, agentDir);
+        } finally {
+            console.log = originalLog;
+        }
+
+        expect(code).toBe(0);
+        const identity = "local:" + realpathSync(pkgDir);
+        const matchingLines = logs.filter((l) => l.includes(identity));
+        expect(matchingLines).toHaveLength(1);
+        expect(matchingLines[0]).toContain("(project)");
+    });
+
+    // P2: package update must snapshot declared overlay service ids/validity
+    // before and after, then process changed/new overlays without blindly
+    // granting. Existing-service grants persist; new ids surface as
+    // untrusted; a newly-malformed overlay fails the command with
+    // partial-update remediation. Reaches the real `update` command path.
+    test("update: existing grant persists, a newly-declared service id stays untrusted (not auto-granted)", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "svc-pkg-update");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        const installCode = await runPackageCommand(["install", "../svc-pkg-update", "--allow-daemon-services"], cwd, agentDir);
+        expect(installCode).toBe(0);
+        const identity = "local:" + realpathSync(pkgDir);
+        expect(getGrantedServiceIds(identity)).toEqual(new Set(["github"]));
+
+        // Local sources are update no-ops in upstream (only npm/git are
+        // re-fetched), so there is no way to observe a before/after content
+        // transition through a single `runPackageCommand(["update"])` call
+        // with a local fixture — nothing mutates the package between the
+        // internal before/after snapshots taken inside one call. Exercise
+        // the exact functions `runPackageCommand`'s update branch calls
+        // (snapshotOverlayServiceIds before, handlePostUpdateOverlay after)
+        // directly, with the mutation happening between them, matching
+        // exactly how a real npm/git update would be observed.
+        const before = snapshotOverlayServiceIds(cwd, agentDir);
+        expect(before.get(identity)?.serviceIds).toEqual(["github"]);
+
+        writeFileSync(
+            join(pkgDir, "package.json"),
+            JSON.stringify({
+                name: "fixture",
+                pi: {
+                    pizzapi: {
+                        schemaVersion: 1,
+                        services: [
+                            { id: "github", label: "GitHub", entry: "./service.ts" },
+                            { id: "gitlab", label: "GitLab", entry: "./service.ts" },
+                        ],
+                    },
+                },
+            }),
+        );
+
+        const originalLog = console.log;
+        const logs: string[] = [];
+        console.log = ((...a: unknown[]) => { logs.push(a.join(" ")); }) as typeof console.log;
+        let updateCode: number;
+        try {
+            updateCode = handlePostUpdateOverlay(cwd, agentDir, before);
+        } finally {
+            console.log = originalLog;
+        }
+
+        expect(updateCode).toBe(0);
+        // Existing grant persists untouched.
+        expect(getGrantedServiceIds(identity)).toEqual(new Set(["github"]));
+        // New id was never granted, but is surfaced.
+        expect(logs.join("\n")).toContain("gitlab");
+        expect(logs.join("\n")).toContain("untrusted");
+    });
+
+    test("update: overlay that becomes malformed after update fails the command with remediation", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "svc-pkg-update-bad");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        const installCode = await runPackageCommand(["install", "../svc-pkg-update-bad"], cwd, agentDir);
+        expect(installCode).toBe(0);
+
+        // Simulate an update that ships a broken overlay.
+        writeFileSync(
+            join(pkgDir, "package.json"),
+            JSON.stringify({ name: "fixture", pi: { pizzapi: { schemaVersion: 1, bogusKey: true } } }),
+        );
+
+        const originalError = console.error;
+        const errors: string[] = [];
+        console.error = ((...a: unknown[]) => { errors.push(a.join(" ")); }) as typeof console.error;
+        let updateCode: number;
+        try {
+            updateCode = await runPackageCommand(["update"], cwd, agentDir);
+        } finally {
+            console.error = originalError;
+        }
+
+        expect(updateCode).not.toBe(0);
+        expect(errors.join("\n")).toContain("invalid");
     });
 });

--- a/packages/cli/src/package-commands.test.ts
+++ b/packages/cli/src/package-commands.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
+import { _setGlobalConfigDir } from "./config/io.js";
+import { getGrantedServiceIds } from "./overlay/grants.js";
 
 describe("package command dispatch", () => {
     test("isPackageCommand recognizes package verbs", () => {
@@ -116,5 +118,102 @@ describe("runPackageCommand", () => {
         const cwd = join(tmpDir, "project");
         const code = await runPackageCommand(["install", "./not-a-package"], cwd, agentDir);
         expect(code).not.toBe(0);
+    });
+
+    test("--allow-daemon-services / --no-allow-daemon-services never reach upstream (plain package installs fine)", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "plain-pkg");
+        mkdirSync(pkgDir, { recursive: true });
+        writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "plain-pkg", pi: { extensions: [] } }));
+        // If upstream saw the unknown --allow-daemon-services flag, it would either
+        // error or (best case) silently mis-parse; either way this proves stripping works.
+        const code = await runPackageCommand(["install", "../plain-pkg", "--allow-daemon-services"], cwd, agentDir);
+        expect(code).toBe(0);
+    });
+});
+
+describe("overlay trust integration", () => {
+    let tmpDir: string;
+    let originalCwd: string;
+    let originalAgentDir: string | undefined;
+    let originalGlobalConfigDir: string;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-overlay-cmd-"));
+        mkdirSync(join(tmpDir, "agent"), { recursive: true });
+        mkdirSync(join(tmpDir, "project"), { recursive: true });
+        originalCwd = process.cwd();
+        originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+        originalGlobalConfigDir = join(tmpDir, "global-config");
+        _setGlobalConfigDir(originalGlobalConfigDir);
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+        _setGlobalConfigDir(null);
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // ignore
+        }
+    });
+
+    function writeFixturePackage(dir: string, overlay: unknown): void {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+        writeFileSync(join(dir, "service.ts"), "export default {};");
+    }
+
+    test("non-interactive install of a package declaring services installs but leaves them untrusted (exit 0)", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "svc-pkg");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        const code = await runPackageCommand(["install", "../svc-pkg"], cwd, agentDir);
+        expect(code).toBe(0);
+        expect(getGrantedServiceIds("local:" + realpathSync(pkgDir)).size).toBe(0);
+    });
+
+    test("--allow-daemon-services grants the currently declared service ids", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "svc-pkg2");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "github", label: "GitHub", entry: "./service.ts" }],
+        });
+
+        const code = await runPackageCommand(["install", "../svc-pkg2", "--allow-daemon-services"], cwd, agentDir);
+        expect(code).toBe(0);
+        expect(getGrantedServiceIds("local:" + realpathSync(pkgDir))).toEqual(new Set(["github"]));
+    });
+
+    test("malformed overlay: install returns non-zero, reports errors, grants nothing", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "bad-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, bogusKey: true });
+
+        const originalError = console.error;
+        const errors: string[] = [];
+        console.error = ((...a: unknown[]) => { errors.push(a.join(" ")); }) as typeof console.error;
+        let code: number;
+        try {
+            code = await runPackageCommand(["install", "../bad-pkg"], cwd, agentDir);
+        } finally {
+            console.error = originalError;
+        }
+
+        expect(code).not.toBe(0);
+        expect(errors.join("\n")).toContain("bogusKey");
+        expect(errors.join("\n")).toContain("pi-native package install may remain");
+        expect(getGrantedServiceIds("local:" + realpathSync(pkgDir)).size).toBe(0);
     });
 });

--- a/packages/cli/src/package-commands.ts
+++ b/packages/cli/src/package-commands.ts
@@ -6,6 +6,7 @@
 
 import { handleConfigCommand, handlePackageCommand } from "@earendil-works/pi-coding-agent";
 import { c } from "./cli-colors.js";
+import { stripDaemonServiceFlags, handlePostInstallOverlay, renderOverlaySummary, runOverlayConfigSubcommand } from "./overlay/cli-support.js";
 
 const PACKAGE_COMMANDS = new Set(["install", "remove", "uninstall", "update", "list", "config"]);
 
@@ -39,11 +40,14 @@ const COMMAND_HELP: HelpEntry[] = [
             { flag: "-l, --local", desc: "Install into the project-local .pizzapi directory" },
             { flag: "-a, --approve", desc: "Trust project-local files for this command" },
             { flag: "-na, --no-approve", desc: "Ignore project-local files for this command" },
+            { flag: "--allow-daemon-services", desc: "Grant declared pi.pizzapi runner services (user scope only)" },
+            { flag: "--no-allow-daemon-services", desc: "Install but leave declared runner services untrusted" },
         ],
         examples: [
             "pizza install npm:@foo/pi-tools",
             "pizza install git:github.com/user/repo",
             "pizza install ./local/path",
+            "pizza install npm:@foo/pi-tools --allow-daemon-services",
         ],
     },
     {
@@ -82,11 +86,15 @@ const COMMAND_HELP: HelpEntry[] = [
     },
     {
         commands: ["config"],
-        usage: "[-a|-na]",
-        description: () => "Interactively enable or disable installed package resources.",
+        usage: "[-a|-na] | grant|revoke <source> [serviceId...]",
+        description: () => "Interactively enable or disable installed package resources, or grant/revoke pi.pizzapi daemon service trust.",
         options: [
             { flag: "-a, --approve", desc: "Trust project-local files" },
             { flag: "-na, --no-approve", desc: "Ignore project-local files" },
+        ],
+        examples: [
+            "pizza config grant npm:@foo/pi-tools",
+            "pizza config revoke npm:@foo/pi-tools github",
         ],
     },
 ];
@@ -176,6 +184,8 @@ export async function runPackageCommand(args: string[], cwd: string, agentDir: s
 
     try {
         args = stripCwdFlag(args);
+        const { args: strippedArgs, allowDaemonServices } = stripDaemonServiceFlags(args);
+        args = strippedArgs;
 
         if (!process.env.PI_CODING_AGENT_DIR) {
             process.env.PI_CODING_AGENT_DIR = agentDir;
@@ -188,6 +198,14 @@ export async function runPackageCommand(args: string[], cwd: string, agentDir: s
 
         if (args.includes("--help") || args.includes("-h")) {
             printCommandHelp(args[0] ?? "install");
+            return 0;
+        }
+
+        if (args[0] === "config") {
+            const overlayCode = await runOverlayConfigSubcommand(args, cwd, agentDir);
+            if (overlayCode !== undefined) return overlayCode;
+            // handleConfigCommand exits the process itself.
+            await handleConfigCommand(args);
             return 0;
         }
 
@@ -213,14 +231,17 @@ export async function runPackageCommand(args: string[], cwd: string, agentDir: s
         }
 
         try {
-            if (args[0] === "config") {
-                // handleConfigCommand exits the process itself.
-                await handleConfigCommand(args);
-                return 0;
+            const handled = await handlePackageCommand(args);
+            let code = handled ? Number(process.exitCode ?? 0) : 1;
+
+            if (handled && code === 0 && args[0] === "install") {
+                code = await handlePostInstallOverlay(args, cwd, agentDir, allowDaemonServices);
+            }
+            if (handled && code === 0 && args[0] === "list") {
+                renderOverlaySummary(cwd, agentDir);
             }
 
-            const handled = await handlePackageCommand(args);
-            return handled ? Number(process.exitCode ?? 0) : 1;
+            return code;
         } catch (err) {
             console.error(`pizza ${args[0]}: ${err instanceof Error ? err.message : String(err)}`);
             return 1;

--- a/packages/cli/src/package-commands.ts
+++ b/packages/cli/src/package-commands.ts
@@ -6,7 +6,14 @@
 
 import { handleConfigCommand, handlePackageCommand } from "@earendil-works/pi-coding-agent";
 import { c } from "./cli-colors.js";
-import { stripDaemonServiceFlags, handlePostInstallOverlay, renderOverlaySummary, runOverlayConfigSubcommand } from "./overlay/cli-support.js";
+import {
+    stripDaemonServiceFlags,
+    handlePostInstallOverlay,
+    handlePostUpdateOverlay,
+    renderOverlaySummary,
+    runOverlayConfigSubcommand,
+    snapshotOverlayServiceIds,
+} from "./overlay/cli-support.js";
 
 const PACKAGE_COMMANDS = new Set(["install", "remove", "uninstall", "update", "list", "config"]);
 
@@ -217,11 +224,21 @@ export async function runPackageCommand(args: string[], cwd: string, agentDir: s
                 return 1;
             }
             const wasRewritten = argsForUpstream !== args;
+            // P2: snapshot declared overlay service ids/validity *before* the
+            // update runs. `packages[]` in settings.json doesn't change on
+            // update, so this is the only way to detect a same-identity
+            // overlay content change (new service ids, or a newly-malformed
+            // overlay) afterward.
+            const overlaySnapshotBefore = snapshotOverlayServiceIds(cwd, agentDir);
             try {
                 const handled = await handlePackageCommand(argsForUpstream);
                 if (handled) {
                     if (wasRewritten) printSelfUpdateNote();
-                    return Number(process.exitCode ?? 0);
+                    let code = Number(process.exitCode ?? 0);
+                    if (code === 0) {
+                        code = handlePostUpdateOverlay(cwd, agentDir, overlaySnapshotBefore);
+                    }
+                    return code;
                 }
                 return 1;
             } catch (err) {

--- a/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
+++ b/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
@@ -71,13 +71,20 @@ describe("reconcileOverlayGrants (daemon startup/reconfigure call path)", () => 
         const missingPkgPath = join(agentDir, "packages", "pkg-missing-not-on-disk");
         const missingIdentity = computePackageIdentity(missingPkgPath, agentDir).identity;
 
-        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [keptPkgPath, missingPkgPath] }));
+        // Configured path exists, but package.json is temporarily absent/corrupt.
+        // This is unreadable, not proof that the package intentionally removed its overlay.
+        const brokenPkgPath = join(agentDir, "packages", "pkg-broken-install");
+        mkdirSync(brokenPkgPath, { recursive: true });
+        const brokenIdentity = computePackageIdentity(brokenPkgPath, agentDir).identity;
+
+        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [keptPkgPath, missingPkgPath, brokenPkgPath] }));
 
         // Never configured at all — a pure orphan.
         const orphanIdentity = "npm:@acme/long-gone";
 
         grantServices(keptIdentity, ["kept", "dropped"]);
         grantServices(missingIdentity, ["still-trusted"]);
+        grantServices(brokenIdentity, ["also-still-trusted"]);
         grantServices(orphanIdentity, ["gone"]);
 
         const writes: string[] = [];
@@ -97,14 +104,17 @@ describe("reconcileOverlayGrants (daemon startup/reconfigure call path)", () => 
         expect(getGrantedServiceIds(keptIdentity)).toEqual(new Set(["kept"]));
         // Fail-closed: missing installed path leaves the grant untouched.
         expect(getGrantedServiceIds(missingIdentity)).toEqual(new Set(["still-trusted"]));
+        // Fail-closed: an existing but unreadable package install is also retained.
+        expect(getGrantedServiceIds(brokenIdentity)).toEqual(new Set(["also-still-trusted"]));
         // Fully unconfigured identity is removed entirely.
         expect(getGrantedServiceIds(orphanIdentity).size).toBe(0);
-        expect(getOverlayServiceGrants().map((g) => g.package).sort()).toEqual([keptIdentity, missingIdentity].sort());
+        expect(getOverlayServiceGrants().map((g) => g.package).sort()).toEqual([brokenIdentity, keptIdentity, missingIdentity].sort());
 
         const logged = writes.join("");
         expect(logged).toContain(orphanIdentity);
         expect(logged).toContain("dropped");
         expect(logged).not.toContain("still-trusted");
+        expect(logged).not.toContain("also-still-trusted");
     });
 
     test("no configured packages and no grants is a silent no-op", () => {

--- a/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
+++ b/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
@@ -117,6 +117,15 @@ describe("reconcileOverlayGrants (daemon startup/reconfigure call path)", () => 
         expect(logged).not.toContain("also-still-trusted");
     });
 
+    test("corrupt user settings preserves all grants fail-closed", () => {
+        const identity = "npm:@acme/configured-before-corruption";
+        grantServices(identity, ["github"]);
+        writeFileSync(join(agentDir, "settings.json"), "{ truncated", "utf-8");
+
+        expect(() => reconcileOverlayGrants(projectDir)).not.toThrow();
+        expect(getGrantedServiceIds(identity)).toEqual(new Set(["github"]));
+    });
+
     test("no configured packages and no grants is a silent no-op", () => {
         writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [] }));
         expect(() => reconcileOverlayGrants(projectDir)).not.toThrow();

--- a/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
+++ b/packages/cli/src/runner/daemon.grant-reconciliation.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setGlobalConfigDir } from "../config/io.js";
+import { getOverlayServiceGrants, getGrantedServiceIds, grantServices } from "../overlay/grants.js";
+import { computePackageIdentity } from "../overlay/identity.js";
+import { reconcileOverlayGrants } from "./daemon.js";
+
+/**
+ * `reconcileOverlayGrants()` is the exact helper `runDaemon()` calls at
+ * startup and the `reconfigure_services` socket handler calls on every
+ * reconfiguration (daemon.ts). Testing it directly exercises that call
+ * path's real behavior without needing to spin up the full socket.io
+ * daemon — see the docstring on reconcileOverlayGrants() in daemon.ts.
+ */
+describe("reconcileOverlayGrants (daemon startup/reconfigure call path)", () => {
+    const originalHome = process.env.HOME;
+    let tmpDir: string;
+    let home: string;
+    let agentDir: string;
+    let projectDir: string;
+    let globalDir: string;
+
+    function makePackage(name: string, serviceIds: string[]): string {
+        const dir = join(agentDir, "packages", name);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "index.js"), "// noop\n");
+        writeFileSync(
+            join(dir, "package.json"),
+            JSON.stringify({
+                name,
+                version: "1.0.0",
+                pi: {
+                    pizzapi: {
+                        schemaVersion: 1,
+                        services: serviceIds.map((id) => ({ id, label: id, entry: "./index.js" })),
+                    },
+                },
+            }),
+        );
+        return dir;
+    }
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "daemon-grant-reconcile-test-"));
+        home = join(tmpDir, "home");
+        agentDir = join(home, ".pizzapi");
+        projectDir = join(tmpDir, "project");
+        globalDir = join(tmpDir, "global");
+        mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({ agentDir }));
+        _setGlobalConfigDir(globalDir);
+        process.env.HOME = home;
+    });
+
+    afterEach(() => {
+        _setGlobalConfigDir(null);
+        process.env.HOME = originalHome;
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("removes unconfigured package grants, trims undeclared ids, and keeps a fail-closed missing package's grant", () => {
+        // Configured and installed: still declares "kept", no longer declares "dropped".
+        const keptPkgPath = makePackage("pkg-kept", ["kept"]);
+        const keptIdentity = computePackageIdentity(keptPkgPath, agentDir).identity;
+
+        // Configured in settings.json but its installed path does not exist —
+        // e.g. npm store not yet warmed at daemon boot. Must be left alone.
+        const missingPkgPath = join(agentDir, "packages", "pkg-missing-not-on-disk");
+        const missingIdentity = computePackageIdentity(missingPkgPath, agentDir).identity;
+
+        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [keptPkgPath, missingPkgPath] }));
+
+        // Never configured at all — a pure orphan.
+        const orphanIdentity = "npm:@acme/long-gone";
+
+        grantServices(keptIdentity, ["kept", "dropped"]);
+        grantServices(missingIdentity, ["still-trusted"]);
+        grantServices(orphanIdentity, ["gone"]);
+
+        const writes: string[] = [];
+        const originalWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+            return true;
+        }) as typeof process.stdout.write;
+
+        try {
+            reconcileOverlayGrants(projectDir);
+        } finally {
+            process.stdout.write = originalWrite;
+        }
+
+        // Declared id kept, undeclared id trimmed.
+        expect(getGrantedServiceIds(keptIdentity)).toEqual(new Set(["kept"]));
+        // Fail-closed: missing installed path leaves the grant untouched.
+        expect(getGrantedServiceIds(missingIdentity)).toEqual(new Set(["still-trusted"]));
+        // Fully unconfigured identity is removed entirely.
+        expect(getGrantedServiceIds(orphanIdentity).size).toBe(0);
+        expect(getOverlayServiceGrants().map((g) => g.package).sort()).toEqual([keptIdentity, missingIdentity].sort());
+
+        const logged = writes.join("");
+        expect(logged).toContain(orphanIdentity);
+        expect(logged).toContain("dropped");
+        expect(logged).not.toContain("still-trusted");
+    });
+
+    test("no configured packages and no grants is a silent no-op", () => {
+        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [] }));
+        expect(() => reconcileOverlayGrants(projectDir)).not.toThrow();
+        expect(getOverlayServiceGrants()).toHaveLength(0);
+    });
+});

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -61,6 +61,7 @@ import { registerPackagesHandlers } from "./daemon-handlers/packages.js";
 
 // Re-export migration from shared module — used on daemon startup
 import { migrateAgentDir } from "../migrations.js";
+import { buildConfiguredGrantIdentities, reconcileGrants } from "../overlay/grants.js";
 
 /** Map variable name (e.g. "PROJECT_DIR") to camelCase query param key. */
 const VAR_TO_PARAM: Record<string, string> = {
@@ -295,6 +296,31 @@ export function resolveConfiguredAgentDir(cwd = process.cwd()): string {
 }
 
 /**
+ * Reconcile overlayServiceGrants against currently configured USER packages
+ * and their currently declared manifest service IDs (§7.2). Call at daemon
+ * startup and on `reconfigure_services` — this only edits
+ * ~/.pizzapi/config.json, it never mounts/unmounts services (that's driven
+ * separately by discoverServices()). Exported standalone (rather than an
+ * inline closure) so the startup/reconfigure call path has direct
+ * regression coverage without spinning up the full socket.io daemon.
+ */
+export function reconcileOverlayGrants(cwd = process.cwd()): void {
+    try {
+        const agentDir = resolveConfiguredAgentDir(cwd);
+        const configured = buildConfiguredGrantIdentities(cwd, agentDir);
+        const removals = reconcileGrants(configured);
+        for (const removal of removals) {
+            logInfo(
+                `[grants] reconciliation removed [${removal.removedServiceIds.join(", ")}] for ${removal.package}` +
+                    `${removal.fullyRemoved ? " (grant cleared)" : " (grant trimmed)"}`,
+            );
+        }
+    } catch (err) {
+        logWarn(`[grants] reconciliation failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+/**
  * Model discovery for the daemon's `list_models` socket event and context-window
  * lookups. Builds a bare ModelRuntime (no extension loading), so ollama-cloud
  * needs an explicit registerOllamaCloudProvider() call to be recognized at all —
@@ -352,6 +378,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
     // Migrate session storage from legacy locations into flat ~/.pizzapi/
     migrateAgentDir();
+
+    // Reconcile overlayServiceGrants against currently configured USER
+    // packages before anything else touches trust state (§7.2). No service
+    // mounting happens here — grants-only bookkeeping.
+    reconcileOverlayGrants();
 
     // Initialize usage tracking
     initUsage();
@@ -1015,6 +1046,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 }
 
                 logInfo(`[services] reconfiguring: disabling ${Array.from(newDisabledServices).join(", ") || "none"}`);
+
+                // Reconcile overlayServiceGrants against currently configured
+                // USER packages (§7.2) — grants-only bookkeeping, no service
+                // (un)mounting here.
+                reconcileOverlayGrants();
 
                 // Update config on disk
                 const currentConfig = loadGlobalConfig();


### PR DESCRIPTION
## Summary

- add a shared strict `pi.pizzapi` v1 manifest reader and path/content validator
- add normalized npm/git/local package identities pinned against pi 0.82.1
- add exact per-package/per-service daemon grants, fail-closed persistence, and daemon reconciliation
- extend the existing upstream package-command wrapper with explicit grant flags, overlay list/config output, and install/update validation
- preserve project scope, native resource filtering semantics, and upstream install/update behavior

## Security invariants

- service entry modules are never imported during validation
- absolute/traversing/escaping-symlink paths are rejected
- malformed sidecars and protocol declaration shapes reject the whole overlay
- arbitrary unconfigured local directories cannot receive daemon grants
- malformed global config is never overwritten
- missing/unreadable configured packages retain grants fail-closed; removed identities/IDs are pruned
- project packages cannot receive daemon grants in schema v1

## Validation

- focused overlay/package/config/daemon tests — 251 passed
- `bun run typecheck` — passed after full integration
- upstream identity parity characterization — passed
- Opus security review: 4 P1 + 4 P2 findings fixed
- fresh Fable final review — LGTM, no P0–P2 findings

## Stack

- base: #653 (`feat/pi-extension-sdk`)
- no merge performed
