### PR TITLE
feat(cli): discover trusted package runner services

### DIFF
--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -507,32 +507,40 @@ function validateSigilDef(entry: unknown, field: string, push: PushFn): void {
  * declarations so junk (wrong types, missing type/label, malformed params)
  * is rejected rather than silently forwarded.
  */
+/**
+ * Validate a triggers/sigils field and return the fully resolved array of
+ * definitions (whether declared inline or via a sidecar JSON path) so
+ * callers never need to re-parse a sidecar file themselves. Returns
+ * `undefined` on any validation failure — the caller already tracked the
+ * issue via `push`.
+ */
 function validateTriggerOrSigilField(
     sidecarValue: unknown,
     field: string,
     packageRoot: string,
     kind: "triggers" | "sigils",
     push: PushFn,
-): void {
+): unknown[] | undefined {
     const validateEntry = kind === "triggers" ? validateTriggerDef : validateSigilDef;
 
     if (typeof sidecarValue === "string") {
         const parsed = readSidecarJson(packageRoot, sidecarValue, field, push);
-        if (parsed === undefined) return;
+        if (parsed === undefined) return undefined;
         if (!Array.isArray(parsed)) {
             push(field, "sidecar JSON must be an array of definitions", `Fix the ${kind} sidecar file to contain a top-level JSON array.`);
-            return;
+            return undefined;
         }
         parsed.forEach((entry, i) => validateEntry(entry, `${field}[${i}]`, push));
-        return;
+        return parsed;
     }
 
     if (Array.isArray(sidecarValue)) {
         sidecarValue.forEach((entry, i) => validateEntry(entry, `${field}[${i}]`, push));
-        return;
+        return sidecarValue;
     }
 
     push(field, "must be a package-relative JSON path or an inline array", `Set ${field} to a string path or an array.`);
+    return undefined;
 }
 
 function validateServices(
@@ -654,11 +662,17 @@ function validateServices(
 
         // Note: trigger/sigil shape issues push directly via `push`, which
         // rejects the whole overlay in readOverlayManifest regardless of the
-        // `valid` flag below — no local bookkeeping needed here.
+        // `valid` flag below — no local bookkeeping needed here. The resolved
+        // array (inline or sidecar-parsed) is written back onto `raw` so
+        // downstream consumers (daemon package-service discovery) always see
+        // a literal ServiceTriggerDef[]/ServiceSigilDef[], never a sidecar path.
         for (const sidecarField of ["triggers", "sigils"] as const) {
             const sidecarValue = raw[sidecarField];
             if (sidecarValue === undefined) continue;
-            validateTriggerOrSigilField(sidecarValue, `${field}.${sidecarField}`, packageRoot, sidecarField, push);
+            const resolved = validateTriggerOrSigilField(sidecarValue, `${field}.${sidecarField}`, packageRoot, sidecarField, push);
+            if (resolved !== undefined) {
+                (raw as Record<string, unknown>)[sidecarField] = resolved;
+            }
         }
 
         if (valid) {

--- a/packages/cli/src/runner/daemon-package-reconcile.test.ts
+++ b/packages/cli/src/runner/daemon-package-reconcile.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
     canRegisterDiscoveredService,
+    clearServiceRuntimePorts,
     panelEntryFromManifest,
     planPackageServiceReconcile,
     raceWithTimeout,
     timedOutPackageDiscoveryResult,
     PACKAGE_DISCOVERY_TIMEOUT_MS,
+    type PanelEntry,
 } from "./daemon.js";
 import { ServiceRegistry } from "./service-handler.js";
 import { BUILTIN_SERVICE_IDS, NON_DISABLEABLE_SERVICE_IDS } from "./services/builtin-service-ids.js";
@@ -95,6 +97,28 @@ describe("panelEntryFromManifest (fix #3: hasPanel routing)", () => {
         const entry = panelEntryFromManifest("svc", manifest, 4321);
         expect(entry?.port).toBe(4321);
         expect(entry?.label).toBe("New Label");
+    });
+});
+
+describe("clearServiceRuntimePorts (final-review port hygiene)", () => {
+    test("identity swap or legacy eviction removes all stale runtime metadata", () => {
+        const panels = new Map<string, PanelEntry>([["svc", { serviceId: "svc", label: "Old", icon: "square", port: 4321 }]]);
+        const sigilPorts = new Map([["svc", 8765]]);
+
+        clearServiceRuntimePorts("svc", panels, sigilPorts, false);
+
+        expect(panels.has("svc")).toBe(false);
+        expect(sigilPorts.has("svc")).toBe(false);
+    });
+
+    test("disable keeps metadata visible but strips panel and sigil-server ports", () => {
+        const panels = new Map<string, PanelEntry>([["svc", { serviceId: "svc", label: "Svc", icon: "square", port: 4321 }]]);
+        const sigilPorts = new Map([["svc", 8765]]);
+
+        clearServiceRuntimePorts("svc", panels, sigilPorts, true);
+
+        expect(panels.get("svc")).toEqual({ serviceId: "svc", label: "Svc", icon: "square" });
+        expect(sigilPorts.has("svc")).toBe(false);
     });
 });
 

--- a/packages/cli/src/runner/daemon-package-reconcile.test.ts
+++ b/packages/cli/src/runner/daemon-package-reconcile.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import {
+    canRegisterDiscoveredService,
+    panelEntryFromManifest,
+    planPackageServiceReconcile,
+    raceWithTimeout,
+    timedOutPackageDiscoveryResult,
+    PACKAGE_DISCOVERY_TIMEOUT_MS,
+} from "./daemon.js";
+import { ServiceRegistry } from "./service-handler.js";
+import { BUILTIN_SERVICE_IDS, NON_DISABLEABLE_SERVICE_IDS } from "./services/builtin-service-ids.js";
+import type { ServiceHandler } from "./service-handler.js";
+import type { ServiceManifest } from "./service-loader.js";
+
+function makeHandler(id: string): ServiceHandler {
+    return { id, init() {}, dispose() {} };
+}
+
+describe("canRegisterDiscoveredService — package-before-legacy ordering (§8)", () => {
+    test("first caller for an id wins; a second caller for the same id is rejected as a collision", () => {
+        const registry = new ServiceRegistry();
+        const packageHandler = makeHandler("shared");
+        const legacyHandler = makeHandler("shared");
+
+        // Mirrors daemon.ts: package discovery is awaited + registered
+        // before legacy discovery, so it reaches this guard first.
+        const packageDecision = canRegisterDiscoveredService(BUILTIN_SERVICE_IDS.has("shared"), registry.has("shared"));
+        expect(packageDecision).toEqual({ register: true });
+        registry.register(packageHandler);
+
+        // Legacy discovery runs second — same id, now collides.
+        const legacyDecision = canRegisterDiscoveredService(BUILTIN_SERVICE_IDS.has("shared"), registry.has("shared"));
+        expect(legacyDecision).toEqual({ register: false, reason: "collision" });
+        expect(registry.get("shared")).toBe(packageHandler);
+        expect(registry.get("shared")).not.toBe(legacyHandler);
+    });
+
+    test("built-ins are rejected before the collision check even runs, regardless of order", () => {
+        const registry = new ServiceRegistry();
+        const decision = canRegisterDiscoveredService(BUILTIN_SERVICE_IDS.has("terminal"), registry.has("terminal"));
+        expect(decision).toEqual({ register: false, reason: "builtin" });
+    });
+});
+
+describe("NON_DISABLEABLE_SERVICE_IDS vs BUILTIN_SERVICE_IDS (addendum A)", () => {
+    test("memory and process are collision-reserved but NOT in the runtime non-disableable set", () => {
+        expect(BUILTIN_SERVICE_IDS.has("memory")).toBe(true);
+        expect(BUILTIN_SERVICE_IDS.has("process")).toBe(true);
+        expect(NON_DISABLEABLE_SERVICE_IDS.has("memory")).toBe(false);
+        expect(NON_DISABLEABLE_SERVICE_IDS.has("process")).toBe(false);
+    });
+
+    test("the original five (terminal/file-explorer/git/time/tunnel) stay non-disableable", () => {
+        expect([...NON_DISABLEABLE_SERVICE_IDS].sort()).toEqual(
+            ["file-explorer", "git", "terminal", "time", "tunnel"],
+        );
+    });
+});
+
+describe("panelEntryFromManifest (fix #3: hasPanel routing)", () => {
+    test("a service with a panel gets hasPanel: true", () => {
+        const manifest: ServiceManifest = { id: "svc", label: "Svc", icon: "square", panel: { dir: "/abs/panel" } };
+        const entry = panelEntryFromManifest("svc", manifest);
+        expect(entry?.hasPanel).toBe(true);
+    });
+
+    test("a service with only triggers/sigils and no panel gets hasPanel: false", () => {
+        const manifest: ServiceManifest = {
+            id: "svc",
+            label: "Svc",
+            icon: "square",
+            hasPanel: false,
+            triggers: [{ type: "svc:event", label: "Event" }],
+        };
+        const entry = panelEntryFromManifest("svc", manifest);
+        expect(entry?.hasPanel).toBe(false);
+        expect(entry?.triggers).toHaveLength(1);
+    });
+
+    test("legacy manifests without an explicit hasPanel infer it from panel presence", () => {
+        const withPanel: ServiceManifest = { id: "svc", label: "Svc", icon: "square", panel: { dir: "/x" } };
+        const withoutPanel: ServiceManifest = { id: "svc", label: "Svc", icon: "square", sigils: [{ type: "x", label: "X" }] };
+        expect(panelEntryFromManifest("svc", withPanel)?.hasPanel).toBe(true);
+        expect(panelEntryFromManifest("svc", withoutPanel)?.hasPanel).toBe(false);
+    });
+
+    test("no panel/triggers/sigils at all yields null (nothing to track)", () => {
+        const manifest: ServiceManifest = { id: "svc", label: "Svc", icon: "square" };
+        expect(panelEntryFromManifest("svc", manifest)).toBeNull();
+        expect(panelEntryFromManifest("svc", undefined)).toBeNull();
+    });
+
+    test("preserves an already-announced port across a metadata refresh", () => {
+        const manifest: ServiceManifest = { id: "svc", label: "New Label", icon: "square", panel: { dir: "/x" } };
+        const entry = panelEntryFromManifest("svc", manifest, 4321);
+        expect(entry?.port).toBe(4321);
+        expect(entry?.label).toBe("New Label");
+    });
+});
+
+describe("planPackageServiceReconcile (fix #4 + addendum B: reconfigure lifecycle)", () => {
+    test("revocation: an id no longer in the fresh set is queued for disposal", () => {
+        const plan = planPackageServiceReconcile(
+            [],
+            new Map([["gone", { identity: "npm:gone" }]]),
+            new Set(),
+            () => true,
+        );
+        expect(plan.revoke).toEqual(["gone"]);
+        expect(plan.registerNew).toEqual([]);
+    });
+
+    test("unchanged identity + still registered: preserve lifecycle, only refresh metadata", () => {
+        const plan = planPackageServiceReconcile(
+            [{ id: "svc", identity: "npm:pkg" }],
+            new Map([["svc", { identity: "npm:pkg" }]]),
+            new Set(),
+            (id) => id === "svc",
+        );
+        expect(plan.preserveRefreshMetadata).toEqual(["svc"]);
+        expect(plan.replaceIdentitySwap).toEqual([]);
+        expect(plan.registerNew).toEqual([]);
+    });
+
+    test("identity swap: same id, different winning package identity — dispose + replace", () => {
+        const plan = planPackageServiceReconcile(
+            [{ id: "svc", identity: "npm:new-pkg" }],
+            new Map([["svc", { identity: "npm:old-pkg" }]]),
+            new Set(),
+            (id) => id === "svc",
+        );
+        expect(plan.replaceIdentitySwap).toEqual(["svc"]);
+        expect(plan.preserveRefreshMetadata).toEqual([]);
+    });
+
+    test("re-enable after disable: not in packageServiceIds and not registered — treated as a fresh registration", () => {
+        const plan = planPackageServiceReconcile(
+            [{ id: "svc", identity: "npm:pkg" }],
+            new Map(), // dropped from tracking when disabled
+            new Set(),
+            () => false, // unregistered while disabled
+        );
+        expect(plan.registerNew).toEqual(["svc"]);
+    });
+
+    test("legacy eviction: a legacy-origin incumbent yields to a newly-declaring package (§8 dynamically)", () => {
+        const plan = planPackageServiceReconcile(
+            [{ id: "svc", identity: "npm:pkg" }],
+            new Map(), // never package-mounted before
+            new Set(["svc"]), // currently held by a legacy-origin handler
+            (id) => id === "svc", // legacy handler is registered
+        );
+        expect(plan.evictLegacyThenRegister).toEqual(["svc"]);
+        expect(plan.registerNew).toEqual([]);
+        expect(plan.replaceIdentitySwap).toEqual([]);
+    });
+
+    test("brand new id with no incumbent at all: plain fresh registration", () => {
+        const plan = planPackageServiceReconcile(
+            [{ id: "svc", identity: "npm:pkg" }],
+            new Map(),
+            new Set(),
+            () => false,
+        );
+        expect(plan.registerNew).toEqual(["svc"]);
+    });
+});
+
+describe("raceWithTimeout (addendum C: bounded discovery)", () => {
+    test("resolves with the real value when the promise settles before the timeout", async () => {
+        const result = await raceWithTimeout(Promise.resolve("real"), 50, () => "fallback");
+        expect(result).toEqual({ value: "real", timedOut: false });
+    });
+
+    test("a never-resolving promise falls back after the timeout instead of hanging forever", async () => {
+        const never = new Promise<string>(() => {});
+        const result = await raceWithTimeout(never, 20, () => "fallback");
+        expect(result).toEqual({ value: "fallback", timedOut: true });
+    });
+
+    test("a late resolution after timeout is reported via onLate, not returned as the result", async () => {
+        let resolveLate!: (v: string) => void;
+        const late = new Promise<string>((r) => { resolveLate = r; });
+        const lateValues: string[] = [];
+        const resultPromise = raceWithTimeout(late, 10, () => "fallback", (v) => lateValues.push(v));
+        const result = await resultPromise;
+        expect(result).toEqual({ value: "fallback", timedOut: true });
+        resolveLate("too-late");
+        await new Promise((r) => setTimeout(r, 5));
+        expect(lateValues).toEqual(["too-late"]);
+    });
+});
+
+describe("timedOutPackageDiscoveryResult (fix #1 + addendum C interaction)", () => {
+    test("a timeout fallback is explicitly non-authoritative, matching corrupt-settings semantics", () => {
+        const result = timedOutPackageDiscoveryResult("/agent-dir");
+        expect(result.authoritative).toBe(false);
+        expect(result.services).toEqual([]);
+        expect(result.errors[0]?.error).toContain(String(PACKAGE_DISCOVERY_TIMEOUT_MS));
+    });
+});

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -21,8 +21,8 @@ import { MemoryService } from "./services/memory-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
 import type { ServiceManifest, ServicePluginResult } from "./service-loader.js";
-import { discoverPackageServices } from "./package-service-loader.js";
-import { BUILTIN_SERVICE_IDS } from "./services/builtin-service-ids.js";
+import { discoverPackageServices, type DiscoverPackageServicesResult } from "./package-service-loader.js";
+import { BUILTIN_SERVICE_IDS, NON_DISABLEABLE_SERVICE_IDS } from "./services/builtin-service-ids.js";
 import { globalPluginDirs } from "../plugins/discover.js";
 import { io, type Socket } from "socket.io-client";
 import {
@@ -83,6 +83,219 @@ function resolveRequires(requires: string[]): Record<string, string> {
         if (key) params[key] = resolvePizzaPiVar(name);
     }
     return params;
+}
+
+/** Panel/trigger/sigil metadata tracked per active service, keyed by service id. */
+export type PanelEntry = {
+    serviceId: string;
+    label: string;
+    icon: string;
+    port?: number;
+    /** Trigger types declared in this service's manifest */
+    triggers?: ServiceTriggerDef[];
+    /** Sigil types declared in this service's manifest */
+    sigils?: ServiceSigilDef[];
+    /**
+     * Whether this service has a UI panel shown to users.
+     * false = service has trigger/sigil defs but no panel (e.g. the time service).
+     */
+    hasPanel?: boolean;
+    /**
+     * Variable names the panel requires. The UI resolves these and appends
+     * them as query params to the iframe src.
+     */
+    requires?: string[];
+};
+
+export interface TimeoutRaceResult<T> {
+    value: T;
+    timedOut: boolean;
+}
+
+/**
+ * Race `promise` against `timeoutMs`. On timeout, resolves immediately with
+ * `fallback()` and `timedOut: true` so a stalled discovery pass (e.g. a
+ * hung dynamic `import()`) can never strand the rest of startup/reconfigure.
+ * The original promise keeps running in the background; if/when it settles
+ * after the timeout already fired, `onLate` is called with its value so the
+ * caller can dispose it instead of silently mutating shared state (registry,
+ * panel entries, etc.) out from under an already-completed pass.
+ *
+ * Pure/host-independent — exported for direct regression coverage with a
+ * never-resolving promise, without real services or timers.
+ */
+export function raceWithTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    fallback: () => T,
+    onLate?: (value: T) => void,
+): Promise<TimeoutRaceResult<T>> {
+    return new Promise((resolve) => {
+        let settled = false;
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            resolve({ value: fallback(), timedOut: true });
+        }, timeoutMs);
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                if (settled) {
+                    onLate?.(value);
+                    return;
+                }
+                settled = true;
+                resolve({ value, timedOut: false });
+            },
+            () => {
+                clearTimeout(timer);
+                if (!settled) {
+                    settled = true;
+                    resolve({ value: fallback(), timedOut: true });
+                }
+            },
+        );
+    });
+}
+
+/**
+ * Bound on a single discoverPackageServices() pass (dynamic `import()` of a
+ * package's service entry can hang indefinitely on a bad/malicious module).
+ * Shorter than PLUGIN_DISCOVERY_TIMEOUT_MS (the outer runner_registered
+ * race) so a package timeout still leaves headroom for legacy discovery to
+ * run and for registration to proceed on schedule.
+ */
+export const PACKAGE_DISCOVERY_TIMEOUT_MS = 20_000;
+
+/** Fallback result used when a discoverPackageServices() pass times out — deliberately non-authoritative (see DiscoverPackageServicesResult). */
+export function timedOutPackageDiscoveryResult(agentDir: string): DiscoverPackageServicesResult {
+    return {
+        services: [],
+        errors: [{ path: agentDir, error: `package service discovery timed out after ${PACKAGE_DISCOVERY_TIMEOUT_MS}ms — treating as unknown, not "no packages"` }],
+        authoritative: false,
+    };
+}
+
+/** Best-effort disposal of a late (post-timeout) discoverPackageServices() result — never initialized, so dispose() is cleanup-only. */
+function disposeLatePackageDiscovery(result: DiscoverPackageServicesResult): void {
+    if (result.services.length === 0) return;
+    logWarn(`[services] package service discovery finished after its timeout — discarding ${result.services.length} late result(s): ${result.services.map((s) => s.handler.id).join(", ")}`);
+    for (const { handler } of result.services) {
+        try {
+            handler.dispose();
+        } catch {
+            // Never initialized — best-effort cleanup only.
+        }
+    }
+}
+
+export interface PackageServiceReconcilePlan {
+    /** Ids that were package-mounted before but are no longer declared/granted this pass — dispose+unregister, drop all tracking. */
+    revoke: string[];
+    /** Ids whose winning identity is unchanged and still registered — preserve the running handler, only refresh panel/trigger/sigil metadata. */
+    preserveRefreshMetadata: string[];
+    /** Ids whose winning package identity changed since the last pass — dispose the old handler, then register the fresh one. */
+    replaceIdentitySwap: string[];
+    /** Ids currently held by a legacy-origin handler that package discovery now claims — dispose the legacy incumbent, then register the package handler. */
+    evictLegacyThenRegister: string[];
+    /** Ids with no incumbent at all — just register + init. */
+    registerNew: string[];
+}
+
+/**
+ * Decide what to do with each freshly-discovered package service against
+ * the currently mounted state, without touching the registry/sockets/panel
+ * map itself — the daemon executes the plan against real state; this
+ * function is the actual decision logic reconfigure_services runs, exported
+ * so package-before-legacy precedence and every reconfigure lifecycle edge
+ * case (revocation/identity-swap/legacy-eviction/unchanged-preserve) has
+ * direct regression coverage without spinning up sockets.
+ */
+export function planPackageServiceReconcile(
+    freshPackageServices: ReadonlyArray<{ id: string; identity: string }>,
+    packageServiceIds: ReadonlyMap<string, { identity: string }>,
+    legacyServiceIds: ReadonlySet<string>,
+    isRegistered: (id: string) => boolean,
+): PackageServiceReconcilePlan {
+    const freshIds = new Set(freshPackageServices.map((s) => s.id));
+    const revoke = [...packageServiceIds.keys()].filter((id) => !freshIds.has(id));
+
+    const preserveRefreshMetadata: string[] = [];
+    const replaceIdentitySwap: string[] = [];
+    const evictLegacyThenRegister: string[] = [];
+    const registerNew: string[] = [];
+
+    for (const { id, identity } of freshPackageServices) {
+        const existing = packageServiceIds.get(id);
+        if (existing && existing.identity === identity && isRegistered(id)) {
+            preserveRefreshMetadata.push(id);
+        } else if (existing) {
+            replaceIdentitySwap.push(id);
+        } else if (legacyServiceIds.has(id) && isRegistered(id)) {
+            evictLegacyThenRegister.push(id);
+        } else {
+            registerNew.push(id);
+        }
+    }
+
+    return { revoke, preserveRefreshMetadata, replaceIdentitySwap, evictLegacyThenRegister, registerNew };
+}
+
+export type DiscoveredServiceRejectReason = "builtin" | "collision";
+
+/**
+ * The has()-before-register collision guard registerDiscoveredService() runs
+ * before mounting any discovered (non-built-in) service. Built-ins always
+ * win; otherwise the FIRST caller to reach this check for a given id wins —
+ * which is what makes package-before-legacy precedence (§8) fall out of
+ * simply awaiting/registering the package discovery pass before the legacy
+ * pass, rather than depending on ServiceRegistry.register() throwing.
+ *
+ * Pure/host-independent — exported for direct regression coverage of
+ * registration-order precedence with a real ServiceRegistry, without
+ * spinning up sockets.
+ */
+export function canRegisterDiscoveredService(
+    isBuiltinReserved: boolean,
+    isAlreadyRegistered: boolean,
+): { register: true } | { register: false; reason: DiscoveredServiceRejectReason } {
+    if (isBuiltinReserved) return { register: false, reason: "builtin" };
+    if (isAlreadyRegistered) return { register: false, reason: "collision" };
+    return { register: true };
+}
+
+/**
+ * Derive the panelEntries value for a service from its manifest, preserving
+ * an already-announced port across re-registration/metadata refresh.
+ * Returns null when the manifest declares no panel/triggers/sigils (nothing
+ * worth tracking). `hasPanel` prefers the manifest's explicit value (set by
+ * package discovery) and falls back to inferring from `panel` presence for
+ * legacy folder-based manifests that never set it explicitly — this is what
+ * routes a trigger/sigil-only service to `announceSigilServer` instead of
+ * `announcePanel` at init time.
+ *
+ * Pure and host-independent — exported for direct regression coverage
+ * without spinning up the daemon/socket.
+ */
+export function panelEntryFromManifest(
+    serviceId: string,
+    manifest: ServiceManifest | undefined,
+    existingPort?: number,
+): PanelEntry | null {
+    if (!manifest) return null;
+    const hasTriggers = !!(manifest.triggers && manifest.triggers.length > 0);
+    const hasSigils = !!(manifest.sigils && manifest.sigils.length > 0);
+    if (!manifest.panel && !hasTriggers && !hasSigils) return null;
+    return {
+        serviceId,
+        label: manifest.label,
+        icon: manifest.icon,
+        hasPanel: manifest.hasPanel ?? !!manifest.panel,
+        ...(existingPort !== undefined ? { port: existingPort } : {}),
+        ...(hasTriggers ? { triggers: manifest.triggers } : {}),
+        ...(hasSigils ? { sigils: manifest.sigils } : {}),
+        ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
+    };
 }
 
 /**
@@ -609,27 +822,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         tunnelService.setTunnelClient(tunnelClient);
 
         // Panel tracking — manifests from folder-based services, ports from announcePanel()
-        type PanelEntry = {
-            serviceId: string;
-            label: string;
-            icon: string;
-            port?: number;
-            /** Trigger types declared in this service's manifest */
-            triggers?: ServiceTriggerDef[];
-            /** Sigil types declared in this service's manifest */
-            sigils?: ServiceSigilDef[];
-            /**
-             * Whether this service has a UI panel shown to users.
-             * false = service has trigger/sigil defs but no panel (e.g. the time service).
-             * Defaults to true for plugin-provided services with a panel manifest.
-             */
-            hasPanel?: boolean;
-            /**
-             * Variable names the panel requires. The UI resolves these and appends
-             * them as query params to the iframe src.
-             */
-            requires?: string[];
-        };
         const panelEntries = new Map<string, PanelEntry>();
         // Track ALL discovered service IDs (including disabled ones) so the UI can show them.
         const allDiscoveredServiceIds = new Set<string>();
