### PR TITLE
test(ui): verify package-origin runner services end to end

### DIFF
--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -17,6 +17,8 @@ import type {
     RunnerPlugin,
     RunnerHook,
     ServicePanelInfo,
+    ServiceTriggerDef,
+    ServiceSigilDef,
 } from "@pizzapi/protocol";
 
 import type { TestServer } from "./types.js";
@@ -102,6 +104,10 @@ export interface MockRunnerOptions {
     serviceIds?: string[];
     /** Service panels to announce (dynamic iframe panels). */
     panels?: ServicePanelInfo[];
+    /** Trigger types declared by announced services (e.g. package-origin manifests). */
+    triggerDefs?: ServiceTriggerDef[];
+    /** Sigil types declared by announced services (e.g. package-origin manifests). */
+    sigilDefs?: ServiceSigilDef[];
 }
 
 export interface MockRunner {
@@ -131,7 +137,14 @@ export interface MockRunner {
     onFileRequest(handler: (data: unknown) => unknown): void;
 
     // Services
-    announceServices(serviceIds: string[], panels?: ServicePanelInfo[]): void;
+    announceServices(
+        serviceIds: string[],
+        panels?: ServicePanelInfo[],
+        triggerDefs?: ServiceTriggerDef[],
+        sigilDefs?: ServiceSigilDef[],
+    ): void;
+    /** Disabled service IDs currently applied (mutated by reconfigure_services, mirrors real daemon). */
+    readonly disabledServiceIds: ReadonlySet<string>;
 
     // Utilities
     waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
@@ -279,6 +292,14 @@ export async function createMockRunner(
     let restartRequested = false;
     let shutdownRequested = false;
     let isShuttingDown = false;
+    // Mutable service_announce state — mirrors the real daemon's panelEntries/
+    // disabledServices so announceServices() and reconfigure_services can both
+    // re-emit a consistent full announce.
+    let currentServiceIds: string[] = opts?.serviceIds ?? [];
+    let currentPanels: ServicePanelInfo[] = opts?.panels ?? [];
+    let currentTriggerDefs: ServiceTriggerDef[] = opts?.triggerDefs ?? [];
+    let currentSigilDefs: ServiceSigilDef[] = opts?.sigilDefs ?? [];
+    const disabledServiceIdsSet = new Set<string>();
 
     // Populate initial skills
     const initialSkills = opts?.skills ?? defaultSkills();
@@ -381,10 +402,12 @@ export async function createMockRunner(
                     }
                 }
                 // Announce services after registration (like real daemon)
-                if (opts?.serviceIds && opts.serviceIds.length > 0) {
+                if (currentServiceIds.length > 0) {
                     (socket as any).emit("service_announce", {
-                        serviceIds: opts.serviceIds,
-                        ...(opts.panels && opts.panels.length > 0 ? { panels: opts.panels } : {}),
+                        serviceIds: currentServiceIds,
+                        ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
+                        ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
+                        ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
                     });
                 }
                 resolve();
@@ -753,6 +776,25 @@ export async function createMockRunner(
                 content: agent.content ?? `# ${agentName}\n\nAgent definition placeholder.`,
             });
         }
+    });
+
+    // --- Services (reconfigure_services → re-announce, mirrors daemon.ts) ---
+
+    socket.on("reconfigure_services", (data: any) => {
+        if (isShuttingDown) return;
+        const incoming = Array.isArray(data?.disabledServiceIds) ? data.disabledServiceIds as string[] : [];
+        disabledServiceIdsSet.clear();
+        for (const id of incoming) disabledServiceIdsSet.add(id);
+        // Real daemon re-emits a full service_announce after applying the
+        // reconfigure command so the server (and Redis persistence) picks up
+        // the new disabledServiceIds — mirror that here.
+        (socket as any).emit("service_announce", {
+            serviceIds: currentServiceIds,
+            ...(disabledServiceIdsSet.size > 0 ? { disabledServiceIds: Array.from(disabledServiceIdsSet) } : {}),
+            ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
+            ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
+            ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
+        });
     });
 
     // --- Plugins ---
@@ -1182,10 +1224,26 @@ export async function createMockRunner(
             return shutdownRequested;
         },
 
