### PR TITLE
feat(cli): converge package session resources onto pi

### DIFF
--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -12,6 +12,7 @@ import {
 } from "./types.js";
 import { mergeSandboxConfig } from "./sandbox.js";
 import { createLogger } from "@pizzapi/tools";
+import { ProjectTrustStore } from "@earendil-works/pi-coding-agent";
 
 const log = createLogger("hooks");
 const emittedLoadConfigWarnings = new Set<string>();
@@ -410,6 +411,22 @@ export function defaultAgentDir(): string {
 export function resolveAgentDir(cwd: string = process.cwd()): string {
     const config = loadConfig(cwd);
     return config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+}
+
+/**
+ * Explicit, persisted pi project-trust decision for `cwd` — the single
+ * authority for gating native pi project resources (extensions/skills/
+ * prompts) AND the session-side `pi.pizzapi` overlay (which reuses the same
+ * pi `SettingsManager`/`DefaultPackageManager` resolution — see
+ * overlay/resolve.ts). Fails CLOSED: `null` (never decided) or `false`
+ * (explicitly untrusted) both resolve to untrusted. Mirrors pi's own
+ * `main.js` (`trustStore.get(cwd) === true`) — no PizzaPi-side default-trust
+ * shortcut and no new trust UI here; an already-untrusted repo simply stays
+ * untrusted until the user goes through pi's own trust flow (or trusts it
+ * via pi's CLI/TUI, which writes to the same `trust.json`).
+ */
+export function resolveExplicitProjectTrust(cwd: string, agentDir: string): boolean {
+    return new ProjectTrustStore(agentDir).get(cwd) === true;
 }
 
 // ── Session info variable substitution ─────────────────────────────────────────

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -399,6 +399,19 @@ export function defaultAgentDir(): string {
     return join(homedir(), ".pizzapi");
 }
 
+/**
+ * Resolve the effective agent dir for `cwd`: `config.agentDir` (expanded)
+ * when set, else `defaultAgentDir()`. Mirrors the pattern already inlined
+ * at each entrypoint (index.ts, runner/worker.ts) — extracted so session
+ * extensions that need `agentDir` outside those entrypoints (overlay
+ * package resolution, MCP overlay merge) resolve it identically rather
+ * than re-deriving it.
+ */
+export function resolveAgentDir(cwd: string = process.cwd()): string {
+    const config = loadConfig(cwd);
+    return config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+}
+
 // ── Session info variable substitution ─────────────────────────────────────────
 
 const VARIABLE_RE = /@(PWD|SESSION_ID|HOME|USER|PROJECT_DIR)@/g;

--- a/packages/cli/src/config/project-trust-gate.test.ts
+++ b/packages/cli/src/config/project-trust-gate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * P0 end-to-end characterization: an untrusted project's native pi
+ * extensions AND session-side `pi.pizzapi` overlay (agents/rules/mcp) must
+ * both be absent; a trusted project's must both be present. Exercises the
+ * REAL `DefaultResourceLoader` + `SettingsManager` + `ProjectTrustStore`
+ * pipeline `index.ts`/`worker.ts` use — not a mock — so a regression that
+ * re-introduces implicit trust (e.g. dropping `{ projectTrusted }` from a
+ * `SettingsManager.create()` call) fails this test.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DefaultResourceLoader, ProjectTrustStore, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { runPackageCommand } from "../package-commands.js";
+import { resolveExplicitProjectTrust, _setGlobalConfigDir } from "./io.js";
+import { resolveSessionOverlays } from "../overlay/session-packages.js";
+import { mergeOverlayMcpServers } from "../extensions/mcp-overlay.js";
+
+describe("project-trust gate — native extensions + pi.pizzapi overlay (session-side)", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDirEnv: string | undefined;
+
+    beforeEach(() => {
+        // runPackageCommand() chdir()s the process into cwd and only sets
+        // PI_CODING_AGENT_DIR when unset — both must be restored, or the
+        // NEXT test file to run in this same bun test process inherits a
+        // deleted tmp directory as its cwd (breaking anything that shells
+        // out or resolves relative paths) and/or a stale agentDir.
+        originalCwd = process.cwd();
+        originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+        delete process.env.PI_CODING_AGENT_DIR;
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-trust-gate-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeNativeProjectExtension(): void {
+        const dir = join(cwd, ".pizzapi", "extensions");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "marker.ts"),
+            "export default function markerExtension(pi) {\n" +
+                "  pi.registerTool({ name: 'trust_gate_marker', label: 'marker', description: 'marker', parameters: { type: 'object', properties: {} }, async execute() { return { content: [] }; } });\n" +
+                "}\n",
+        );
+    }
+
+    function writeOverlayPackage(scope: "user" | "project"): void {
+        const pkgDir = join(tmpDir, `overlay-pkg-${scope}`);
+        mkdirSync(join(pkgDir, "agents"), { recursive: true });
+        mkdirSync(join(pkgDir, "rules"), { recursive: true });
+        writeFileSync(
+            join(pkgDir, "package.json"),
+            JSON.stringify({
+                name: "overlay-pkg",
+                pi: { pizzapi: { schemaVersion: 1, agents: ["./agents"], rules: ["./rules"], mcp: "./.mcp.json" } },
+            }),
+        );
+        writeFileSync(join(pkgDir, "agents", "a.md"), "---\nname: a\ndescription: A\n---\nBody");
+        writeFileSync(join(pkgDir, "rules", "r.md"), "A project rule.");
+        writeFileSync(join(pkgDir, ".mcp.json"), JSON.stringify({ mcpServers: { fromOverlay: { command: "echo" } } }));
+    }
+
+    async function installProjectPackage(): Promise<void> {
+        writeOverlayPackage("project");
+        const code = await runPackageCommand(["install", "../overlay-pkg-project", "-l"], cwd, agentDir);
+        expect(code).toBe(0);
+    }
+
+    test("untrusted project: native pi extension is NOT loaded, and overlay agents/rules/mcp are absent", async () => {
+        // Install FIRST, then add the native extension — pi's own package-
+        // command CLI trust check treats a cwd with no trust-requiring
+        // resources YET as safe to write project settings.json into
+        // (hasTrustRequiringProjectResources()); adding `.pizzapi/extensions`
+        // first would make the install itself refuse non-interactively.
+        await installProjectPackage();
+        writeNativeProjectExtension();
+
+        // No ProjectTrustStore entry at all — resolveExplicitProjectTrust must
+        // fail closed (null decision treated as untrusted).
+        const projectTrusted = resolveExplicitProjectTrust(cwd, agentDir);
+        expect(projectTrusted).toBe(false);
+
+        const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+        const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager, noThemes: true });
+        await loader.reload();
+
+        const extensionPaths = loader.getExtensions().extensions.map((e: any) => e.path ?? e.resolvedPath ?? "");
+        expect(extensionPaths.some((p: string) => p.includes("marker.ts"))).toBe(false);
+
+        const overlays = resolveSessionOverlays(cwd, agentDir, projectTrusted);
+        expect(overlays.packages.some((p) => p.scope === "project")).toBe(false);
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, projectTrusted);
+        expect(config.mcpServers?.fromOverlay).toBeUndefined();
+        expect(serverProvenance).toHaveLength(0);
+    });
+
+    test("trusted project (explicit ProjectTrustStore entry): native pi extension IS loaded, and overlay agents/rules/mcp are present", async () => {
+        await installProjectPackage();
+        writeNativeProjectExtension();
+        new ProjectTrustStore(agentDir).set(cwd, true);
+
+        const projectTrusted = resolveExplicitProjectTrust(cwd, agentDir);
+        expect(projectTrusted).toBe(true);
+
+        const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+        const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager, noThemes: true });
+        await loader.reload();
+
+        const extensionPaths = loader.getExtensions().extensions.map((e: any) => e.path ?? e.resolvedPath ?? "");
+        expect(extensionPaths.some((p: string) => p.includes("marker.ts"))).toBe(true);
+
+        const overlays = resolveSessionOverlays(cwd, agentDir, projectTrusted);
+        expect(overlays.packages.some((p) => p.scope === "project")).toBe(true);
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, projectTrusted);
+        expect(config.mcpServers?.fromOverlay).toBeDefined();
+        expect(serverProvenance.some((p) => p.name === "fromOverlay" && p.owner === "project")).toBe(true);
+    });
+
+    test("explicit distrust (ProjectTrustStore set to false) behaves identically to a never-decided project", async () => {
+        await installProjectPackage();
+        writeNativeProjectExtension();
+        new ProjectTrustStore(agentDir).set(cwd, false);
+
+        expect(resolveExplicitProjectTrust(cwd, agentDir)).toBe(false);
+    });
+});

--- a/packages/cli/src/config/trust-gates.test.ts
+++ b/packages/cli/src/config/trust-gates.test.ts
@@ -23,7 +23,7 @@ import {
     _setGlobalConfigDir,
 } from "./io.js";
 import { discoverProviders, globalProvidersDir } from "../providers/loader.js";
-import { createClaudePluginExtension, getPluginSkillPaths, getPluginAgentPaths } from "../extensions/claude-plugins.js";
+import { createClaudePluginExtension, getPluginSkillPaths, getPluginAgentPaths, getPluginPromptTemplatePaths } from "../extensions/claude-plugins.js";
 
 let tmpHome: string;
 let projectDir: string;
@@ -548,7 +548,11 @@ describe("trustedPlugins enforcement via createClaudePluginExtension / getPlugin
             { hasUI: false, ui: { notify() {} }, cwd: projectDir },
         );
 
-        expect(commands.has("test")).toBe(true);
+        // "test" is a top-level, plain .md command — native-compatible, so it's
+        // routed through pi's own prompt-template loader (getPluginPromptTemplatePaths)
+        // instead of the bespoke pi.registerCommand() adapter (see isNativeCompatibleCommand).
+        expect(commands.has("test")).toBe(false);
+        expect(getPluginPromptTemplatePaths(projectDir)).toContain(join(pluginDir, "commands", "test.md"));
         expect(prompted).toBe(false);
     });
 

--- a/packages/cli/src/config/trust-gates.test.ts
+++ b/packages/cli/src/config/trust-gates.test.ts
@@ -556,6 +556,36 @@ describe("trustedPlugins enforcement via createClaudePluginExtension / getPlugin
         expect(prompted).toBe(false);
     });
 