@@ -661,29 +853,17 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             kind: "package" | "legacy",
         ): boolean => {
             const from = source.pluginName ?? source.path;
-            if (BUILTIN_SERVICE_IDS.has(handler.id)) {
-                logWarn(`[services] ${kind} service "${handler.id}" from ${from} collides with a reserved built-in service id — skipped`);
-                return false;
-            }
-            if (registry.has(handler.id)) {
-                logWarn(`[services] ${kind} service "${handler.id}" from ${from} collides with an already-registered service — skipped`);
+            const decision = canRegisterDiscoveredService(BUILTIN_SERVICE_IDS.has(handler.id), registry.has(handler.id));
+            if (!decision.register) {
+                const why = decision.reason === "builtin" ? "collides with a reserved built-in service id" : "collides with an already-registered service";
+                logWarn(`[services] ${kind} service "${handler.id}" from ${from} ${why} — skipped`);
                 return false;
             }
             registry.register(handler);
             allDiscoveredServiceIds.add(handler.id);
             logInfo(`[services] loaded ${kind} service "${handler.id}" from ${from}`);
-            if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0) || (manifest?.sigils && manifest.sigils.length > 0)) {
-                const existing = panelEntries.get(handler.id);
-                panelEntries.set(handler.id, {
-                    serviceId: handler.id,
-                    label: manifest.label,
-                    icon: manifest.icon,
-                    ...(existing?.port !== undefined ? { port: existing.port } : {}),
-                    ...(manifest.triggers && manifest.triggers.length > 0 ? { triggers: manifest.triggers } : {}),
-                    ...(manifest.sigils && manifest.sigils.length > 0 ? { sigils: manifest.sigils } : {}),
-                    ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
-                });
-            }
+            const entry = panelEntryFromManifest(handler.id, manifest, panelEntries.get(handler.id)?.port);
+            if (entry) panelEntries.set(handler.id, entry);
             if (kind === "package") packageServiceIds.set(handler.id, { identity: source.pluginName ?? handler.id });
             else legacyServiceIds.add(handler.id);
             return true;