-        announceServices(serviceIds: string[], panels?: ServicePanelInfo[]): void {
+        get disabledServiceIds(): ReadonlySet<string> {
+            return disabledServiceIdsSet;
+        },
+
+        announceServices(
+            serviceIds: string[],
+            panels?: ServicePanelInfo[],
+            triggerDefs?: ServiceTriggerDef[],
+            sigilDefs?: ServiceSigilDef[],
+        ): void {
+            currentServiceIds = serviceIds;
+            currentPanels = panels ?? [];
+            currentTriggerDefs = triggerDefs ?? [];
+            currentSigilDefs = sigilDefs ?? [];
             (socket as any).emit("service_announce", {
                 serviceIds,
-                ...(panels && panels.length > 0 ? { panels } : {}),
+                ...(disabledServiceIdsSet.size > 0 ? { disabledServiceIds: Array.from(disabledServiceIdsSet) } : {}),
+                ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
+                ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
+                ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
             });
         },
 

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -300,6 +300,21 @@ export async function createMockRunner(
     let currentTriggerDefs: ServiceTriggerDef[] = opts?.triggerDefs ?? [];
     let currentSigilDefs: ServiceSigilDef[] = opts?.sigilDefs ?? [];
     const disabledServiceIdsSet = new Set<string>();
+    // The daemon never unloads these runtime-pinned built-ins on reconfigure.
+    const nonDisableableServiceIds = new Set(["terminal", "file-explorer", "git", "time", "tunnel"]);
+
+    const emitServiceAnnounce = () => {
+        const activeServiceIds = new Set(currentServiceIds.filter(
+            (id) => !disabledServiceIdsSet.has(id) || nonDisableableServiceIds.has(id),
+        ));
+        (socket as any).emit("service_announce", {
+            serviceIds: Array.from(activeServiceIds),
+            ...(disabledServiceIdsSet.size > 0 ? { disabledServiceIds: Array.from(disabledServiceIdsSet) } : {}),
+            ...(currentPanels.length > 0 ? { panels: currentPanels.filter((panel) => activeServiceIds.has(panel.serviceId)) } : {}),
+            ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs.filter((trigger) => activeServiceIds.has(trigger.type.split(":")[0])) } : {}),
+            ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs.filter((sigil) => activeServiceIds.has(sigil.serviceId ?? sigil.type.split(":")[0])) } : {}),
+        });
+    };
 
     // Populate initial skills
     const initialSkills = opts?.skills ?? defaultSkills();
@@ -785,16 +800,8 @@ export async function createMockRunner(
         const incoming = Array.isArray(data?.disabledServiceIds) ? data.disabledServiceIds as string[] : [];
         disabledServiceIdsSet.clear();
         for (const id of incoming) disabledServiceIdsSet.add(id);
-        // Real daemon re-emits a full service_announce after applying the
-        // reconfigure command so the server (and Redis persistence) picks up
-        // the new disabledServiceIds — mirror that here.
-        (socket as any).emit("service_announce", {
-            serviceIds: currentServiceIds,
-            ...(disabledServiceIdsSet.size > 0 ? { disabledServiceIds: Array.from(disabledServiceIdsSet) } : {}),
-            ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
-            ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
-            ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
-        });
+        // Real daemon re-emits only active service metadata after reconfigure.
+        emitServiceAnnounce();
     });
 
     // --- Plugins ---