+    test("accepting the trust prompt makes a newly-trusted plugin's native-compatible command available via resources_discover in the SAME session_start bind cycle — no restart", async () => {
+        const pluginDir = writeLocalPlugin("newly-trusted-cmd");
+        const factory = createClaudePluginExtension(projectDir);
+        expect(factory).not.toBeNull();
+
+        const { api, handlers, events } = makeMockPi();
+        factory!(api as any);
+        events.on("plugin:trust_prompt", (data: any) => data.respond(true));
+
+        // Before session_start: the plugin isn't trusted yet, so pi's
+        // startup-time additionalPromptTemplatePaths (built from
+        // getPluginPromptTemplatePaths() before this factory ever runs)
+        // would not have included it either — nothing to assert here except
+        // that trust hasn't happened yet.
+        expect(isPluginTrusted(pluginDir)).toBe(false);
+
+        // Real ordering: pi's bindExtensions() awaits session_start handlers
+        // to fully resolve (including this factory's trust-prompt await),
+        // THEN fires resources_discover — all within one bind cycle, no
+        // process restart in between.
+        await handlers.get("session_start")?.(
+            { type: "session_start" },
+            { hasUI: false, ui: { notify() {} }, cwd: projectDir },
+        );
+        expect(isPluginTrusted(pluginDir)).toBe(true); // trust was persisted
+
+        const discovered = await handlers.get("resources_discover")?.({ cwd: projectDir, reason: "startup" }, {} as any) as { promptPaths?: string[] } | undefined;
+        expect(discovered?.promptPaths).toContain(join(pluginDir, "commands", "test.md"));
+    });
+
     test("getPluginSkillPaths excludes an untrusted local plugin's skills dir", () => {
         const pluginDir = writeLocalPlugin("untrusted-skill", { skill: true });
         expect(getPluginSkillPaths(projectDir)).not.toContain(join(pluginDir, "skills"));

--- a/packages/cli/src/extensions/claude-plugins.test.ts
+++ b/packages/cli/src/extensions/claude-plugins.test.ts
@@ -1,8 +1,46 @@
 /**
- * Tests for Claude Code Plugin adapter — template expansion.
+ * Tests for Claude Code Plugin adapter — template expansion and
+ * native-compatible command routing.
  */
 import { describe, test, expect } from "bun:test";
-import { expandArguments } from "./claude-plugins.js";
+import { expandArguments, isNativeCompatibleCommand } from "./claude-plugins.js";
+import type { PluginCommand } from "../plugins.js";
+
+function cmd(overrides: Partial<PluginCommand>): PluginCommand {
+    return {
+        name: "foo",
+        content: "Do the thing with $ARGUMENTS",
+        frontmatter: {},
+        filePath: "/plugin/commands/foo.md",
+        ...overrides,
+    };
+}
+
+describe("isNativeCompatibleCommand", () => {
+    test("a plain top-level .md command using $ARGUMENTS/$1 is native-compatible", () => {
+        expect(isNativeCompatibleCommand(cmd({ content: "Deploy $1 to $ARGUMENTS" }))).toBe(true);
+    });
+
+    test("nested command names (prefix/name) are NOT native-compatible (pi names by bare filename)", () => {
+        expect(isNativeCompatibleCommand(cmd({ name: "pm/epic-start" }))).toBe(false);
+    });
+
+    test(".toml-sourced commands are NOT native-compatible (pi's loader only reads .md)", () => {
+        expect(isNativeCompatibleCommand(cmd({ filePath: "/plugin/commands/foo.toml" }))).toBe(false);
+    });
+
+    test("PizzaPi's $ARGUMENTS[N] bracket-indexed syntax is NOT native-compatible", () => {
+        expect(isNativeCompatibleCommand(cmd({ content: "first: $ARGUMENTS[0]" }))).toBe(false);
+    });
+
+    test("inline shell expansion is NOT native-compatible", () => {
+        expect(isNativeCompatibleCommand(cmd({ content: "Current branch: !`git branch --show-current`" }))).toBe(false);
+    });
+
+    test("${CLAUDE_PLUGIN_ROOT} references are NOT native-compatible", () => {
+        expect(isNativeCompatibleCommand(cmd({ content: "Run ${CLAUDE_PLUGIN_ROOT}/script.sh" }))).toBe(false);
+    });
+});
 
 describe("expandArguments", () => {
     test("expands $ARGUMENTS with the full args string", () => {

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -548,6 +548,29 @@ export function createClaudePluginExtension(cwd: string): ExtensionFactory | nul
         // picked up on the next session_start without re-registering ones
         // already loaded.
         const registeredLocalPaths = new Set<string>();
+        const localByRootPath = new Map(localOnly.map((p) => [p.rootPath, p]));
+
+        // Newly-trusted local plugins' native-compatible commands (see
+        // isNativeCompatibleCommand()) are only mounted here, via
+        // `resources_discover` — NOT through registerPlugin()/registerCommand()
+        // above (registerPlugin explicitly skips them, matching
+        // getPluginPromptTemplatePaths()'s startup-time list). pi fires
+        // `resources_discover` right after `session_start` handlers resolve
+        // (agent-session.js bindExtensions(): emit(session_start) THEN
+        // extendResourcesFromExtensions()), in the SAME bind cycle — so a
+        // plugin trusted via the trust prompt or a pre-trusted rescan just
+        // above becomes usable immediately, no process restart required.
+        pi.on("resources_discover", () => {
+            const promptPaths: string[] = [];
+            for (const rootPath of registeredLocalPaths) {
+                const plugin = localByRootPath.get(rootPath);
+                if (!plugin) continue;
+                for (const cmd of plugin.commands) {
+                    if (isNativeCompatibleCommand(cmd)) promptPaths.push(cmd.filePath);
+                }
+            }
+            return { promptPaths };
+        });
 
         pi.on("session_start", async (_event, ctx) => {
             // Notify about global plugins

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -117,6 +117,33 @@ export function expandArguments(template: string, args: string | undefined): str
     return result;
 }
 
+// ── Native-compatible command routing ───────────────────────────────────────
+//
+// pi's own prompt-template loader (docs/prompt-templates.md) already
+// supports `$1`/`$@`/`$ARGUMENTS`/defaults/slicing and `argument-hint` —
+// the same argument syntax Claude Code plugin commands use. A command is
+// routed through pi's native loader instead of the bespoke
+// `pi.registerCommand()` adapter below when ALL of the following hold,
+// since none of these are things pi's loader can do:
+//   - top-level (no `prefix/name` nesting — pi names commands by bare
+//     filename only, so a nested command routed natively would lose its
+//     `pm/epic-start`-style name and collide with same-named siblings);
+//   - sourced from a `.md` file (pi's loader only reads `.md`, not `.toml`);
+//   - doesn't use PizzaPi's `$ARGUMENTS[N]` bracket-indexed extra syntax;
+//   - doesn't use inline shell `` !`cmd` `` expansion; and
+//   - doesn't reference `${CLAUDE_PLUGIN_ROOT}` (pi's loader reads the raw
+//     file verbatim — it has no notion of a plugin root to substitute).
+const INLINE_SHELL_RE = /!`[^`]+`/;
+
+export function isNativeCompatibleCommand(cmd: PluginCommand): boolean {
+    if (cmd.name.includes("/")) return false;
+    if (!cmd.filePath.toLowerCase().endsWith(".md")) return false;
+    if (cmd.content.includes("$ARGUMENTS[")) return false;
+    if (cmd.content.includes("${CLAUDE_PLUGIN_ROOT}")) return false;
+    if (INLINE_SHELL_RE.test(cmd.content)) return false;
+    return true;
+}
+
 // ── Command registration ──────────────────────────────────────────────────────
 
 function registerPluginCommand(
@@ -354,6 +381,10 @@ function pluginSummary(p: DiscoveredPlugin): string {
 
 function registerPlugin(pi: ExtensionAPI, plugin: DiscoveredPlugin): void {
     for (const cmd of plugin.commands) {
+        // Native-compatible commands are routed through pi's own
+        // prompt-template loader instead (see getPluginPromptTemplatePaths()
+        // below) — registering both here and there would double-register.
+        if (isNativeCompatibleCommand(cmd)) continue;
         registerPluginCommand(pi, plugin, cmd);
     }
     registerPluginHooks(pi, plugin);
@@ -690,6 +721,42 @@ export function getPluginSkillPaths(cwd: string): string[] {
     for (const plugin of [...globalPlugins, ...trustedLocal]) {
         if (plugin.skills.length > 0) {
             paths.push(join(plugin.rootPath, "skills"));
+        }
+    }
+    return paths;
+}
+
+/**
+ * Get individual `.md` file paths for every discovered plugin command that
+ * qualifies as native-compatible (see isNativeCompatibleCommand()) — these
+ * are fed into pi's own `additionalPromptTemplatePaths` instead of the
+ * bespoke `pi.registerCommand()` adapter. Includes global plugins and any
+ * project-local plugins that are already trusted, mirroring
+ * getPluginSkillPaths()/getPluginAgentPaths().
+ */
+export function getPluginPromptTemplatePaths(cwd: string): string[] {
+    const globalPlugins = discoverPlugins(cwd);
+    const globalNames = new Set(globalPlugins.map(p => p.name));
+
+    const localDirs = projectPluginDirs(cwd);
+    const localByName = new Map<string, DiscoveredPlugin>();
+    for (const dir of localDirs) {
+        for (const plugin of scanPluginsDir(dir)) {
+            if (globalNames.has(plugin.name)) continue;
+            const existing = localByName.get(plugin.name);
+            if (!existing) {
+                localByName.set(plugin.name, plugin);
+            } else if (!isPluginTrusted(existing.rootPath) && isPluginTrusted(plugin.rootPath)) {
+                localByName.set(plugin.name, plugin);
+            }
+        }
+    }
+    const trustedLocal = Array.from(localByName.values()).filter(p => isPluginTrusted(p.rootPath));
+
+    const paths: string[] = [];
+    for (const plugin of [...globalPlugins, ...trustedLocal]) {
+        for (const cmd of plugin.commands) {
+            if (isNativeCompatibleCommand(cmd)) paths.push(cmd.filePath);
         }
     }
     return paths;

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -33,6 +33,7 @@ import { backgroundBashExtension } from "./background-bash.js";
 import { queueFlushExtension } from "./queue-flush.js";
 import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
 import { hostAnnounceExtension } from "./host-announce.js";
+import { runPackageCommand } from "../package-commands.js";
 
 // resource-paths is a factory *created per call* (createResourcePathsExtension(...)),
 // so it's never reference-equal to a statically imported factory. Split the
@@ -264,5 +265,93 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
         } finally {
             try { rmSync(projectDir, { recursive: true, force: true }); } catch {}
         }
+    });
+});
+
+// ── Package-overlay-rules factory: project-trust gate + ordering ─────────────
+
+describe("buildPizzaPiExtensionFactories — package-overlay-rules trust gate", () => {
+    function writeFixturePackage(dir: string, overlay: unknown, files?: Record<string, string>) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+        for (const [rel, content] of Object.entries(files ?? {})) {
+            const filePath = join(dir, rel);
+            mkdirSync(join(filePath, ".."), { recursive: true });
+            writeFileSync(filePath, content);
+        }
+    }
+
+    // runPackageCommand() chdir()s the process into cwd and only sets
+    // PI_CODING_AGENT_DIR when unset — both must be restored, or a LATER
+    // test file sharing this bun test process inherits a deleted tmp cwd
+    // (breaking anything that shells out or resolves relative paths) and/or
+    // a stale agentDir (see other overlay tests' identical notes).
+    async function withRestoredProcessState<T>(fn: () => Promise<T>): Promise<T> {
+        const originalCwd = process.cwd();
+        const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+        try {
+            return await fn();
+        } finally {
+            process.chdir(originalCwd);
+            if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+            else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+        }
+    }
+
+    test("projectTrusted: true wires the package-overlay-rules factory for a project-scope package; false excludes it (defaults to false when omitted)", async () => {
+        await withRestoredProcessState(async () => {
+            const rootDir = mkdtempSync(join(tmpdir(), "pizzapi-factories-overlay-rules-"));
+            const cwd = join(rootDir, "project");
+            const agentDir = join(rootDir, "agent");
+            mkdirSync(cwd, { recursive: true });
+            mkdirSync(agentDir, { recursive: true });
+            try {
+                const pkgDir = join(rootDir, "rules-pkg");
+                writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Be terse." });
+                const code = await runPackageCommand(["install", "../rules-pkg", "-l"], cwd, agentDir);
+                expect(code).toBe(0);
+
+                const untrustedFactories = buildPizzaPiExtensionFactories({ cwd, agentDir, skipPlugins: true });
+                expect(untrustedFactories.length).toBe(CORE_EXTENSIONS_COUNT); // no projectTrusted passed — fails closed
+
+                const explicitlyUntrusted = buildPizzaPiExtensionFactories({ cwd, agentDir, skipPlugins: true, projectTrusted: false });
+                expect(explicitlyUntrusted.length).toBe(CORE_EXTENSIONS_COUNT);
+
+                const trustedFactories = buildPizzaPiExtensionFactories({ cwd, agentDir, skipPlugins: true, projectTrusted: true });
+                expect(trustedFactories.length).toBe(CORE_EXTENSIONS_COUNT + 1);
+                expect((trustedFactories[trustedFactories.length - 1] as any).displayName).toBe("package-overlay-rules");
+            } finally {
+                try { rmSync(rootDir, { recursive: true, force: true }); } catch {}
+            }
+        });
+    });
+
+    test("package-overlay-rules factory is registered before the legacy Claude-plugin rules factory (package-before-legacy ordering)", async () => {
+        await withRestoredProcessState(async () => {
+            const rootDir = mkdtempSync(join(tmpdir(), "pizzapi-factories-overlay-order-"));
+            const cwd = join(rootDir, "project");
+            const agentDir = join(rootDir, "agent");
+            mkdirSync(cwd, { recursive: true });
+            mkdirSync(agentDir, { recursive: true });
+            try {
+                const pkgDir = join(rootDir, "rules-pkg2");
+                writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Be terse." });
+                const code = await runPackageCommand(["install", "../rules-pkg2", "-l"], cwd, agentDir);
+                expect(code).toBe(0);
+
+                const pluginDir = join(cwd, ".pizzapi", "plugins", "legacy-plugin");
+                mkdirSync(join(pluginDir, "rules"), { recursive: true });
+                writeFileSync(join(pluginDir, "rules", "b.md"), "# Legacy rule\nLegacy content.");
+
+                const factories = buildPizzaPiExtensionFactories({ cwd, agentDir, projectTrusted: true });
+                const overlayIdx = factories.findIndex((f) => (f as any).displayName === "package-overlay-rules");
+                const pluginsIdx = factories.findIndex((f) => (f as any).displayName === "plugins");
+                expect(overlayIdx).toBeGreaterThanOrEqual(0);
+                expect(pluginsIdx).toBeGreaterThanOrEqual(0);
+                expect(overlayIdx).toBeLessThan(pluginsIdx);
+            } finally {
+                try { rmSync(rootDir, { recursive: true, force: true }); } catch {}
+            }
+        });
     });
 });

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -32,11 +32,18 @@ import { sessionProcessesExtension } from "./session-processes.js";
 import { backgroundBashExtension } from "./background-bash.js";
 import { queueFlushExtension } from "./queue-flush.js";
 import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
+import { hostAnnounceExtension } from "./host-announce.js";
 
 // resource-paths is a factory *created per call* (createResourcePathsExtension(...)),
 // so it's never reference-equal to a statically imported factory. Split the
 // otherwise-static core list around it and assert its presence/type separately.
+// Isolated, empty agent dir so package-overlay-rules resolution (which reads
+// pi settings via SettingsManager) never picks up real packages configured
+// on the machine running these tests — keeps exact-length assertions stable.
+const TEST_AGENT_DIR = mkdtempSync(join(tmpdir(), "pizzapi-factories-agentdir-"));
+
 const CORE_EXTENSIONS_HEAD: ExtensionFactory[] = [
+    hostAnnounceExtension,
     ollamaCloudProviderExtension,
     providerRequestLogExtension,
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
@@ -83,7 +90,7 @@ function expectCoreExtensionsPrefix(factories: ExtensionFactory[]) {
  */
 describe("buildPizzaPiExtensionFactories", () => {
     test("returns core extensions by default", () => {
-        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipPlugins: true });
+        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", agentDir: TEST_AGENT_DIR, skipPlugins: true });
         expect(factories).toHaveLength(CORE_EXTENSIONS_COUNT);
         expectCoreExtensionsPrefix(factories);
     });
@@ -91,6 +98,7 @@ describe("buildPizzaPiExtensionFactories", () => {
     test("includes initial prompt extension for worker mode", () => {
         const factories = buildPizzaPiExtensionFactories({
             cwd: "/tmp/pizzapi-test",
+            agentDir: TEST_AGENT_DIR,
             includeInitialPrompt: true,
             skipPlugins: true,
         });
@@ -107,6 +115,7 @@ describe("buildPizzaPiExtensionFactories", () => {
 
         const factories = buildPizzaPiExtensionFactories({
             cwd: "/tmp/pizzapi-test",
+            agentDir: TEST_AGENT_DIR,
             hooks,
             skipPlugins: true,
         });
@@ -123,6 +132,7 @@ describe("buildPizzaPiExtensionFactories", () => {
 
         const factories = buildPizzaPiExtensionFactories({
             cwd: "/tmp/pizzapi-test",
+            agentDir: TEST_AGENT_DIR,
             hooks,
             includeInitialPrompt: true,
             skipPlugins: true,
@@ -139,7 +149,7 @@ describe("buildPizzaPiExtensionFactories", () => {
 
 describe("buildPizzaPiExtensionFactories — safe mode", () => {
     test("skipMcp excludes MCP extension", () => {
-        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipMcp: true });
+        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", agentDir: TEST_AGENT_DIR, skipMcp: true });
         expect(factories).not.toContain(mcpExtension);
         // Other core extensions should still be present
         expect(factories).toContain(remoteExtension);
@@ -147,7 +157,7 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
     });
 
     test("skipRelay excludes remote extension and tunnel tools", () => {
-        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipRelay: true });
+        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", agentDir: TEST_AGENT_DIR, skipRelay: true });
         expect(factories).not.toContain(remoteExtension);
         expect(factories).not.toContain(tunnelToolsExtension);
         expect(factories).toContain(mcpExtension);
@@ -160,8 +170,8 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
             mkdirSync(join(pluginDir, "commands"), { recursive: true });
             writeFileSync(join(pluginDir, "commands", "hello.md"), "# Hello");
 
-            const withPlugins = buildPizzaPiExtensionFactories({ cwd: projectDir });
-            const withoutPlugins = buildPizzaPiExtensionFactories({ cwd: projectDir, skipPlugins: true });
+            const withPlugins = buildPizzaPiExtensionFactories({ cwd: projectDir, agentDir: TEST_AGENT_DIR });
+            const withoutPlugins = buildPizzaPiExtensionFactories({ cwd: projectDir, agentDir: TEST_AGENT_DIR, skipPlugins: true });
 
             // Without skipPlugins, there should be more extensions (plugin extension appended)
             expect(withPlugins.length).toBeGreaterThan(withoutPlugins.length);
@@ -177,6 +187,7 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
 
         const factories = buildPizzaPiExtensionFactories({
             cwd: "/tmp/pizzapi-test",
+            agentDir: TEST_AGENT_DIR,
             skipMcp: true,
             skipRelay: true,
             skipPlugins: true,
@@ -210,7 +221,7 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
             mkdirSync(join(pluginDir, "commands"), { recursive: true });
             writeFileSync(join(pluginDir, "commands", "hello.md"), "# Hello");
 
-            const factories = buildPizzaPiExtensionFactories({ cwd: projectDir });
+            const factories = buildPizzaPiExtensionFactories({ cwd: projectDir, agentDir: TEST_AGENT_DIR });
 
             // Core + plugin extension (at minimum)
             expect(factories.length).toBeGreaterThan(CORE_EXTENSIONS_COUNT);
@@ -225,7 +236,7 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
         // Use an empty temp dir — no global or local plugins
         const emptyDir = mkdtempSync(join(tmpdir(), "pizzapi-factories-noplugin-"));
         try {
-            const factories = buildPizzaPiExtensionFactories({ cwd: emptyDir });
+            const factories = buildPizzaPiExtensionFactories({ cwd: emptyDir, agentDir: TEST_AGENT_DIR });
             // May or may not have plugin extension depending on real HOME plugins.
             // The key invariant: core extensions are always first.
             expectCoreExtensionsPrefix(factories);
@@ -245,7 +256,7 @@ describe("buildPizzaPiExtensionFactories — plugin extension", () => {
                 PreToolUse: [{ matcher: "Bash", hooks: [{ command: "echo hook" }] }],
             };
 
-            const factories = buildPizzaPiExtensionFactories({ cwd: projectDir, hooks });
+            const factories = buildPizzaPiExtensionFactories({ cwd: projectDir, agentDir: TEST_AGENT_DIR, hooks });
 
             // Core + hooks + plugin (at least)
             expect(factories.length).toBeGreaterThanOrEqual(CORE_EXTENSIONS_COUNT + 2);

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -48,6 +48,14 @@ export interface BuildExtensionFactoriesOptions {
     skipRelay?: boolean;
     /** `config.skills` — extra skill directories from the resolved PizzaPi config. */
     configSkills?: string[];
+    /**
+     * Explicit, persisted pi project-trust decision for `cwd` (see
+     * config/io.ts `resolveExplicitProjectTrust`). Gates project-scope
+     * `pi.pizzapi` overlay rules — defaults to `false` (untrusted) when
+     * omitted so a caller that forgets to thread trust fails closed instead
+     * of silently re-trusting an untrusted repo's project-scope packages.
+     */
+    projectTrusted?: boolean;
 }
 
 /** Tag a factory with a display name for the boot info listing. */
@@ -144,7 +152,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     // pi.pizzapi.rules from configured packages — registered BEFORE the
     // legacy Claude-plugin rules adapter below so package rules land in the
     // system prompt first ("package-before-legacy" ordering, §4.3).
-    const overlayRulesExtension = createPackageOverlayRulesExtension(options.cwd, agentDir);
+    const overlayRulesExtension = createPackageOverlayRulesExtension(options.cwd, agentDir, options.projectTrusted ?? false);
     if (overlayRulesExtension) {
         factories.push(named(overlayRulesExtension, "package-overlay-rules"));
     }

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -30,9 +30,14 @@ import { providerExtension } from "./providers/extension.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
 import { providerRequestLogExtension } from "./provider-request-log.js";
 import { createResourcePathsExtension } from "./resource-paths.js";
+import { hostAnnounceExtension } from "./host-announce.js";
+import { createPackageOverlayRulesExtension } from "./package-overlay-rules.js";
+import { resolveAgentDir } from "../config.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
+    /** Resolved agent dir. Defaults to `resolveAgentDir(cwd)` when omitted. */
+    agentDir?: string;
     hooks?: HooksConfig;
     includeInitialPrompt?: boolean;
     /** Skip MCP server connections (safe mode). */
@@ -58,6 +63,12 @@ function named(factory: ExtensionFactory, displayName: string): ExtensionFactory
  */
 export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesOptions): ExtensionFactory[] {
     const factories: ExtensionFactory[] = [];
+    const agentDir = options.agentDir ?? resolveAgentDir(options.cwd);
+
+    // Host capability announcement — first among PizzaPi's own inline
+    // factories so package extensions subscribed via onPizzaPiHost() see
+    // pizzapi:host:ready as early as possible (§9.3).
+    factories.push(named(hostAnnounceExtension, "host-announce"));
 
     // Static Ollama Cloud provider + fallback model catalog baseline — must
     // run before other factories so --provider ollama-cloud and model listing
@@ -128,6 +139,14 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     const hooksExtension = createHooksExtension(options.hooks, options.cwd);
     if (hooksExtension) {
         factories.push(named(hooksExtension, "hooks"));
+    }
+
+    // pi.pizzapi.rules from configured packages — registered BEFORE the
+    // legacy Claude-plugin rules adapter below so package rules land in the
+    // system prompt first ("package-before-legacy" ordering, §4.3).
+    const overlayRulesExtension = createPackageOverlayRulesExtension(options.cwd, agentDir);
+    if (overlayRulesExtension) {
+        factories.push(named(overlayRulesExtension, "package-overlay-rules"));
     }
 
     // Claude Code plugin adapter — discovers and loads plugins from standard dirs

--- a/packages/cli/src/extensions/host-announce.test.ts
+++ b/packages/cli/src/extensions/host-announce.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { isPizzaPiHostInfo, detectPizzaPiHost, onPizzaPiHost } from "@pizzapi/extension-sdk";
+import { createEventBus } from "@earendil-works/pi-coding-agent";
 import { hostAnnounceExtension, buildHostInfo } from "./host-announce.js";
 
 /** Minimal synchronous pi.events fake — enough to exercise probe/ready semantics. */
@@ -20,6 +21,10 @@ function fakePiEvents() {
                 for (const handler of listeners.get(type) ?? []) handler(payload);
             },
         },
+        // Lifecycle events (session_shutdown, etc.) are a separate mechanism
+        // from the `.events` pub/sub bus — hostAnnounceExtension only needs
+        // session_shutdown, so that's all this fake wires up.
+        on(_type: string, _handler: () => void) {},
     };
 }
 
@@ -64,5 +69,48 @@ describe("hostAnnounceExtension", () => {
         });
 
         expect(delivered).toEqual(buildHostInfo());
+    });
+
+    /**
+     * Build a minimal but REAL-bus pi fake: `.events` is backed by pi's own
+     * `createEventBus()` (real Node EventEmitter under the hood), not a
+     * hand-rolled listeners map — so this test actually characterizes the
+     * accumulation behavior a fake could silently diverge from. `.on()` is a
+     * small session-lifecycle-event shim (session_shutdown only, which is
+     * all this extension uses) that hands back the same real emitter's
+     * listener count for assertions.
+     */
+    function realBusPi() {
+        const bus = createEventBus();
+        const shutdownHandlers: Array<() => void> = [];
+        const pi = {
+            events: bus,
+            on(event: string, handler: () => void) {
+                if (event === "session_shutdown") shutdownHandlers.push(handler);
+            },
+        };
+        return {
+            pi,
+            bus,
+            fireShutdown: () => { for (const h of shutdownHandlers.splice(0)) h(); },
+        };
+    }
+
+    test("session_shutdown removes the probe listener from the real pi event bus (no accumulation across reloads)", () => {
+        const { pi, bus, fireShutdown } = realBusPi();
+
+        // Simulate `/reload`: pi re-invokes the SAME inline factory against the
+        // SAME bus on every reload (resource-loader.js loadExtensionFactories()
+        // runs again), firing session_shutdown for the previous runner first.
+        for (let i = 0; i < 3; i++) {
+            hostAnnounceExtension(pi as any);
+            expect(detectPizzaPiHost(pi as any)).toEqual(buildHostInfo());
+            fireShutdown();
+        }
+
+        // After the last shutdown, the probe listener must be gone — a probe
+        // now gets no response, proving each factory run's listener was
+        // actually removed rather than accumulating one per iteration.
+        expect(detectPizzaPiHost(pi as any)).toBeUndefined();
     });
 });

--- a/packages/cli/src/extensions/host-announce.test.ts
+++ b/packages/cli/src/extensions/host-announce.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test";
+import { isPizzaPiHostInfo, detectPizzaPiHost, onPizzaPiHost } from "@pizzapi/extension-sdk";
+import { hostAnnounceExtension, buildHostInfo } from "./host-announce.js";
+
+/** Minimal synchronous pi.events fake — enough to exercise probe/ready semantics. */
+function fakePiEvents() {
+    const listeners = new Map<string, Array<(payload: unknown) => void>>();
+    return {
+        events: {
+            on(type: string, handler: (payload: unknown) => void) {
+                const arr = listeners.get(type) ?? [];
+                arr.push(handler);
+                listeners.set(type, arr);
+                return () => {
+                    const idx = arr.indexOf(handler);
+                    if (idx >= 0) arr.splice(idx, 1);
+                };
+            },
+            emit(type: string, payload: unknown) {
+                for (const handler of listeners.get(type) ?? []) handler(payload);
+            },
+        },
+    };
+}
+
+describe("hostAnnounceExtension", () => {
+    test("buildHostInfo() returns a valid PizzaPiHostInfo", () => {
+        const info = buildHostInfo();
+        expect(isPizzaPiHostInfo(info)).toBe(true);
+        expect(info.apiVersion).toBe(1);
+        expect(info.capabilities.length).toBeGreaterThan(0);
+    });
+
+    test("detectPizzaPiHost() succeeds once the extension has registered its probe listener", () => {
+        const pi = fakePiEvents();
+        expect(detectPizzaPiHost(pi as any)).toBeUndefined(); // no host yet — vanilla pi
+        hostAnnounceExtension(pi as any);
+        expect(detectPizzaPiHost(pi as any)).toEqual(buildHostInfo());
+    });
+
+    test("onPizzaPiHost() delivers via the ready event when subscribed BEFORE the host factory runs", () => {
+        // Mirrors the real ordering constraint: package extensions run their
+        // factory (and may call onPizzaPiHost) before PizzaPi's own inline
+        // host-announce factory runs.
+        const pi = fakePiEvents();
+        let delivered: unknown;
+        onPizzaPiHost(pi as any, (host) => {
+            delivered = host;
+        });
+        expect(delivered).toBeUndefined();
+
+        hostAnnounceExtension(pi as any);
+
+        expect(delivered).toEqual(buildHostInfo());
+    });
+
+    test("onPizzaPiHost() delivers immediately via synchronous probe when subscribed AFTER the host factory runs", () => {
+        const pi = fakePiEvents();
+        hostAnnounceExtension(pi as any);
+
+        let delivered: unknown;
+        onPizzaPiHost(pi as any, (host) => {
+            delivered = host;
+        });
+
+        expect(delivered).toEqual(buildHostInfo());
+    });
+});

--- a/packages/cli/src/extensions/host-announce.ts
+++ b/packages/cli/src/extensions/host-announce.ts
@@ -36,7 +36,19 @@ export const hostAnnounceExtension: ExtensionFactory = (pi) => {
     // Synchronous probe responder — per spec §9.3 this MUST reply
     // synchronously; pi's event bus invokes listeners before emit() returns,
     // but only for this synchronous tick.
-    pi.events.on("pizzapi:host:probe", (payload: unknown) => {
+    //
+    // pi's real `createEventBus()` (core/event-bus.ts) backs `pi.events` with
+    // a single Node `EventEmitter` that OUTLIVES a `/reload` — reload()
+    // re-invokes every inline extension factory (including this one) against
+    // the SAME bus (see resource-loader.ts reload() -> loadExtensionFactories()),
+    // so a probe listener registered here and never removed would
+    // accumulate one more listener per reload for the life of the process.
+    // `.on()` returns pi's own unsubscribe function for exactly this reason
+    // — capture it and remove the listener on session_shutdown, which pi
+    // fires for the CURRENT extension runner before reload() re-runs
+    // factories (agent-session.ts reload(): emitSessionShutdownEvent(...)
+    // happens before this._resourceLoader.reload()).
+    const unsubscribeProbe = pi.events.on("pizzapi:host:probe", (payload: unknown) => {
         const respond = (payload as { respond?: (value: unknown) => void } | undefined)?.respond;
         if (typeof respond === "function") respond(hostInfo);
     });
@@ -45,4 +57,8 @@ export const hostAnnounceExtension: ExtensionFactory = (pi) => {
     // package extension whose factory already ran and subscribed to
     // "pizzapi:host:ready" receives this synchronously.
     pi.events.emit("pizzapi:host:ready", hostInfo);
+
+    pi.on("session_shutdown", () => {
+        unsubscribeProbe();
+    });
 };

--- a/packages/cli/src/extensions/host-announce.ts
+++ b/packages/cli/src/extensions/host-announce.ts
@@ -1,0 +1,48 @@
+/**
+ * PizzaPi host capability announcement (docs/specs/pi-pizzapi-overlay.md
+ * §9.3) — the daemon-side counterpart of `@pizzapi/extension-sdk`'s
+ * `detectPizzaPiHost()`/`onPizzaPiHost()`.
+ *
+ * Pi 0.82.1 loads configured package extensions BEFORE PizzaPi's inline
+ * factories, so a package extension's factory body cannot rely on a
+ * synchronous `pizzapi:host:probe` reply arriving before its own setup
+ * finishes — this extension hasn't registered its probe listener yet at
+ * that point. That's exactly why the SDK also exposes `pizzapi:host:ready`:
+ * a package that calls `onPizzaPiHost()` during its factory registers a
+ * `pizzapi:host:ready` listener FIRST (its factory already ran), so when
+ * this factory runs afterward and emits `pizzapi:host:ready`, every such
+ * listener — already subscribed — receives it synchronously.
+ *
+ * Must be registered as early as possible among PizzaPi's own inline
+ * factories (see factories.ts) so the ready announcement isn't delayed
+ * behind unrelated PizzaPi setup work.
+ */
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import type { PizzaPiHostInfo } from "@pizzapi/extension-sdk";
+
+/**
+ * Capabilities a package can rely on when this host responds. Kept as a
+ * flat list (not versioned per-capability) — v1 hosts support the full set.
+ */
+const HOST_CAPABILITIES: readonly string[] = ["services", "agents", "rules", "mcp", "panels", "triggers", "sigils"];
+
+export function buildHostInfo(): PizzaPiHostInfo {
+    return { apiVersion: 1, capabilities: HOST_CAPABILITIES };
+}
+
+export const hostAnnounceExtension: ExtensionFactory = (pi) => {
+    const hostInfo = buildHostInfo();
+
+    // Synchronous probe responder — per spec §9.3 this MUST reply
+    // synchronously; pi's event bus invokes listeners before emit() returns,
+    // but only for this synchronous tick.
+    pi.events.on("pizzapi:host:probe", (payload: unknown) => {
+        const respond = (payload as { respond?: (value: unknown) => void } | undefined)?.respond;
+        if (typeof respond === "function") respond(hostInfo);
+    });
+
+    // Announce readiness now, while still inside factory execution — any
+    // package extension whose factory already ran and subscribed to
+    // "pizzapi:host:ready" receives this synchronously.
+    pi.events.emit("pizzapi:host:ready", hostInfo);
+};

--- a/packages/cli/src/extensions/mcp-extension.test.ts
+++ b/packages/cli/src/extensions/mcp-extension.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from "bun:test";
-import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState, reconcileMcpActiveTools, shouldLogMcpEagerInitFailure } from "./mcp-extension.js";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState, inspectMcpConfig, reconcileMcpActiveTools, shouldLogMcpEagerInitFailure } from "./mcp-extension.js";
+import { mergeOverlayMcpServers } from "./mcp-overlay.js";
+import { runPackageCommand } from "../package-commands.js";
+import { _setGlobalConfigDir } from "../config/io.js";
 
 describe("shouldLogMcpEagerInitFailure", () => {
   test("suppresses expected pre-runtime and abort eager init failures", () => {
@@ -197,5 +203,88 @@ describe("buildMcpStatusModel", () => {
       expect.objectContaining({ name: "mcp_github_create_issue", state: "loaded_on_demand" }),
       expect.objectContaining({ name: "mcp_github_create_pr", state: "deferred" }),
     ]);
+  });
+});
+
+// ── P1.4: /mcp status + disable/enable completion must see overlay-origin servers ──
+//
+// mcp-extension.ts's load() feeds mergeOverlayMcpServers()'s `serverProvenance`
+// into inspectMcpConfig() so the SAME merge that produces the live MCP
+// registry also produces what `/mcp` status renders and what disable/enable
+// tab-completion offers (lastSnapshot.config.effectiveServers). This
+// exercises that real wiring end-to-end (real package install, real merge,
+// real inspection) rather than asserting on either half in isolation.
+describe("inspectMcpConfig — overlay/legacy server provenance (real mergeOverlayMcpServers wiring)", () => {
+  let tmpDir: string;
+  let cwd: string;
+  let agentDir: string;
+  let originalCwd: string;
+  let originalAgentDirEnv: string | undefined;
+
+  beforeEach(() => {
+    // runPackageCommand() chdir()s into cwd and only sets
+    // PI_CODING_AGENT_DIR when unset — both must be restored so later test
+    // files in this same bun test process don't inherit a deleted tmp cwd
+    // or a stale agentDir (see other overlay tests' identical notes).
+    originalCwd = process.cwd();
+    originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
+    tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-mcpext-overlay-"));
+    cwd = join(tmpDir, "project");
+    agentDir = join(tmpDir, "agent");
+    mkdirSync(cwd, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    _setGlobalConfigDir(join(tmpDir, "global-config"));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+    _setGlobalConfigDir(null);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("a package-overlay MCP server appears in effectiveServers with 'user-package' scope, feeding /mcp status and disable/enable completion", async () => {
+    const pkgDir = join(tmpDir, "status-mcp-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "status-mcp-pkg", pi: { pizzapi: { schemaVersion: 1, mcp: "./.mcp.json" } } }));
+    writeFileSync(join(pkgDir, ".mcp.json"), JSON.stringify({ mcpServers: { fromOverlayStatus: { command: "echo" } } }));
+    const code = await runPackageCommand(["install", "../status-mcp-pkg"], cwd, agentDir);
+    expect(code).toBe(0);
+
+    const { serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+    const inspection = inspectMcpConfig(cwd, serverProvenance);
+
+    const entry = inspection.effectiveServers.find((s) => s.name === "fromOverlayStatus");
+    expect(entry).toBeDefined();
+    expect(entry?.scope).toBe("user-package");
+    expect(entry?.transport).toBe("stdio");
+
+    // Disable/enable tab-completion (mcp-extension.ts's getArgumentCompletions)
+    // pools names straight from effectiveServers — assert the same source
+    // list a package-origin server needs to be present in to be toggleable.
+    const allServerNames = inspection.effectiveServers.map((s) => s.name);
+    expect(allServerNames).toContain("fromOverlayStatus");
+  });
+
+  test("an explicit config-file server is NOT duplicated into overlay provenance (config always wins, never double-listed)", async () => {
+    const pkgDir = join(tmpDir, "collide-mcp-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "collide-mcp-pkg", pi: { pizzapi: { schemaVersion: 1, mcp: "./.mcp.json" } } }));
+    writeFileSync(join(pkgDir, ".mcp.json"), JSON.stringify({ mcpServers: { shared: { command: "pkg-cmd" } } }));
+    const code = await runPackageCommand(["install", "../collide-mcp-pkg"], cwd, agentDir);
+    expect(code).toBe(0);
+
+    mkdirSync(join(cwd, ".pizzapi"), { recursive: true });
+    writeFileSync(join(cwd, ".pizzapi", "config.json"), JSON.stringify({ mcpServers: { shared: { command: "explicit-cmd" } } }));
+
+    const base = { mcpServers: { shared: { command: "explicit-cmd" } } };
+    const { serverProvenance } = mergeOverlayMcpServers(base, cwd, agentDir, true);
+    const inspection = inspectMcpConfig(cwd, serverProvenance);
+
+    const sharedEntries = inspection.effectiveServers.filter((s) => s.name === "shared");
+    expect(sharedEntries).toHaveLength(1);
+    expect(sharedEntries[0]?.scope).toBe("project"); // from the explicit .pizzapi/config.json, not the package overlay
   });
 });

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -1,7 +1,8 @@
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { loadConfig, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
+import { loadConfig, resolveAgentDir, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
+import { mergeOverlayMcpServers } from "./mcp-overlay.js";
 import {
   registerMcpTools,
   type McpConfig,
@@ -672,7 +673,11 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   let loadLifecycleController = new AbortController();
 
   async function load(): Promise<McpSnapshot> {
-    const mergedConfig = loadConfig(process.cwd()) as PizzaPiConfig & McpConfig;
+    const cwd = process.cwd();
+    const baseConfig = loadConfig(cwd) as PizzaPiConfig & McpConfig;
+    // Feed pi.pizzapi.mcp overlay sidecars (and the legacy plugin .mcp.json
+    // gap) into the same registry — explicit config always wins a collision.
+    const mergedConfig = mergeOverlayMcpServers(baseConfig, cwd, resolveAgentDir(cwd));
     const inspection = inspectMcpConfig(process.cwd());
 
     // Remember previous MCP tool names so we can update active tools after reload.

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -1,8 +1,8 @@
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { loadConfig, resolveAgentDir, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
-import { mergeOverlayMcpServers } from "./mcp-overlay.js";
+import { loadConfig, resolveAgentDir, resolveExplicitProjectTrust, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
+import { mergeOverlayMcpServers, inferMcpCompatTransport, type OverlayMcpServerProvenance } from "./mcp-overlay.js";
 import {
   registerMcpTools,
   type McpConfig,
@@ -39,9 +39,18 @@ type McpConfigFileState = {
 };
 
 type EffectiveMcpServer = McpServerConfigEntry & {
-  scope: "global" | "project";
+  /** "global"/"project" for explicit PizzaPi config file entries; "user-package"/"project-package"/"legacy-plugin" for pi.pizzapi overlay + legacy Claude-plugin .mcp.json entries (see mcp-overlay.ts's OverlayMcpServerProvenance). */
+  scope: "global" | "project" | "user-package" | "project-package" | "legacy-plugin";
   sourcePath: string;
 };
+
+function overlayOwnerToScope(owner: OverlayMcpServerProvenance["owner"]): EffectiveMcpServer["scope"] {
+  switch (owner) {
+    case "user": return "user-package";
+    case "project": return "project-package";
+    case "legacy": return "legacy-plugin";
+  }
+}
 
 type McpConfigInspection = {
   global: McpConfigFileState;
@@ -312,22 +321,7 @@ function parseConfigFile(scope: "global" | "project", path: string): McpConfigFi
   const compatibilityServers: McpServerConfigEntry[] = [];
   if (isRecord(raw.mcpServers)) {
     for (const [name, value] of Object.entries(raw.mcpServers)) {
-      let transport = "unknown";
-      if (isRecord(value) && typeof value.command === "string") {
-        transport = "stdio";
-      } else if (isRecord(value) && typeof value.url === "string") {
-        // "transport" is our field; "type" is Claude Code / VS Code format.
-        // In the standard MCP ecosystem, type "http" = streamable HTTP.
-        if (typeof value.transport === "string") {
-          transport = value.transport;
-        } else if (value.type === "http") {
-          transport = "streamable";
-        } else if (typeof value.type === "string") {
-          transport = value.type;
-        } else {
-          transport = "http";
-        }
-      }
+      const transport = isRecord(value) ? inferMcpCompatTransport(value) : "unknown";
 
       compatibilityServers.push({
         name,
@@ -349,7 +343,7 @@ function parseConfigFile(scope: "global" | "project", path: string): McpConfigFi
   };
 }
 
-function inspectMcpConfig(cwd: string): McpConfigInspection {
+export function inspectMcpConfig(cwd: string, overlayProvenance: OverlayMcpServerProvenance[] = []): McpConfigInspection {
   const globalPath = join(globalConfigDir(), "config.json");
   const projectPath = join(cwd, ".pizzapi", "config.json");
 
@@ -414,6 +408,21 @@ function inspectMcpConfig(cwd: string): McpConfigInspection {
         effectiveServers.push({ ...entry, scope: source.scope, sourcePath: source.path });
       }
     }
+  }
+
+  // Overlay/legacy-plugin servers — carried over from the SAME merge that
+  // feeds the live MCP registry (mergeOverlayMcpServers()), so `/mcp`
+  // status and disable/enable completion see exactly what's actually
+  // running, not just explicit config-file entries.
+  for (const p of overlayProvenance) {
+    effectiveServers.push({
+      name: p.name,
+      transport: p.transport,
+      keyPath: p.identity,
+      format: "mcpServers",
+      scope: overlayOwnerToScope(p.owner),
+      sourcePath: p.sourcePath,
+    });
   }
 
   // Collect disabled server names from merged config
@@ -677,8 +686,9 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
     const baseConfig = loadConfig(cwd) as PizzaPiConfig & McpConfig;
     // Feed pi.pizzapi.mcp overlay sidecars (and the legacy plugin .mcp.json
     // gap) into the same registry — explicit config always wins a collision.
-    const mergedConfig = mergeOverlayMcpServers(baseConfig, cwd, resolveAgentDir(cwd));
-    const inspection = inspectMcpConfig(process.cwd());
+    const agentDir = resolveAgentDir(cwd);
+    const { config: mergedConfig, serverProvenance } = mergeOverlayMcpServers(baseConfig, cwd, agentDir, resolveExplicitProjectTrust(cwd, agentDir));
+    const inspection = inspectMcpConfig(process.cwd(), serverProvenance);
 
     // Remember previous MCP tool names so we can update active tools after reload.
     const previousMcpToolNames = new Set(lastSnapshot.toolNames);

--- a/packages/cli/src/extensions/mcp-overlay.test.ts
+++ b/packages/cli/src/extensions/mcp-overlay.test.ts
@@ -62,8 +62,8 @@ describe("mergeOverlayMcpServers", () => {
         });
         await install("../mcp-pkg");
 
-        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
-        expect(merged.mcpServers?.fromPkg).toBeDefined();
+        const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect(config.mcpServers?.fromPkg).toBeDefined();
     });
 
     test("explicit PizzaPi config always wins a server-name collision over package overlay", async () => {
@@ -74,8 +74,8 @@ describe("mergeOverlayMcpServers", () => {
         await install("../mcp-collide-pkg");
 
         const base = { mcpServers: { shared: { command: "explicit-config-command" } } };
-        const merged = mergeOverlayMcpServers(base, cwd, agentDir);
-        expect((merged.mcpServers?.shared as any).command).toBe("explicit-config-command");
+        const { config } = mergeOverlayMcpServers(base, cwd, agentDir, true);
+        expect((config.mcpServers?.shared as any).command).toBe("explicit-config-command");
     });
 
     test("project-scope package wins over user-scope package for the same server name", async () => {
@@ -91,8 +91,50 @@ describe("mergeOverlayMcpServers", () => {
         });
         await install("../mcp-project-pkg", { project: true });
 
-        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
-        expect((merged.mcpServers?.shared as any).command).toBe("project-command");
+        const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect((config.mcpServers?.shared as any).command).toBe("project-command");
+    });
+
+    test("project-scope package overlay is excluded when the project is not explicitly trusted", async () => {
+        const userPkg = join(tmpDir, "mcp-trust-user-pkg");
+        writeFixturePackage(userPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { fromUser: { command: "user-command" } } }),
+        });
+        await install("../mcp-trust-user-pkg");
+
+        const projectPkg = join(tmpDir, "mcp-trust-project-pkg");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { fromProject: { command: "project-command" } } }),
+        });
+        await install("../mcp-trust-project-pkg", { project: true });
+
+        const untrusted = mergeOverlayMcpServers({}, cwd, agentDir, false);
+        expect(untrusted.config.mcpServers?.fromUser).toBeDefined();
+        expect(untrusted.config.mcpServers?.fromProject).toBeUndefined();
+        expect(untrusted.serverProvenance.some((p) => p.name === "fromProject")).toBe(false);
+        expect(untrusted.serverProvenance.some((p) => p.name === "fromUser" && p.owner === "user")).toBe(true);
+
+        const trusted = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect(trusted.config.mcpServers?.fromProject).toBeDefined();
+        expect(trusted.serverProvenance.some((p) => p.name === "fromProject" && p.owner === "project")).toBe(true);
+    });
+
+    test("malformed mcp sidecar shape (re-parsed at mount time) is skipped with a warning, not silently treated as empty", async () => {
+        const pkgDir = join(tmpDir, "mcp-malformed-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { fromPkg: { command: "echo" } } }),
+        });
+        await install("../mcp-malformed-pkg");
+
+        // Simulate the sidecar being replaced with a malformed shape between
+        // manifest validation and mount-time read (manifest.ts only validates
+        // the `mcp` path points to a confined, readable location — not the
+        // referenced file's own JSON shape).
+        writeFileSync(join(pkgDir, ".mcp.json"), JSON.stringify(["not", "an", "object"]));
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect(config.mcpServers?.fromPkg).toBeUndefined();
+        expect(serverProvenance.some((p) => p.name === "fromPkg")).toBe(false);
     });
 
     /**
@@ -121,8 +163,8 @@ describe("mergeOverlayMcpServers", () => {
     test("legacy global Claude-plugin .mcp.json is picked up (fixes the previously-ignored gap) at lowest precedence", () => {
         installLegacyPlugin("legacy-plugin", { legacyServer: { command: "legacy-command" } });
 
-        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
-        expect((merged.mcpServers?.legacyServer as any).command).toBe("legacy-command");
+        const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect((config.mcpServers?.legacyServer as any).command).toBe("legacy-command");
     });
 
     test("package overlay mcp wins over legacy plugin .mcp.json for the same name", async () => {
@@ -134,7 +176,7 @@ describe("mergeOverlayMcpServers", () => {
         });
         await install("../mcp-beats-legacy-pkg");
 
-        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
-        expect((merged.mcpServers?.shared as any).command).toBe("package-command");
+        const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect((config.mcpServers?.shared as any).command).toBe("package-command");
     });
 });

--- a/packages/cli/src/extensions/mcp-overlay.test.ts
+++ b/packages/cli/src/extensions/mcp-overlay.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPackageCommand } from "../package-commands.js";
+import { _setGlobalConfigDir } from "../config/io.js";
+import { mergeOverlayMcpServers } from "./mcp-overlay.js";
+
+describe("mergeOverlayMcpServers", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDir: string | undefined;
+    let originalHome: string | undefined;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-mcpoverlay-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+        originalCwd = process.cwd();
+        originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+        // discoverPlugins() reads process.env.HOME for the legacy plugin-dir scan.
+        originalHome = process.env.HOME;
+        process.env.HOME = join(tmpDir, "home");
+        mkdirSync(process.env.HOME, { recursive: true });
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeFixturePackage(dir: string, overlay: unknown, files?: Record<string, string>) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+        for (const [rel, content] of Object.entries(files ?? {})) {
+            const filePath = join(dir, rel);
+            mkdirSync(join(filePath, ".."), { recursive: true });
+            writeFileSync(filePath, content);
+        }
+    }
+
+    async function install(relOrAbs: string, opts?: { project?: boolean }) {
+        const args = opts?.project ? ["install", relOrAbs, "-l"] : ["install", relOrAbs];
+        const code = await runPackageCommand(args, cwd, agentDir);
+        expect(code).toBe(0);
+    }
+
+    test("package overlay mcp server is added to the base config", async () => {
+        const pkgDir = join(tmpDir, "mcp-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { fromPkg: { command: "echo" } } }),
+        });
+        await install("../mcp-pkg");
+
+        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
+        expect(merged.mcpServers?.fromPkg).toBeDefined();
+    });
+
+    test("explicit PizzaPi config always wins a server-name collision over package overlay", async () => {
+        const pkgDir = join(tmpDir, "mcp-collide-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "pkg-command" } } }),
+        });
+        await install("../mcp-collide-pkg");
+
+        const base = { mcpServers: { shared: { command: "explicit-config-command" } } };
+        const merged = mergeOverlayMcpServers(base, cwd, agentDir);
+        expect((merged.mcpServers?.shared as any).command).toBe("explicit-config-command");
+    });
+
+    test("project-scope package wins over user-scope package for the same server name", async () => {
+        const userPkg = join(tmpDir, "mcp-user-pkg");
+        writeFixturePackage(userPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "user-command" } } }),
+        });
+        await install("../mcp-user-pkg");
+
+        const projectPkg = join(tmpDir, "mcp-project-pkg");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "project-command" } } }),
+        });
+        await install("../mcp-project-pkg", { project: true });
+
+        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
+        expect((merged.mcpServers?.shared as any).command).toBe("project-command");
+    });
+
+    /**
+     * Legacy global-plugin discovery (globalPluginDirs()) reads homedir(),
+     * which Bun caches at process start — process.env.HOME overrides don't
+     * reach it in tests (see claude-plugins.e2e.test.ts's note). The Claude
+     * Code marketplace-installed path (discoverClaudeInstalledPlugins) DOES
+     * read process.env.HOME directly, so fixtures go through
+     * ~/.claude/plugins/installed_plugins.json instead — same discoverPlugins()
+     * call, same .mcp.json gap being fixed.
+     */
+    function installLegacyPlugin(name: string, mcpServers: Record<string, unknown>): void {
+        const installPath = join(tmpDir, "claude-plugin-cache", name);
+        mkdirSync(join(installPath, "commands"), { recursive: true });
+        writeFileSync(join(installPath, "commands", "noop.md"), "noop");
+        writeFileSync(join(installPath, ".mcp.json"), JSON.stringify({ mcpServers }));
+
+        const installedPluginsPath = join(process.env.HOME!, ".claude", "plugins", "installed_plugins.json");
+        mkdirSync(join(installedPluginsPath, ".."), { recursive: true });
+        writeFileSync(installedPluginsPath, JSON.stringify({
+            version: 1,
+            plugins: { [`${name}@test`]: [{ scope: "user", installPath }] },
+        }));
+    }
+
+    test("legacy global Claude-plugin .mcp.json is picked up (fixes the previously-ignored gap) at lowest precedence", () => {
+        installLegacyPlugin("legacy-plugin", { legacyServer: { command: "legacy-command" } });
+
+        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
+        expect((merged.mcpServers?.legacyServer as any).command).toBe("legacy-command");
+    });
+
+    test("package overlay mcp wins over legacy plugin .mcp.json for the same name", async () => {
+        installLegacyPlugin("legacy-plugin2", { shared: { command: "legacy-command" } });
+
+        const pkgDir = join(tmpDir, "mcp-beats-legacy-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "package-command" } } }),
+        });
+        await install("../mcp-beats-legacy-pkg");
+
+        const merged = mergeOverlayMcpServers({}, cwd, agentDir);
+        expect((merged.mcpServers?.shared as any).command).toBe("package-command");
+    });
+});

--- a/packages/cli/src/extensions/mcp-overlay.ts
+++ b/packages/cli/src/extensions/mcp-overlay.ts
@@ -17,6 +17,14 @@
  *      precedence theme used for runner services (§8).
  * `disabledMcpServers` is untouched here — it already applies by name in
  * the existing registry regardless of where a server definition came from.
+ *
+ * `serverProvenance` on the result carries, for every overlay/legacy server
+ * that won a name, WHERE it came from (package identity / legacy plugin,
+ * scope, source path). mcp-extension.ts's `inspectMcpConfig()` folds this
+ * into the same `effectiveServers` list its `/mcp` status and
+ * disable/enable tab-completion already read — without it, an overlay- or
+ * legacy-plugin-origin server is registered and running but invisible to
+ * `/mcp` and can never be targeted by `/mcp disable <name>` completion.
  */
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -31,6 +39,24 @@ const log = createLogger("mcp-overlay");
 
 type Owner = "config" | "user" | "project" | "legacy";
 
+export type McpServerOwner = Exclude<Owner, "config">;
+
+export interface OverlayMcpServerProvenance {
+    name: string;
+    owner: McpServerOwner;
+    /** Package identity (e.g. "npm:@acme/pkg") or "plugin:<name>" for legacy plugins. */
+    identity: string;
+    /** Package install root or legacy plugin root — display-only. */
+    sourcePath: string;
+    transport: string;
+}
+
+export interface MergeOverlayMcpServersResult {
+    config: PizzaPiConfig & McpConfig;
+    /** Provenance for every name whose winning definition came from an overlay/legacy source (not explicit PizzaPi config). */
+    serverProvenance: OverlayMcpServerProvenance[];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -43,6 +69,24 @@ function readJsonCapped(path: string): unknown | undefined {
     } catch {
         return undefined;
     }
+}
+
+/**
+ * Revalidate a re-parsed mcp sidecar's top-level shape at mount time —
+ * `readOverlayManifest()` only validates the `pi.pizzapi` manifest
+ * (confirming `mcp` points at a confined, allowed path); it never opens the
+ * sidecar file itself. Between manifest validation and this mount-time
+ * read, the file could have been replaced with something that parses as
+ * valid JSON but isn't a `{mcp:{servers:[...]}}`/`{mcpServers:{...}}`
+ * object (e.g. a JSON array or scalar) — that must be skipped with a
+ * warning, not silently treated as "declares zero servers".
+ */
+function isValidMcpSidecarShape(parsed: unknown): parsed is Record<string, unknown> {
+    if (!isRecord(parsed)) return false;
+    if ("mcp" in parsed && parsed.mcp !== undefined && !isRecord(parsed.mcp)) return false;
+    if (isRecord(parsed.mcp) && "servers" in parsed.mcp && parsed.mcp.servers !== undefined && !Array.isArray(parsed.mcp.servers)) return false;
+    if ("mcpServers" in parsed && parsed.mcpServers !== undefined && !isRecord(parsed.mcpServers)) return false;
+    return true;
 }
 
 /** Extract `{ preferred, compat }` server entries from a parsed mcp sidecar/`.mcp.json` value. */
@@ -62,12 +106,38 @@ function extractServers(parsed: unknown): { preferred: Record<string, unknown>[]
     return { preferred, compat };
 }
 
-export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: string, agentDir: string): PizzaPiConfig & McpConfig {
+/**
+ * Infer a display transport for a `mcpServers.<name>` compatibility-format
+ * entry — shared with mcp-extension.ts's `parseConfigFile()` so `/mcp`
+ * status shows the same transport label regardless of whether a server came
+ * from an explicit config file or an overlay/legacy sidecar.
+ */
+export function inferMcpCompatTransport(value: Record<string, unknown>): string {
+    if (typeof value.command === "string") return "stdio";
+    if (typeof value.url === "string") {
+        // "transport" is our field; "type" is Claude Code / VS Code format.
+        // In the standard MCP ecosystem, type "http" = streamable HTTP.
+        if (typeof value.transport === "string") return value.transport;
+        if (value.type === "http") return "streamable";
+        if (typeof value.type === "string") return value.type;
+        return "http";
+    }
+    return "unknown";
+}
+
+export function mergeOverlayMcpServers(
+    base: PizzaPiConfig & McpConfig,
+    cwd: string,
+    agentDir: string,
+    projectTrusted: boolean,
+): MergeOverlayMcpServersResult {
     const owner = new Map<string, Owner>();
     const preferredByName = new Map<string, Record<string, unknown>>();
     const compatByName = new Map<string, Record<string, unknown>>();
+    const provenanceByName = new Map<string, OverlayMcpServerProvenance>();
 
-    // Seed with explicit PizzaPi config — never overridden below.
+    // Seed with explicit PizzaPi config — never overridden below, never
+    // given overlay provenance (it's already visible via McpConfigFileState).
     for (const s of Array.isArray(base.mcp?.servers) ? (base.mcp!.servers as unknown[]) : []) {
         if (isRecord(s) && typeof s.name === "string") {
             owner.set(s.name, "config");
@@ -79,7 +149,13 @@ export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: str
         compatByName.set(name, val as Record<string, unknown>);
     }
 
-    function addPass(scope: Owner, identity: string, preferred: Record<string, unknown>[], compat: Record<string, Record<string, unknown>>): void {
+    function addPass(
+        scope: McpServerOwner,
+        identity: string,
+        sourcePath: string,
+        preferred: Record<string, unknown>[],
+        compat: Record<string, Record<string, unknown>>,
+    ): void {
         for (const s of preferred) {
             const name = s.name as string;
             const existing = owner.get(name);
@@ -91,6 +167,13 @@ export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: str
             owner.set(name, scope);
             preferredByName.set(name, s);
             compatByName.delete(name);
+            provenanceByName.set(name, {
+                name,
+                owner: scope,
+                identity,
+                sourcePath,
+                transport: typeof s.transport === "string" ? s.transport : "unknown",
+            });
         }
         for (const [name, val] of Object.entries(compat)) {
             const existing = owner.get(name);
@@ -102,11 +185,12 @@ export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: str
             owner.set(name, scope);
             compatByName.set(name, val);
             preferredByName.delete(name);
+            provenanceByName.set(name, { name, owner: scope, identity, sourcePath, transport: inferMcpCompatTransport(val) });
         }
     }
 
     // ── Package overlays: user pass, then project pass (project overrides user) ──
-    const { packages } = resolveSessionOverlays(cwd, agentDir);
+    const { packages } = resolveSessionOverlays(cwd, agentDir, projectTrusted);
     for (const scope of ["user", "project"] as const) {
         for (const pkg of packages.filter((p) => p.scope === scope)) {
             if (!pkg.overlay.mcp) continue;
@@ -120,8 +204,12 @@ export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: str
                 log.warn(`[${pkg.identity}] mcp sidecar could not be read/parsed at mount time`);
                 continue;
             }
+            if (!isValidMcpSidecarShape(parsed)) {
+                log.warn(`[${pkg.identity}] mcp sidecar has an invalid shape at mount time (expected {mcp:{servers:[...]}} and/or {mcpServers:{...}}) — skipped`);
+                continue;
+            }
             const { preferred, compat } = extractServers(parsed);
-            addPass(scope, pkg.identity, preferred, compat);
+            addPass(scope, pkg.identity, pkg.installedPath, preferred, compat);
         }
     }
 
@@ -135,16 +223,28 @@ export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: str
             log.warn(`[plugin:${plugin.name}] .mcp.json could not be read/parsed at mount time`);
             continue;
         }
+        if (!isValidMcpSidecarShape(parsed)) {
+            log.warn(`[plugin:${plugin.name}] .mcp.json has an invalid shape at mount time (expected {mcp:{servers:[...]}} and/or {mcpServers:{...}}) — skipped`);
+            continue;
+        }
         const { preferred, compat } = extractServers(parsed);
-        addPass("legacy", `plugin:${plugin.name}`, preferred, compat);
+        addPass("legacy", `plugin:${plugin.name}`, plugin.rootPath, preferred, compat);
     }
 
     const mergedPreferred = [...preferredByName.values()];
     const mergedCompat = Object.fromEntries(compatByName.entries());
 
-    return {
+    const config: PizzaPiConfig & McpConfig = {
         ...base,
         ...(mergedPreferred.length > 0 ? { mcp: { ...base.mcp, servers: mergedPreferred as never } } : { mcp: base.mcp }),
         ...(Object.keys(mergedCompat).length > 0 ? { mcpServers: mergedCompat as never } : { mcpServers: base.mcpServers }),
     };
+
+    // Only names still owned by an overlay/legacy source at the end (never
+    // shadowed by config or a higher-precedence pass) get provenance —
+    // mirrors `owner`'s final state exactly since both maps are updated
+    // together in addPass().
+    const serverProvenance = [...provenanceByName.values()].filter((p) => owner.get(p.name) === p.owner);
+
+    return { config, serverProvenance };
 }

--- a/packages/cli/src/extensions/mcp-overlay.ts
+++ b/packages/cli/src/extensions/mcp-overlay.ts
@@ -1,0 +1,150 @@
+/**
+ * Feeds `pi.pizzapi.mcp` overlay sidecars — and the legacy Claude-plugin
+ * `.mcp.json` file that was previously detected-but-ignored (`hasMcp` was a
+ * boolean only) — into the existing MCP registry (mcp-extension.ts /
+ * mcp/registry.ts). No second MCP runtime: this module only *augments* the
+ * `PizzaPiConfig & McpConfig` object that already flows into
+ * `registerMcpTools()`.
+ *
+ * Precedence (docs/specs/pi-pizzapi-overlay.md §4.3):
+ *   1. Explicit PizzaPi config (`~/.pizzapi/config.json` / project
+ *      `.pizzapi/config.json`) always wins a server-name collision — never
+ *      overridden here.
+ *   2. Between packages: project scope wins user scope, then settings
+ *      order (first configured wins).
+ *   3. Legacy global Claude-plugin `.mcp.json` servers fill in only names
+ *      nothing else has claimed — package-over-legacy, matching the same
+ *      precedence theme used for runner services (§8).
+ * `disabledMcpServers` is untouched here — it already applies by name in
+ * the existing registry regardless of where a server definition came from.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "@pizzapi/tools";
+import type { PizzaPiConfig } from "../config.js";
+import type { McpConfig } from "./mcp.js";
+import { resolveSessionOverlays } from "../overlay/session-packages.js";
+import { OVERLAY_SIDECAR_MAX_BYTES, resolveConfinedPath } from "../overlay/manifest.js";
+import { discoverPlugins } from "../plugins.js";
+
+const log = createLogger("mcp-overlay");
+
+type Owner = "config" | "user" | "project" | "legacy";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Read+parse a JSON file with the same size cap overlay sidecars use. Returns undefined on any failure. */
+function readJsonCapped(path: string): unknown | undefined {
+    try {
+        if (statSync(path).size > OVERLAY_SIDECAR_MAX_BYTES) return undefined;
+        return JSON.parse(readFileSync(path, "utf-8"));
+    } catch {
+        return undefined;
+    }
+}
+
+/** Extract `{ preferred, compat }` server entries from a parsed mcp sidecar/`.mcp.json` value. */
+function extractServers(parsed: unknown): { preferred: Record<string, unknown>[]; compat: Record<string, Record<string, unknown>> } {
+    const preferred: Record<string, unknown>[] = [];
+    const compat: Record<string, Record<string, unknown>> = {};
+    if (!isRecord(parsed)) return { preferred, compat };
+    const mcpServers = isRecord(parsed.mcp) ? (parsed.mcp as Record<string, unknown>).servers : undefined;
+    if (Array.isArray(mcpServers)) {
+        for (const s of mcpServers) if (isRecord(s) && typeof s.name === "string") preferred.push(s);
+    }
+    if (isRecord(parsed.mcpServers)) {
+        for (const [name, val] of Object.entries(parsed.mcpServers)) {
+            if (isRecord(val)) compat[name] = val;
+        }
+    }
+    return { preferred, compat };
+}
+
+export function mergeOverlayMcpServers(base: PizzaPiConfig & McpConfig, cwd: string, agentDir: string): PizzaPiConfig & McpConfig {
+    const owner = new Map<string, Owner>();
+    const preferredByName = new Map<string, Record<string, unknown>>();
+    const compatByName = new Map<string, Record<string, unknown>>();
+
+    // Seed with explicit PizzaPi config — never overridden below.
+    for (const s of Array.isArray(base.mcp?.servers) ? (base.mcp!.servers as unknown[]) : []) {
+        if (isRecord(s) && typeof s.name === "string") {
+            owner.set(s.name, "config");
+            preferredByName.set(s.name, s);
+        }
+    }
+    for (const [name, val] of Object.entries(base.mcpServers ?? {})) {
+        owner.set(name, "config");
+        compatByName.set(name, val as Record<string, unknown>);
+    }
+
+    function addPass(scope: Owner, identity: string, preferred: Record<string, unknown>[], compat: Record<string, Record<string, unknown>>): void {
+        for (const s of preferred) {
+            const name = s.name as string;
+            const existing = owner.get(name);
+            const canSet = existing === undefined || (scope === "project" && existing === "user");
+            if (!canSet) {
+                log.warn(`[${identity}] mcp server "${name}" ignored — already defined by ${existing}`);
+                continue;
+            }
+            owner.set(name, scope);
+            preferredByName.set(name, s);
+            compatByName.delete(name);
+        }
+        for (const [name, val] of Object.entries(compat)) {
+            const existing = owner.get(name);
+            const canSet = existing === undefined || (scope === "project" && existing === "user");
+            if (!canSet) {
+                log.warn(`[${identity}] mcp server "${name}" ignored — already defined by ${existing}`);
+                continue;
+            }
+            owner.set(name, scope);
+            compatByName.set(name, val);
+            preferredByName.delete(name);
+        }
+    }
+
+    // ── Package overlays: user pass, then project pass (project overrides user) ──
+    const { packages } = resolveSessionOverlays(cwd, agentDir);
+    for (const scope of ["user", "project"] as const) {
+        for (const pkg of packages.filter((p) => p.scope === scope)) {
+            if (!pkg.overlay.mcp) continue;
+            const resolved = resolveConfinedPath(pkg.installedPath, pkg.overlay.mcp);
+            if (!resolved.ok) {
+                log.warn(`[${pkg.identity}] mcp sidecar failed re-validation: ${resolved.message}`);
+                continue;
+            }
+            const parsed = readJsonCapped(resolved.absolutePath);
+            if (parsed === undefined) {
+                log.warn(`[${pkg.identity}] mcp sidecar could not be read/parsed at mount time`);
+                continue;
+            }
+            const { preferred, compat } = extractServers(parsed);
+            addPass(scope, pkg.identity, preferred, compat);
+        }
+    }
+
+    // ── Legacy: global (auto-trusted) Claude-plugin .mcp.json — lowest precedence ──
+    for (const plugin of discoverPlugins(cwd)) {
+        if (!plugin.hasMcp) continue;
+        const mcpPath = join(plugin.rootPath, ".mcp.json");
+        if (!existsSync(mcpPath)) continue;
+        const parsed = readJsonCapped(mcpPath);
+        if (parsed === undefined) {
+            log.warn(`[plugin:${plugin.name}] .mcp.json could not be read/parsed at mount time`);
+            continue;
+        }
+        const { preferred, compat } = extractServers(parsed);
+        addPass("legacy", `plugin:${plugin.name}`, preferred, compat);
+    }
+
+    const mergedPreferred = [...preferredByName.values()];
+    const mergedCompat = Object.fromEntries(compatByName.entries());
+
+    return {
+        ...base,
+        ...(mergedPreferred.length > 0 ? { mcp: { ...base.mcp, servers: mergedPreferred as never } } : { mcp: base.mcp }),
+        ...(Object.keys(mergedCompat).length > 0 ? { mcpServers: mergedCompat as never } : { mcpServers: base.mcpServers }),
+    };
+}

--- a/packages/cli/src/extensions/package-overlay-rules.test.ts
+++ b/packages/cli/src/extensions/package-overlay-rules.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPackageCommand } from "../package-commands.js";
+import { _setGlobalConfigDir } from "../config/io.js";
+import { createPackageOverlayRulesExtension } from "./package-overlay-rules.js";
+
+describe("createPackageOverlayRulesExtension", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDir: string | undefined;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-overlayrules-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+        originalCwd = process.cwd();
+        originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeFixturePackage(dir: string, overlay: unknown, files?: Record<string, string>) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+        for (const [rel, content] of Object.entries(files ?? {})) {
+            const filePath = join(dir, rel);
+            mkdirSync(join(filePath, ".."), { recursive: true });
+            writeFileSync(filePath, content);
+        }
+    }
+
+    async function install(relOrAbs: string) {
+        const code = await runPackageCommand(["install", relOrAbs], cwd, agentDir);
+        expect(code).toBe(0);
+    }
+
+    test("returns null when no configured package declares rules", () => {
+        expect(createPackageOverlayRulesExtension(cwd, agentDir)).toBeNull();
+    });
+
+    test("appends rule content additively via before_agent_start", async () => {
+        const pkgDir = join(tmpDir, "rules-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Always be terse." });
+        await install("../rules-pkg");
+
+        const factory = createPackageOverlayRulesExtension(cwd, agentDir);
+        expect(factory).not.toBeNull();
+
+        let handler: ((event: { systemPrompt: string }) => Promise<{ systemPrompt: string }>) | undefined;
+        const pi = {
+            on(type: string, h: any) {
+                if (type === "before_agent_start") handler = h;
+            },
+        };
+        factory!(pi as any);
+        expect(handler).toBeDefined();
+
+        const result = await handler!({ systemPrompt: "BASE PROMPT" });
+        expect(result.systemPrompt.startsWith("BASE PROMPT")).toBe(true);
+        expect(result.systemPrompt).toContain("Always be terse.");
+    });
+});

--- a/packages/cli/src/extensions/package-overlay-rules.test.ts
+++ b/packages/cli/src/extensions/package-overlay-rules.test.ts
@@ -48,7 +48,7 @@ describe("createPackageOverlayRulesExtension", () => {
     }
 
     test("returns null when no configured package declares rules", () => {
-        expect(createPackageOverlayRulesExtension(cwd, agentDir)).toBeNull();
+        expect(createPackageOverlayRulesExtension(cwd, agentDir, true)).toBeNull();
     });
 
     test("appends rule content additively via before_agent_start", async () => {
@@ -56,7 +56,7 @@ describe("createPackageOverlayRulesExtension", () => {
         writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Always be terse." });
         await install("../rules-pkg");
 
-        const factory = createPackageOverlayRulesExtension(cwd, agentDir);
+        const factory = createPackageOverlayRulesExtension(cwd, agentDir, true);
         expect(factory).not.toBeNull();
 
         let handler: ((event: { systemPrompt: string }) => Promise<{ systemPrompt: string }>) | undefined;
@@ -71,5 +71,15 @@ describe("createPackageOverlayRulesExtension", () => {
         const result = await handler!({ systemPrompt: "BASE PROMPT" });
         expect(result.systemPrompt.startsWith("BASE PROMPT")).toBe(true);
         expect(result.systemPrompt).toContain("Always be terse.");
+    });
+
+    test("project-scope package rules are excluded when the project is not explicitly trusted", async () => {
+        const pkgDir = join(tmpDir, "untrusted-rules-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Secret project rule." });
+        const code = await runPackageCommand(["install", "../untrusted-rules-pkg", "-l"], cwd, agentDir);
+        expect(code).toBe(0);
+
+        expect(createPackageOverlayRulesExtension(cwd, agentDir, false)).toBeNull();
+        expect(createPackageOverlayRulesExtension(cwd, agentDir, true)).not.toBeNull();
     });
 });

--- a/packages/cli/src/extensions/package-overlay-rules.ts
+++ b/packages/cli/src/extensions/package-overlay-rules.ts
@@ -1,0 +1,30 @@
+/**
+ * Mounts `pi.pizzapi.rules` from configured pi packages as additive
+ * `before_agent_start` context (docs/specs/pi-pizzapi-overlay.md §4.3, §9.1).
+ *
+ * Registered in factories.ts BEFORE the legacy Claude-plugin rules adapter
+ * (claude-plugins.ts) so package rules land in the system prompt first —
+ * "package-before-legacy" ordering. The legacy dir-based plugin `rules/`
+ * adapter is retained unchanged during migration.
+ */
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { collectOverlayRuleBlocks } from "../overlay/session-packages.js";
+
+/**
+ * Build the extension factory. Rule discovery runs once at factory-creation
+ * time (same convention as claude-plugins.ts) — a malformed overlay never
+ * throws (resolveSessionOverlays already isolates and warns), so a broken
+ * package can never prevent this factory (or session startup) from loading.
+ */
+export function createPackageOverlayRulesExtension(cwd: string, agentDir: string): ExtensionFactory | null {
+    const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+    if (blocks.length === 0) return null;
+
+    const section = `\n\n# Package Rules\n\n${blocks.map((b) => b.text).join("\n\n")}`;
+
+    return (pi) => {
+        pi.on("before_agent_start", async (event) => {
+            return { systemPrompt: event.systemPrompt + section };
+        });
+    };
+}

--- a/packages/cli/src/extensions/package-overlay-rules.ts
+++ b/packages/cli/src/extensions/package-overlay-rules.ts
@@ -16,8 +16,8 @@ import { collectOverlayRuleBlocks } from "../overlay/session-packages.js";
  * throws (resolveSessionOverlays already isolates and warns), so a broken
  * package can never prevent this factory (or session startup) from loading.
  */
-export function createPackageOverlayRulesExtension(cwd: string, agentDir: string): ExtensionFactory | null {
-    const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+export function createPackageOverlayRulesExtension(cwd: string, agentDir: string, projectTrusted: boolean): ExtensionFactory | null {
+    const blocks = collectOverlayRuleBlocks(cwd, agentDir, projectTrusted);
     if (blocks.length === 0) return null;
 
     const section = `\n\n# Package Rules\n\n${blocks.map((b) => b.text).join("\n\n")}`;

--- a/packages/cli/src/extensions/resource-paths.ts
+++ b/packages/cli/src/extensions/resource-paths.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { buildPromptTemplatePaths, buildSkillPaths } from "../skills.js";
-import { getPluginSkillPaths } from "./claude-plugins.js";
+import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "./claude-plugins.js";
 
 /**
  * Resource-paths extension — supplies skill and prompt-template paths via
@@ -50,7 +50,10 @@ export function createResourcePathsExtension(options: {
                     ...buildSkillPaths(cwd, options.configSkills),
                     ...(options.skipPlugins ? [] : getPluginSkillPaths(cwd)),
                 ],
-                promptPaths: buildPromptTemplatePaths(cwd),
+                promptPaths: [
+                    ...buildPromptTemplatePaths(cwd),
+                    ...(options.skipPlugins ? [] : getPluginPromptTemplatePaths(cwd)),
+                ],
             };
         });
     };

--- a/packages/cli/src/extensions/subagent-agents.test.ts
+++ b/packages/cli/src/extensions/subagent-agents.test.ts
@@ -381,6 +381,46 @@ describe("built-in agents", () => {
         // No tools restriction — inherits all coding tools
         expect(task!.tools).toBeUndefined();
     });
+
+    test("extraProjectDirs contributes project-scope agents, mirroring extraUserDirs", () => {
+        const overlayAgentsDir = mkdtempSync(join(tmpdir(), "overlay-agents-"));
+        createAgentFile(overlayAgentsDir, "pkg-agent.md", {
+            name: "pkg-agent",
+            description: "From a project-scope package overlay",
+        }, "Body");
+
+        const result = discoverAgents(tmpDir, "project", { extraProjectDirs: [overlayAgentsDir] });
+        const pkgAgent = result.agents.find(a => a.name === "pkg-agent");
+        expect(pkgAgent).toBeDefined();
+        expect(pkgAgent!.source).toBe("project");
+
+        rmSync(overlayAgentsDir, { recursive: true, force: true });
+    });
+
+    test("extraProjectDirs agents are absent under the default agentScope: \"user\"", () => {
+        const overlayAgentsDir = mkdtempSync(join(tmpdir(), "overlay-agents-"));
+        createAgentFile(overlayAgentsDir, "pkg-agent.md", { name: "pkg-agent", description: "desc" }, "Body");
+
+        const result = discoverAgents(tmpDir, "user", { extraProjectDirs: [overlayAgentsDir] });
+        expect(result.agents.find(a => a.name === "pkg-agent")).toBeUndefined();
+
+        rmSync(overlayAgentsDir, { recursive: true, force: true });
+    });
+
+    test("local .pizzapi/agents/ takes precedence over extraProjectDirs on name collision", () => {
+        const agentsDir = join(tmpDir, ".pizzapi", "agents");
+        mkdirSync(agentsDir, { recursive: true });
+        createAgentFile(agentsDir, "dup.md", { name: "dup", description: "Local wins" }, "Body");
+
+        const overlayAgentsDir = mkdtempSync(join(tmpdir(), "overlay-agents-"));
+        createAgentFile(overlayAgentsDir, "dup.md", { name: "dup", description: "Package loses" }, "Body");
+
+        const result = discoverAgents(tmpDir, "project", { extraProjectDirs: [overlayAgentsDir] });
+        const dup = result.agents.find(a => a.name === "dup");
+        expect(dup!.description).toBe("Local wins");
+
+        rmSync(overlayAgentsDir, { recursive: true, force: true });
+    });
 });
 
 describe("formatAgentList", () => {

--- a/packages/cli/src/extensions/subagent-agents.ts
+++ b/packages/cli/src/extensions/subagent-agents.ts
@@ -78,6 +78,70 @@ export const BUILTIN_AGENTS: AgentConfig[] = [
 ];
 
 /**
+ * Parse a single agent `.md` file's frontmatter + body into an `AgentConfig`.
+ * Returns `null` when the file is missing/unreadable, has malformed YAML
+ * frontmatter, or is missing the required `name`/`description` fields.
+ */
+function loadAgentFromFile(filePath: string, source: "user" | "project"): AgentConfig | null {
+    let content: string;
+    try {
+        content = fs.readFileSync(filePath, "utf-8");
+    } catch {
+        return null;
+    }
+
+    let frontmatter: Record<string, string | boolean | number>;
+    let body: string;
+    try {
+        ({ frontmatter, body } = parseFrontmatter<Record<string, string | boolean | number>>(content));
+    } catch {
+        // Malformed YAML frontmatter — silently skip this file
+        return null;
+    }
+
+    const name = String(frontmatter.name ?? "").trim();
+    const description = String(frontmatter.description ?? "").trim();
+    if (!name || !description) {
+        return null;
+    }
+
+    const toolsStr = typeof frontmatter.tools === "string" ? frontmatter.tools : "";
+    const tools = toolsStr
+        .split(",")
+        .map((t: string) => t.trim())
+        .filter(Boolean);
+
+    const disallowedStr = typeof frontmatter.disallowedTools === "string" ? frontmatter.disallowedTools : "";
+    const disallowedTools = disallowedStr
+        .split(",")
+        .map((t: string) => t.trim())
+        .filter(Boolean);
+
+    const rawMaxTurns = frontmatter.maxTurns;
+    const maxTurns = rawMaxTurns ? parseInt(String(rawMaxTurns), 10) : undefined;
+    // YAML parses `true` as boolean, but it might also be the string "true" / "yes"
+    const rawBg = frontmatter.background;
+    const background = rawBg === true || rawBg === "true" || rawBg === "yes";
+
+    const model = typeof frontmatter.model === "string" ? frontmatter.model : undefined;
+    const permissionMode = typeof frontmatter.permissionMode === "string" ? frontmatter.permissionMode : undefined;
+
+    return {
+        name,
+        description,
+        tools: tools.length > 0 ? tools : undefined,
+        disallowedTools: disallowedTools.length > 0 ? disallowedTools : undefined,
+        model,
+        maxTurns: maxTurns && !isNaN(maxTurns) ? maxTurns : undefined,
+        permissionMode,
+        background: background || undefined,
+        systemPrompt: body,
+        source,
+        filePath,
+    };
+}
+
+/**
  * Load agent definitions from a directory of .md files.
  *
  * Each .md file must have YAML frontmatter with at least `name` and `description`.
@@ -102,65 +166,27 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
         if (!entry.name.endsWith(".md")) continue;
         if (!entry.isFile() && !entry.isSymbolicLink()) continue;
 
-        const filePath = path.join(dir, entry.name);
-        let content: string;
-        try {
-            content = fs.readFileSync(filePath, "utf-8");
-        } catch {
-            continue;
-        }
-
-        let frontmatter: Record<string, string | boolean | number>;
-        let body: string;
-        try {
-            ({ frontmatter, body } = parseFrontmatter<Record<string, string | boolean | number>>(content));
-        } catch {
-            // Malformed YAML frontmatter — silently skip this file
-            continue;
-        }
-
-        const name = String(frontmatter.name ?? "").trim();
-        const description = String(frontmatter.description ?? "").trim();
-        if (!name || !description) {
-            continue;
-        }
-
-        const toolsStr = typeof frontmatter.tools === "string" ? frontmatter.tools : "";
-        const tools = toolsStr
-            .split(",")
-            .map((t: string) => t.trim())
-            .filter(Boolean);
-
-        const disallowedStr = typeof frontmatter.disallowedTools === "string" ? frontmatter.disallowedTools : "";
-        const disallowedTools = disallowedStr
-            .split(",")
-            .map((t: string) => t.trim())
-            .filter(Boolean);
-
-        const rawMaxTurns = frontmatter.maxTurns;
-        const maxTurns = rawMaxTurns ? parseInt(String(rawMaxTurns), 10) : undefined;
-        // YAML parses `true` as boolean, but it might also be the string "true" / "yes"
-        const rawBg = frontmatter.background;
-        const background = rawBg === true || rawBg === "true" || rawBg === "yes";
-
-        const model = typeof frontmatter.model === "string" ? frontmatter.model : undefined;
-        const permissionMode = typeof frontmatter.permissionMode === "string" ? frontmatter.permissionMode : undefined;
-
-        agents.push({
-            name,
-            description,
-            tools: tools.length > 0 ? tools : undefined,
-            disallowedTools: disallowedTools.length > 0 ? disallowedTools : undefined,
-            model,
-            maxTurns: maxTurns && !isNaN(maxTurns) ? maxTurns : undefined,
-            permissionMode,
-            background: background || undefined,
-            systemPrompt: body,
-            source,
-            filePath,
-        });
+        const agent = loadAgentFromFile(path.join(dir, entry.name), source);
+        if (agent) agents.push(agent);
     }
 
+    return agents;
+}
+
+/**
+ * Load exactly the declared `.md` files as agents — unlike
+ * `loadAgentsFromDir()`, sibling files in the same directory that weren't
+ * explicitly listed are never picked up. Used for overlay `agents` entries
+ * that name a single file (docs/specs/pi-pizzapi-overlay.md §4.3): a
+ * package declaring `agents: ["agents/a.md"]` must not also load an
+ * unrelated `agents/b.md` sitting next to it.
+ */
+export function loadAgentsFromFile(files: string[], source: "user" | "project"): AgentConfig[] {
+    const agents: AgentConfig[] = [];
+    for (const filePath of files) {
+        const agent = loadAgentFromFile(filePath, source);
+        if (agent) agents.push(agent);
+    }
     return agents;
 }
 
@@ -237,8 +263,17 @@ export function getUserAgentsDir(): string {
  *   still carry `source: "project"`, so they remain excluded from the
  *   default `agentScope: "user"` and still trigger `confirmProjectAgents`
  *   (docs/specs/pi-pizzapi-overlay.md §4.3).
+ * @param opts.extraUserFiles / extraProjectFiles - Additional exact `.md`
+ *   files (not directories) to load as user-/project-scope agents, loaded
+ *   after the corresponding `extra*Dirs`. Used for overlay `agents` entries
+ *   that name a single file: loaded via `loadAgentsFromFile()` so a sibling
+ *   `.md` file in the same directory that wasn't declared is never picked up.
  */
-export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUserDirs?: string[]; extraProjectDirs?: string[] }): AgentDiscoveryResult {
+export function discoverAgents(
+    cwd: string,
+    scope: AgentScope,
+    opts?: { extraUserDirs?: string[]; extraProjectDirs?: string[]; extraUserFiles?: string[]; extraProjectFiles?: string[] },
+): AgentDiscoveryResult {
     const userDirs = getUserAgentsDirs();
     const projectAgentsDirs = findNearestProjectAgentsDirs(cwd);
 
@@ -247,12 +282,14 @@ export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUse
     if (scope !== "project") {
         const seen = new Set<string>();
         const allUserDirs = [...userDirs, ...(opts?.extraUserDirs ?? [])];
-        for (const dir of allUserDirs) {
-            for (const agent of loadAgentsFromDir(dir, "user")) {
-                if (!seen.has(agent.name)) {
-                    seen.add(agent.name);
-                    userAgents.push(agent);
-                }
+        const userAgentSources = [
+            ...allUserDirs.flatMap((dir) => loadAgentsFromDir(dir, "user")),
+            ...loadAgentsFromFile(opts?.extraUserFiles ?? [], "user"),
+        ];
+        for (const agent of userAgentSources) {
+            if (!seen.has(agent.name)) {
+                seen.add(agent.name);
+                userAgents.push(agent);
             }
         }
     }
@@ -263,12 +300,14 @@ export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUse
     if (scope !== "user") {
         const seen = new Set<string>();
         const allProjectDirs = [...projectAgentsDirs, ...(opts?.extraProjectDirs ?? [])];
-        for (const dir of allProjectDirs) {
-            for (const agent of loadAgentsFromDir(dir, "project")) {
-                if (!seen.has(agent.name)) {
-                    seen.add(agent.name);
-                    projectAgents.push(agent);
-                }
+        const projectAgentSources = [
+            ...allProjectDirs.flatMap((dir) => loadAgentsFromDir(dir, "project")),
+            ...loadAgentsFromFile(opts?.extraProjectFiles ?? [], "project"),
+        ];
+        for (const agent of projectAgentSources) {
+            if (!seen.has(agent.name)) {
+                seen.add(agent.name);
+                projectAgents.push(agent);
             }
         }
     }

--- a/packages/cli/src/extensions/subagent-agents.ts
+++ b/packages/cli/src/extensions/subagent-agents.ts
@@ -230,8 +230,15 @@ export function getUserAgentsDir(): string {
  * @param opts.extraUserDirs - Additional directories to treat as user-scope
  *   (e.g. plugin agents/ dirs). Loaded after ~/.pizzapi and ~/.claude, so
  *   user-owned agents always take precedence.
+ * @param opts.extraProjectDirs - Additional directories to treat as
+ *   project-scope (e.g. `pi.pizzapi.agents` from project-scoped packages).
+ *   Loaded after the walked-up `.pizzapi`/`.claude` project dirs, so
+ *   project-owned agents always take precedence. Agents sourced from here
+ *   still carry `source: "project"`, so they remain excluded from the
+ *   default `agentScope: "user"` and still trigger `confirmProjectAgents`
+ *   (docs/specs/pi-pizzapi-overlay.md §4.3).
  */
-export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUserDirs?: string[] }): AgentDiscoveryResult {
+export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUserDirs?: string[]; extraProjectDirs?: string[] }): AgentDiscoveryResult {
     const userDirs = getUserAgentsDirs();
     const projectAgentsDirs = findNearestProjectAgentsDirs(cwd);
 
@@ -250,11 +257,13 @@ export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUse
         }
     }
 
-    // Load project agents from all found dirs (first-name-wins: .pizzapi before .claude)
+    // Load project agents from all found dirs, then extraProjectDirs
+    // (first-name-wins: .pizzapi before .claude before extraProjectDirs)
     let projectAgents: AgentConfig[] = [];
-    if (scope !== "user" && projectAgentsDirs.length > 0) {
+    if (scope !== "user") {
         const seen = new Set<string>();
-        for (const dir of projectAgentsDirs) {
+        const allProjectDirs = [...projectAgentsDirs, ...(opts?.extraProjectDirs ?? [])];
+        for (const dir of allProjectDirs) {
             for (const agent of loadAgentsFromDir(dir, "project")) {
                 if (!seen.has(agent.name)) {
                     seen.add(agent.name);

--- a/packages/cli/src/extensions/subagent/index.test.ts
+++ b/packages/cli/src/extensions/subagent/index.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Runtime wiring test for the subagent tool's overlay agent-directory/file
+ * resolution (docs/specs/pi-pizzapi-overlay.md §4.3). Exercises the REAL
+ * `subagentExtension` factory + real `runPackageCommand` install +
+ * `collectOverlayAgentDirs` wiring in subagent/index.ts — not a mock of
+ * `discoverAgents()` — so a regression that drops the overlay wiring (or
+ * forgets to thread `extraUserFiles`/`extraProjectFiles`) fails this test.
+ * Only exercises the "list available agents" fallback path (no agent/task
+ * given) so it never spawns a real subagent AgentSession.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { subagentExtension } from "./index.js";
+import { runPackageCommand } from "../../package-commands.js";
+import { _setGlobalConfigDir } from "../../config/io.js";
+import { ProjectTrustStore } from "@earendil-works/pi-coding-agent";
+
+describe("subagentExtension — overlay agent wiring", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDirEnv: string | undefined;
+
+    beforeEach(() => {
+        originalCwd = process.cwd();
+        // runPackageCommand() only sets PI_CODING_AGENT_DIR when it's unset
+        // ("upstream handlers use the env var, not an explicit param") —
+        // without clearing it here, the FIRST test in this file to install a
+        // package pins every later test's install to ITS agentDir, even
+        // though each test uses its own fresh tmpdir (see session-packages.
+        // test.ts / mcp-overlay.test.ts, which follow this same pattern).
+        originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+        delete process.env.PI_CODING_AGENT_DIR;
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-subagent-overlay-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+        // resolveAgentDir(cwd) reads config.agentDir from project config —
+        // point it at our isolated test agentDir instead of ~/.pizzapi
+        // (homedir() is cached by Bun at process start, so HOME overrides
+        // don't reach it — see other overlay tests' notes on this).
+        mkdirSync(join(cwd, ".pizzapi"), { recursive: true });
+        writeFileSync(join(cwd, ".pizzapi", "config.json"), JSON.stringify({ agentDir }));
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function registerTool() {
+        const tools: any[] = [];
+        const pi = { registerTool: (t: any) => tools.push(t), on: () => {} };
+        subagentExtension(pi as any);
+        return tools[0];
+    }
+
+    async function installOverlayPackage(opts: { project: boolean; agentFile: string; agentName: string }): Promise<void> {
+        const pkgDir = join(tmpDir, `overlay-agent-pkg-${opts.project ? "project" : "user"}`);
+        mkdirSync(join(pkgDir, "agents"), { recursive: true });
+        writeFileSync(
+            join(pkgDir, "package.json"),
+            JSON.stringify({ name: "overlay-agent-pkg", pi: { pizzapi: { schemaVersion: 1, agents: [`./agents/${opts.agentFile}`] } } }),
+        );
+        writeFileSync(
+            join(pkgDir, "agents", opts.agentFile),
+            `---\nname: ${opts.agentName}\ndescription: From overlay\n---\nBody`,
+        );
+        // Unrelated sibling agent file that was NOT declared — proves exact
+        // single-file loading (must never be picked up alongside it).
+        writeFileSync(
+            join(pkgDir, "agents", "undeclared-sibling.md"),
+            "---\nname: undeclared-sibling\ndescription: Should never load\n---\nBody",
+        );
+        const args = opts.project
+            ? ["install", `../${pkgDir.split("/").pop()}`, "-l"]
+            : ["install", `../${pkgDir.split("/").pop()}`];
+        const code = await runPackageCommand(args, cwd, agentDir);
+        expect(code).toBe(0);
+    }
+
+    test("project-scope overlay agent is discoverable via the real subagent tool once the project is trusted, with confirmProjectAgents required", async () => {
+        await installOverlayPackage({ project: true, agentFile: "special.md", agentName: "overlay-special" });
+        new ProjectTrustStore(agentDir).set(cwd, true);
+
+        const tool = registerTool();
+        const result = await tool.execute(
+            "call-1",
+            { agentScope: "project", confirmProjectAgents: false },
+            new AbortController().signal,
+            undefined,
+            { cwd, hasUI: false, modelRegistry: undefined },
+        );
+
+        const text = result.content[0].text as string;
+        expect(text).toContain("overlay-special");
+        expect(text).not.toContain("undeclared-sibling"); // exact single-file loading, not folder-folded
+    });
+
+    test("project-scope overlay agent is absent when the project is not trusted", async () => {
+        await installOverlayPackage({ project: true, agentFile: "special2.md", agentName: "overlay-special-untrusted" });
+        // No ProjectTrustStore entry — fails closed.
+
+        const tool = registerTool();
+        const result = await tool.execute(
+            "call-2",
+            { agentScope: "project", confirmProjectAgents: false },
+            new AbortController().signal,
+            undefined,
+            { cwd, hasUI: false, modelRegistry: undefined },
+        );
+
+        const text = result.content[0].text as string;
+        expect(text).not.toContain("overlay-special-untrusted");
+    });
+
+    test("user-scope overlay agent is discoverable regardless of project trust", async () => {
+        await installOverlayPackage({ project: false, agentFile: "userspecial.md", agentName: "overlay-user-special" });
+
+        const tool = registerTool();
+        const result = await tool.execute(
+            "call-3",
+            { agentScope: "user" },
+            new AbortController().signal,
+            undefined,
+            { cwd, hasUI: false, modelRegistry: undefined },
+        );
+
+        const text = result.content[0].text as string;
+        expect(text).toContain("overlay-user-special");
+    });
+});

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -25,7 +25,7 @@ import { tmpdir } from "node:os";
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type AgentScope, discoverAgents } from "../subagent-agents.js";
 import { getPluginAgentPaths } from "../claude-plugins.js";
-import { loadGlobalConfig, resolveAgentDir } from "../../config.js";
+import { loadGlobalConfig, resolveAgentDir, resolveExplicitProjectTrust } from "../../config.js";
 import { collectOverlayAgentDirs } from "../../overlay/session-packages.js";
 import {
     DEFAULT_MAX_PARALLEL_TASKS,
@@ -159,10 +159,14 @@ export const subagentExtension = (pi: ExtensionAPI, runAgent = runSingleAgent) =
             // matching the package-over-legacy precedence used elsewhere in the
             // overlay (docs/specs/pi-pizzapi-overlay.md §8) — listed first so
             // discoverAgents' first-name-wins merge prefers them.
-            const overlayAgentDirs = collectOverlayAgentDirs(ctx.cwd, resolveAgentDir(ctx.cwd));
+            const overlayAgentDir = resolveAgentDir(ctx.cwd);
+            const overlayProjectTrusted = resolveExplicitProjectTrust(ctx.cwd, overlayAgentDir);
+            const overlayAgentDirs = collectOverlayAgentDirs(ctx.cwd, overlayAgentDir, overlayProjectTrusted);
             const discovery = discoverAgents(ctx.cwd, agentScope, {
                 extraUserDirs: [...overlayAgentDirs.userDirs, ...pluginAgentDirs],
                 extraProjectDirs: overlayAgentDirs.projectDirs,
+                extraUserFiles: overlayAgentDirs.userFiles,
+                extraProjectFiles: overlayAgentDirs.projectFiles,
             });
             const agents = discovery.agents;
             const confirmProjectAgents = params.confirmProjectAgents ?? true;

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -25,7 +25,8 @@ import { tmpdir } from "node:os";
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type AgentScope, discoverAgents } from "../subagent-agents.js";
 import { getPluginAgentPaths } from "../claude-plugins.js";
-import { loadGlobalConfig } from "../../config.js";
+import { loadGlobalConfig, resolveAgentDir } from "../../config.js";
+import { collectOverlayAgentDirs } from "../../overlay/session-packages.js";
 import {
     DEFAULT_MAX_PARALLEL_TASKS,
     DEFAULT_MAX_CONCURRENCY,
@@ -154,7 +155,15 @@ export const subagentExtension = (pi: ExtensionAPI, runAgent = runSingleAgent) =
             };
             const agentScope: AgentScope = params.agentScope ?? "user";
             const pluginAgentDirs = getPluginAgentPaths(ctx.cwd);
-            const discovery = discoverAgents(ctx.cwd, agentScope, { extraUserDirs: pluginAgentDirs });
+            // Package-origin agent dirs win legacy plugin-dir name collisions,
+            // matching the package-over-legacy precedence used elsewhere in the
+            // overlay (docs/specs/pi-pizzapi-overlay.md §8) — listed first so
+            // discoverAgents' first-name-wins merge prefers them.
+            const overlayAgentDirs = collectOverlayAgentDirs(ctx.cwd, resolveAgentDir(ctx.cwd));
+            const discovery = discoverAgents(ctx.cwd, agentScope, {
+                extraUserDirs: [...overlayAgentDirs.userDirs, ...pluginAgentDirs],
+                extraProjectDirs: overlayAgentDirs.projectDirs,
+            });
             const agents = discovery.agents;
             const confirmProjectAgents = params.confirmProjectAgents ?? true;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ import { isPackageCommand, runPackageCommand } from "./package-commands.js";
 import { getOAuthAccessToken, getAnthropicKeychainToken } from "./runner/usage-auth.js";
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "./skills.js";
-import { getPluginSkillPaths } from "./extensions/claude-plugins.js";
+import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "./extensions/claude-plugins.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { setRemoteSessionHost } from "./extensions/remote/session-host-ref.js";
 import { runtimeSessionHost } from "./runner/session-host.js";
@@ -492,6 +492,7 @@ async function main() {
     // Build extension list — includes configured hooks when present.
     const extensionFactories = buildPizzaPiExtensionFactories({
         cwd,
+        agentDir,
         hooks: noHooks ? undefined : config.hooks,
         skipMcp: noMcp,
         skipPlugins: noPlugins,
@@ -507,7 +508,10 @@ async function main() {
             ...buildSkillPaths(cwd, config.skills),
             ...(noPlugins ? [] : getPluginSkillPaths(cwd)),
         ],
-        additionalPromptTemplatePaths: buildPromptTemplatePaths(cwd),
+        additionalPromptTemplatePaths: [
+            ...buildPromptTemplatePaths(cwd),
+            ...(noPlugins ? [] : getPluginPromptTemplatePaths(cwd)),
+        ],
         ...(config.systemPrompt !== undefined
             ? { systemPromptOverride: () => config.systemPrompt }
             : {}
@@ -532,7 +536,10 @@ async function main() {
                     ...buildSkillPaths(opts.cwd, config.skills),
                     ...(noPlugins ? [] : getPluginSkillPaths(opts.cwd)),
                 ],
-                additionalPromptTemplatePaths: buildPromptTemplatePaths(opts.cwd),
+                additionalPromptTemplatePaths: [
+                    ...buildPromptTemplatePaths(opts.cwd),
+                    ...(noPlugins ? [] : getPluginPromptTemplatePaths(opts.cwd)),
+                ],
                 ...(config.systemPrompt !== undefined && {
                     systemPromptOverride: () => config.systemPrompt,
                 }),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,10 +8,11 @@ import {
     InteractiveMode,
     readStoredCredential,
     SessionManager,
+    SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
 import { join } from "path";
-import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
+import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv, resolveExplicitProjectTrust } from "./config.js";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
 import { getOAuthAccessToken, getAnthropicKeychainToken } from "./runner/usage-auth.js";
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
@@ -489,6 +490,16 @@ async function main() {
         process.env.PIZZAPI_RELAY_URL = "off";
     }
 
+    // Explicit, persisted pi project-trust decision for the initial cwd — the
+    // single authority gating native pi project resources (extensions/
+    // skills/prompts) AND the session-side pi.pizzapi overlay (agents/rules/
+    // mcp from project-scope configured packages). Fails closed: an
+    // undecided or explicitly-untrusted repo never auto-executes project
+    // package code. No new trust UI here — pi's own persisted trust.json is
+    // the authority (see config/io.ts resolveExplicitProjectTrust).
+    const projectTrusted = resolveExplicitProjectTrust(cwd, agentDir);
+    const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+
     // Build extension list — includes configured hooks when present.
     const extensionFactories = buildPizzaPiExtensionFactories({
         cwd,
@@ -498,11 +509,13 @@ async function main() {
         skipPlugins: noPlugins,
         skipRelay: noRelay,
         configSkills: config.skills,
+        projectTrusted,
     });
 
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
+        settingsManager,
         extensionFactories,
         additionalSkillPaths: [
             ...buildSkillPaths(cwd, config.skills),
@@ -527,9 +540,17 @@ async function main() {
     const sessionManager = SessionManager.create(cwd, join(agentDir, "sessions"));
 
     const createRuntime = async (opts: { cwd: string; agentDir: string; sessionManager: SessionManager }) => {
+        // Re-resolve trust explicitly for THIS cwd/agentDir — createRuntime is
+        // reused across /new, /resume, /fork, and session switches, which can
+        // target a different cwd than the process started in, and pi's own
+        // trust.json can change between calls (e.g. the user trusts the repo
+        // via pi's own flow mid-process).
+        const rtProjectTrusted = resolveExplicitProjectTrust(opts.cwd, opts.agentDir);
+        const rtSettingsManager = SettingsManager.create(opts.cwd, opts.agentDir, { projectTrusted: rtProjectTrusted });
         const services = await createAgentSessionServices({
             cwd: opts.cwd,
             agentDir: opts.agentDir,
+            settingsManager: rtSettingsManager,
             resourceLoaderOptions: {
                 extensionFactories: extensionFactories as any,
                 additionalSkillPaths: [

--- a/packages/cli/src/overlay/cli-support.ts
+++ b/packages/cli/src/overlay/cli-support.ts
@@ -7,12 +7,13 @@
  * docs/specs/pi-pizzapi-overlay.md §7.3.
  */
 import { createInterface } from "node:readline";
-import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import type { DefaultPackageManager } from "@earendil-works/pi-coding-agent";
 import { c } from "../cli-colors.js";
 import { loadGlobalConfig } from "../config/io.js";
 import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
 import { formatOverlayIssue, readOverlayManifest, type OverlayReadResult, type PackageProvenance } from "./manifest.js";
 import { getGrantedServiceIds, grantServices, revokeServices, resolveServiceGrantState } from "./grants.js";
+import { dedupeConfiguredPackages, packageManagerFor, type ConfiguredPkg } from "./resolve.js";
 import { defaultStatePath, isPidRunning, type RunnerState } from "../runner/runner-state.js";
 import { existsSync, readFileSync } from "node:fs";
 
@@ -74,14 +75,6 @@ function askYesNo(question: string): Promise<boolean> {
     });
 }
 
-function packageManagerFor(cwd: string, agentDir: string): DefaultPackageManager {
-    const settingsManager = SettingsManager.create(cwd, agentDir);
-    return new DefaultPackageManager({ cwd, agentDir, settingsManager });
-}
-
-/** `ConfiguredPackage` isn't re-exported from the package root; derive it structurally. */
-type ConfiguredPkg = ReturnType<DefaultPackageManager["listConfiguredPackages"]>[number];
-
 interface ConfiguredMatch {
     provenance: PackageProvenance;
     installedPath: string;
@@ -126,36 +119,6 @@ function readOverlayFor(cwd: string, agentDir: string, source: string, scope: "u
     const match = findConfiguredOverlaySource(pm, source, scope, cwd, agentDir);
     if (!match) return undefined;
     return { provenance: match.provenance, result: readOverlayManifest(match.installedPath, match.provenance) };
-}
-
-/**
- * Dedupe configured packages by normalized identity before display —
- * project entries override user entries for the same identity, matching
- * pi's own scope/dedup rule (docs/packages.md "Scope and Deduplication").
- * Preserves stable order: the winning entry keeps the position of its first
- * occurrence, only its content (source/scope) is replaced.
- */
-function dedupeConfiguredPackages(
-    configured: ConfiguredPkg[],
-    cwd: string,
-    agentDir: string,
-): Array<{ identity: string; pkg: ConfiguredPkg }> {
-    const order: string[] = [];
-    const byIdentity = new Map<string, { identity: string; pkg: ConfiguredPkg }>();
-    for (const pkg of configured) {
-        const baseDir = packageScopeBaseDir(pkg.scope, cwd, agentDir);
-        const identity = computePackageIdentity(pkg.source, baseDir).identity;
-        const existing = byIdentity.get(identity);
-        if (!existing) {
-            byIdentity.set(identity, { identity, pkg });
-            order.push(identity);
-            continue;
-        }
-        if (pkg.scope === "project" && existing.pkg.scope === "user") {
-            byIdentity.set(identity, { identity, pkg });
-        }
-    }
-    return order.map((identity) => byIdentity.get(identity)!);
 }
 
 /**

--- a/packages/cli/src/overlay/cli-support.ts
+++ b/packages/cli/src/overlay/cli-support.ts
@@ -115,7 +115,9 @@ function findConfiguredOverlaySource(
 }
 
 function readOverlayFor(cwd: string, agentDir: string, source: string, scope: "user" | "project"): { provenance: PackageProvenance; result: OverlayReadResult } | undefined {
-    const pm = packageManagerFor(cwd, agentDir);
+    // Explicit CLI inspection command, not session-side autoloading — always
+    // show all configured packages regardless of project trust (see resolve.ts).
+    const pm = packageManagerFor(cwd, agentDir, true);
     const match = findConfiguredOverlaySource(pm, source, scope, cwd, agentDir);
     if (!match) return undefined;
     return { provenance: match.provenance, result: readOverlayManifest(match.installedPath, match.provenance) };
@@ -200,7 +202,9 @@ export async function handlePostInstallOverlay(args: string[], cwd: string, agen
 
 /** Render the overlay/service-trust section appended to `pizza list` output. */
 export function renderOverlaySummary(cwd: string, agentDir: string): void {
-    const pm = packageManagerFor(cwd, agentDir);
+    // Explicit CLI inspection command, not session-side autoloading — always
+    // show all configured packages regardless of project trust (see resolve.ts).
+    const pm = packageManagerFor(cwd, agentDir, true);
     const configured = pm.listConfiguredPackages();
     if (configured.length === 0) return;
 
@@ -305,7 +309,9 @@ export interface OverlaySnapshotEntry {
  * newly-malformed overlay.
  */
 export function snapshotOverlayServiceIds(cwd: string, agentDir: string): Map<string, OverlaySnapshotEntry> {
-    const pm = packageManagerFor(cwd, agentDir);
+    // Explicit CLI inspection command, not session-side autoloading — always
+    // show all configured packages regardless of project trust (see resolve.ts).
+    const pm = packageManagerFor(cwd, agentDir, true);
     const configured = pm.listConfiguredPackages().filter((p) => p.scope === "user");
     const deduped = dedupeConfiguredPackages(configured, cwd, agentDir);
     const snapshot = new Map<string, OverlaySnapshotEntry>();

--- a/packages/cli/src/overlay/resolve.test.ts
+++ b/packages/cli/src/overlay/resolve.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { packageManagerFor, dedupeConfiguredPackages, type ConfiguredPkg } from "./resolve.js";
+
+describe("dedupeConfiguredPackages — order within the winning scope", () => {
+    function pkg(source: string, scope: "user" | "project"): ConfiguredPkg {
+        return { source, scope, filtered: false, installedPath: `/pkgs/${scope}/${source}` } as ConfiguredPkg;
+    }
+
+    test("a project entry replacing a user entry takes the PROJECT's own position, not the user entry's", () => {
+        // Configured order (mirrors pi's listConfiguredPackages: all user
+        // entries, then all project entries, each in settings-file order):
+        //   user:    [A, B]
+        //   project: [B', A']   (reversed relative to user)
+        // A single-pass "replace in place" implementation anchors each
+        // winner at the LOSER's position, yielding [A', B'] — reversed from
+        // the actual project settings file order. The fix must yield the
+        // project file's own order: [B', A'].
+        const configured = [
+            pkg("npm:@acme/a", "user"),
+            pkg("npm:@acme/b", "user"),
+            pkg("npm:@acme/b", "project"),
+            pkg("npm:@acme/a", "project"),
+        ];
+        const deduped = dedupeConfiguredPackages(configured, "/cwd", "/agent");
+        expect(deduped.map((d) => d.pkg.scope)).toEqual(["project", "project"]);
+        expect(deduped.map((d) => d.identity)).toEqual(["npm:@acme/b", "npm:@acme/a"]);
+    });
+
+    test("user-only and project-only entries keep their own settings-file order untouched", () => {
+        const configured = [
+            pkg("npm:@acme/u1", "user"),
+            pkg("npm:@acme/u2", "user"),
+            pkg("npm:@acme/p1", "project"),
+            pkg("npm:@acme/p2", "project"),
+        ];
+        const deduped = dedupeConfiguredPackages(configured, "/cwd", "/agent");
+        expect(deduped.map((d) => d.identity)).toEqual([
+            "npm:@acme/u1",
+            "npm:@acme/u2",
+            "npm:@acme/p1",
+            "npm:@acme/p2",
+        ]);
+    });
+});
+
+describe("packageManagerFor — corrupt settings", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalWarn: typeof console.warn;
+    let warnCalls: string[];
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-resolve-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        warnCalls = [];
+        originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => { warnCalls.push(args.join(" ")); };
+    });
+
+    afterEach(() => {
+        console.warn = originalWarn;
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("a corrupt user-scope settings.json warns once and still resolves project-scope packages (scopes are isolated)", () => {
+        writeFileSync(join(agentDir, "settings.json"), "{ not valid json");
+        mkdirSync(join(cwd, ".pizzapi"), { recursive: true });
+        writeFileSync(join(cwd, ".pizzapi", "settings.json"), JSON.stringify({ packages: ["npm:@acme/ok"] }));
+
+        const pm = packageManagerFor(cwd, agentDir, true);
+        const configured = pm.listConfiguredPackages();
+
+        // Global (user) scope is corrupt -> empty, but project scope still
+        // resolves independently.
+        expect(configured.some((p) => p.scope === "project" && p.source === "npm:@acme/ok")).toBe(true);
+
+        const joined = warnCalls.join("\n");
+        expect(joined).toContain("global");
+        expect(joined.toLowerCase()).toContain("fail");
+
+        // A second call with the SAME error must not warn again.
+        const warnCountAfterFirst = warnCalls.length;
+        packageManagerFor(cwd, agentDir, true).listConfiguredPackages();
+        expect(warnCalls.length).toBe(warnCountAfterFirst);
+    });
+});

--- a/packages/cli/src/overlay/resolve.ts
+++ b/packages/cli/src/overlay/resolve.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared "configured pi packages" resolution — the single place that talks
+ * to pi's `SettingsManager`/`DefaultPackageManager` and applies pi's own
+ * project-over-user identity dedup (docs/packages.md "Scope and
+ * Deduplication"). Reused by the CLI trust UX (cli-support.ts), daemon
+ * package-service discovery, and session-side overlay mounting (agents,
+ * rules, MCP) so the dedup/order rules can never drift between call sites.
+ */
+import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
+
+export type ConfiguredPkg = ReturnType<DefaultPackageManager["listConfiguredPackages"]>[number];
+
+export function packageManagerFor(cwd: string, agentDir: string): DefaultPackageManager {
+    const settingsManager = SettingsManager.create(cwd, agentDir);
+    return new DefaultPackageManager({ cwd, agentDir, settingsManager });
+}
+
+export interface DedupedConfiguredPackage {
+    identity: string;
+    pkg: ConfiguredPkg;
+}
+
+/**
+ * Dedupe configured packages by normalized identity before display/mount —
+ * project entries override user entries for the same identity, matching
+ * pi's own scope/dedup rule. Preserves stable order: the winning entry
+ * keeps the position of its first occurrence, only its content
+ * (source/scope) is replaced.
+ */
+export function dedupeConfiguredPackages(
+    configured: ConfiguredPkg[],
+    cwd: string,
+    agentDir: string,
+): DedupedConfiguredPackage[] {
+    const order: string[] = [];
+    const byIdentity = new Map<string, DedupedConfiguredPackage>();
+    for (const pkg of configured) {
+        const baseDir = packageScopeBaseDir(pkg.scope, cwd, agentDir);
+        const identity = computePackageIdentity(pkg.source, baseDir).identity;
+        const existing = byIdentity.get(identity);
+        if (!existing) {
+            byIdentity.set(identity, { identity, pkg });
+            order.push(identity);
+            continue;
+        }
+        if (pkg.scope === "project" && existing.pkg.scope === "user") {
+            byIdentity.set(identity, { identity, pkg });
+        }
+    }
+    return order.map((identity) => byIdentity.get(identity)!);
+}
+
+/** Convenience: resolve + dedupe configured packages for `cwd`/`agentDir` in one call. */
+export function listDedupedConfiguredPackages(cwd: string, agentDir: string): DedupedConfiguredPackage[] {
+    const pm = packageManagerFor(cwd, agentDir);
+    return dedupeConfiguredPackages(pm.listConfiguredPackages(), cwd, agentDir);
+}

--- a/packages/cli/src/overlay/resolve.ts
+++ b/packages/cli/src/overlay/resolve.ts
@@ -7,12 +7,45 @@
  * rules, MCP) so the dedup/order rules can never drift between call sites.
  */
 import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { createLogger } from "@pizzapi/tools";
 import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
+
+const log = createLogger("overlay/resolve");
 
 export type ConfiguredPkg = ReturnType<DefaultPackageManager["listConfiguredPackages"]>[number];
 
-export function packageManagerFor(cwd: string, agentDir: string): DefaultPackageManager {
-    const settingsManager = SettingsManager.create(cwd, agentDir);
+// Warn-once-per-process dedup for SettingsManager parse errors, keyed by
+// `scope:message` — packageManagerFor() runs on nearly every session-side
+// overlay resolution call (subagent invocations, MCP loads/reloads, rules
+// extension setup), so without dedup a single corrupt settings.json would
+// spam a warning on every one of those instead of surfacing once.
+const warnedSettingsErrors = new Set<string>();
+
+function warnSettingsErrorsOnce(settingsManager: SettingsManager): void {
+    for (const { scope, error } of settingsManager.drainErrors()) {
+        const key = `${scope}:${error.message}`;
+        if (warnedSettingsErrors.has(key)) continue;
+        warnedSettingsErrors.add(key);
+        // pi's SettingsManager loads global/project scopes independently
+        // (settings-manager.js: separate try/catch per scope) — a corrupt
+        // scope here never blocks the other from loading; this only
+        // surfaces the corruption so it doesn't silently read back as "no
+        // packages configured" for the broken scope.
+        log.warn(`${scope} pi settings failed to parse — treating ${scope}-scope configured packages as empty until fixed: ${error.message}`);
+    }
+}
+
+/**
+ * `projectTrusted` MUST be the caller's explicit, persisted trust decision
+ * (see config/io.ts `resolveExplicitProjectTrust`) — never omitted. pi's
+ * `SettingsManager.create()` defaults to `projectTrusted: true` when the
+ * option is left out, which would silently re-trust an untrusted repo's
+ * project-scope configured packages (and therefore its `pi.pizzapi`
+ * overlay) for every session-side caller of this function.
+ */
+export function packageManagerFor(cwd: string, agentDir: string, projectTrusted: boolean): DefaultPackageManager {
+    const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+    warnSettingsErrorsOnce(settingsManager);
     return new DefaultPackageManager({ cwd, agentDir, settingsManager });
 }
 
@@ -24,35 +57,51 @@ export interface DedupedConfiguredPackage {
 /**
  * Dedupe configured packages by normalized identity before display/mount —
  * project entries override user entries for the same identity, matching
- * pi's own scope/dedup rule. Preserves stable order: the winning entry
- * keeps the position of its first occurrence, only its content
- * (source/scope) is replaced.
+ * pi's own scope/dedup rule. Preserves stable order WITHIN the winning
+ * scope: two passes — first decide the winner per identity (project beats
+ * user), then walk `configured` again and record each identity's position
+ * at the winner's OWN occurrence (not the loser's). A single-pass "replace
+ * in place" approach anchors a project winner at whatever position the user
+ * entry it replaced happened to occupy, which can reorder (or even reverse)
+ * project entries relative to their actual settings-file order whenever the
+ * user- and project-scope lists don't share the same relative ordering for
+ * shared identities (e.g. user=[A,B], project=[B',A'] would previously
+ * yield [A',B'] — reversed from the project settings file).
  */
 export function dedupeConfiguredPackages(
     configured: ConfiguredPkg[],
     cwd: string,
     agentDir: string,
 ): DedupedConfiguredPackage[] {
+    const identities = configured.map(
+        (pkg) => computePackageIdentity(pkg.source, packageScopeBaseDir(pkg.scope, cwd, agentDir)).identity,
+    );
+
+    const winners = new Map<string, ConfiguredPkg>();
+    configured.forEach((pkg, i) => {
+        const identity = identities[i];
+        const existing = winners.get(identity);
+        if (!existing || pkg.scope === "project") winners.set(identity, pkg);
+    });
+
     const order: string[] = [];
-    const byIdentity = new Map<string, DedupedConfiguredPackage>();
-    for (const pkg of configured) {
-        const baseDir = packageScopeBaseDir(pkg.scope, cwd, agentDir);
-        const identity = computePackageIdentity(pkg.source, baseDir).identity;
-        const existing = byIdentity.get(identity);
-        if (!existing) {
-            byIdentity.set(identity, { identity, pkg });
-            order.push(identity);
-            continue;
-        }
-        if (pkg.scope === "project" && existing.pkg.scope === "user") {
-            byIdentity.set(identity, { identity, pkg });
-        }
-    }
-    return order.map((identity) => byIdentity.get(identity)!);
+    const seen = new Set<string>();
+    configured.forEach((pkg, i) => {
+        const identity = identities[i];
+        if (seen.has(identity) || winners.get(identity) !== pkg) return;
+        seen.add(identity);
+        order.push(identity);
+    });
+
+    return order.map((identity) => ({ identity, pkg: winners.get(identity)! }));
 }
 
 /** Convenience: resolve + dedupe configured packages for `cwd`/`agentDir` in one call. */
-export function listDedupedConfiguredPackages(cwd: string, agentDir: string): DedupedConfiguredPackage[] {
-    const pm = packageManagerFor(cwd, agentDir);
+export function listDedupedConfiguredPackages(
+    cwd: string,
+    agentDir: string,
+    projectTrusted: boolean,
+): DedupedConfiguredPackage[] {
+    const pm = packageManagerFor(cwd, agentDir, projectTrusted);
     return dedupeConfiguredPackages(pm.listConfiguredPackages(), cwd, agentDir);
 }

--- a/packages/cli/src/overlay/session-packages.test.ts
+++ b/packages/cli/src/overlay/session-packages.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPackageCommand } from "../package-commands.js";
+import { _setGlobalConfigDir } from "../config/io.js";
+import { resolveSessionOverlays, collectOverlayAgentDirs, collectOverlayRuleBlocks } from "./session-packages.js";
+
+describe("session-packages overlay mounting", () => {
+    let tmpDir: string;
+    let cwd: string;
+    let agentDir: string;
+    let originalCwd: string;
+    let originalAgentDir: string | undefined;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-sesspkg-"));
+        cwd = join(tmpDir, "project");
+        agentDir = join(tmpDir, "agent");
+        mkdirSync(cwd, { recursive: true });
+        mkdirSync(agentDir, { recursive: true });
+        _setGlobalConfigDir(join(tmpDir, "global-config"));
+        originalCwd = process.cwd();
+        originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+        _setGlobalConfigDir(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeFixturePackage(dir: string, overlay: unknown, files?: Record<string, string>) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture", pi: { pizzapi: overlay } }));
+        for (const [rel, content] of Object.entries(files ?? {})) {
+            const filePath = join(dir, rel);
+            mkdirSync(join(filePath, ".."), { recursive: true });
+            writeFileSync(filePath, content);
+        }
+    }
+
+    async function install(relOrAbs: string, opts?: { project?: boolean; allowInvalidOverlay?: boolean }) {
+        const args = opts?.project ? ["install", relOrAbs, "-l"] : ["install", relOrAbs];
+        const code = await runPackageCommand(args, cwd, agentDir);
+        // An invalid overlay makes the CLI wrapper exit non-zero (see
+        // cli-support.ts handlePostInstallOverlay) even though the upstream
+        // pi-native install itself succeeded and the package is configured.
+        expect(code).toBe(opts?.allowInvalidOverlay ? 1 : 0);
+    }
+
+    test("valid overlay contributes to packages[]; invalid overlay is skipped with a warning", async () => {
+        const validDir = join(tmpDir, "valid-pkg");
+        writeFixturePackage(validDir, { schemaVersion: 1, rules: ["./rules"] }, { "rules/a.md": "Rule A" });
+        await install("../valid-pkg");
+
+        const invalidDir = join(tmpDir, "invalid-pkg");
+        writeFixturePackage(invalidDir, { schemaVersion: 1, bogus: true });
+        await install("../invalid-pkg", { allowInvalidOverlay: true });
+
+        const { packages, warnings } = resolveSessionOverlays(cwd, agentDir);
+        expect(packages).toHaveLength(1);
+        expect(packages[0]!.source).toContain("valid-pkg");
+        expect(warnings.some((w) => w.includes("bogus"))).toBe(true);
+    });
+
+    test("collectOverlayAgentDirs partitions user vs project scope", async () => {
+        const userPkg = join(tmpDir, "user-agents-pkg");
+        writeFixturePackage(userPkg, { schemaVersion: 1, agents: ["./agents"] }, { "agents/foo.md": "---\nname: foo\ndescription: Foo\n---\nBody" });
+        await install("../user-agents-pkg");
+
+        const projectPkg = join(tmpDir, "project-agents-pkg");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, agents: ["./agents"] }, { "agents/bar.md": "---\nname: bar\ndescription: Bar\n---\nBody" });
+        await install("../project-agents-pkg", { project: true });
+
+        const { userDirs, projectDirs } = collectOverlayAgentDirs(cwd, agentDir);
+        expect(userDirs).toHaveLength(1);
+        expect(userDirs[0]).toContain("user-agents-pkg");
+        expect(projectDirs).toHaveLength(1);
+        expect(projectDirs[0]).toContain("project-agents-pkg");
+    });
+
+    test("collectOverlayRuleBlocks orders user-scope packages before project-scope packages", async () => {
+        const projectPkg = join(tmpDir, "z-project-rules-pkg");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, rules: ["./rules"] }, { "rules/r.md": "Project rule" });
+        await install("../z-project-rules-pkg", { project: true });
+
+        const userPkg = join(tmpDir, "a-user-rules-pkg");
+        writeFixturePackage(userPkg, { schemaVersion: 1, rules: ["./rules"] }, { "rules/r.md": "User rule" });
+        await install("../a-user-rules-pkg");
+
+        const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+        expect(blocks).toHaveLength(2);
+        expect(blocks[0]!.scope).toBe("user");
+        expect(blocks[0]!.text).toContain("User rule");
+        expect(blocks[1]!.scope).toBe("project");
+        expect(blocks[1]!.text).toContain("Project rule");
+    });
+
+    test("recursive rules directory traversal picks up nested .md files", async () => {
+        const pkgDir = join(tmpDir, "nested-rules-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, {
+            "rules/top.md": "Top rule",
+            "rules/nested/deep.md": "Deep rule",
+        });
+        await install("../nested-rules-pkg");
+
+        const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]!.text).toContain("Top rule");
+        expect(blocks[0]!.text).toContain("Deep rule");
+    });
+});

--- a/packages/cli/src/overlay/session-packages.test.ts
+++ b/packages/cli/src/overlay/session-packages.test.ts
@@ -60,7 +60,7 @@ describe("session-packages overlay mounting", () => {
         writeFixturePackage(invalidDir, { schemaVersion: 1, bogus: true });
         await install("../invalid-pkg", { allowInvalidOverlay: true });
 
-        const { packages, warnings } = resolveSessionOverlays(cwd, agentDir);
+        const { packages, warnings } = resolveSessionOverlays(cwd, agentDir, true);
         expect(packages).toHaveLength(1);
         expect(packages[0]!.source).toContain("valid-pkg");
         expect(warnings.some((w) => w.includes("bogus"))).toBe(true);
@@ -75,11 +75,50 @@ describe("session-packages overlay mounting", () => {
         writeFixturePackage(projectPkg, { schemaVersion: 1, agents: ["./agents"] }, { "agents/bar.md": "---\nname: bar\ndescription: Bar\n---\nBody" });
         await install("../project-agents-pkg", { project: true });
 
-        const { userDirs, projectDirs } = collectOverlayAgentDirs(cwd, agentDir);
+        const { userDirs, projectDirs } = collectOverlayAgentDirs(cwd, agentDir, true);
         expect(userDirs).toHaveLength(1);
         expect(userDirs[0]).toContain("user-agents-pkg");
         expect(projectDirs).toHaveLength(1);
         expect(projectDirs[0]).toContain("project-agents-pkg");
+    });
+
+    test("collectOverlayAgentDirs returns a single .md agents entry as a file, not folded into its directory", async () => {
+        const pkg = join(tmpDir, "single-file-agents-pkg");
+        writeFixturePackage(pkg, { schemaVersion: 1, agents: ["./agents/a.md"] }, {
+            "agents/a.md": "---\nname: a\ndescription: A\n---\nBody A",
+            "agents/b.md": "---\nname: b\ndescription: B\n---\nBody B",
+        });
+        await install("../single-file-agents-pkg");
+
+        const { userDirs, userFiles } = collectOverlayAgentDirs(cwd, agentDir, true);
+        expect(userDirs).toHaveLength(0);
+        expect(userFiles).toHaveLength(1);
+        expect(userFiles[0]).toContain("a.md");
+        expect(userFiles.some((f) => f.endsWith("b.md"))).toBe(false);
+    });
+
+    test("project-scope overlays are excluded from resolution when the project is not explicitly trusted", async () => {
+        const userPkg = join(tmpDir, "user-untrust-pkg");
+        writeFixturePackage(userPkg, { schemaVersion: 1, agents: ["./agents"] }, { "agents/foo.md": "---\nname: foo\ndescription: Foo\n---\nBody" });
+        await install("../user-untrust-pkg");
+
+        const projectPkg = join(tmpDir, "project-untrust-pkg");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, agents: ["./agents"] }, { "agents/bar.md": "---\nname: bar\ndescription: Bar\n---\nBody" });
+        await install("../project-untrust-pkg", { project: true });
+
+        // projectTrusted: false — project-scope configured packages (and thus
+        // their overlays) must not resolve at all, matching pi's own
+        // SettingsManager behavior (getProjectSettings() returns {} when
+        // untrusted).
+        const trusted = resolveSessionOverlays(cwd, agentDir, true);
+        expect(trusted.packages.some((p) => p.scope === "project")).toBe(true);
+
+        const untrusted = resolveSessionOverlays(cwd, agentDir, false);
+        expect(untrusted.packages.some((p) => p.scope === "project")).toBe(false);
+        expect(untrusted.packages.some((p) => p.scope === "user")).toBe(true);
+
+        const { projectDirs } = collectOverlayAgentDirs(cwd, agentDir, false);
+        expect(projectDirs).toHaveLength(0);
     });
 
     test("collectOverlayRuleBlocks orders user-scope packages before project-scope packages", async () => {
@@ -91,7 +130,7 @@ describe("session-packages overlay mounting", () => {
         writeFixturePackage(userPkg, { schemaVersion: 1, rules: ["./rules"] }, { "rules/r.md": "User rule" });
         await install("../a-user-rules-pkg");
 
-        const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+        const blocks = collectOverlayRuleBlocks(cwd, agentDir, true);
         expect(blocks).toHaveLength(2);
         expect(blocks[0]!.scope).toBe("user");
         expect(blocks[0]!.text).toContain("User rule");
@@ -107,9 +146,34 @@ describe("session-packages overlay mounting", () => {
         });
         await install("../nested-rules-pkg");
 
-        const blocks = collectOverlayRuleBlocks(cwd, agentDir);
+        const blocks = collectOverlayRuleBlocks(cwd, agentDir, true);
         expect(blocks).toHaveLength(1);
         expect(blocks[0]!.text).toContain("Top rule");
         expect(blocks[0]!.text).toContain("Deep rule");
+    });
+
+    test("recursive rules directory traversal visits entries in deterministic sorted order", async () => {
+        const pkgDir = join(tmpDir, "sorted-rules-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, rules: ["./rules"] }, {
+            "rules/zeta.md": "Zeta",
+            "rules/alpha.md": "Alpha",
+            "rules/mid/b.md": "Mid B",
+            "rules/mid/a.md": "Mid A",
+        });
+        await install("../sorted-rules-pkg");
+
+        const blocks = collectOverlayRuleBlocks(cwd, agentDir, true);
+        expect(blocks).toHaveLength(1);
+        const text = blocks[0]!.text;
+        // Sorted traversal: top-level entries alphabetically (alpha.md, mid/, zeta.md),
+        // and within mid/, a.md before b.md.
+        const alphaIdx = text.indexOf("Alpha");
+        const midAIdx = text.indexOf("Mid A");
+        const midBIdx = text.indexOf("Mid B");
+        const zetaIdx = text.indexOf("Zeta");
+        expect(alphaIdx).toBeGreaterThanOrEqual(0);
+        expect(alphaIdx).toBeLessThan(midAIdx);
+        expect(midAIdx).toBeLessThan(midBIdx);
+        expect(midBIdx).toBeLessThan(zetaIdx);
     });
 });

--- a/packages/cli/src/overlay/session-packages.ts
+++ b/packages/cli/src/overlay/session-packages.ts
@@ -48,11 +48,11 @@ export interface SessionOverlayResolution {
  * provenance-rich warning and never block that package's pi-native
  * resources (which pi mounts independently of this module).
  */
-export function resolveSessionOverlays(cwd: string, agentDir: string): SessionOverlayResolution {
+export function resolveSessionOverlays(cwd: string, agentDir: string, projectTrusted: boolean): SessionOverlayResolution {
     const warnings: string[] = [];
     let deduped: ReturnType<typeof listDedupedConfiguredPackages>;
     try {
-        deduped = listDedupedConfiguredPackages(cwd, agentDir);
+        deduped = listDedupedConfiguredPackages(cwd, agentDir, projectTrusted);
     } catch (err) {
         warnings.push(`overlay: failed to resolve configured packages: ${err instanceof Error ? err.message : String(err)}`);
         return { packages: [], warnings };
@@ -109,36 +109,50 @@ export function splitPathEntries(entries: string[] | undefined, packageRoot: str
 }
 
 /**
- * Collect overlay agent directories, partitioned by scope, for
- * `subagent-agents.ts`'s `extraUserDirs`/`extraProjectDirs`.
- *
- * ponytail: a single `.md` file entry is folded in via its containing
- * directory (loadAgentsFromDir scans a directory, not one file) rather than
- * adding a parallel single-file loading path to subagent-agents.ts. This
- * means sibling `.md` files in that same directory are also picked up.
- * Upgrade to per-file loading if a package needs to declare one agent file
- * alongside unrelated markdown in the same directory.
+ * Collect overlay agent directories AND single-file entries, partitioned by
+ * scope, for `subagent-agents.ts`'s `extraUserDirs`/`extraProjectDirs`/
+ * `extraUserFiles`/`extraProjectFiles`. A declared `agents` entry that
+ * points at a single `.md` file is returned as a file (loaded exactly, via
+ * `loadAgentsFromFile`) — NOT folded into its containing directory — so a
+ * package that declares `agents: ["agents/a.md"]` never picks up an
+ * unrelated sibling `agents/b.md` it didn't declare.
  */
-export function collectOverlayAgentDirs(cwd: string, agentDir: string): { userDirs: string[]; projectDirs: string[] } {
-    const { packages } = resolveSessionOverlays(cwd, agentDir);
+export function collectOverlayAgentDirs(
+    cwd: string,
+    agentDir: string,
+    projectTrusted: boolean,
+): { userDirs: string[]; projectDirs: string[]; userFiles: string[]; projectFiles: string[] } {
+    const { packages } = resolveSessionOverlays(cwd, agentDir, projectTrusted);
     const userDirs: string[] = [];
     const projectDirs: string[] = [];
+    const userFiles: string[] = [];
+    const projectFiles: string[] = [];
     for (const pkg of packages) {
         if (!pkg.overlay.agents?.length) continue;
         const { dirs, files } = splitPathEntries(pkg.overlay.agents, pkg.installedPath, pkg.identity, "agents");
-        const allDirs = [...dirs, ...new Set(files.map((f) => dirname(f)))];
-        if (pkg.scope === "user") userDirs.push(...allDirs);
-        else projectDirs.push(...allDirs);
+        if (pkg.scope === "user") {
+            userDirs.push(...dirs);
+            userFiles.push(...files);
+        } else {
+            projectDirs.push(...dirs);
+            projectFiles.push(...files);
+        }
     }
-    return { userDirs, projectDirs };
+    return { userDirs, projectDirs, userFiles, projectFiles };
 }
 
-/** Recursively collect `.md` files under `dir` (symlink-safe, entry-capped — mirrors plugins/parse.ts conventions). */
+/**
+ * Recursively collect `.md` files under `dir` (symlink-safe, entry-capped —
+ * mirrors plugins/parse.ts conventions). Entries are sorted before
+ * recursing so traversal order — and therefore the order files land in the
+ * rendered rules block — is deterministic across platforms/filesystems
+ * instead of following whatever order `readdirSync()` happens to return.
+ */
 function collectMarkdownFilesRecursive(dir: string, out: string[], depth = 0): void {
     if (depth > 10 || out.length >= MAX_ENTRIES_PER_DIR) return;
     let entries: string[];
     try {
-        entries = readdirSync(dir);
+        entries = readdirSync(dir).sort();
     } catch {
         return;
     }
@@ -174,8 +188,8 @@ export interface OverlayRuleBlock {
  * its scope (§4.3: "User-package rules are injected before project-package
  * rules; settings order is preserved within each scope.").
  */
-export function collectOverlayRuleBlocks(cwd: string, agentDir: string): OverlayRuleBlock[] {
-    const { packages } = resolveSessionOverlays(cwd, agentDir);
+export function collectOverlayRuleBlocks(cwd: string, agentDir: string, projectTrusted: boolean): OverlayRuleBlock[] {
+    const { packages } = resolveSessionOverlays(cwd, agentDir, projectTrusted);
     const build = (pkg: ResolvedOverlayPackage): OverlayRuleBlock | null => {
         if (!pkg.overlay.rules?.length) return null;
         const { dirs, files } = splitPathEntries(pkg.overlay.rules, pkg.installedPath, pkg.identity, "rules");

--- a/packages/cli/src/overlay/session-packages.ts
+++ b/packages/cli/src/overlay/session-packages.ts
@@ -1,0 +1,208 @@
+/**
+ * Session-side `pi.pizzapi` overlay mounting — resolves configured pi
+ * packages (both user and project scope; see docs/specs/pi-pizzapi-overlay.md
+ * §9.1) and exposes their validated `agents`/`rules`/`mcp` declarations to
+ * the extensions that mount them (subagent-agents.ts, the rules
+ * before_agent_start extension, and the MCP registry).
+ *
+ * Unlike `runner/package-service-loader.ts` (daemon services, user-scope
+ * only), session-side capabilities are session-process code that already
+ * runs with the session's execution rights, so BOTH user- and project-scope
+ * packages contribute here once pi's own project-trust gate has let the
+ * package's native resources load (§4.3: "A package extension already has
+ * arbitrary session-process execution rights.").
+ *
+ * A malformed overlay is skipped as a unit with a provenance-rich warning —
+ * it never throws, so a broken package overlay can never take down session
+ * startup or block that package's pi-native resources (§5.2, §10.1).
+ */
+import { lstatSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { PizzaPiOverlayV1 } from "@pizzapi/extension-sdk";
+import { createLogger } from "@pizzapi/tools";
+import { listDedupedConfiguredPackages } from "./resolve.js";
+import { formatOverlayIssue, readOverlayManifest, resolveConfinedPath } from "./manifest.js";
+import { readFileCapped, MAX_ENTRIES_PER_DIR } from "../plugins/types.js";
+
+const log = createLogger("overlay/session");
+
+export interface ResolvedOverlayPackage {
+    identity: string;
+    source: string;
+    scope: "user" | "project";
+    /** Installed package root — overlay paths are package-relative to this. */
+    installedPath: string;
+    overlay: PizzaPiOverlayV1;
+}
+
+export interface SessionOverlayResolution {
+    /** Valid overlays only, in stable settings order (project-over-user deduped). */
+    packages: ResolvedOverlayPackage[];
+    warnings: string[];
+}
+
+/**
+ * Resolve every configured (user + project scope) pi package's validated
+ * `pi.pizzapi` overlay. Packages without an overlay, or with an invalid one,
+ * are omitted from `packages` — invalid overlays instead produce a
+ * provenance-rich warning and never block that package's pi-native
+ * resources (which pi mounts independently of this module).
+ */
+export function resolveSessionOverlays(cwd: string, agentDir: string): SessionOverlayResolution {
+    const warnings: string[] = [];
+    let deduped: ReturnType<typeof listDedupedConfiguredPackages>;
+    try {
+        deduped = listDedupedConfiguredPackages(cwd, agentDir);
+    } catch (err) {
+        warnings.push(`overlay: failed to resolve configured packages: ${err instanceof Error ? err.message : String(err)}`);
+        return { packages: [], warnings };
+    }
+
+    const packages: ResolvedOverlayPackage[] = [];
+    for (const { identity, pkg } of deduped) {
+        if (!pkg.installedPath) continue; // configured but not installed — non-interactive skip, no prompt
+        const provenance = { identity, source: pkg.source, scope: pkg.scope };
+        let result: ReturnType<typeof readOverlayManifest>;
+        try {
+            result = readOverlayManifest(pkg.installedPath, provenance);
+        } catch (err) {
+            warnings.push(`[${identity}] failed to read overlay: ${err instanceof Error ? err.message : String(err)}`);
+            continue;
+        }
+        if (result.present && !result.overlay) {
+            for (const issue of result.issues) warnings.push(formatOverlayIssue(issue));
+            continue;
+        }
+        if (!result.overlay) continue;
+        packages.push({ identity, source: pkg.source, scope: pkg.scope, installedPath: pkg.installedPath, overlay: result.overlay });
+    }
+
+    for (const w of warnings) log.warn(w);
+    return { packages, warnings };
+}
+
+/**
+ * Resolve an overlay's package-relative `agents`/`rules` entries to
+ * confined absolute paths, split into directories and single `.md` files.
+ * Entries that fail re-validation (moved/removed since manifest read) are
+ * dropped with a warning rather than throwing.
+ */
+export function splitPathEntries(entries: string[] | undefined, packageRoot: string, identity: string, field: string): { dirs: string[]; files: string[] } {
+    const dirs: string[] = [];
+    const files: string[] = [];
+    for (const entry of entries ?? []) {
+        const resolved = resolveConfinedPath(packageRoot, entry);
+        if (!resolved.ok) {
+            log.warn(`[${identity}] ${field} entry "${entry}" failed re-validation: ${resolved.message}`);
+            continue;
+        }
+        let isDir = false;
+        try {
+            isDir = statSync(resolved.absolutePath).isDirectory();
+        } catch {
+            continue;
+        }
+        if (isDir) dirs.push(resolved.absolutePath);
+        else files.push(resolved.absolutePath);
+    }
+    return { dirs, files };
+}
+
+/**
+ * Collect overlay agent directories, partitioned by scope, for
+ * `subagent-agents.ts`'s `extraUserDirs`/`extraProjectDirs`.
+ *
+ * ponytail: a single `.md` file entry is folded in via its containing
+ * directory (loadAgentsFromDir scans a directory, not one file) rather than
+ * adding a parallel single-file loading path to subagent-agents.ts. This
+ * means sibling `.md` files in that same directory are also picked up.
+ * Upgrade to per-file loading if a package needs to declare one agent file
+ * alongside unrelated markdown in the same directory.
+ */
+export function collectOverlayAgentDirs(cwd: string, agentDir: string): { userDirs: string[]; projectDirs: string[] } {
+    const { packages } = resolveSessionOverlays(cwd, agentDir);
+    const userDirs: string[] = [];
+    const projectDirs: string[] = [];
+    for (const pkg of packages) {
+        if (!pkg.overlay.agents?.length) continue;
+        const { dirs, files } = splitPathEntries(pkg.overlay.agents, pkg.installedPath, pkg.identity, "agents");
+        const allDirs = [...dirs, ...new Set(files.map((f) => dirname(f)))];
+        if (pkg.scope === "user") userDirs.push(...allDirs);
+        else projectDirs.push(...allDirs);
+    }
+    return { userDirs, projectDirs };
+}
+
+/** Recursively collect `.md` files under `dir` (symlink-safe, entry-capped — mirrors plugins/parse.ts conventions). */
+function collectMarkdownFilesRecursive(dir: string, out: string[], depth = 0): void {
+    if (depth > 10 || out.length >= MAX_ENTRIES_PER_DIR) return;
+    let entries: string[];
+    try {
+        entries = readdirSync(dir);
+    } catch {
+        return;
+    }
+    for (const entry of entries) {
+        if (out.length >= MAX_ENTRIES_PER_DIR) return;
+        const entryPath = join(dir, entry);
+        let st;
+        try {
+            st = lstatSync(entryPath);
+        } catch {
+            continue;
+        }
+        if (st.isSymbolicLink()) continue; // never follow symlinks out of the package root
+        if (st.isDirectory()) {
+            collectMarkdownFilesRecursive(entryPath, out, depth + 1);
+        } else if (st.isFile() && entry.toLowerCase().endsWith(".md")) {
+            out.push(entryPath);
+        }
+    }
+}
+
+export interface OverlayRuleBlock {
+    identity: string;
+    scope: "user" | "project";
+    /** Markdown section text, ready to append to the system prompt. */
+    text: string;
+}
+
+/**
+ * Build one Markdown section per package that declares `pi.pizzapi.rules`,
+ * in mount order: all user-scope package rules first, then all
+ * project-scope package rules, each preserving stable settings order within
+ * its scope (§4.3: "User-package rules are injected before project-package
+ * rules; settings order is preserved within each scope.").
+ */
+export function collectOverlayRuleBlocks(cwd: string, agentDir: string): OverlayRuleBlock[] {
+    const { packages } = resolveSessionOverlays(cwd, agentDir);
+    const build = (pkg: ResolvedOverlayPackage): OverlayRuleBlock | null => {
+        if (!pkg.overlay.rules?.length) return null;
+        const { dirs, files } = splitPathEntries(pkg.overlay.rules, pkg.installedPath, pkg.identity, "rules");
+        const mdFiles: string[] = [...files];
+        for (const dir of dirs) collectMarkdownFilesRecursive(dir, mdFiles);
+        const parts: string[] = [];
+        for (const file of mdFiles) {
+            const content = readFileCapped(file);
+            if (content === null) continue;
+            parts.push(content.trim());
+        }
+        if (parts.length === 0) return null;
+        return {
+            identity: pkg.identity,
+            scope: pkg.scope,
+            text: `## [${pkg.identity}]\n\n${parts.join("\n\n")}`,
+        };
+    };
+
+    const blocks: OverlayRuleBlock[] = [];
+    for (const pkg of packages.filter((p) => p.scope === "user")) {
+        const block = build(pkg);
+        if (block) blocks.push(block);
+    }
+    for (const pkg of packages.filter((p) => p.scope === "project")) {
+        const block = build(pkg);
+        if (block) blocks.push(block);
+    }
+    return blocks;
+}

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,3 +1,23 @@
+/**
+ * Legacy ExtensionProvider contract — Stage 0 coexistence compatibility
+ * shim (docs/specs/pi-pizzapi-overlay.md §9.1, §12.2). `context` and
+ * `lifecycle` already map 1:1 onto plain pi extension events
+ * (`before_agent_start`, `session_start`/`turn_end`/`session_shutdown` —
+ * see extensions/providers/extension.ts, the thin adapter that already
+ * bridges those events into `ProviderBridge`). `ui-panel` maps onto
+ * `pi.pizzapi.services[].panel` and `metadata` onto ordinary extension
+ * events or a declared service, once a provider migrates to a package.
+ *
+ * There has never been a "custom model provider" capability here — that
+ * always went through `pi.registerProvider()` directly, unaffected by this
+ * migration.
+ *
+ * Full retirement (removing `~/.pizzapi/providers` discovery and this
+ * bridge) waits for Stage 2 (§12.4): one release of deprecation warnings
+ * after installed providers have had a chance to migrate to overlay
+ * packages. This module is the compatibility shim to keep during that
+ * window, not dead code to delete early.
+ */
 export const PROVIDER_CAPABILITIES = [
   "context",
   "lifecycle",

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
-import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
+import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "../extensions/claude-plugins.js";
 import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
@@ -366,6 +366,7 @@ async function main(): Promise<void> {
         agentDir,
         extensionFactories: buildPizzaPiExtensionFactories({
             cwd,
+            agentDir,
             hooks: process.env.PIZZAPI_NO_HOOKS === "1" ? undefined : config.hooks,
             includeInitialPrompt: true,
             skipMcp: process.env.PIZZAPI_NO_MCP === "1",
@@ -377,7 +378,10 @@ async function main(): Promise<void> {
             ...buildSkillPaths(cwd, config.skills),
             ...(skipPlugins ? [] : getPluginSkillPaths(cwd)),
         ],
-        additionalPromptTemplatePaths: buildPromptTemplatePaths(cwd),
+        additionalPromptTemplatePaths: [
+            ...buildPromptTemplatePaths(cwd),
+            ...(skipPlugins ? [] : getPluginPromptTemplatePaths(cwd)),
+        ],
         ...(config.systemPrompt !== undefined
             ? { systemPromptOverride: () => config.systemPrompt }
             : {}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -2,7 +2,7 @@ import { createAgentSession, DefaultResourceLoader, ModelRuntime, readStoredCred
 import { SHELL_PROC_CAPTURE_PREFIX } from "./session-procs.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
+import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv, resolveExplicitProjectTrust } from "../config.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
 import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "../extensions/claude-plugins.js";
 import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
@@ -360,10 +360,21 @@ async function main(): Promise<void> {
         sendAgentsMd: config.sendAgentsMd !== false,
     });
 
+    // Explicit, persisted pi project-trust decision for this worker's cwd —
+    // the single authority gating native pi project resources AND the
+    // session-side pi.pizzapi overlay (see index.ts / config/io.ts
+    // resolveExplicitProjectTrust). Built once and reused for both the
+    // resource loader and session creation below so trust can't drift
+    // between the two (previously the loader used an implicitly-trusted
+    // default SettingsManager while session creation built a separate one).
+    const projectTrusted = resolveExplicitProjectTrust(cwd, agentDir);
+    const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+
     bootTimer.start("[boot] resource-loader");
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
+        settingsManager,
         extensionFactories: buildPizzaPiExtensionFactories({
             cwd,
             agentDir,
@@ -373,6 +384,7 @@ async function main(): Promise<void> {
             skipPlugins,
             skipRelay: process.env.PIZZAPI_NO_RELAY === "1",
             configSkills: config.skills,
+            projectTrusted,
         }),
         additionalSkillPaths: [
             ...buildSkillPaths(cwd, config.skills),
@@ -444,7 +456,8 @@ async function main(): Promise<void> {
     // applyOverrides, which settingsManager.reload() would wipe) survives
     // reloads and is baked into the bash tool at build time. Unix-only: the
     // prefix uses POSIX shell + $$ and group tracking needs pgrep/ps.
-    const settingsManager = SettingsManager.create(cwd, agentDir);
+    // Reuses the SAME settingsManager the resource loader was built with
+    // (see above) so project trust can't diverge between the two.
     if (process.platform !== "win32") {
         const origGetPrefix = settingsManager.getShellCommandPrefix.bind(settingsManager);
         settingsManager.getShellCommandPrefix = () =>


### PR DESCRIPTION
## Summary
- mount validated `pi.pizzapi` agents, rules, and MCP resources from configured pi packages
- preserve user/project scope, exact single-file declarations, native project-agent confirmation, and deterministic package ordering
- route compatible Claude-plugin commands through pi prompt templates while retaining the legacy adapter for PizzaPi-only syntax
- add PizzaPi host probe/ready support for package extensions
- keep the legacy ExtensionProvider path as the documented Stage 0 compatibility shim

## Security and trust
- persisted pi `ProjectTrustStore` decisions now fail closed across both native project package resources and PizzaPi overlays in TUI and workers
- undecided or distrusted repositories cannot load project package extensions, MCP processes, rules, or agents
- corrupt settings are surfaced without suppressing the valid scope
- MCP sidecars are revalidated at mount time and package servers appear in `/mcp` status and completion

## Migration behavior
- package resources mount before legacy plugin resources where specified
- legacy plugin `.mcp.json` now feeds the existing MCP registry
- newly trusted plugin prompt templates become available in the same session
- no second MCP runtime, package manager, provider system, or pi patch growth

## Verification
- 107 targeted trust/overlay/runtime regressions pass
- full monorepo typecheck passes
- full CLI-suite deviations reproduced identically on the clean base
- Opus security review findings fixed
- final Fable review: LGTM, no P0–P2 findings

## Stack
- base: #655 (`feat/pi-package-service-discovery`)
- implements Godmother idea `0wtzqMu7`