@@ -778,11 +958,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const pluginServicesReady = new Promise<void>(r => { resolvePluginServices = r; });
         (async () => {
             try {
-                const { services, errors } = await discoverPackageServices({
-                    cwd: packageDiscoveryCwd,
-                    agentDir: packageDiscoveryAgentDir,
-                    disabledIds: disabledServices,
-                });
+                // Bounded so a stalled package import can never strand legacy
+                // discovery below (§C) — late results are discarded, not mutated in.
+                const { value: { services, errors }, timedOut } = await raceWithTimeout(
+                    discoverPackageServices({
+                        cwd: packageDiscoveryCwd,
+                        agentDir: packageDiscoveryAgentDir,
+                        disabledIds: disabledServices,
+                    }),
+                    PACKAGE_DISCOVERY_TIMEOUT_MS,
+                    () => timedOutPackageDiscoveryResult(packageDiscoveryAgentDir),
+                    disposeLatePackageDiscovery,
+                );
+                if (timedOut) logWarn(`[services] package service discovery did not complete within ${PACKAGE_DISCOVERY_TIMEOUT_MS}ms; proceeding without package services this pass`);
                 for (const { handler, source, manifest } of services) {
                     registerDiscoveredService(handler, source, manifest, "package");
                 }
@@ -1144,10 +1332,14 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     return opts;
                 };
 
-                // Disable any non-built-in service (package- or legacy-origin)
-                // that is now in the disabled set.
+                // Disable any non-permanently-pinned service (package-,
+                // legacy-, or the memory/process built-ins) that is now in
+                // the disabled set. NON_DISABLEABLE_SERVICE_IDS (not the
+                // broader BUILTIN_SERVICE_IDS collision-reservation set) is
+                // the runtime-disable gate — memory/process must stay
+                // disableable at runtime like every other built-in used to be.
                 const servicesToDisable = registry.getAll()
-                    .filter(s => !BUILTIN_SERVICE_IDS.has(s.id) && newDisabledServices.has(s.id));
+                    .filter(s => !NON_DISABLEABLE_SERVICE_IDS.has(s.id) && newDisabledServices.has(s.id));
                 for (const svc of servicesToDisable) {
                     logInfo(`[services] disabling service "${svc.id}"`);
                     try {
@@ -1178,41 +1370,118 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 };
 
                 // ── Package-origin services: awaited + registered before legacy (§8) ──
-                const { services: freshPackageServices, errors: packageErrors } = await discoverPackageServices({
-                    cwd: packageDiscoveryCwd,
-                    agentDir: packageDiscoveryAgentDir,
-                    disabledIds: newDisabledServices,
-                });
-                const freshPackageIds = new Set(freshPackageServices.map((s) => s.handler.id));
+                // Bounded so a stalled package import can never hang reconfigure
+                // indefinitely (§C); a timeout also forces authoritative=false below.
+                const {
+                    value: { services: freshPackageServices, errors: packageErrors, authoritative: packageDiscoveryAuthoritative },
+                    timedOut: packageDiscoveryTimedOut,
+                } = await raceWithTimeout(
+                    discoverPackageServices({
+                        cwd: packageDiscoveryCwd,
+                        agentDir: packageDiscoveryAgentDir,
+                        disabledIds: newDisabledServices,
+                    }),
+                    PACKAGE_DISCOVERY_TIMEOUT_MS,
+                    () => timedOutPackageDiscoveryResult(packageDiscoveryAgentDir),
+                    disposeLatePackageDiscovery,
+                );
+                if (packageDiscoveryTimedOut) {
+                    logWarn(`[services] package service discovery did not complete within ${PACKAGE_DISCOVERY_TIMEOUT_MS}ms during reconfigure`);
+                }
 
-                // Dispose/unregister package services whose grant/package/declaration
-                // was revoked or removed (distinct from the disable-set handling above).
-                for (const id of [...packageServiceIds.keys()]) {
-                    if (freshPackageIds.has(id)) continue;
-                    const svc = registry.get(id);
-                    if (svc) {
-                        logInfo(`[services] unregistering package service "${id}" (revoked or no longer declared)`);
+                if (!packageDiscoveryAuthoritative) {
+                    // Corrupt/unreadable GLOBAL settings, or a discovery timeout: the
+                    // fresh result is not a trustworthy "no packages" answer. Never
+                    // treat it as authorization to dispose currently running package
+                    // services — skip the reconcile/register diff entirely and just
+                    // surface whatever per-package errors did come through.
+                    logWarn(`[services] package service discovery is not authoritative this pass — preserving ${packageServiceIds.size} currently active package service(s) untouched`);
+                    for (const { path, error } of packageErrors) {
+                        logWarn(`[services] package service discovery: ${error} (${path})`);
+                    }
+                } else {
+                    const freshById = new Map(freshPackageServices.map((s) => [s.handler.id, s] as const));
+                    const plan = planPackageServiceReconcile(
+                        freshPackageServices.map((s) => ({ id: s.handler.id, identity: s.source.pluginName ?? s.handler.id })),
+                        packageServiceIds,
+                        legacyServiceIds,
+                        (id) => registry.has(id),
+                    );
+
+                    // Ids that were package-mounted before but are no longer
+                    // declared/granted this pass (distinct from the disable-set
+                    // handling above).
+                    for (const id of plan.revoke) {
+                        const svc = registry.get(id);
+                        if (svc) {
+                            logInfo(`[services] unregistering package service "${id}" (revoked or no longer declared)`);
+                            try {
+                                svc.dispose();
+                            } catch (err) {
+                                logWarn(`[services] dispose failed for "${id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+                            }
+                            registry.unregister(id);
+                            initializedServiceIds.delete(id);
+                        }
+                        packageServiceIds.delete(id);
+                        allDiscoveredServiceIds.delete(id);
+                        panelEntries.delete(id);
+                        sigilServerPorts.delete(id);
+                    }
+
+                    // Unchanged winning identity — preserve the running lifecycle,
+                    // but refresh panel/trigger/sigil metadata from the fresh
+                    // manifest (the package could have been reinstalled/updated
+                    // without its identity changing).
+                    for (const id of plan.preserveRefreshMetadata) {
+                        const manifest = freshById.get(id)?.manifest;
+                        const entry = panelEntryFromManifest(id, manifest, panelEntries.get(id)?.port);
+                        if (entry) panelEntries.set(id, entry);
+                        else panelEntries.delete(id);
+                    }
+
+                    const disposeIncumbent = (id: string, reason: string) => {
+                        const oldSvc = registry.get(id);
+                        if (!oldSvc) return;
+                        logInfo(`[services] ${reason}`);
                         try {
-                            svc.dispose();
+                            oldSvc.dispose();
                         } catch (err) {
                             logWarn(`[services] dispose failed for "${id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
                         }
                         registry.unregister(id);
                         initializedServiceIds.delete(id);
-                    }
-                    packageServiceIds.delete(id);
-                    allDiscoveredServiceIds.delete(id);
-                    panelEntries.delete(id);
-                    sigilServerPorts.delete(id);
-                }
+                    };
 
-                for (const { handler, source, manifest } of freshPackageServices) {
-                    if (packageServiceIds.has(handler.id) && registry.has(handler.id)) continue; // unchanged — preserve lifecycle
-                    if (!registerDiscoveredService(handler, source, manifest, "package")) continue;
-                    initAndTrack(handler, "package");
-                }
-                for (const { path, error } of packageErrors) {
-                    logWarn(`[services] package service discovery: ${error} (${path})`);
+                    // Same service id, but the package identity that won it changed
+                    // underneath it — dispose the incumbent before mounting the new
+                    // one so stale handler state/timers never linger alongside it.
+                    for (const id of plan.replaceIdentitySwap) {
+                        const existing = packageServiceIds.get(id);
+                        const freshIdentity = freshById.get(id)?.source.pluginName ?? id;
+                        disposeIncumbent(id, `package service "${id}" identity changed (${existing?.identity} → ${freshIdentity}) — disposing old handler`);
+                        packageServiceIds.delete(id);
+                    }
+
+                    // A legacy-origin service currently holds this id from an
+                    // earlier pass, but package discovery now declares it — evict
+                    // the legacy incumbent so package-over-legacy precedence (§8)
+                    // holds dynamically, without requiring a daemon restart.
+                    for (const id of plan.evictLegacyThenRegister) {
+                        disposeIncumbent(id, `package service "${id}" supersedes legacy incumbent — disposing legacy handler`);
+                        legacyServiceIds.delete(id);
+                        allDiscoveredServiceIds.delete(id);
+                    }
+
+                    for (const id of [...plan.replaceIdentitySwap, ...plan.evictLegacyThenRegister, ...plan.registerNew]) {
+                        const fresh = freshById.get(id);
+                        if (!fresh) continue;
+                        if (!registerDiscoveredService(fresh.handler, fresh.source, fresh.manifest, "package")) continue;
+                        initAndTrack(fresh.handler, "package");
+                    }
+                    for (const { path, error } of packageErrors) {
+                        logWarn(`[services] package service discovery: ${error} (${path})`);
+                    }
                 }
 
                 // ── Legacy plugin-provided services ────────────────────────────────

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -298,6 +298,24 @@ export function panelEntryFromManifest(
     };
 }
 
+/** Remove ports owned by a stopped handler; optionally retain its disabled-state metadata. */
+export function clearServiceRuntimePorts(
+    serviceId: string,
+    panelEntries: Map<string, PanelEntry>,
+    sigilServerPorts: Map<string, number>,
+    keepMetadata: boolean,
+): void {
+    sigilServerPorts.delete(serviceId);
+    const entry = panelEntries.get(serviceId);
+    if (!entry) return;
+    if (!keepMetadata) {
+        panelEntries.delete(serviceId);
+        return;
+    }
+    const { port: _stalePort, ...metadata } = entry;
+    panelEntries.set(serviceId, metadata);
+}
+
 /**
  * Resolve the set of runner service IDs that should be skipped.
  * Built-in services: "terminal", "file-explorer", "git", "tunnel", "time".
@@ -1351,8 +1369,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     initializedServiceIds.delete(svc.id);
                     packageServiceIds.delete(svc.id);
                     legacyServiceIds.delete(svc.id);
-                    // Keep panel entry for disabled services so they still appear in service_announce
-                    sigilServerPorts.delete(svc.id);
+                    // Keep disabled-service metadata visible, but never re-announce its dead ports.
+                    clearServiceRuntimePorts(svc.id, panelEntries, sigilServerPorts, true);
                 }
 
                 const initAndTrack = (handler: ServiceHandler, kind: "package" | "legacy") => {
@@ -1461,6 +1479,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         const freshIdentity = freshById.get(id)?.source.pluginName ?? id;
                         disposeIncumbent(id, `package service "${id}" identity changed (${existing?.identity} → ${freshIdentity}) — disposing old handler`);
                         packageServiceIds.delete(id);
+                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false);
                     }
 
                     // A legacy-origin service currently holds this id from an
@@ -1471,6 +1490,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         disposeIncumbent(id, `package service "${id}" supersedes legacy incumbent — disposing legacy handler`);
                         legacyServiceIds.delete(id);
                         allDiscoveredServiceIds.delete(id);
+                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false);
                     }
 
                     for (const id of [...plan.replaceIdentitySwap, ...plan.evictLegacyThenRegister, ...plan.registerNew]) {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -20,6 +20,9 @@ import { ProcessService } from "./services/process-service.js";
 import { MemoryService } from "./services/memory-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
+import type { ServiceManifest, ServicePluginResult } from "./service-loader.js";
+import { discoverPackageServices } from "./package-service-loader.js";
+import { BUILTIN_SERVICE_IDS } from "./services/builtin-service-ids.js";
 import { globalPluginDirs } from "../plugins/discover.js";
 import { io, type Socket } from "socket.io-client";
 import {
@@ -415,6 +418,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     let disabledServices = resolveDisabledRunnerServices(daemonConfig);
     const isServiceDisabled = (id: string) => disabledServices.has(id);
 
+    // Package-origin service discovery is runner-global (grants are user-scope
+    // only, §7.2) — resolve once, reused by startup discovery and every
+    // reconfigure_services pass.
+    const packageDiscoveryCwd = process.cwd();
+    const packageDiscoveryAgentDir = resolveConfiguredAgentDir(packageDiscoveryCwd);
+
     // Priority: env var > config.json > default
     const apiKey =
         process.env.PIZZAPI_RUNNER_API_KEY ??
@@ -624,6 +633,61 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const panelEntries = new Map<string, PanelEntry>();
         // Track ALL discovered service IDs (including disabled ones) so the UI can show them.
         const allDiscoveredServiceIds = new Set<string>();
+        // Package-origin service ids currently mounted, keyed by their normalized
+        // package identity (§7.2/§9.2 provenance). Reconfiguration diffs this
+        // against a fresh discoverPackageServices() pass to dispose/unregister
+        // services whose grant/package/declaration was revoked or removed.
+        const packageServiceIds = new Map<string, { identity: string }>();
+        // Legacy-origin (global-dir/project-dir/plugin-manifest) service ids
+        // currently mounted — lets reconfigure distinguish "this id is already
+        // active from an earlier pass of the SAME origin, leave it running" from
+        // "this id now collides with a different origin," without relying on
+        // ServiceRegistry.register() throwing.
+        const legacyServiceIds = new Set<string>();
+
+        /**
+         * Register a discovered (non-built-in) service if its id isn't reserved
+         * by a built-in or already claimed by an earlier registration this pass.
+         * Shared by the package/legacy startup and reconfigure loops so the
+         * has()-before-register collision rule (§8) — built-ins always win, never
+         * rely on ServiceRegistry.register() throwing for duplicates — lives in
+         * exactly one place, and package-before-legacy precedence falls out of
+         * simply awaiting the package loop before the legacy loop.
+         */
+        const registerDiscoveredService = (
+            handler: ServiceHandler,
+            source: ServicePluginResult["source"],
+            manifest: ServiceManifest | undefined,
+            kind: "package" | "legacy",
+        ): boolean => {
+            const from = source.pluginName ?? source.path;
+            if (BUILTIN_SERVICE_IDS.has(handler.id)) {
+                logWarn(`[services] ${kind} service "${handler.id}" from ${from} collides with a reserved built-in service id — skipped`);
+                return false;
+            }
+            if (registry.has(handler.id)) {
+                logWarn(`[services] ${kind} service "${handler.id}" from ${from} collides with an already-registered service — skipped`);
+                return false;
+            }
+            registry.register(handler);
+            allDiscoveredServiceIds.add(handler.id);
+            logInfo(`[services] loaded ${kind} service "${handler.id}" from ${from}`);
+            if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0) || (manifest?.sigils && manifest.sigils.length > 0)) {
+                const existing = panelEntries.get(handler.id);
+                panelEntries.set(handler.id, {
+                    serviceId: handler.id,
+                    label: manifest.label,
+                    icon: manifest.icon,
+                    ...(existing?.port !== undefined ? { port: existing.port } : {}),
+                    ...(manifest.triggers && manifest.triggers.length > 0 ? { triggers: manifest.triggers } : {}),
+                    ...(manifest.sigils && manifest.sigils.length > 0 ? { sigils: manifest.sigils } : {}),
+                    ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
+                });
+            }
+            if (kind === "package") packageServiceIds.set(handler.id, { identity: source.pluginName ?? handler.id });
+            else legacyServiceIds.add(handler.id);
+            return true;
+        };
 
         // Register built-in Time service trigger/sigil defs so they flow through service_announce.
         // The Time service has no panel — it only runs an HTTP server for sigil resolve calls.
@@ -703,48 +767,46 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             });
         };
 