@@ -1238,13 +1245,7 @@ export async function createMockRunner(
             currentPanels = panels ?? [];
             currentTriggerDefs = triggerDefs ?? [];
             currentSigilDefs = sigilDefs ?? [];
-            (socket as any).emit("service_announce", {
-                serviceIds,
-                ...(disabledServiceIdsSet.size > 0 ? { disabledServiceIds: Array.from(disabledServiceIdsSet) } : {}),
-                ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
-                ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
-                ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
-            });
+            emitServiceAnnounce();
         },
 
         onSkillRequest(handler: (data: unknown) => unknown): void {

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -708,7 +708,7 @@ async function main() {
                 serviceId: GODMOTHER_LITE_SERVICE_ID,
                 description: "Reference to a Godmother Lite idea",
                 icon: "lightbulb",
-                resolve: "/api/resolve/gm-idea",
+                resolve: "/api/resolve/gm-idea/{id}",
                 resolvePort: godmotherLitePort,
             },
         ],

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -119,7 +119,7 @@ src/config.ts:8:    trustedOrigins: ["http://localhost:5173"],`)],
 
     // Assistant: conclusion
     events.push(buildAssistantMessage(
-        "Good news — CSRF protection is handled in the middleware layer at `src/middleware.ts:12`. The `trustedOrigins` are configured in `src/config.ts`.\n\n### Summary\n\n| Check | Status |\n|-------|--------|\n| Rate limiting | ✅ Configured |\n| Session expiry | ✅ 7 days |\n| CSRF protection | ✅ In middleware |\n| Trusted origins | ✅ Configured |\n| Password hashing | ✅ better-auth default (argon2) |\n\nThe auth module looks secure. No P0-P2 issues found. **LGTM** 🎉",
+        "Good news — CSRF protection is handled in the middleware layer at `src/middleware.ts:12`. The `trustedOrigins` are configured in `src/config.ts`.\n\n### Summary\n\n| Check | Status |\n|-------|--------|\n| Rate limiting | ✅ Configured |\n| Session expiry | ✅ 7 days |\n| CSRF protection | ✅ In middleware |\n| Trusted origins | ✅ Configured |\n| Password hashing | ✅ better-auth default (argon2) |\n\nThe auth module looks secure. No P0-P2 issues found. **LGTM** 🎉\n\nLogged as [[gm-idea:GM-42]] — package-origin sigil smoke test.",
     ));
 
     return events;
@@ -572,6 +572,69 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-seri
     return { port: server.port!, stop: () => server.stop(true) };
 }
 
+// ── Mock package-origin service (panel + trigger + sigil) ──────────────────────────
+// Mirrors what a real package (installed via `pizza install`, declaring a
+// `pi.pizzapi` overlay with services[]) would mount: an iframe panel, a
+// namespaced trigger, and a resolvable sigil type. The wire protocol
+// (service_announce) carries no origin discriminator, so this mock is
+// indistinguishable — by design — from the folder-based system-monitor mock
+// above. See packages/cli/src/runner/package-service-loader.ts.
+
+const GODMOTHER_LITE_SERVICE_ID = "godmother-lite";
+const GODMOTHER_LITE_IDEAS: Record<string, { title: string; status: string }> = {
+    "GM-42": { title: "Ship the overlay verification suite", status: "execute" },
+};
+
+function startMockGodmotherLitePackageService(): { port: number; stop: () => void } {
+    const PANEL_HTML = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Godmother Lite</title><style>
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;background:#0a0a0b;color:#e4e4e7;font-size:12px;padding:12px}
+h1{font-size:13px;margin-bottom:8px}
+ul{list-style:none;padding:0;margin:0}
+li{padding:6px 8px;border:1px solid #27272a;border-radius:6px;margin-bottom:6px;background:#131316}
+.status{color:#22c55e;font-size:10px;text-transform:uppercase;letter-spacing:.05em}
+</style></head><body>
+<h1>🧚 Godmother Lite (package-origin mock service)</h1>
+<ul id="list"></ul>
+<script>
+fetch('./api/ideas').then(r=>r.json()).then(function(ideas){
+  var ul=document.getElementById('list');
+  Object.keys(ideas).forEach(function(id){
+    var li=document.createElement('li');
+    li.innerHTML='<div>'+id+' — '+ideas[id].title+'</div><div class="status">'+ideas[id].status+'</div>';
+    ul.appendChild(li);
+  });
+});
+</script></body></html>`;
+
+    const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+            const url = new URL(req.url);
+            // Sigil resolve endpoint — mirrors a package service's HTTP resolve
+            // server (announceSigilServer), used by SigilPill to enrich [[gm-idea:ID]].
+            const resolveMatch = url.pathname.match(/\/api\/resolve\/gm-idea\/([^/]+)$/);
+            if (resolveMatch) {
+                const id = decodeURIComponent(resolveMatch[1]);
+                const idea = GODMOTHER_LITE_IDEAS[id];
+                if (!idea) return new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } });
+                return new Response(JSON.stringify({ id, ...idea }), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } });
+            }
+            if (url.pathname === "/api/ideas" || url.pathname.endsWith("/api/ideas")) {
+                return new Response(JSON.stringify(GODMOTHER_LITE_IDEAS), {
+                    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+                });
+            }
+            return new Response(PANEL_HTML, {
+                headers: { "Content-Type": "text/html; charset=utf-8" },
+            });
+        },
+    });
+
+    return { port: server.port!, stop: () => server.stop(true) };
+}
+
 async function main() {
     const opts = parseCliOptions(process.argv.slice(2));
 
@@ -612,15 +675,42 @@ async function main() {
     const monitorPort = monitorServer.port;
     console.log(`  📊 Mock system monitor panel on port ${monitorPort}`);
 
+    // Start mock package-origin service (panel + trigger + sigil) — exercises
+    // the same wire-compatible service_announce path as any other service.
+    const godmotherLiteServer = startMockGodmotherLitePackageService();
+    const godmotherLitePort = godmotherLiteServer.port;
+    console.log(`  Mock package-origin service (godmother-lite) on port ${godmotherLitePort}`);
+
     // Create a default mock runner so sessions have a runner association
     // and service_announce reaches viewers.
     const defaultRunner = await createMockRunner(server, {
         name: "sandbox-runner",
         roots: ["/Users/jordan/Documents/Projects/PizzaPi"],
         platform: "darwin",
-        serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor"],
+        serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor", GODMOTHER_LITE_SERVICE_ID],
         panels: [
             { serviceId: "system-monitor", port: monitorPort, label: "System Monitor", icon: "activity" },
+            { serviceId: GODMOTHER_LITE_SERVICE_ID, port: godmotherLitePort, label: "Godmother Lite", icon: "sparkles" },
+        ],
+        triggerDefs: [
+            {
+                type: "godmother-lite:idea_moved",
+                label: "Idea Status Changed",
+                description: "Fires when a Godmother Lite idea's status changes",
+                schema: { type: "object", properties: { id: { type: "string" }, status: { type: "string" } } },
+                params: [{ name: "project", label: "Project", type: "string", required: false }],
+            },
+        ],
+        sigilDefs: [
+            {
+                type: "gm-idea",
+                label: "Godmother Idea",
+                serviceId: GODMOTHER_LITE_SERVICE_ID,
+                description: "Reference to a Godmother Lite idea",
+                icon: "lightbulb",
+                resolve: "/api/resolve/gm-idea",
+                resolvePort: godmotherLitePort,
+            },
         ],
         skills: [
             { name: "code-review", description: "Code review", filePath: "/skills/code-review/SKILL.md" },

--- a/packages/server/tests/harness/service-announce-package-origin.test.ts
+++ b/packages/server/tests/harness/service-announce-package-origin.test.ts
@@ -14,7 +14,7 @@
  * require sequential server creation — see mock-runner.test.ts).
  */
 import { describe, test, expect } from "bun:test";
-import type { ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef, ServiceAnnounceData } from "@pizzapi/protocol";
+import type { ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef, ServiceAnnounceData, ServiceAnnounceDelta } from "@pizzapi/protocol";
 import { createTestServer } from "./server.js";
 import { TestScenario } from "./scenario.js";
 import type { TestServer } from "./types.js";
@@ -231,10 +231,10 @@ describe("package-origin service_announce integration", () => {
                     });
                 });
 
-                // Wait for the re-announce the mock runner sends in response to
-                // reconfigure_services (mirrors daemon.ts's emitServiceAnnounce()).
-                const reannouncePromise = new Promise<ServiceAnnounceData>((resolve, reject) => {
-                    const timer = setTimeout(() => reject(new Error("timed out waiting for reconfigure re-announce")), 8000);
+                // The daemon removes disabled non-built-ins and their metadata
+                // from service_announce, retaining only disabledServiceIds.
+                const disabledAnnounce = new Promise<ServiceAnnounceData>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for disabled re-announce")), 8000);
                     viewer.socket.on("service_announce", (data) => {
                         const d = data as ServiceAnnounceData;
                         if (d.disabledServiceIds?.includes(PACKAGE_SERVICE_ID)) {
@@ -254,16 +254,46 @@ describe("package-origin service_announce integration", () => {
                 );
                 expect(putRes.status).toBe(200);
 
-                const reannounce = await reannouncePromise;
-                expect(reannounce.disabledServiceIds).toContain(PACKAGE_SERVICE_ID);
-                // Disabling never drops the service's metadata — the UI still needs
-                // labels/panel info to render a "disabled" row.
-                expect(reannounce.serviceIds).toContain(PACKAGE_SERVICE_ID);
+                const disabled = await disabledAnnounce;
+                expect(disabled.disabledServiceIds).toContain(PACKAGE_SERVICE_ID);
+                expect(disabled.serviceIds).not.toContain(PACKAGE_SERVICE_ID);
+                expect(disabled.panels).not.toContainEqual(PACKAGE_PANEL);
+                expect(disabled.triggerDefs).not.toContainEqual(PACKAGE_TRIGGER);
+                expect(disabled.sigilDefs).not.toContainEqual(PACKAGE_SIGIL);
 
-                // Persisted state (what a reload would GET) reflects the disable too.
+                // Persisted state (what a reload would GET) matches the daemon too.
                 const res = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/services`);
                 const body = await res.json() as ServiceAnnounceData;
                 expect(body.disabledServiceIds).toContain(PACKAGE_SERVICE_ID);
+                expect(body.serviceIds).not.toContain(PACKAGE_SERVICE_ID);
+                expect(body.panels).not.toContainEqual(PACKAGE_PANEL);
+                expect(body.triggerDefs).not.toContainEqual(PACKAGE_TRIGGER);
+                expect(body.sigilDefs).not.toContainEqual(PACKAGE_SIGIL);
+
+                const enabledAnnounce = new Promise<ServiceAnnounceDelta>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for enabled re-announce")), 8000);
+                    viewer.socket.on("service_announce_delta", (data) => {
+                        const d = data as ServiceAnnounceDelta;
+                        if (d.added.serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve(d);
+                        }
+                    });
+                });
+                const reenableRes = await server.fetch(
+                    `/api/runners/${encodeURIComponent(runner.runnerId)}/services/${encodeURIComponent(PACKAGE_SERVICE_ID)}/enabled`,
+                    {
+                        method: "PUT",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ enabled: true }),
+                    },
+                );
+                expect(reenableRes.status).toBe(200);
+
+                const enabled = await enabledAnnounce;
+                expect(enabled.added.panels).toContainEqual(PACKAGE_PANEL);
+                expect(enabled.added.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(enabled.added.sigilDefs).toContainEqual(PACKAGE_SIGIL);
             } finally {
                 await scenario.teardown();
                 await cleanupServer(server);

--- a/packages/server/tests/harness/service-announce-package-origin.test.ts
+++ b/packages/server/tests/harness/service-announce-package-origin.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration coverage for a PACKAGE-ORIGIN runner service flowing through
+ * the wire-compatible service_announce pipeline (Godmother nIMOA8cm).
+ *
+ * The wire protocol (service_announce / ServiceAnnounceData) has no origin
+ * discriminator — a package-origin service (declared via a package's
+ * pi.pizzapi overlay manifest, see packages/cli/src/runner/package-service-loader.ts)
+ * must flow through announce -> Redis persistence -> viewer hydration exactly
+ * like any folder-based or plugin-manifest service. These tests use the mock
+ * runner harness to announce a realistic package-style service (panel +
+ * trigger + sigil) and verify the relay/server treat it identically.
+ *
+ * Each test creates and cleans up its OWN server (module-level singletons
+ * require sequential server creation — see mock-runner.test.ts).
+ */
+import { describe, test, expect } from "bun:test";
+import type { ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef, ServiceAnnounceData } from "@pizzapi/protocol";
+import { createTestServer } from "./server.js";
+import { TestScenario } from "./scenario.js";
+import type { TestServer } from "./types.js";
+
+const TEST_TIMEOUT = 30_000;
+
+async function cleanupServer(server: TestServer): Promise<void> {
+    await server.io.disconnectSockets(true);
+    await new Promise<void>((r) => setTimeout(r, 100));
+    const httpServer = (server.io as unknown as { httpServer?: { closeIdleConnections?(): void } }).httpServer;
+    if (typeof httpServer?.closeIdleConnections === "function") {
+        httpServer.closeIdleConnections();
+    }
+    await server.cleanup();
+}
+
+// A realistic package-origin service manifest, mirroring what
+// discoverPackageServices() would hand the daemon: a panel, a namespaced
+// trigger, and a sigil type — the exact shape package-service-loader.ts
+// builds from a pi.pizzapi overlay's `services[]` declaration.
+const PACKAGE_SERVICE_ID = "godmother-lite";
+const PACKAGE_PANEL: ServicePanelInfo = {
+    serviceId: PACKAGE_SERVICE_ID,
+    port: 34567,
+    label: "Godmother Lite",
+    icon: "sparkles",
+};
+const PACKAGE_TRIGGER: ServiceTriggerDef = {
+    type: "godmother-lite:idea_moved",
+    label: "Idea Status Changed",
+    description: "Fires when an idea's status changes",
+    schema: { type: "object", properties: { id: { type: "string" }, status: { type: "string" } } },
+    params: [{ name: "project", label: "Project", type: "string", required: false }],
+};
+const PACKAGE_SIGIL: ServiceSigilDef = {
+    type: "gm-idea",
+    label: "Godmother Idea",
+    serviceId: PACKAGE_SERVICE_ID,
+    description: "Reference to a Godmother idea",
+    icon: "lightbulb",
+    resolve: "/api/resolve/gm-idea/{id}",
+};
+
+describe("package-origin service_announce integration", () => {
+    test(
+        "panel + trigger + sigil defs reach a connected viewer verbatim, with no origin field",
+        async () => {
+            const server = await createTestServer();
+            const scenario = new TestScenario();
+            scenario.setServer(server);
+            try {
+                const runner = await scenario.addRunner({
+                    serviceIds: ["terminal", "file-explorer", "git", "tunnel", PACKAGE_SERVICE_ID],
+                    panels: [PACKAGE_PANEL],
+                    triggerDefs: [PACKAGE_TRIGGER],
+                    sigilDefs: [PACKAGE_SIGIL],
+                });
+                const session = await scenario.addSession({ cwd: "/tmp/test" });
+                runner.emitSessionReady(session.sessionId);
+
+                const viewer = await scenario.addViewer(session.sessionId);
+                const announce = await new Promise<ServiceAnnounceData>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for service_announce")), 8000);
+                    viewer.socket.on("service_announce", (data) => {
+                        const d = data as ServiceAnnounceData;
+                        if (d.serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve(d);
+                        }
+                    });
+                });
+
+                expect(announce.serviceIds).toContain(PACKAGE_SERVICE_ID);
+                expect(announce.panels).toContainEqual(PACKAGE_PANEL);
+                expect(announce.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(announce.sigilDefs).toContainEqual(PACKAGE_SIGIL);
+                // The wire payload never carries an origin/provenance discriminator —
+                // package-origin services are indistinguishable from any other source.
+                expect(announce).not.toHaveProperty("origin");
+                expect(announce).not.toHaveProperty("source");
+                for (const panel of announce.panels ?? []) expect(panel).not.toHaveProperty("origin");
+                for (const t of announce.triggerDefs ?? []) expect(t).not.toHaveProperty("origin");
+                for (const s of announce.sigilDefs ?? []) expect(s).not.toHaveProperty("origin");
+            } finally {
+                await scenario.teardown();
+                await cleanupServer(server);
+            }
+        },
+        TEST_TIMEOUT,
+    );
+
+    test(
+        "panel/trigger/sigil metadata is persisted to Redis and served via GET /api/runners/:id/services",
+        async () => {
+            const server = await createTestServer();
+            const scenario = new TestScenario();
+            scenario.setServer(server);
+            try {
+                const runner = await scenario.addRunner({
+                    serviceIds: ["terminal", PACKAGE_SERVICE_ID],
+                    panels: [PACKAGE_PANEL],
+                    triggerDefs: [PACKAGE_TRIGGER],
+                    sigilDefs: [PACKAGE_SIGIL],
+                });
+                const session = await scenario.addSession({ cwd: "/tmp/test" });
+                runner.emitSessionReady(session.sessionId);
+                // Attach a viewer solely to know the announce has round-tripped
+                // through the server (and therefore been persisted) before we GET.
+                const viewer = await scenario.addViewer(session.sessionId);
+                await new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for service_announce")), 8000);
+                    viewer.socket.on("service_announce", (data) => {
+                        if ((data as ServiceAnnounceData).serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve();
+                        }
+                    });
+                });
+
+                const res = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/services`);
+                expect(res.status).toBe(200);
+                const body = await res.json() as ServiceAnnounceData;
+                expect(body.serviceIds).toContain(PACKAGE_SERVICE_ID);
+                expect(body.panels).toContainEqual(PACKAGE_PANEL);
+                expect(body.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(body.sigilDefs).toContainEqual(PACKAGE_SIGIL);
+            } finally {
+                await scenario.teardown();
+                await cleanupServer(server);
+            }
+        },
+        TEST_TIMEOUT,
+    );
+
+    test(
+        "a fresh viewer connection (reload/reconnect) hydrates panel/trigger/sigil defs from the server cache without a new runner announce",
+        async () => {
+            const server = await createTestServer();
+            const scenario = new TestScenario();
+            scenario.setServer(server);
+            try {
+                const runner = await scenario.addRunner({
+                    serviceIds: ["terminal", PACKAGE_SERVICE_ID],
+                    panels: [PACKAGE_PANEL],
+                    triggerDefs: [PACKAGE_TRIGGER],
+                    sigilDefs: [PACKAGE_SIGIL],
+                });
+                const session = await scenario.addSession({ cwd: "/tmp/test" });
+                runner.emitSessionReady(session.sessionId);
+
+                const firstViewer = await scenario.addViewer(session.sessionId);
+                await new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for first announce")), 8000);
+                    firstViewer.socket.on("service_announce", (data) => {
+                        if ((data as ServiceAnnounceData).serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve();
+                        }
+                    });
+                });
+                // Simulate a viewer reload: disconnect entirely, then reconnect a
+                // brand-new socket to the same session. No new runner announce
+                // is sent — this must hydrate purely from server-side state
+                // (the connect-time "cache-first hydration" path in viewer.ts).
+                await firstViewer.disconnect();
+
+                const secondViewer = await scenario.addViewer(session.sessionId);
+                const rehydrated = await new Promise<ServiceAnnounceData>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for rehydrated announce")), 8000);
+                    secondViewer.socket.on("service_announce", (data) => {
+                        const d = data as ServiceAnnounceData;
+                        if (d.serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve(d);
+                        }
+                    });
+                });
+
+                expect(rehydrated.panels).toContainEqual(PACKAGE_PANEL);
+                expect(rehydrated.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(rehydrated.sigilDefs).toContainEqual(PACKAGE_SIGIL);
+            } finally {
+                await scenario.teardown();
+                await cleanupServer(server);
+            }
+        },
+        TEST_TIMEOUT,
+    );
+
+    test(
+        "disabling the package service via the reconfigure route round-trips through the runner and persists",
+        async () => {
+            const server = await createTestServer();
+            const scenario = new TestScenario();
+            scenario.setServer(server);
+            try {
+                const runner = await scenario.addRunner({
+                    serviceIds: ["terminal", PACKAGE_SERVICE_ID],
+                    panels: [PACKAGE_PANEL],
+                    triggerDefs: [PACKAGE_TRIGGER],
+                    sigilDefs: [PACKAGE_SIGIL],
+                });
+                const session = await scenario.addSession({ cwd: "/tmp/test" });
+                runner.emitSessionReady(session.sessionId);
+
+                const viewer = await scenario.addViewer(session.sessionId);
+                await new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for initial announce")), 8000);
+                    viewer.socket.on("service_announce", (data) => {
+                        if ((data as ServiceAnnounceData).serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve();
+                        }
+                    });
+                });
+
+                // Wait for the re-announce the mock runner sends in response to
+                // reconfigure_services (mirrors daemon.ts's emitServiceAnnounce()).
+                const reannouncePromise = new Promise<ServiceAnnounceData>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for reconfigure re-announce")), 8000);
+                    viewer.socket.on("service_announce", (data) => {
+                        const d = data as ServiceAnnounceData;
+                        if (d.disabledServiceIds?.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve(d);
+                        }
+                    });
+                });
+
+                const putRes = await server.fetch(
+                    `/api/runners/${encodeURIComponent(runner.runnerId)}/services/${encodeURIComponent(PACKAGE_SERVICE_ID)}/enabled`,
+                    {
+                        method: "PUT",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ enabled: false }),
+                    },
+                );
+                expect(putRes.status).toBe(200);
+
+                const reannounce = await reannouncePromise;
+                expect(reannounce.disabledServiceIds).toContain(PACKAGE_SERVICE_ID);
+                // Disabling never drops the service's metadata — the UI still needs
+                // labels/panel info to render a "disabled" row.
+                expect(reannounce.serviceIds).toContain(PACKAGE_SERVICE_ID);
+
+                // Persisted state (what a reload would GET) reflects the disable too.
+                const res = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/services`);
+                const body = await res.json() as ServiceAnnounceData;
+                expect(body.disabledServiceIds).toContain(PACKAGE_SERVICE_ID);
+            } finally {
+                await scenario.teardown();
+                await cleanupServer(server);
+            }
+        },
+        TEST_TIMEOUT,
+    );
+
+    test(
+        "subscribing to the package trigger creates a listener visible via GET /api/runners/:id/triggers",
+        async () => {
+            const server = await createTestServer();
+            const scenario = new TestScenario();
+            scenario.setServer(server);
+            try {
+                const runner = await scenario.addRunner({
+                    serviceIds: ["terminal", PACKAGE_SERVICE_ID],
+                    panels: [PACKAGE_PANEL],
+                    triggerDefs: [PACKAGE_TRIGGER],
+                    sigilDefs: [PACKAGE_SIGIL],
+                });
+                const session = await scenario.addSession({ cwd: "/tmp/test" });
+                runner.emitSessionReady(session.sessionId);
+
+                const viewer = await scenario.addViewer(session.sessionId);
+                await new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(() => reject(new Error("timed out waiting for announce")), 8000);
+                    viewer.socket.on("service_announce", (data) => {
+                        if ((data as ServiceAnnounceData).serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            clearTimeout(timer);
+                            resolve();
+                        }
+                    });
+                });
+
+                const subRes = await server.fetch(
+                    `/api/runners/${encodeURIComponent(runner.runnerId)}/trigger-listeners`,
+                    {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({
+                            triggerType: PACKAGE_TRIGGER.type,
+                            params: { project: "PizzaPi" },
+                            prompt: "Summarize the moved idea",
+                        }),
+                    },
+                );
+                expect(subRes.status).toBe(200);
+                const subBody = await subRes.json() as { listenerId?: string };
+                expect(subBody.listenerId).toBeTruthy();
+
+                const triggersRes = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/triggers`);
+                expect(triggersRes.status).toBe(200);
+                const triggersBody = await triggersRes.json() as { triggerDefs: ServiceTriggerDef[]; listeners: Array<{ triggerType: string; listenerId?: string }> };
+                expect(triggersBody.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(triggersBody.listeners.some((l) => l.triggerType === PACKAGE_TRIGGER.type)).toBe(true);
+            } finally {
+                await scenario.teardown();
+                await cleanupServer(server);
+            }
+        },
+        TEST_TIMEOUT,
+    );
+});

