### PR TITLE
fix(ui): render extracted tool result images

### DIFF
--- a/packages/ui/src/components/session-viewer/tool-rendering.test.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { renderReadToolResult } from "./tool-rendering";
+
+function findImage(node: React.ReactNode): React.ReactElement<React.ImgHTMLAttributes<HTMLImageElement>> | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const image = findImage(child);
+      if (image) return image;
+    }
+    return null;
+  }
+  if (!React.isValidElement(node)) return null;
+  if (node.type === "img") {
+    return node as React.ReactElement<React.ImgHTMLAttributes<HTMLImageElement>>;
+  }
+  return findImage((node.props as { children?: React.ReactNode }).children);
+}
+
+describe("renderReadToolResult", () => {
+  test("renders an image extracted to an attachment URL", () => {
+    const image = findImage(renderReadToolResult([
+      {
+        type: "image",
+        mimeType: "image/png",
+        source: {
+          type: "url",
+          url: "/api/attachments/image-id",
+          extracted: true,
+          originalSizeBytes: 12_345,
+        },
+      },
+    ]));
+
+    expect(image?.props.src).toBe("/api/attachments/image-id");
+    expect(image?.props.loading).toBe("lazy");
+  });
+
+  test("does not render unsafe extracted image URLs", () => {
+    const image = findImage(renderReadToolResult([
+      {
+        type: "image",
+        mimeType: "image/png",
+        source: { type: "url", url: "javascript:alert(1)" },
+      },
+    ]));
+
+    expect(image).toBeNull();
+  });
+});

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -51,6 +51,7 @@ import { CopyableCodeBlock } from "@/components/session-viewer/cards/InterAgentC
 import { WriteFileCard } from "@/components/session-viewer/cards/WriteFileCard";
 import { TodoCard } from "@/components/session-viewer/cards/TodoCard";
 import type { TodoItem } from "@/lib/types";
+import { resolveMobileMediaUrl } from "@/lib/mobile-runtime";
 import { SessionNameCard } from "@/components/session-viewer/cards/SessionNameCard";
 import {
   truncateSessionId,
@@ -112,6 +113,16 @@ export function metadataBadge(label: string, value: string) {
   );
 }
 
+function isSafeImageUrl(url: string): boolean {
+  if (url.startsWith("/") && !url.startsWith("//")) return true;
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function renderReadToolResult(
   content: unknown,
   isError?: boolean,
@@ -142,15 +153,24 @@ export function renderReadToolResult(
       : [];
 
   const imageBlocks = blocks.filter((block) => {
+    const source = block.source && typeof block.source === "object"
+      ? block.source as Record<string, unknown>
+      : {};
     const mimeType =
       typeof block.mimeType === "string"
         ? block.mimeType
         : typeof block.mime === "string"
           ? block.mime
-          : "";
+          : typeof source.media_type === "string"
+            ? source.media_type
+            : typeof source.mediaType === "string"
+              ? source.mediaType
+              : "";
+    const data = typeof block.data === "string" ? block.data : source.data;
+    const url = source.url;
     return (
       (block.type === "image" || mimeType.startsWith("image/")) &&
-      typeof block.data === "string"
+      (typeof data === "string" || (typeof url === "string" && isSafeImageUrl(url)))
     );
   });
 
@@ -186,14 +206,26 @@ export function renderReadToolResult(
   ) : null;
 
   const imageNodes = imageBlocks.map((block, idx) => {
+    const source = block.source && typeof block.source === "object"
+      ? block.source as Record<string, unknown>
+      : {};
     const path = typeof block.path === "string" ? block.path : defaultPath;
     const imgMime =
       typeof block.mimeType === "string"
         ? block.mimeType
         : typeof block.mime === "string"
           ? block.mime
-          : "image/png";
-    const data = block.data as string;
+          : typeof source.media_type === "string"
+            ? source.media_type
+            : typeof source.mediaType === "string"
+              ? source.mediaType
+              : "image/png";
+    const data = typeof block.data === "string"
+      ? block.data
+      : typeof source.data === "string"
+        ? source.data
+        : null;
+    const url = typeof source.url === "string" ? source.url : null;
     const width =
       typeof block.width === "number"
         ? block.width
@@ -216,7 +248,9 @@ export function renderReadToolResult(
             ? block.size
             : null;
 
-    const sizeBytes = explicitSize ?? estimateBase64Bytes(data);
+    const sizeBytes = explicitSize ??
+      (typeof source.originalSizeBytes === "number" ? source.originalSizeBytes : null) ??
+      estimateBase64Bytes(data ?? "");
 
     const mtimeRaw =
       block.mtime ??
@@ -245,9 +279,10 @@ export function renderReadToolResult(
             {mtime ? metadataBadge("mtime", mtime) : null}
           </div>
           <img
-            src={`data:${imgMime};base64,${data}`}
+            src={data ? `data:${imgMime};base64,${data}` : resolveMobileMediaUrl(url!)}
             alt={title}
             className="max-w-full rounded border border-border/70 bg-background object-contain"
+            loading="lazy"
           />
         </div>
       </FileTypeCard>


### PR DESCRIPTION
## Summary
- render URL-backed images after the server extracts inline base64 tool results
- preserve inline and source-backed image handling across web and bundled mobile
- reject unsafe image URL schemes and lazy-load rendered images

## Verification
- `cd packages/ui && bun test src` — 1,231 passed, 1 skipped
- `bunx tsc --noEmit -p packages/ui/tsconfig.json`
- `bun run --cwd packages/ui build`

## Scope
The file explorer already uses its own image viewer and is unchanged. Git views are also unchanged.