-        // Discover and register plugin-provided services.
-        // pluginServicesReady resolves once discovery + registration is complete.
+        // Discover and register package-origin and legacy plugin-provided
+        // services. pluginServicesReady resolves once both passes are complete.
         // The runner_registered handler awaits this before announcing services.
+        //
+        // Package discovery (§6/§7/§9.2) is AWAITED and registered before legacy
+        // discovery (§8) — this is what makes package-over-legacy precedence
+        // deterministic rather than dependent on async completion order.
         let resolvePluginServices: () => void;
         const pluginServicesReady = new Promise<void>(r => { resolvePluginServices = r; });
-        discoverServices({ pluginDirs: globalPluginDirs(), disabledIds: disabledServices }).then(({ services, errors }) => {
-            for (const { handler, source, manifest } of services) {
-                try {
-                    registry.register(handler);
-                    allDiscoveredServiceIds.add(handler.id);
-                    logInfo(`[services] loaded plugin service "${handler.id}" from ${source.pluginName ?? source.path}`);
-                    // Track panel metadata and trigger defs from folder-based services
-                    if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0) || (manifest?.sigils && manifest.sigils.length > 0)) {
-                        const existing = panelEntries.get(handler.id);
-                        panelEntries.set(handler.id, {
-                            serviceId: handler.id,
-                            label: manifest.label,
-                            icon: manifest.icon,
-                            ...(existing?.port !== undefined ? { port: existing.port } : {}),
-                            ...(manifest.triggers && manifest.triggers.length > 0
-                                ? { triggers: manifest.triggers }
-                                : {}),
-                            ...(manifest.sigils && manifest.sigils.length > 0
-                                ? { sigils: manifest.sigils }
-                                : {}),
-                            ...(manifest.panel?.requires
-                                ? { requires: manifest.panel.requires }
-                                : {}),
-                        });
-                    }
-                } catch (err) {
-                    logWarn(`[services] failed to register plugin service "${handler.id}": ${err}`);
+        (async () => {
+            try {
+                const { services, errors } = await discoverPackageServices({
+                    cwd: packageDiscoveryCwd,
+                    agentDir: packageDiscoveryAgentDir,
+                    disabledIds: disabledServices,
+                });
+                for (const { handler, source, manifest } of services) {
+                    registerDiscoveredService(handler, source, manifest, "package");
                 }
+                for (const { path, error } of errors) {
+                    logWarn(`[services] package service discovery: ${error} (${path})`);
+                }
+            } catch (err) {
+                logWarn(`[services] package service discovery failed: ${err}`);
             }
-            for (const { path, error } of errors) {
-                logWarn(`[services] plugin service load error at ${path}: ${error}`);
+
+            try {
+                const { services, errors } = await discoverServices({ pluginDirs: globalPluginDirs(), disabledIds: disabledServices });
+                for (const { handler, source, manifest } of services) {
+                    registerDiscoveredService(handler, source, manifest, "legacy");
+                }
+                for (const { path, error } of errors) {
+                    logWarn(`[services] plugin service load error at ${path}: ${error}`);
+                }
+            } catch (err) {
+                logWarn(`[services] plugin service discovery failed: ${err}`);
             }
-        }).catch(err => {
-            logWarn(`[services] plugin service discovery failed: ${err}`);
-        }).finally(() => {
+
             resolvePluginServices!();
-        });
+        })();
 
         const socket: Socket<RunnerServerToClientEvents, RunnerClientToServerEvents> = io(
             sioUrl + "/runner",
@@ -1082,12 +1144,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     return opts;
                 };
 
-                // Disable plugin services that are now in the disabled set
-                const BUILTIN_IDS = new Set(["terminal", "file-explorer", "git", "tunnel", "time"]);
-                const pluginsToDisable = registry.getAll()
-                    .filter(s => !BUILTIN_IDS.has(s.id) && newDisabledServices.has(s.id));
-                for (const svc of pluginsToDisable) {
-                    logInfo(`[services] disabling plugin service "${svc.id}"`);
+                // Disable any non-built-in service (package- or legacy-origin)
+                // that is now in the disabled set.
+                const servicesToDisable = registry.getAll()
+                    .filter(s => !BUILTIN_SERVICE_IDS.has(s.id) && newDisabledServices.has(s.id));
+                for (const svc of servicesToDisable) {
+                    logInfo(`[services] disabling service "${svc.id}"`);
                     try {
                         svc.dispose();
                     } catch (err) {
@@ -1095,42 +1157,14 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     }
                     registry.unregister(svc.id);
                     initializedServiceIds.delete(svc.id);
+                    packageServiceIds.delete(svc.id);
+                    legacyServiceIds.delete(svc.id);
                     // Keep panel entry for disabled services so they still appear in service_announce
                     sigilServerPorts.delete(svc.id);
                 }
 
-                // Re-discover plugin services with new disabled list
-                const { services: discoveredServices, errors } = await discoverServices(
-                    { pluginDirs: globalPluginDirs(), disabledIds: newDisabledServices },
-                );
-
-                // Remove services that are no longer discoverable (plugin deleted) and not disabled
-                for (const id of allDiscoveredServiceIds) {
-                    if (newDisabledServices.has(id)) continue; // Keep disabled services
-                    if (discoveredServices.some(s => s.handler.id === id)) continue; // Still exists
-                    // Plugin was removed and is not disabled - clean up
-                    allDiscoveredServiceIds.delete(id);
-                    panelEntries.delete(id);
-                    sigilServerPorts.delete(id);
-                }
-
-                // Register any newly enabled plugin services
-                for (const { handler, source, manifest } of discoveredServices) {
-                    if (registry.has(handler.id)) continue;
-                    allDiscoveredServiceIds.add(handler.id);
+                const initAndTrack = (handler: ServiceHandler, kind: "package" | "legacy") => {
                     try {
-                        registry.register(handler);
-                        logInfo(`[services] loaded plugin service "${handler.id}" from ${source.pluginName ?? source.path}`);
-                        if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0) || (manifest?.sigils && manifest.sigils.length > 0)) {
-                            panelEntries.set(handler.id, {
-                                serviceId: handler.id,
-                                label: manifest.label,
-                                icon: manifest.icon,
-                                ...(manifest.triggers && manifest.triggers.length > 0 ? { triggers: manifest.triggers } : {}),
-                                ...(manifest.sigils && manifest.sigils.length > 0 ? { sigils: manifest.sigils } : {}),
-                                ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
-                            });
-                        }
                         handler.init(socket as unknown as PizzaPiSocket, optsForInit(handler.id));
                         initializedServiceIds.add(handler.id);
                         if (typeof handler.reconcileSubscriptions === "function") {
@@ -1139,10 +1173,70 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             logInfo(`[trigger-reconciliation] service "${handler.id}" hot-reload applied ${result.applied}/${subs.length} cached subscriptions${result.errors?.length ? `, errors=${result.errors.length}` : ""}`);
                         }
                     } catch (err) {
-                        logWarn(`[services] failed to register plugin service "${handler.id}": ${err}`);
+                        logWarn(`[services] failed to init ${kind} service "${handler.id}": ${err}`);
                     }
+                };
+
+                // ── Package-origin services: awaited + registered before legacy (§8) ──
+                const { services: freshPackageServices, errors: packageErrors } = await discoverPackageServices({
+                    cwd: packageDiscoveryCwd,
+                    agentDir: packageDiscoveryAgentDir,
+                    disabledIds: newDisabledServices,
+                });
+                const freshPackageIds = new Set(freshPackageServices.map((s) => s.handler.id));
+
+                // Dispose/unregister package services whose grant/package/declaration
+                // was revoked or removed (distinct from the disable-set handling above).
+                for (const id of [...packageServiceIds.keys()]) {
+                    if (freshPackageIds.has(id)) continue;
+                    const svc = registry.get(id);
+                    if (svc) {
+                        logInfo(`[services] unregistering package service "${id}" (revoked or no longer declared)`);
+                        try {
+                            svc.dispose();
+                        } catch (err) {
+                            logWarn(`[services] dispose failed for "${id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+                        }
+                        registry.unregister(id);
+                        initializedServiceIds.delete(id);
+                    }
+                    packageServiceIds.delete(id);
+                    allDiscoveredServiceIds.delete(id);
+                    panelEntries.delete(id);
+                    sigilServerPorts.delete(id);
                 }
 
+                for (const { handler, source, manifest } of freshPackageServices) {
+                    if (packageServiceIds.has(handler.id) && registry.has(handler.id)) continue; // unchanged — preserve lifecycle
+                    if (!registerDiscoveredService(handler, source, manifest, "package")) continue;
+                    initAndTrack(handler, "package");
+                }
+                for (const { path, error } of packageErrors) {
+                    logWarn(`[services] package service discovery: ${error} (${path})`);
+                }
+
+                // ── Legacy plugin-provided services ────────────────────────────────
+                const { services: discoveredServices, errors } = await discoverServices(
+                    { pluginDirs: globalPluginDirs(), disabledIds: newDisabledServices },
+                );
+
+                // Remove legacy services that are no longer discoverable (plugin
+                // deleted) and not disabled. Package-origin ids are reconciled above.
+                for (const id of [...allDiscoveredServiceIds]) {
+                    if (packageServiceIds.has(id)) continue;
+                    if (newDisabledServices.has(id)) continue; // Keep disabled services
+                    if (discoveredServices.some(s => s.handler.id === id)) continue; // Still exists
+                    allDiscoveredServiceIds.delete(id);
+                    legacyServiceIds.delete(id);
+                    panelEntries.delete(id);
+                    sigilServerPorts.delete(id);
+                }
+
+                for (const { handler, source, manifest } of discoveredServices) {
+                    if (legacyServiceIds.has(handler.id) && registry.has(handler.id)) continue; // unchanged — preserve lifecycle
+                    if (!registerDiscoveredService(handler, source, manifest, "legacy")) continue;
+                    initAndTrack(handler, "legacy");
+                }
                 for (const { path, error } of errors) {
                     logWarn(`[services] plugin service load error at ${path}: ${error}`);
                 }

--- a/packages/cli/src/runner/package-service-loader.test.ts
+++ b/packages/cli/src/runner/package-service-loader.test.ts
@@ -190,6 +190,122 @@ describe("discoverPackageServices", () => {
         expect(errors.some((e) => e.error.includes("collides with already-registered package"))).toBe(true);
     });
 
+    test("corrupt GLOBAL settings make discovery non-authoritative, not an empty valid result (fix #1)", async () => {
+        // Malformed JSON in the global (user-scope) settings file — this is
+        // what `DefaultPackageManager.listConfiguredPackages()` silently
+        // degrades to `[]` for, which must NOT be read as "user has no
+        // packages configured".
+        writeFileSync(join(agentDir, "settings.json"), "{ not valid json");
+
+        const { services, errors, authoritative } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(authoritative).toBe(false);
+        expect(errors.some((e) => e.error.includes("not authoritative"))).toBe(true);
+    });
+
+    test("a project-scope settings load error does NOT flip authoritative (fix #1)", async () => {
+        // Project settings failures must not gate user-scope daemon service
+        // discovery — only GLOBAL (user-scope) load errors do.
+        mkdirSync(join(cwd, ".pizzapi"), { recursive: true });
+        writeFileSync(join(cwd, ".pizzapi", "settings.json"), "{ not valid json");
+
+        const { authoritative } = await discoverPackageServices({ cwd, agentDir });
+        expect(authoritative).toBe(true);
+    });
+
+    test("an untrusted (ungranted) first package still reserves its id — a later granted package cannot impersonate it (fix #5)", async () => {
+        const pkgADir = join(tmpDir, "untrusted-first");
+        const pkgBDir = join(tmpDir, "granted-second");
+        writeFixturePackage(pkgADir, { schemaVersion: 1, services: [{ id: "shared-id", label: "A", entry: "./service.ts" }] });
+        writeFileSync(join(pkgADir, "service.ts"), "export default { id: 'shared-id', init(){}, dispose(){} };");
+        writeFixturePackage(pkgBDir, { schemaVersion: 1, services: [{ id: "shared-id", label: "B", entry: "./service.ts" }] });
+        writeFileSync(join(pkgBDir, "service.ts"), "export default { id: 'shared-id', init(){}, dispose(){} };");
+
+        await installLocal("../untrusted-first");
+        await installLocal("../granted-second");
+        const identityB = "local:" + realpathSync(pkgBDir);
+        // Only B is granted — A is left untrusted (broken/untrusted-first case).
+        grantServices(identityB, ["shared-id"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0); // A is untrusted, B is blocked by A's reservation
+        expect(errors.some((e) => e.error.includes("is not granted"))).toBe(true);
+        expect(errors.some((e) => e.error.includes("collides with already-registered package"))).toBe(true);
+    });
+
+    test("panel.dir failing re-validation immediately before use rejects the whole service (fix #2, TOCTOU)", async () => {
+        // A pre-deleted panel dir would already be caught by
+        // readOverlayManifest()'s own validation (before the per-service
+        // TOCTOU recheck even runs) — to exercise the *actual* re-validation
+        // gap, delete the panel dir as a side effect of importing the entry
+        // module. Manifest validation (which reads panel.dir first) has
+        // already passed by the time the entry is imported; the panel-dir
+        // recheck runs immediately AFTER import, so it must catch this.
+        const pkgDir = join(tmpDir, "panel-toctou-pkg");
+        const panelDir = join(pkgDir, "panel");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "panel-svc", label: "X", entry: "./service.ts", panel: { dir: "./panel" } }],
+        });
+        writeFileSync(
+            join(pkgDir, "service.ts"),
+            `import { rmSync } from "node:fs";\n` +
+            `rmSync(${JSON.stringify(panelDir)}, { recursive: true, force: true });\n` +
+            `export default { id: "panel-svc", init(){}, dispose(){} };\n`,
+        );
+        mkdirSync(panelDir, { recursive: true });
+        writeFileSync(join(panelDir, "index.html"), "<html></html>");
+        await installLocal("../panel-toctou-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["panel-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0); // never register a broken-panel service
+        expect(errors.some((e) => e.error.includes("panel.dir failed re-validation"))).toBe(true);
+    });
+
+    test("a package service with only triggers/sigils (no panel) gets hasPanel: false in its manifest (fix #3)", async () => {
+        const pkgDir = join(tmpDir, "no-panel-pkg");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{
+                id: "sigil-svc",
+                label: "X",
+                entry: "./service.ts",
+                sigils: [{ type: "thing", label: "Thing" }],
+            }],
+        });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'sigil-svc', init(){}, dispose(){} };");
+        await installLocal("../no-panel-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["sigil-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(errors).toEqual([]);
+        expect(services).toHaveLength(1);
+        expect(services[0]!.manifest?.hasPanel).toBe(false);
+        expect(services[0]!.manifest?.panel).toBeUndefined();
+    });
+
+    test("a package service with a panel gets hasPanel: true in its manifest (fix #3)", async () => {
+        const pkgDir = join(tmpDir, "with-panel-pkg");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{ id: "panel-svc2", label: "X", entry: "./service.ts", panel: { dir: "./panel" } }],
+        });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'panel-svc2', init(){}, dispose(){} };");
+        mkdirSync(join(pkgDir, "panel"), { recursive: true });
+        writeFileSync(join(pkgDir, "panel", "index.html"), "<html></html>");
+        await installLocal("../with-panel-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["panel-svc2"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(errors).toEqual([]);
+        expect(services).toHaveLength(1);
+        expect(services[0]!.manifest?.hasPanel).toBe(true);
+    });
+
     test("one invalid package does not block discovery of a valid one", async () => {
         const badPkgDir = join(tmpDir, "bad-pkg");
         const goodPkgDir = join(tmpDir, "good-pkg");

--- a/packages/cli/src/runner/package-service-loader.test.ts
+++ b/packages/cli/src/runner/package-service-loader.test.ts
@@ -1,0 +1,213 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPackageCommand } from "../package-commands.js";
+import { _setGlobalConfigDir } from "../config/io.js";
+import { grantServices } from "../overlay/grants.js";
+import { discoverPackageServices } from "./package-service-loader.js";
+
+describe("discoverPackageServices", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDir: string | undefined;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-pkgsvc-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+        originalCwd = process.cwd();
+        originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    /** Writes a marker file on import so tests can prove import did/didn't happen. */
+    function writeMarkerService(dir: string, id: string, markerPath: string) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "service.ts"),
+            `import { writeFileSync } from "node:fs";\n` +
+            `writeFileSync(${JSON.stringify(markerPath)}, "imported");\n` +
+            `export default { id: ${JSON.stringify(id)}, init() {}, dispose() {} };\n`,
+        );
+    }
+
+    function writeFixturePackage(dir: string, overlay: unknown) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+    }
+
+    async function installLocal(relOrAbs: string) {
+        const code = await runPackageCommand(["install", relOrAbs], cwd, agentDir);
+        expect(code).toBe(0);
+    }
+
+    test("configured-only discovery: an orphan install directory not in settings is never inspected", async () => {
+        const orphanDir = join(tmpDir, "orphan-pkg");
+        const markerPath = join(tmpDir, "orphan-marker.txt");
+        writeFixturePackage(orphanDir, { schemaVersion: 1, services: [{ id: "orphan-svc", label: "Orphan", entry: "./service.ts" }] });
+        writeMarkerService(orphanDir, "orphan-svc", markerPath);
+        // NOT installed/configured — just sitting on disk.
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.find((e) => e.error.includes("orphan-svc"))).toBeUndefined();
+        expect(existsSync(markerPath)).toBe(false);
+    });
+
+    test("missing configured source is skipped with a warning, no import, no crash", async () => {
+        const pkgDir = join(tmpDir, "vanishing-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "svc", label: "Svc", entry: "./service.ts" }] });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'svc', init(){}, dispose(){} };");
+        await installLocal("../vanishing-pkg");
+        // Simulate the install directory disappearing after configuration.
+        rmSync(pkgDir, { recursive: true, force: true });
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.some((e) => e.error.includes("not installed") && e.error.includes("skipping"))).toBe(true);
+    });
+
+    test("service module is never imported before grant (untrusted service)", async () => {
+        const pkgDir = join(tmpDir, "untrusted-pkg");
+        const markerPath = join(tmpDir, "untrusted-marker.txt");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "untrusted-svc", label: "X", entry: "./service.ts" }] });
+        writeMarkerService(pkgDir, "untrusted-svc", markerPath);
+        await installLocal("../untrusted-pkg");
+        // No grantServices() call — service remains untrusted.
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.some((e) => e.error.includes("not granted"))).toBe(true);
+        expect(existsSync(markerPath)).toBe(false);
+    });
+
+    test("granted service is imported and registered with a matching handler id", async () => {
+        const pkgDir = join(tmpDir, "granted-pkg");
+        const markerPath = join(tmpDir, "granted-marker.txt");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "granted-svc", label: "X", entry: "./service.ts" }] });
+        writeMarkerService(pkgDir, "granted-svc", markerPath);
+        await installLocal("../granted-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["granted-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(errors).toEqual([]);
+        expect(services).toHaveLength(1);
+        expect(services[0]!.handler.id).toBe("granted-svc");
+        expect(services[0]!.source.origin).toBe("package");
+        expect(services[0]!.source.pluginName).toBe(identity);
+        expect(existsSync(markerPath)).toBe(true);
+    });
+
+    test("disabled service is never imported even when granted", async () => {
+        const pkgDir = join(tmpDir, "disabled-pkg");
+        const markerPath = join(tmpDir, "disabled-marker.txt");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "disabled-svc", label: "X", entry: "./service.ts" }] });
+        writeMarkerService(pkgDir, "disabled-svc", markerPath);
+        await installLocal("../disabled-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["disabled-svc"]);
+
+        const { services } = await discoverPackageServices({ cwd, agentDir, disabledIds: new Set(["disabled-svc"]) });
+        expect(services).toHaveLength(0);
+        expect(existsSync(markerPath)).toBe(false);
+    });
+
+    test("project-scope package with a declared service warns and is skipped, never imported", async () => {
+        const pkgDir = join(tmpDir, "project-pkg");
+        const markerPath = join(tmpDir, "project-marker.txt");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "project-svc", label: "X", entry: "./service.ts" }] });
+        writeMarkerService(pkgDir, "project-svc", markerPath);
+        const code = await runPackageCommand(["install", "../project-pkg", "--local"], cwd, agentDir);
+        expect(code).toBe(0);
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["project-svc"]); // even if granted, project scope must not mount
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.some((e) => e.error.includes("project-svc") && e.error.includes("schema v1"))).toBe(true);
+        expect(existsSync(markerPath)).toBe(false);
+    });
+
+    test("handler id mismatch is rejected", async () => {
+        const pkgDir = join(tmpDir, "mismatch-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "declared-id", label: "X", entry: "./service.ts" }] });
+        mkdirSync(pkgDir, { recursive: true });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'actual-id', init(){}, dispose(){} };");
+        await installLocal("../mismatch-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["declared-id"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.some((e) => e.error.includes("does not match the declared id"))).toBe(true);
+    });
+
+    test("built-in service ids are reserved — a package cannot impersonate one, even granted", async () => {
+        const pkgDir = join(tmpDir, "impersonator-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "terminal", label: "X", entry: "./service.ts" }] });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'terminal', init(){}, dispose(){} };");
+        await installLocal("../impersonator-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["terminal"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(0);
+        expect(errors.some((e) => e.error.includes("reserved built-in"))).toBe(true);
+    });
+
+    test("package-vs-package collision: first configured package wins, stable order", async () => {
+        const pkgADir = join(tmpDir, "pkg-a");
+        const pkgBDir = join(tmpDir, "pkg-b");
+        writeFixturePackage(pkgADir, { schemaVersion: 1, services: [{ id: "shared-id", label: "A", entry: "./service.ts" }] });
+        writeFileSync(join(pkgADir, "service.ts"), "export default { id: 'shared-id', init(){}, dispose(){} };");
+        writeFixturePackage(pkgBDir, { schemaVersion: 1, services: [{ id: "shared-id", label: "B", entry: "./service.ts" }] });
+        writeFileSync(join(pkgBDir, "service.ts"), "export default { id: 'shared-id', init(){}, dispose(){} };");
+
+        await installLocal("../pkg-a");
+        await installLocal("../pkg-b");
+        const identityA = "local:" + realpathSync(pkgADir);
+        const identityB = "local:" + realpathSync(pkgBDir);
+        grantServices(identityA, ["shared-id"]);
+        grantServices(identityB, ["shared-id"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(1);
+        expect(services[0]!.source.pluginName).toBe(identityA); // first configured wins
+        expect(errors.some((e) => e.error.includes("collides with already-registered package"))).toBe(true);
+    });
+
+    test("one invalid package does not block discovery of a valid one", async () => {
+        const badPkgDir = join(tmpDir, "bad-pkg");
+        const goodPkgDir = join(tmpDir, "good-pkg");
+        writeFixturePackage(badPkgDir, { schemaVersion: 1, bogusKey: true });
+        writeFixturePackage(goodPkgDir, { schemaVersion: 1, services: [{ id: "good-svc", label: "Good", entry: "./service.ts" }] });
+        writeFileSync(join(goodPkgDir, "service.ts"), "export default { id: 'good-svc', init(){}, dispose(){} };");
+
+        // "install" (via runPackageCommand) would refuse the malformed
+        // overlay non-zero; configure both packages directly in settings.json
+        // instead, mirroring the "list dedupes" test's direct-settings-write
+        // pattern, so both are configured regardless of overlay validity.
+        writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ packages: [badPkgDir, goodPkgDir] }));
+        const goodIdentity = "local:" + realpathSync(goodPkgDir);
+        grantServices(goodIdentity, ["good-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(services).toHaveLength(1);
+        expect(services[0]!.handler.id).toBe("good-svc");
+        expect(errors.some((e) => e.error.includes("bogusKey"))).toBe(true);
+    });
+});

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -45,6 +45,15 @@ export interface DiscoverPackageServicesOptions {
 export interface DiscoverPackageServicesResult {
     services: ServicePluginResult[];
     errors: ServiceLoadError[];
+    /**
+     * False when USER-scope (global) settings failed to load (e.g. corrupt
+     * JSON) — `services` is then an untrustworthy "nothing configured"
+     * result, not a real "no packages" answer. Callers (daemon reconfigure)
+     * MUST NOT treat a non-authoritative result as authorization to dispose
+     * currently running package services. Project-scope settings errors do
+     * not affect this flag — daemon services are user-scope only.
+     */
+    authoritative: boolean;
 }
 
 export async function discoverPackageServices(
@@ -57,18 +66,33 @@ export async function discoverPackageServices(
     // serviceId -> identity of the package that already won it, for the
     // package-vs-package collision warning (§8: stable first-configured wins).
     const winnerByServiceId = new Map<string, string>();
+    let authoritative = true;
 
     let configured: ReturnType<DefaultPackageManager["listConfiguredPackages"]>;
     try {
         const settingsManager = SettingsManager.create(cwd, agentDir);
         const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
         configured = packageManager.listConfiguredPackages();
+        // A corrupt/unreadable GLOBAL (user-scope) settings file loads as an
+        // empty `{}` rather than throwing — listConfiguredPackages() above
+        // would silently report "no packages configured" even though the
+        // user genuinely has packages, which must never be read as "user
+        // revoked everything". Project-scope errors are ignored here: project
+        // packages never mount user daemon services anyway (§6.3).
+        const globalError = settingsManager.drainErrors().find((e) => e.scope === "global");
+        if (globalError) {
+            authoritative = false;
+            errors.push({
+                path: agentDir,
+                error: `package service discovery: global (user-scope) settings failed to load (${globalError.error.message}) — result is not authoritative; treat as "unknown", not "no packages"`,
+            });
+        }
     } catch (err) {
         errors.push({
             path: cwd,
             error: `package service discovery: failed to load configured packages: ${err instanceof Error ? err.message : String(err)}`,
         });
-        return { services, errors };
+        return { services, errors, authoritative: false };
     }
 
     // ── Project-scope packages never mount daemon services in v1 (§6.3) ───
@@ -132,8 +156,8 @@ export async function discoverPackageServices(
         const grantedIds = getGrantedServiceIds(identity);
 
         for (const decl of overlay.services) {
-            if (disabledIds.has(decl.id)) continue; // operationally disabled — never imported
-
+            // Built-ins always win, regardless of package order — reject
+            // immediately, before any collision reservation (§8).
             if (BUILTIN_SERVICE_IDS.has(decl.id)) {
                 errors.push({
                     path: packageRoot,
@@ -143,13 +167,22 @@ export async function discoverPackageServices(
             }
 
             const existingWinner = winnerByServiceId.get(decl.id);
-            if (existingWinner) {
+            if (existingWinner && existingWinner !== identity) {
                 errors.push({
                     path: packageRoot,
                     error: `[${identity}] service "${decl.id}" collides with already-registered package "${existingWinner}" — first configured package wins, skipped.`,
                 });
                 continue;
             }
+            // The first valid (non-built-in-colliding) declaration reserves
+            // the id in stable configured-package order — BEFORE the
+            // disabled/grant/import checks below, so an untrusted or broken
+            // first package still blocks a later package from impersonating
+            // the same id, matching spec §8 (reservation is by declaration
+            // order, not by which package happens to finish importing first).
+            if (!existingWinner) winnerByServiceId.set(decl.id, identity);
+
+            if (disabledIds.has(decl.id)) continue; // operationally disabled — never imported
 
             if (!grantedIds.has(decl.id)) {
                 // Untrusted: NEVER imported (§9.2). Trust state is surfaced
@@ -187,15 +220,20 @@ export async function discoverPackageServices(
             }
 
             // Revalidate panel.dir immediately before use, same TOCTOU
-            // rationale as the entry path above.
+            // rationale as the entry path above. Unlike the entry path (which
+            // gates the whole service earlier), a panel.dir that fails this
+            // late check must reject the service outright rather than fall
+            // back to registering it panel-less — a package that declared a
+            // panel and lost it between validation and use is broken, not
+            // silently trigger/sigil-only.
             let panelDir: string | undefined;
             if (decl.panel?.dir) {
                 const resolvedPanel = resolveConfinedPath(packageRoot, decl.panel.dir);
                 if (!resolvedPanel.ok) {
-                    errors.push({ path: packageRoot, error: `[${identity}] service "${decl.id}" panel.dir failed re-validation before use: ${resolvedPanel.message}` });
-                } else {
-                    panelDir = resolvedPanel.absolutePath;
+                    errors.push({ path: packageRoot, error: `[${identity}] service "${decl.id}" panel.dir failed re-validation before use: ${resolvedPanel.message} — service rejected (never registering a broken panel).` });
+                    continue;
                 }
+                panelDir = resolvedPanel.absolutePath;
             }
 
             const manifest: ServiceManifest = {
@@ -203,12 +241,15 @@ export async function discoverPackageServices(
                 label: decl.label,
                 icon: decl.icon ?? "square",
                 entry: decl.entry,
+                // hasPanel is explicit (not inferred from presence of the `panel`
+                // key downstream) so a service with only triggers/sigils gets
+                // announceSigilServer, not announcePanel, at init time.
+                hasPanel: !!decl.panel,
                 ...(decl.panel ? { panel: { dir: panelDir, requires: decl.panel.requires } } : {}),
                 ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
                 ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),
             };
 
-            winnerByServiceId.set(decl.id, identity);
             services.push({
                 handler,
                 source: { origin: "package", path: resolvedEntry.absolutePath, pluginName: identity },
@@ -217,5 +258,5 @@ export async function discoverPackageServices(
         }
     }
 
-    return { services, errors };
+    return { services, errors, authoritative };
 }

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -1,0 +1,221 @@
+/**
+ * Package-origin runner service discovery (docs/specs/pi-pizzapi-overlay.md
+ * §6, §7, §8, §9.2).
+ *
+ * Inspects ONLY packages already configured through pi settings/package
+ * commands (`DefaultPackageManager.listConfiguredPackages()`) — this never
+ * crawls `.pizzapi/npm` or `.pizzapi/git` directories directly, so an orphan
+ * install directory that isn't in settings is never touched (§6.1). A
+ * configured-but-not-installed source is skipped with one provenance-rich
+ * warning; this loader never installs or prompts.
+ *
+ * Only user-scope packages mount daemon services (§6.2/§6.3) — a project
+ * entry for the same identity never suppresses an already-configured
+ * user-scope service, so project packages are read from
+ * `listConfiguredPackages()` independently, purely to emit a "v1 does not
+ * mount project services" warning when they declare any.
+ *
+ * Reading/validating a `pi.pizzapi` overlay (via `readOverlayManifest()`)
+ * never imports code. For every declared service, the exact per-service
+ * grant is checked BEFORE the entry module is dynamically imported — an
+ * untrusted, disabled, or built-in-colliding service is never imported.
+ * The confined entry (and panel) path is re-resolved immediately before
+ * import/use rather than reusing the path resolved during the earlier
+ * manifest-validation pass, and the loaded handler's runtime `id` must
+ * equal the declared id or the service is rejected.
+ */
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { computePackageIdentity, packageScopeBaseDir } from "../overlay/identity.js";
+import { formatOverlayIssue, readOverlayManifest, resolveConfinedPath, type PackageProvenance } from "../overlay/manifest.js";
+import { getGrantedServiceIds } from "../overlay/grants.js";
+import { BUILTIN_SERVICE_IDS } from "./services/builtin-service-ids.js";
+import { loadServiceModule } from "./service-loader.js";
+import type { ServiceHandler } from "./service-handler.js";
+import type { ServiceLoadError, ServiceManifest, ServicePluginResult } from "./service-loader.js";
+
+export interface DiscoverPackageServicesOptions {
+    /** Working directory used to resolve project-scope base dir and pass to the package manager. */
+    cwd: string;
+    /** Resolved agent dir (user-scope base dir for local package paths and settings). */
+    agentDir: string;
+    /** Service IDs to skip, regardless of grant — never imported. */
+    disabledIds?: Set<string>;
+}
+
+export interface DiscoverPackageServicesResult {
+    services: ServicePluginResult[];
+    errors: ServiceLoadError[];
+}
+
+export async function discoverPackageServices(
+    options: DiscoverPackageServicesOptions,
+): Promise<DiscoverPackageServicesResult> {
+    const { cwd, agentDir } = options;
+    const disabledIds = options.disabledIds ?? new Set<string>();
+    const services: ServicePluginResult[] = [];
+    const errors: ServiceLoadError[] = [];
+    // serviceId -> identity of the package that already won it, for the
+    // package-vs-package collision warning (§8: stable first-configured wins).
+    const winnerByServiceId = new Map<string, string>();
+
+    let configured: ReturnType<DefaultPackageManager["listConfiguredPackages"]>;
+    try {
+        const settingsManager = SettingsManager.create(cwd, agentDir);
+        const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+        configured = packageManager.listConfiguredPackages();
+    } catch (err) {
+        errors.push({
+            path: cwd,
+            error: `package service discovery: failed to load configured packages: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        return { services, errors };
+    }
+
+    // ── Project-scope packages never mount daemon services in v1 (§6.3) ───
+    // Warn only — never read further, never import.
+    for (const pkg of configured) {
+        if (pkg.scope !== "project" || !pkg.installedPath) continue;
+        try {
+            const identity = computePackageIdentity(pkg.source, packageScopeBaseDir("project", cwd, agentDir)).identity;
+            const provenance: PackageProvenance = { identity, source: pkg.source, scope: "project" };
+            const { overlay } = readOverlayManifest(pkg.installedPath, provenance);
+            if (overlay?.services?.length) {
+                errors.push({
+                    path: pkg.installedPath,
+                    error: `[${identity} (project: ${pkg.source})] declares runner service(s) [${overlay.services.map((s) => s.id).join(", ")}] — ` +
+                        "project-scoped packages do not mount daemon services in schema v1; the session-side surface still loads after project trust.",
+                });
+            }
+        } catch {
+            // Best-effort warning only — never blocks discovery of other packages.
+        }
+    }
+
+    // ── User-scope packages: the only scope eligible for daemon services ──
+    const seenIdentities = new Set<string>();
+
+    for (const pkg of configured) {
+        if (pkg.scope !== "user") continue;
+        // §6.1: explicit package order is stable — first configured entry
+        // for a given identity wins if settings somehow list it twice.
+        const identity = computePackageIdentity(pkg.source, agentDir).identity;
+        if (seenIdentities.has(identity)) continue;
+        seenIdentities.add(identity);
+
+        if (!pkg.installedPath) {
+            // Non-interactive onMissing=skip (§6.1): never install, never prompt.
+            errors.push({
+                path: identity,
+                error: `[${identity} (user: ${pkg.source})] configured package is not installed — skipping (no install/prompt). Run \`pizza install ${pkg.source}\` to install it.`,
+            });
+            continue;
+        }
+        const packageRoot = pkg.installedPath;
+        const provenance: PackageProvenance = { identity, source: pkg.source, scope: "user" };
+
+        let overlayResult: ReturnType<typeof readOverlayManifest>;
+        try {
+            overlayResult = readOverlayManifest(packageRoot, provenance);
+        } catch (err) {
+            // Isolate: one unreadable package must not block the others.
+            errors.push({ path: packageRoot, error: `[${identity}] failed to read overlay: ${err instanceof Error ? err.message : String(err)}` });
+            continue;
+        }
+        const { overlay, present, issues } = overlayResult;
+        if (present && !overlay) {
+            // Malformed overlay is rejected as a unit (§5.2/§11) — never partially mount.
+            for (const issue of issues) errors.push({ path: packageRoot, error: formatOverlayIssue(issue) });
+            continue;
+        }
+        if (!overlay?.services?.length) continue;
+
+        const grantedIds = getGrantedServiceIds(identity);
+
+        for (const decl of overlay.services) {
+            if (disabledIds.has(decl.id)) continue; // operationally disabled — never imported
+
+            if (BUILTIN_SERVICE_IDS.has(decl.id)) {
+                errors.push({
+                    path: packageRoot,
+                    error: `[${identity}] service "${decl.id}" collides with a reserved built-in service id — built-in wins, package service skipped.`,
+                });
+                continue;
+            }
+
+            const existingWinner = winnerByServiceId.get(decl.id);
+            if (existingWinner) {
+                errors.push({
+                    path: packageRoot,
+                    error: `[${identity}] service "${decl.id}" collides with already-registered package "${existingWinner}" — first configured package wins, skipped.`,
+                });
+                continue;
+            }
+
+            if (!grantedIds.has(decl.id)) {
+                // Untrusted: NEVER imported (§9.2). Trust state is surfaced
+                // through `pizza list`/`pizza config`, not service_announce.
+                errors.push({
+                    path: packageRoot,
+                    error: `[${identity}] service "${decl.id}" is not granted — skipped (not imported). Run \`pizza config grant ${pkg.source} ${decl.id}\` to trust it.`,
+                });
+                continue;
+            }
+
+            // Revalidate the confined entry path immediately before import —
+            // deliberately re-resolved here rather than reused from
+            // readOverlayManifest()'s earlier validation pass.
+            const resolvedEntry = resolveConfinedPath(packageRoot, decl.entry);
+            if (!resolvedEntry.ok) {
+                errors.push({ path: packageRoot, error: `[${identity}] service "${decl.id}" entry failed re-validation before import: ${resolvedEntry.message}` });
+                continue;
+            }
+
+            let handler: ServiceHandler | null;
+            try {
+                handler = await loadServiceModule(resolvedEntry.absolutePath);
+            } catch (err) {
+                errors.push({ path: resolvedEntry.absolutePath, error: `[${identity}] service "${decl.id}" failed to import: ${err instanceof Error ? err.message : String(err)}` });
+                continue;
+            }
+            if (!handler) {
+                errors.push({ path: resolvedEntry.absolutePath, error: `[${identity}] service "${decl.id}" entry does not export a valid ServiceHandler (needs default export with id, init, dispose).` });
+                continue;
+            }
+            if (handler.id !== decl.id) {
+                errors.push({ path: resolvedEntry.absolutePath, error: `[${identity}] service "${decl.id}" entry exports runtime id "${handler.id}", which does not match the declared id — rejected.` });
+                continue;
+            }
+
+            // Revalidate panel.dir immediately before use, same TOCTOU
+            // rationale as the entry path above.
+            let panelDir: string | undefined;
+            if (decl.panel?.dir) {
+                const resolvedPanel = resolveConfinedPath(packageRoot, decl.panel.dir);
+                if (!resolvedPanel.ok) {
+                    errors.push({ path: packageRoot, error: `[${identity}] service "${decl.id}" panel.dir failed re-validation before use: ${resolvedPanel.message}` });
+                } else {
+                    panelDir = resolvedPanel.absolutePath;
+                }
+            }
+
+            const manifest: ServiceManifest = {
+                id: decl.id,
+                label: decl.label,
+                icon: decl.icon ?? "square",
+                entry: decl.entry,
+                ...(decl.panel ? { panel: { dir: panelDir, requires: decl.panel.requires } } : {}),
+                ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
+                ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),
+            };
+
+            winnerByServiceId.set(decl.id, identity);
+            services.push({
+                handler,
+                source: { origin: "package", path: resolvedEntry.absolutePath, pluginName: identity },
+                manifest,
+            });
+        }
+    }
+
+    return { services, errors };
+}

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -33,6 +33,14 @@ export interface ServiceManifest {
         /** Variable names the panel requires. UI resolves and passes as query params. */
         requires?: string[];
     };
+    /**
+     * Whether this service has a UI panel shown to users. Defaults to
+     * `!!panel` when omitted (folder-based legacy manifests never set this
+     * explicitly). Package-origin manifests set it explicitly so a
+     * trigger/sigil-only service (no `panel`) reliably gets
+     * `announceSigilServer` at init time instead of `announcePanel`.
+     */
+    hasPanel?: boolean;
     /** Trigger types this service can emit. Declared in triggers.json or manifest.json. */
     triggers?: ServiceTriggerDef[];
     /** Sigil types this service defines. Declared in sigils.json or manifest.json. */

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -48,10 +48,10 @@ export interface ServicePluginResult {
 
 export interface ServicePluginSource {
     /** Where this service was discovered */
-    origin: "global-dir" | "project-dir" | "plugin-manifest";
+    origin: "global-dir" | "project-dir" | "plugin-manifest" | "package";
     /** Absolute path to the source file or plugin directory */
     path: string;
-    /** Plugin name (if from a manifest) */
+    /** Plugin name (if from a manifest) or normalized package identity (if origin is "package") */
     pluginName?: string;
 }
 
@@ -534,7 +534,7 @@ function findDefaultEntry(dir: string): string | null {
  * - Default export is a class with prototype { init, dispose } (needs new)
  * - Default export is a function that returns a ServiceHandler (factory)
  */
-async function loadServiceModule(filePath: string): Promise<ServiceHandler | null> {
+export async function loadServiceModule(filePath: string): Promise<ServiceHandler | null> {
     const mod = await import(filePath);
     const exported = mod.default ?? mod;
 

--- a/packages/cli/src/runner/services/builtin-service-ids.test.ts
+++ b/packages/cli/src/runner/services/builtin-service-ids.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { BUILTIN_SERVICE_IDS } from "./builtin-service-ids.js";
+import { TerminalService } from "./terminal-service.js";
+import { FileExplorerService } from "./file-explorer-service.js";
+import { GitService } from "./git-service.js";
+import { ProcessService } from "./process-service.js";
+import { MemoryService } from "./memory-service.js";
+import { TimeService } from "./time-service.js";
+import { TunnelService } from "./tunnel-service.js";
+
+describe("BUILTIN_SERVICE_IDS", () => {
+    test("is the exact set of ids the daemon's built-in constructors produce", () => {
+        // Mirrors the exact `new XyzService(...)` calls daemon.ts makes when
+        // registering built-ins (ctor args are irrelevant to `.id`).
+        const instances = [
+            new TerminalService(),
+            new FileExplorerService(),
+            new GitService(),
+            new ProcessService(() => null),
+            new MemoryService(() => null),
+            new TimeService(),
+            new TunnelService(),
+        ];
+        const actual: Set<string> = new Set(instances.map((s) => s.id));
+        expect(actual).toEqual(new Set<string>(BUILTIN_SERVICE_IDS));
+        expect(actual.size).toBe(7);
+    });
+
+    test("covers exactly the seven documented built-ins", () => {
+        expect([...BUILTIN_SERVICE_IDS].sort()).toEqual(
+            ["file-explorer", "git", "memory", "process", "terminal", "time", "tunnel"],
+        );
+    });
+});

--- a/packages/cli/src/runner/services/builtin-service-ids.ts
+++ b/packages/cli/src/runner/services/builtin-service-ids.ts
@@ -7,6 +7,17 @@
  * maintaining their own literal — see builtin-service-ids.test.ts, which
  * instantiates the real built-in service classes daemon.ts registers and
  * pins that their `.id`s are exactly this set.
+ *
+ * ponytail: builtin-service-ids.test.ts's characterization instantiates a
+ * second, manually-mirrored list of the seven service classes rather than
+ * deriving them from daemon.ts's actual `registry.register(new XyzService(...))`
+ * call sites — if daemon.ts ever registers an eighth built-in, this test
+ * won't catch the drift. Fixing that for real means centralizing built-in
+ * construction into one shared factory daemon.ts and the test both call
+ * (the constructors close over per-daemon runtime state — session pid
+ * lookup, tunnel wiring — so this is a real refactor, not a one-liner).
+ * Upgrade when a built-in is added/removed and the mirrored list actually
+ * drifts, or as part of a dedicated daemon.ts service-registration cleanup.
  */
 export const BUILTIN_SERVICE_IDS: ReadonlySet<string> = new Set([
     "terminal",
@@ -14,6 +25,27 @@ export const BUILTIN_SERVICE_IDS: ReadonlySet<string> = new Set([
     "git",
     "memory",
     "process",
+    "time",
+    "tunnel",
+]);
+
+/**
+ * Built-in ids that must NEVER be torn down at runtime via
+ * `reconfigure_services` (distinct from BUILTIN_SERVICE_IDS, which is
+ * collision-reservation only — "a package/legacy service can't claim this
+ * id", not "this id can't be disabled"). "memory" and "process" were
+ * runtime-disableable before package-origin discovery unified the daemon's
+ * inline reconfigure BUILTIN_IDS set (which historically omitted them) into
+ * the 7-id BUILTIN_SERVICE_IDS — that unification accidentally made them
+ * permanently non-disableable at runtime too. This narrower set preserves
+ * the original 5 (terminal/file-explorer/git/time/tunnel) as the ones
+ * `reconfigure_services` refuses to dispose; memory/process stay
+ * disable-at-runtime like before.
+ */
+export const NON_DISABLEABLE_SERVICE_IDS: ReadonlySet<string> = new Set([
+    "terminal",
+    "file-explorer",
+    "git",
     "time",
     "tunnel",
 ]);

--- a/packages/cli/src/runner/services/builtin-service-ids.ts
+++ b/packages/cli/src/runner/services/builtin-service-ids.ts
@@ -1,0 +1,19 @@
+/**
+ * Reserved built-in runner service IDs (docs/specs/pi-pizzapi-overlay.md §8).
+ *
+ * Single source of truth for "which service ids are built-in and therefore
+ * always win a collision, even when disabled." Package/legacy discovery
+ * loaders and daemon reconfiguration all import this set instead of
+ * maintaining their own literal — see builtin-service-ids.test.ts, which
+ * instantiates the real built-in service classes daemon.ts registers and
+ * pins that their `.id`s are exactly this set.
+ */
+export const BUILTIN_SERVICE_IDS: ReadonlySet<string> = new Set([
+    "terminal",
+    "file-explorer",
+    "git",
+    "memory",
+    "process",
+    "time",
+    "tunnel",
+]);


### PR DESCRIPTION
## Summary
- discover trusted user-package runner services from validated `pi.pizzapi.services`
- enforce grants, built-in reservations, stable package/package precedence, and package-before-legacy precedence before importing daemon code
- reconcile revocation, disable/re-enable, package identity swaps, legacy eviction, metadata, subscriptions, and runtime ports without restarting the daemon
- preserve mounted services when package settings are unreadable or discovery times out

## Trust and lifecycle guarantees
- only configured user-scope packages are considered; project packages never mount daemon code
- disabled, ungranted, invalid, or built-in-colliding services are never imported
- entry and panel paths are revalidated immediately before use
- corrupt global package settings are non-authoritative and cannot tear down active services
- panel-less trigger/sigil services receive `announceSigilServer`
- replacement handlers never inherit stale panel or sigil ports

## Verification
- 448 runner tests passed in final independent review
- focused package/lifecycle regressions pass
- full monorepo typecheck passes
- Opus lifecycle/security review findings fixed
- final Fable delta review: LGTM, no P0–P2 findings

## Stack
- base: #654 (`feat/pi-package-trust`)
- implements Godmother idea `HJrG9dOI`
- follow-up tracked separately: owner-aware removal of auto-exposed tunnel routes (`WO7U1feT`)