--- a/packages/ui/src/components/RunnerServicesPanel.test.tsx
+++ b/packages/ui/src/components/RunnerServicesPanel.test.tsx
@@ -103,4 +103,44 @@ describe("RunnerServicesPanel", () => {
       expect(container.textContent).toContain('Service "demo" disabled. Change applied immediately.');
     });
   });
+
+  test("renders a disabled service exactly once (serviceIds already includes disabled ids)", async () => {
+    // Wire semantics (see daemon.ts emitServiceAnnounce): `serviceIds` lists
+    // EVERY registered service — disabling one does not remove it from that
+    // array, `disabledServiceIds` is just a subset marker. A package-origin
+    // service surfaced this: naive concatenation of the two arrays rendered
+    // a disabled service twice.
+    const dupFetchSpy = mock(async () => ({
+      ok: true,
+      json: async () => ({
+        serviceIds: ["demo", "godmother-lite"],
+        disabledServiceIds: ["godmother-lite"],
+        panels: [
+          { serviceId: "demo", port: 1234, label: "Demo", icon: "server" },
+          { serviceId: "godmother-lite", port: 5678, label: "Godmother Lite", icon: "sparkles" },
+        ],
+        triggerDefs: [],
+        sigilDefs: [],
+      }),
+    } as unknown as Response));
+    (globalThis as any).fetch = dupFetchSpy;
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <actualTooltip.TooltipProvider>
+          <RunnerServicesPanel runnerId="runner-1" />
+        </actualTooltip.TooltipProvider>,
+      ));
+    });
+
+    await waitFor(() => expect(container.textContent).toContain("Godmother Lite"));
+
+    const godmotherOccurrences = container.querySelectorAll(".text-sm.font-medium.truncate");
+    const labels = Array.from(godmotherOccurrences).map((el) => el.textContent);
+    expect(labels.filter((l) => l === "Godmother Lite")).toHaveLength(1);
+    expect(container.textContent).toContain("Disabled");
+
+    (globalThis as any).fetch = fetchSpy;
+  });
 });

--- a/packages/ui/src/components/RunnerServicesPanel.test.tsx
+++ b/packages/ui/src/components/RunnerServicesPanel.test.tsx
@@ -104,26 +104,18 @@ describe("RunnerServicesPanel", () => {
     });
   });
 
-  test("renders a disabled service exactly once (serviceIds already includes disabled ids)", async () => {
-    // Wire semantics (see daemon.ts emitServiceAnnounce): `serviceIds` lists
-    // EVERY registered service — disabling one does not remove it from that
-    // array, `disabledServiceIds` is just a subset marker. A package-origin
-    // service surfaced this: naive concatenation of the two arrays rendered
-    // a disabled service twice.
-    const dupFetchSpy = mock(async () => ({
+  test("renders a disabled-only service without stale metadata", async () => {
+    const disabledFetchSpy = mock(async () => ({
       ok: true,
       json: async () => ({
-        serviceIds: ["demo", "godmother-lite"],
+        serviceIds: ["demo"],
         disabledServiceIds: ["godmother-lite"],
-        panels: [
-          { serviceId: "demo", port: 1234, label: "Demo", icon: "server" },
-          { serviceId: "godmother-lite", port: 5678, label: "Godmother Lite", icon: "sparkles" },
-        ],
+        panels: [{ serviceId: "demo", port: 1234, label: "Demo", icon: "server" }],
         triggerDefs: [],
         sigilDefs: [],
       }),
     } as unknown as Response));
-    (globalThis as any).fetch = dupFetchSpy;
+    (globalThis as any).fetch = disabledFetchSpy;
 
     let container!: HTMLElement;
     await act(async () => {
@@ -134,12 +126,9 @@ describe("RunnerServicesPanel", () => {
       ));
     });
 
-    await waitFor(() => expect(container.textContent).toContain("Godmother Lite"));
-
-    const godmotherOccurrences = container.querySelectorAll(".text-sm.font-medium.truncate");
-    const labels = Array.from(godmotherOccurrences).map((el) => el.textContent);
-    expect(labels.filter((l) => l === "Godmother Lite")).toHaveLength(1);
+    await waitFor(() => expect(container.textContent).toContain("godmother-lite"));
     expect(container.textContent).toContain("Disabled");
+    expect(container.textContent).not.toContain("Godmother Lite");
 
     (globalThis as any).fetch = fetchSpy;
   });

--- a/packages/ui/src/components/RunnerServicesPanel.tsx
+++ b/packages/ui/src/components/RunnerServicesPanel.tsx
@@ -122,9 +122,16 @@ export function RunnerServicesPanel({ runnerId }: RunnerServicesPanelProps) {
         sigilDefs?: SigilDef[];
       };
 
-      const enabledServiceIds = (data.serviceIds ?? []).filter(id => !BUILTIN_SERVICE_IDS.has(id));
+      // `serviceIds` from service_announce already includes every registered
+      // service id — disabled ones are NOT removed from it, `disabledServiceIds`
+      // is just a subset marker (see daemon.ts emitServiceAnnounce). Naively
+      // concatenating the two lists double-counts every disabled service; union
+      // via a Set instead, while still surfacing a disabled id that no longer
+      // appears in `serviceIds` at all (e.g. a service disabled while offline).
+      const nonBuiltinServiceIds = (data.serviceIds ?? []).filter(id => !BUILTIN_SERVICE_IDS.has(id));
       const disabledServiceIds = (data.disabledServiceIds ?? []).filter(id => !BUILTIN_SERVICE_IDS.has(id));
-      const allServiceIds = [...enabledServiceIds, ...disabledServiceIds];
+      const disabledSet = new Set(disabledServiceIds);
+      const allServiceIds = Array.from(new Set([...nonBuiltinServiceIds, ...disabledServiceIds]));
       const panelMap = new Map((data.panels ?? []).map(p => [p.serviceId, p]));
       const triggerDefs = data.triggerDefs ?? [];
       const sigilDefs = data.sigilDefs ?? [];
@@ -148,7 +155,7 @@ export function RunnerServicesPanel({ runnerId }: RunnerServicesPanelProps) {
         panel: panelMap.get(id),
         triggerCount: triggerCounts.get(id) || 0,
         sigilCount: sigilCounts.get(id) || 0,
-        enabled: enabledServiceIds.includes(id),
+        enabled: !disabledSet.has(id),
       }));
 
       setServices(result);


### PR DESCRIPTION
## Summary
- verify package-origin panels, triggers, and sigils flow unchanged through `service_announce`, Redis persistence, viewer hydration, reload, disable/re-enable, and subscriptions
- extend the sandbox/mock runner with a realistic package-style service
- fix duplicate disabled-service rows in Runner Services
- align mock disable announcements with real daemon active-metadata semantics

## Browser verification
- package-style panel button rendered and iframe loaded through the tunnel proxy
- service label/icon/trigger/sigil counts appeared in Runner Services
- disable/re-enable round-tripped and survived reload
- trigger subscribe/configure/delete flow worked and persisted through reload
- sigil metadata propagation/resolver is automated; transcript rendering remained blocked by an unrelated sandbox replay issue

## Verification
- isolated package announce integration: 5/5 pass
- sandbox harness: 8/8 files pass
- focused UI runner-service/sigil/trigger/panel tests pass
- UI/server test typechecks pass
- Fable found two mock/sandbox P2s; Terra fixed them
- final Terra delta review: LGTM

## Stack
- base: #657 (`feat/pi-session-convergence`)
- completes Godmother `nIMOA8cm`
- follow-up: disabled toolbar panel buttons (`JWrMTxiS`)
