### PR TITLE
feat(cli): resolve package roots in MCP sidecars

### DIFF
--- a/docs/specs/pi-pizzapi-overlay.md
+++ b/docs/specs/pi-pizzapi-overlay.md
@@ -195,6 +195,7 @@ Pi 0.82.1 has no native `pi.agents` package resource, while PizzaPi's subagent r
 - Explicit user/project PizzaPi config wins a server-name collision over package MCP config.
 - Between packages, project scope wins user scope, then settings order wins; later duplicates are warned and skipped.
 - Existing `disabledMcpServers` behavior applies by server name.
+- In a `pi.pizzapi.mcp` sidecar only, `@PACKAGE_ROOT@` is replaced with the host-resolved, package-confined installed root before ordinary config-variable expansion. It is supported only in stdio `command`, `cwd`, string `args` entries, and string `env` values. It is not available to explicit PizzaPi config or legacy Claude-plugin `.mcp.json` files, and does not apply to URLs, headers, or arbitrary nested values.
 
 A package extension already has arbitrary session-process execution rights. Package agents, MCP, and rules therefore remain session-side capabilities and do not require the separate daemon-service grant described below; agent scope/confirmation rules still apply.
 
@@ -694,3 +695,4 @@ The spec is satisfied when:
 | Service trust | separate global per-package/per-service grants |
 | Compat shim | one release after Godmother and Nightshift migrations, then removal |
 | MCP shape | one explicit config path containing one or more servers |
+| Package MCP root | `@PACKAGE_ROOT@` only in package-sidecar stdio command/cwd/string args/env values; host resolves it after confinement |

--- a/docs/specs/pi-pizzapi-overlay.md
+++ b/docs/specs/pi-pizzapi-overlay.md
@@ -190,7 +190,7 @@ Pi 0.82.1 has no native `pi.agents` package resource, while PizzaPi's subagent r
 #### `mcp`
 
 - One explicit package-relative JSON path.
-- The file uses PizzaPi's existing preferred `mcp.servers` array or compatibility `mcpServers` object format.
+- The file uses PizzaPi's existing preferred `mcp.servers` array or compatibility `mcpServers` object format. Preferred entries MUST explicitly set `transport` to `stdio`, `http`, or `streamable`: `stdio` requires `command`; `http`/`streamable` require `url`; command and URL fields cannot be mixed. Compatibility entries retain URL-first transport inference.
 - One file can declare multiple servers; an array of config paths is unnecessary in version 1.
 - Explicit user/project PizzaPi config wins a server-name collision over package MCP config.
 - Between packages, project scope wins user scope, then settings order wins; later duplicates are warned and skipped.

--- a/docs/specs/pi-pizzapi-overlay.md
+++ b/docs/specs/pi-pizzapi-overlay.md
@@ -195,7 +195,7 @@ Pi 0.82.1 has no native `pi.agents` package resource, while PizzaPi's subagent r
 - Explicit user/project PizzaPi config wins a server-name collision over package MCP config.
 - Between packages, project scope wins user scope, then settings order wins; later duplicates are warned and skipped.
 - Existing `disabledMcpServers` behavior applies by server name.
-- In a `pi.pizzapi.mcp` sidecar only, `@PACKAGE_ROOT@` is replaced with the host-resolved, package-confined installed root before ordinary config-variable expansion. It is supported only in stdio `command`, `cwd`, string `args` entries, and string `env` values. It is not available to explicit PizzaPi config or legacy Claude-plugin `.mcp.json` files, and does not apply to URLs, headers, or arbitrary nested values.
+- In a `pi.pizzapi.mcp` sidecar only, `@PACKAGE_ROOT@` is replaced with the host-resolved, package-confined installed root after ordinary config-variable expansion. It is supported only in definitions the registry selects as stdio: `command`, `cwd`, string `args` entries, and string `env` values. URL definitions take precedence over incidental stdio fields and remain untouched. It is not available to explicit PizzaPi config or legacy Claude-plugin `.mcp.json` files, and does not apply to URLs, headers, or arbitrary nested values.
 
 A package extension already has arbitrary session-process execution rights. Package agents, MCP, and rules therefore remain session-side capabilities and do not require the separate daemon-service grant described below; agent scope/confirmation rules still apply.
 

--- a/packages/cli/src/extensions/mcp-overlay.test.ts
+++ b/packages/cli/src/extensions/mcp-overlay.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createMcpClientsFromConfig } from "./mcp.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runPackageCommand } from "../package-commands.js";
@@ -66,7 +67,7 @@ describe("mergeOverlayMcpServers", () => {
         expect(config.mcpServers?.fromPkg).toBeDefined();
     });
 
-    test("materializes @PACKAGE_ROOT@ only in package stdio definitions as literal values", async () => {
+    test("defers @PACKAGE_ROOT@ only for package stdio definitions", async () => {
         const pkgDir = join(tmpDir, "mcp package root $literal");
         writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
             ".mcp.json": JSON.stringify({
@@ -95,19 +96,84 @@ describe("mergeOverlayMcpServers", () => {
 
         const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
         const packageRoot = realpathSync(serverProvenance.find((p) => p.name === "compat")!.sourcePath);
+        expect(packageRoot).toContain("mcp package root $literal");
         expect((config.mcp?.servers?.[0] as any)).toMatchObject({
-            command: `${packageRoot}/gm`,
-            cwd: `${packageRoot}/work dir`,
-            args: ["--config", `${packageRoot}/config.json`, 7],
-            env: { CONFIG: `${packageRoot}/config.json`, COUNT: 1 },
+            command: "@PACKAGE_ROOT@/gm",
+            cwd: "@PACKAGE_ROOT@/work dir",
+            args: ["--config", "@PACKAGE_ROOT@/config.json", 7],
+            env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: 1 },
         });
         expect(config.mcpServers?.compat).toMatchObject({
-            command: `${packageRoot}/bin/gm`,
-            cwd: `${packageRoot}/work dir`,
-            args: [`--config=${packageRoot}/config.json`, false],
-            env: { CONFIG: `${packageRoot}/config.json`, ENABLED: true },
+            command: "@PACKAGE_ROOT@/bin/gm",
+            cwd: "@PACKAGE_ROOT@/work dir",
+            args: ["--config=@PACKAGE_ROOT@/config.json", false],
+            env: { CONFIG: "@PACKAGE_ROOT@/config.json", ENABLED: true },
         });
         expect(config.mcpServers?.remote).toEqual({ url: "https://example.test/@PACKAGE_ROOT@", headers: { Path: "@PACKAGE_ROOT@" } });
+    });
+
+    test("does not materialize package roots in URL definitions with incidental stdio fields", async () => {
+        const pkgDir = join(tmpDir, "mcp-http-with-stdio");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({
+                mcpServers: {
+                    remote: {
+                        url: "https://example.test/@PACKAGE_ROOT@",
+                        type: "sse",
+                        command: "@PACKAGE_ROOT@/must-not-run",
+                        args: ["@PACKAGE_ROOT@/arg"],
+                        cwd: "@PACKAGE_ROOT@/cwd",
+                        env: { ROOT: "@PACKAGE_ROOT@" },
+                    },
+                },
+            }),
+        });
+        await install("../mcp-http-with-stdio");
+
+        const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect(config.mcpServers?.remote).toEqual({
+            url: "https://example.test/@PACKAGE_ROOT@",
+            type: "sse",
+            command: "@PACKAGE_ROOT@/must-not-run",
+            args: ["@PACKAGE_ROOT@/arg"],
+            cwd: "@PACKAGE_ROOT@/cwd",
+            env: { ROOT: "@PACKAGE_ROOT@" },
+        });
+    });
+
+    test("preserves literal config tokens in the installed root through stdio construction", async () => {
+        const pkgDir = join(tmpDir, "mcp-@HOME@-@PROJECT_DIR@");
+        const server = `#!${process.execPath}\nconst snapshot = () => ({ command: process.argv[1], args: process.argv.slice(2), cwd: process.cwd(), root: process.env.ROOT });\nlet buffer = \"\";\nprocess.stdin.on(\"data\", (chunk) => { buffer += chunk; for (;;) { const end = buffer.indexOf(\"\\n\"); if (end < 0) return; const line = buffer.slice(0, end); buffer = buffer.slice(end + 1); const message = JSON.parse(line); if (message.method === \"initialize\") process.stdout.write(JSON.stringify({ jsonrpc: \"2.0\", id: message.id, result: { protocolVersion: \"2025-03-26\", capabilities: {}, serverInfo: { name: \"fixture\", version: \"1\" } } }) + \"\\n\"); else if (message.method === \"tools/list\") process.stdout.write(JSON.stringify({ jsonrpc: \"2.0\", id: message.id, result: { tools: [{ name: \"details\", description: JSON.stringify(snapshot()) }] } }) + \"\\n\"); } });\n`;
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({
+                mcpServers: {
+                    fixture: {
+                        command: "@PACKAGE_ROOT@/stdio-server.js",
+                        args: ["@PACKAGE_ROOT@/argument"],
+                        cwd: "@PACKAGE_ROOT@",
+                        env: { ROOT: "@PACKAGE_ROOT@" },
+                    },
+                },
+            }),
+            "stdio-server.js": server,
+        });
+        chmodSync(join(pkgDir, "stdio-server.js"), 0o755);
+        await install("../mcp-@HOME@-@PROJECT_DIR@");
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        const packageRoot = realpathSync(serverProvenance.find((p) => p.name === "fixture")!.sourcePath);
+        const clients = await createMcpClientsFromConfig(config as any);
+        try {
+            const [tool] = await clients[0].listTools();
+            expect(JSON.parse(tool.description!)).toEqual({
+                command: `${packageRoot}/stdio-server.js`,
+                args: [`${packageRoot}/argument`],
+                cwd: packageRoot,
+                root: packageRoot,
+            });
+        } finally {
+            clients[0].close();
+        }
     });
 
     test("leaves @PACKAGE_ROOT@ untouched in explicit config and legacy plugin MCP definitions", async () => {

--- a/packages/cli/src/extensions/mcp-overlay.test.ts
+++ b/packages/cli/src/extensions/mcp-overlay.test.ts
@@ -77,8 +77,8 @@ describe("mergeOverlayMcpServers", () => {
                         transport: "stdio",
                         command: "@PACKAGE_ROOT@/gm",
                         cwd: "@PACKAGE_ROOT@/work dir",
-                        args: ["--config", "@PACKAGE_ROOT@/config.json", 7],
-                        env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: 1 },
+                        args: ["--config", "@PACKAGE_ROOT@/config.json", "7"],
+                        env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: "1" },
                     }],
                 },
                 mcpServers: {
@@ -100,8 +100,8 @@ describe("mergeOverlayMcpServers", () => {
         expect((config.mcp?.servers?.[0] as any)).toMatchObject({
             command: "@PACKAGE_ROOT@/gm",
             cwd: "@PACKAGE_ROOT@/work dir",
-            args: ["--config", "@PACKAGE_ROOT@/config.json", 7],
-            env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: 1 },
+            args: ["--config", "@PACKAGE_ROOT@/config.json", "7"],
+            env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: "1" },
         });
         expect(config.mcpServers?.compat).toMatchObject({
             command: "@PACKAGE_ROOT@/bin/gm",

--- a/packages/cli/src/extensions/mcp-overlay.test.ts
+++ b/packages/cli/src/extensions/mcp-overlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runPackageCommand } from "../package-commands.js";
@@ -64,6 +64,78 @@ describe("mergeOverlayMcpServers", () => {
 
         const { config } = mergeOverlayMcpServers({}, cwd, agentDir, true);
         expect(config.mcpServers?.fromPkg).toBeDefined();
+    });
+
+    test("materializes @PACKAGE_ROOT@ only in package stdio definitions as literal values", async () => {
+        const pkgDir = join(tmpDir, "mcp package root $literal");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({
+                mcp: {
+                    servers: [{
+                        name: "preferred",
+                        transport: "stdio",
+                        command: "@PACKAGE_ROOT@/gm",
+                        cwd: "@PACKAGE_ROOT@/work dir",
+                        args: ["--config", "@PACKAGE_ROOT@/config.json", 7],
+                        env: { CONFIG: "@PACKAGE_ROOT@/config.json", COUNT: 1 },
+                    }],
+                },
+                mcpServers: {
+                    compat: {
+                        command: "@PACKAGE_ROOT@/bin/gm",
+                        cwd: "@PACKAGE_ROOT@/work dir",
+                        args: ["--config=@PACKAGE_ROOT@/config.json", false],
+                        env: { CONFIG: "@PACKAGE_ROOT@/config.json", ENABLED: true },
+                    },
+                    remote: { url: "https://example.test/@PACKAGE_ROOT@", headers: { Path: "@PACKAGE_ROOT@" } },
+                },
+            }),
+        });
+        await install("../mcp package root $literal");
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        const packageRoot = realpathSync(serverProvenance.find((p) => p.name === "compat")!.sourcePath);
+        expect((config.mcp?.servers?.[0] as any)).toMatchObject({
+            command: `${packageRoot}/gm`,
+            cwd: `${packageRoot}/work dir`,
+            args: ["--config", `${packageRoot}/config.json`, 7],
+            env: { CONFIG: `${packageRoot}/config.json`, COUNT: 1 },
+        });
+        expect(config.mcpServers?.compat).toMatchObject({
+            command: `${packageRoot}/bin/gm`,
+            cwd: `${packageRoot}/work dir`,
+            args: [`--config=${packageRoot}/config.json`, false],
+            env: { CONFIG: `${packageRoot}/config.json`, ENABLED: true },
+        });
+        expect(config.mcpServers?.remote).toEqual({ url: "https://example.test/@PACKAGE_ROOT@", headers: { Path: "@PACKAGE_ROOT@" } });
+    });
+
+    test("leaves @PACKAGE_ROOT@ untouched in explicit config and legacy plugin MCP definitions", async () => {
+        installLegacyPlugin("package-root-legacy", { legacy: { command: "@PACKAGE_ROOT@/legacy", args: ["@PACKAGE_ROOT@"] } });
+        const base = { mcpServers: { explicit: { command: "@PACKAGE_ROOT@/explicit", env: { ROOT: "@PACKAGE_ROOT@" } } } };
+
+        const { config } = mergeOverlayMcpServers(base, cwd, agentDir, true);
+        expect(config.mcpServers?.explicit).toEqual(base.mcpServers.explicit);
+        expect(config.mcpServers?.legacy).toEqual({ command: "@PACKAGE_ROOT@/legacy", args: ["@PACKAGE_ROOT@"] });
+    });
+
+    test("collision winner alone materializes its package root", async () => {
+        const userPkg = join(tmpDir, "mcp-root-user");
+        writeFixturePackage(userPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "@PACKAGE_ROOT@/user" } } }),
+        });
+        await install("../mcp-root-user");
+
+        const projectPkg = join(tmpDir, "mcp-root-project");
+        writeFixturePackage(projectPkg, { schemaVersion: 1, mcp: "./.mcp.json" }, {
+            ".mcp.json": JSON.stringify({ mcpServers: { shared: { command: "@PACKAGE_ROOT@/project" } } }),
+        });
+        await install("../mcp-root-project", { project: true });
+
+        const { config, serverProvenance } = mergeOverlayMcpServers({}, cwd, agentDir, true);
+        expect((config.mcpServers?.shared as any).command).toEndWith("/project");
+        expect((config.mcpServers?.shared as any).command).not.toContain("mcp-root-user");
+        expect(serverProvenance.find((p) => p.name === "shared")?.identity).toContain("mcp-root-project");
     });
 
     test("explicit PizzaPi config always wins a server-name collision over package overlay", async () => {

--- a/packages/cli/src/extensions/mcp-overlay.ts
+++ b/packages/cli/src/extensions/mcp-overlay.ts
@@ -90,28 +90,31 @@ function isValidMcpSidecarShape(parsed: unknown): parsed is Record<string, unkno
 }
 
 /** Extract `{ preferred, compat }` server entries from a parsed mcp sidecar/`.mcp.json` value. */
-const PACKAGE_ROOT_TOKEN = "@PACKAGE_ROOT@";
+const packageMcpRoots = new WeakMap<Record<string, unknown>, string>();
 
-function replacePackageRoot(value: unknown, packageRoot: string): unknown {
-    return typeof value === "string" ? value.replaceAll(PACKAGE_ROOT_TOKEN, packageRoot) : value;
+/** Match the registry's URL-first compatibility transport selection. */
+export function resolveMcpCompatTransport(value: Record<string, unknown>): "stdio" | "http" | "streamable" | "unknown" {
+    if (typeof value.url === "string") {
+        return value.transport === "streamable" || (value.type === "http" && value.transport === undefined)
+            ? "streamable"
+            : "http";
+    }
+    return typeof value.command === "string" ? "stdio" : "unknown";
+}
+
+/** Package roots are internal metadata, not a config field. */
+export function getPackageMcpRoot(server: unknown): string | undefined {
+    return isRecord(server) ? packageMcpRoots.get(server) : undefined;
 }
 
 /**
- * Materialize the one package-scoped token in stdio fields only. This is
- * deliberately narrower than config variable expansion: URLs, headers, and
- * arbitrary nested data keep their literal values, while command arguments
- * remain argv entries rather than shell text.
+ * Preserve @PACKAGE_ROOT@ until the stdio transport expands the definition.
+ * That inserts the canonical root after ordinary variables, so literal tokens
+ * in an installed path cannot be expanded accidentally.
  */
-function materializePackageMcpServer(server: Record<string, unknown>, packageRoot: string): Record<string, unknown> {
+function materializePackageMcpServer(server: Record<string, unknown>, packageRoot: string, isStdio: boolean): Record<string, unknown> {
     const materialized = { ...server };
-    if (typeof server.command === "string") materialized.command = replacePackageRoot(server.command, packageRoot);
-    if (typeof server.cwd === "string") materialized.cwd = replacePackageRoot(server.cwd, packageRoot);
-    if (Array.isArray(server.args)) materialized.args = server.args.map((arg) => replacePackageRoot(arg, packageRoot));
-    if (isRecord(server.env)) {
-        materialized.env = Object.fromEntries(
-            Object.entries(server.env).map(([name, value]) => [name, replacePackageRoot(value, packageRoot)]),
-        );
-    }
+    if (isStdio) packageMcpRoots.set(materialized, packageRoot);
     return materialized;
 }
 
@@ -138,16 +141,7 @@ function extractServers(parsed: unknown): { preferred: Record<string, unknown>[]
  * from an explicit config file or an overlay/legacy sidecar.
  */
 export function inferMcpCompatTransport(value: Record<string, unknown>): string {
-    if (typeof value.command === "string") return "stdio";
-    if (typeof value.url === "string") {
-        // "transport" is our field; "type" is Claude Code / VS Code format.
-        // In the standard MCP ecosystem, type "http" = streamable HTTP.
-        if (typeof value.transport === "string") return value.transport;
-        if (value.type === "http") return "streamable";
-        if (typeof value.type === "string") return value.type;
-        return "http";
-    }
-    return "unknown";
+    return resolveMcpCompatTransport(value);
 }
 
 export function mergeOverlayMcpServers(
@@ -243,8 +237,8 @@ export function mergeOverlayMcpServers(
                 scope,
                 pkg.identity,
                 pkg.installedPath,
-                preferred.map((server) => materializePackageMcpServer(server, packageRoot.absolutePath)),
-                Object.fromEntries(Object.entries(compat).map(([name, server]) => [name, materializePackageMcpServer(server, packageRoot.absolutePath)])),
+                preferred.map((server) => materializePackageMcpServer(server, packageRoot.absolutePath, server.transport === "stdio")),
+                Object.fromEntries(Object.entries(compat).map(([name, server]) => [name, materializePackageMcpServer(server, packageRoot.absolutePath, resolveMcpCompatTransport(server) === "stdio")])),
             );
         }
     }

--- a/packages/cli/src/extensions/mcp-overlay.ts
+++ b/packages/cli/src/extensions/mcp-overlay.ts
@@ -90,6 +90,31 @@ function isValidMcpSidecarShape(parsed: unknown): parsed is Record<string, unkno
 }
 
 /** Extract `{ preferred, compat }` server entries from a parsed mcp sidecar/`.mcp.json` value. */
+const PACKAGE_ROOT_TOKEN = "@PACKAGE_ROOT@";
+
+function replacePackageRoot(value: unknown, packageRoot: string): unknown {
+    return typeof value === "string" ? value.replaceAll(PACKAGE_ROOT_TOKEN, packageRoot) : value;
+}
+
+/**
+ * Materialize the one package-scoped token in stdio fields only. This is
+ * deliberately narrower than config variable expansion: URLs, headers, and
+ * arbitrary nested data keep their literal values, while command arguments
+ * remain argv entries rather than shell text.
+ */
+function materializePackageMcpServer(server: Record<string, unknown>, packageRoot: string): Record<string, unknown> {
+    const materialized = { ...server };
+    if (typeof server.command === "string") materialized.command = replacePackageRoot(server.command, packageRoot);
+    if (typeof server.cwd === "string") materialized.cwd = replacePackageRoot(server.cwd, packageRoot);
+    if (Array.isArray(server.args)) materialized.args = server.args.map((arg) => replacePackageRoot(arg, packageRoot));
+    if (isRecord(server.env)) {
+        materialized.env = Object.fromEntries(
+            Object.entries(server.env).map(([name, value]) => [name, replacePackageRoot(value, packageRoot)]),
+        );
+    }
+    return materialized;
+}
+
 function extractServers(parsed: unknown): { preferred: Record<string, unknown>[]; compat: Record<string, Record<string, unknown>> } {
     const preferred: Record<string, unknown>[] = [];
     const compat: Record<string, Record<string, unknown>> = {};
@@ -195,8 +220,13 @@ export function mergeOverlayMcpServers(
         for (const pkg of packages.filter((p) => p.scope === scope)) {
             if (!pkg.overlay.mcp) continue;
             const resolved = resolveConfinedPath(pkg.installedPath, pkg.overlay.mcp);
+            const packageRoot = resolveConfinedPath(pkg.installedPath, ".");
             if (!resolved.ok) {
                 log.warn(`[${pkg.identity}] mcp sidecar failed re-validation: ${resolved.message}`);
+                continue;
+            }
+            if (!packageRoot.ok) {
+                log.warn(`[${pkg.identity}] package root failed re-validation: ${packageRoot.message}`);
                 continue;
             }
             const parsed = readJsonCapped(resolved.absolutePath);
@@ -209,7 +239,13 @@ export function mergeOverlayMcpServers(
                 continue;
             }
             const { preferred, compat } = extractServers(parsed);
-            addPass(scope, pkg.identity, pkg.installedPath, preferred, compat);
+            addPass(
+                scope,
+                pkg.identity,
+                pkg.installedPath,
+                preferred.map((server) => materializePackageMcpServer(server, packageRoot.absolutePath)),
+                Object.fromEntries(Object.entries(compat).map(([name, server]) => [name, materializePackageMcpServer(server, packageRoot.absolutePath)])),
+            );
         }
     }
 

--- a/packages/cli/src/extensions/mcp.test.ts
+++ b/packages/cli/src/extensions/mcp.test.ts
@@ -321,6 +321,41 @@ describe("MCP HTTP smoke test", () => {
 });
 
 describe("MCP config compatibility", () => {
+    test("URL takes precedence over incidental stdio fields", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+                requestCount++;
+                const body = await req.json() as any;
+                if (!("id" in body)) return new Response(null, { status: 202 });
+                if (body.method === "initialize") {
+                    return Response.json({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: {}, serverInfo: { name: "remote", version: "1" } } });
+                }
+                if (body.method === "tools/list") return Response.json({ jsonrpc: "2.0", id: body.id, result: { tools: [] } });
+                return Response.json({ jsonrpc: "2.0", id: body.id, result: {} });
+            },
+        });
+        try {
+            const clients = await createMcpClientsFromConfig({
+                mcpServers: {
+                    remote: {
+                        url: `http://localhost:${server.port}`,
+                        command: "definitely-not-a-command",
+                        args: ["ignored"],
+                        env: { ROOT: "ignored" },
+                    },
+                },
+            } as any);
+            expect(clients).toHaveLength(1);
+            await clients[0].listTools();
+            expect(requestCount).toBeGreaterThan(0);
+            clients[0].close();
+        } finally {
+            server.stop(true);
+        }
+    });
+
     test("type: 'http' in mcpServers uses streamable transport", async () => {
         // When type: "http" is used (Claude Code / VS Code format), it should
         // create a streamable client, not a plain HTTP client. We verify this by

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -10,6 +10,7 @@
  */
 
 import { type PizzaPiConfig, expandVars, expandVarsDeep } from "../../config.js";
+import { getPackageMcpRoot, resolveMcpCompatTransport } from "../mcp-overlay.js";
 import { PizzaPiOAuthProvider, type RelayContext } from "../mcp-oauth.js";
 import { createLogger, isSandboxActive, getResolvedConfig } from "@pizzapi/tools";
 import { createStdioMcpClient } from "./transport-stdio.js";
@@ -178,6 +179,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
             args: s.args,
             env: s.env,
             cwd: s.cwd,
+            packageRoot: getPackageMcpRoot(s),
           }),
         );
       } catch (err) {
@@ -230,7 +232,8 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
     if (!def || typeof def !== "object") continue;
     if (disabled.has(name)) continue; // skip disabled servers
 
-    if ("command" in def && typeof (def as any).command === "string") {
+    const transport = resolveMcpCompatTransport(def as Record<string, unknown>);
+    if (transport === "stdio") {
       const d = def as { command: string; args?: string[]; env?: Record<string, string>; cwd?: string };
       try {
         clients.push(
@@ -240,6 +243,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
             args: d.args,
             env: d.env,
             cwd: d.cwd,
+            packageRoot: getPackageMcpRoot(def),
           }),
         );
       } catch (err) {
@@ -248,7 +252,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       continue;
     }
 
-    if ("url" in def && typeof (def as any).url === "string") {
+    if (transport === "http" || transport === "streamable") {
       const d = def as { url: string; transport?: string; type?: string; headers?: Record<string, string>; oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string; oauthCallbackPort?: number };
 
       // Expand @VARNAME@ tokens in url and headers
@@ -261,9 +265,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       // Determine transport mode:
       //  - "transport" field (our format): "streamable" → streamable, else plain HTTP
       //  - "type" field (Claude Code / VS Code format): "http" → streamable (per MCP spec)
-      const useStreamable =
-        d.transport === "streamable" ||
-        (d.type === "http" && d.transport === undefined);
+      const useStreamable = transport === "streamable";
 
       if (useStreamable) {
         // Per-server clientId/clientSecret are a pair (see comment above)

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -30,7 +30,7 @@ export type McpConfig = {
   mcp?: {
     servers?: Array<
       | { name: string; transport: "stdio"; command: string; args?: string[]; env?: Record<string, string>; cwd?: string; deferLoading?: boolean }
-      | { name: string; transport: "http"; url: string; headers?: Record<string, string>; oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string; oauthCallbackPort?: number; deferLoading?: boolean }
+      | { name: string; transport: "http"; url: string; headers?: Record<string, string>; deferLoading?: boolean }
       | { name: string; transport: "streamable"; url: string; headers?: Record<string, string>; oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string; oauthCallbackPort?: number; deferLoading?: boolean }
     >;
   };

--- a/packages/cli/src/extensions/mcp/transport-stdio.ts
+++ b/packages/cli/src/extensions/mcp/transport-stdio.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
-import { expandHome, expandVars, expandVarsDeep } from "../../config.js";
+import { expandHome, expandVars } from "../../config.js";
 import { buildSpawnInvocation } from "./windows-command.js";
 import {
   MCP_PROTOCOL_VERSION,
@@ -24,12 +24,16 @@ export async function createStdioMcpClient(opts: {
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;
+  /** Internal package-overlay metadata; never read from user config. */
+  packageRoot?: string;
 }): Promise<McpClient> {
-  // Expand @VARNAME@ tokens in command, args, cwd, and env values
-  const command = expandVars(expandHome(opts.command));
-  const args = (opts.args ?? []).map((a) => expandVars(expandHome(a)));
-  const cwd = opts.cwd ? expandVars(expandHome(opts.cwd)) : undefined;
-  const env = opts.env ? expandVarsDeep({ ...opts.env }) as Record<string, string> : undefined;
+  // Insert a package root after regular variables so literal @HOME@ etc. in
+  // the canonical installed path are not interpreted as configuration tokens.
+  const expandStdioValue = (value: string) => expandVars(expandHome(value)).replaceAll("@PACKAGE_ROOT@", opts.packageRoot ?? "@PACKAGE_ROOT@");
+  const command = expandStdioValue(opts.command);
+  const args = (opts.args ?? []).map(expandStdioValue);
+  const cwd = opts.cwd ? expandStdioValue(opts.cwd) : undefined;
+  const env = opts.env ? Object.fromEntries(Object.entries(opts.env).map(([key, value]) => [key, expandStdioValue(value)])) : undefined;
   const mergedEnv = { ...process.env, ...(env ?? {}) };
 
   // STDIO MCP servers are trusted local processes spawned from the user's

--- a/packages/cli/src/extensions/memory/storage.test.ts
+++ b/packages/cli/src/extensions/memory/storage.test.ts
@@ -39,7 +39,7 @@ test("detail writes a topic file and links it", () => {
 
 test("index truncates at 200 lines", () => {
   const big = mkdtempSync(join(tmpdir(), "membig-"));
-  for (let i = 0; i < 250; i++) S.saveMemory({ summary: `entry ${i}` }, big);
+  S.writeMemoryFile("MEMORY.md", Array.from({ length: 250 }, (_, i) => `- entry ${i}`).join("\n"), big);
   const { text, truncated } = S.readIndexTruncated(big);
   expect(truncated).toBe(true);
   expect(text.split("\n").length).toBeLessThanOrEqual(S.MAX_INDEX_LINES);

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -216,13 +216,14 @@ describe("readOverlayManifest", () => {
         expect(result.issues).toContainEqual(expect.objectContaining({ field: "mcp.servers[0].transport", message: expect.stringContaining("required") }));
     });
 
-    test("preferred mcp.servers rejects unknown and contradictory transport fields", () => {
+    test("preferred mcp.servers rejects every field outside its transport matrix", () => {
         const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad-entry.json" }, (d) => {
             writeFileSync(join(d, "bad-entry.json"), JSON.stringify({
                 mcp: { servers: [
-                    { name: "unknown", transport: "sse", url: "https://example.test/mcp" },
-                    { name: "stdio-url", transport: "stdio", command: "echo", url: "https://example.test/mcp" },
-                    { name: "http-command", transport: "http", command: "echo" },
+                    { name: "unknown", transport: "sse", url: "https://example.test/mcp", bogus: true },
+                    { name: "stdio", transport: "stdio", command: "echo", url: "https://example.test/mcp", headers: {}, oauthClientName: "x", oauthClientId: "id", oauthClientSecret: "secret", oauthCallbackPort: 1, bogus: true },
+                    { name: "http", transport: "http", url: "https://example.test/mcp", command: "echo", args: [], env: {}, cwd: ".", oauthClientName: "x", oauthClientId: "id", oauthClientSecret: "secret", oauthCallbackPort: 1, bogus: true },
+                    { name: "streamable", transport: "streamable", url: "https://example.test/mcp", command: "echo", args: [], env: {}, cwd: ".", bogus: true },
                 ] },
             }));
         });
@@ -230,10 +231,10 @@ describe("readOverlayManifest", () => {
         const result = readOverlayManifest(dir, provenance);
         expect(result.overlay).toBeNull();
         expect(result.issues.map((i) => i.field)).toEqual(expect.arrayContaining([
-            "mcp.servers[0].transport",
-            "mcp.servers[1].url",
-            "mcp.servers[2].url",
-            "mcp.servers[2].command",
+            "mcp.servers[0].transport", "mcp.servers[0].bogus",
+            "mcp.servers[1].url", "mcp.servers[1].headers", "mcp.servers[1].oauthClientName", "mcp.servers[1].oauthClientId", "mcp.servers[1].oauthClientSecret", "mcp.servers[1].oauthCallbackPort", "mcp.servers[1].bogus",
+            "mcp.servers[2].command", "mcp.servers[2].args", "mcp.servers[2].env", "mcp.servers[2].cwd", "mcp.servers[2].oauthClientName", "mcp.servers[2].oauthClientId", "mcp.servers[2].oauthClientSecret", "mcp.servers[2].oauthCallbackPort", "mcp.servers[2].bogus",
+            "mcp.servers[3].command", "mcp.servers[3].args", "mcp.servers[3].env", "mcp.servers[3].cwd", "mcp.servers[3].bogus",
         ]));
     });
 
@@ -257,12 +258,12 @@ describe("readOverlayManifest", () => {
         expect(result.overlay?.mcp).toBe("./mcp.json");
     });
 
-    test("mcp sidecar with all supported preferred transports is accepted", () => {
+    test("mcp sidecar accepts the complete preferred transport field matrix", () => {
         const dir = fixturePkg({ schemaVersion: 1, mcp: "./mcp.json" }, (d) => {
             writeFileSync(join(d, "mcp.json"), JSON.stringify({ mcp: { servers: [
-                { name: "local", transport: "stdio", command: "echo" },
-                { name: "http", transport: "http", url: "https://api.example.com/mcp" },
-                { name: "streamable", transport: "streamable", url: "https://api.example.com/stream" },
+                { name: "local", transport: "stdio", command: "echo", args: ["--flag"], env: { KEY: "value" }, cwd: ".", deferLoading: true },
+                { name: "http", transport: "http", url: "https://api.example.com/mcp", headers: { Authorization: "Bearer token" }, deferLoading: false },
+                { name: "streamable", transport: "streamable", url: "https://api.example.com/stream", headers: { Authorization: "Bearer token" }, oauthClientName: "PizzaPi", oauthClientId: "id", oauthClientSecret: "secret", oauthCallbackPort: 3000, deferLoading: true },
             ] } }));
         });
         dirs.push(dir);

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -206,7 +206,38 @@ describe("readOverlayManifest", () => {
         expect(result.issues.some((i) => i.field === "mcp" && i.message.includes("mcp.servers"))).toBe(true);
     });
 
-    test("mcp sidecar entry missing both command and url is rejected", () => {
+    test("preferred mcp.servers entry with command but no transport is rejected", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad-entry.json" }, (d) => {
+            writeFileSync(join(d, "bad-entry.json"), JSON.stringify({ mcp: { servers: [{ name: "x", command: "echo" }] } }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues).toContainEqual(expect.objectContaining({ field: "mcp.servers[0].transport", message: expect.stringContaining("required") }));
+    });
+
+    test("preferred mcp.servers rejects unknown and contradictory transport fields", () => {
+        const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad-entry.json" }, (d) => {
+            writeFileSync(join(d, "bad-entry.json"), JSON.stringify({
+                mcp: { servers: [
+                    { name: "unknown", transport: "sse", url: "https://example.test/mcp" },
+                    { name: "stdio-url", transport: "stdio", command: "echo", url: "https://example.test/mcp" },
+                    { name: "http-command", transport: "http", command: "echo" },
+                ] },
+            }));
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.map((i) => i.field)).toEqual(expect.arrayContaining([
+            "mcp.servers[0].transport",
+            "mcp.servers[1].url",
+            "mcp.servers[2].url",
+            "mcp.servers[2].command",
+        ]));
+    });
+
+    test("compatibility mcpServers entry missing both command and url is rejected", () => {
         const dir = fixturePkg({ schemaVersion: 1, mcp: "./bad-entry.json" }, (d) => {
             writeFileSync(join(d, "bad-entry.json"), JSON.stringify({ mcpServers: { x: { transport: "stdio" } } }));
         });
@@ -226,9 +257,13 @@ describe("readOverlayManifest", () => {
         expect(result.overlay?.mcp).toBe("./mcp.json");
     });
 
-    test("mcp sidecar with valid mcp.servers array format is accepted", () => {
+    test("mcp sidecar with all supported preferred transports is accepted", () => {
         const dir = fixturePkg({ schemaVersion: 1, mcp: "./mcp.json" }, (d) => {
-            writeFileSync(join(d, "mcp.json"), JSON.stringify({ mcp: { servers: [{ name: "gh", transport: "http", url: "https://api.example.com/mcp" }] } }));
+            writeFileSync(join(d, "mcp.json"), JSON.stringify({ mcp: { servers: [
+                { name: "local", transport: "stdio", command: "echo" },
+                { name: "http", transport: "http", url: "https://api.example.com/mcp" },
+                { name: "streamable", transport: "streamable", url: "https://api.example.com/stream" },
+            ] } }));
         });
         dirs.push(dir);
         const result = readOverlayManifest(dir, provenance);

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -22,6 +22,12 @@ export const OVERLAY_SIDECAR_MAX_BYTES = MAX_PLUGIN_FILE_SIZE;
 
 const TOP_LEVEL_KEYS = new Set(["schemaVersion", "services", "agents", "rules", "mcp"]);
 const PREFERRED_MCP_TRANSPORTS = new Set(["stdio", "http", "streamable"]);
+const PREFERRED_MCP_COMMON_KEYS = new Set(["name", "transport", "deferLoading"]);
+const PREFERRED_MCP_TRANSPORT_KEYS: Record<string, Set<string>> = {
+    stdio: new Set(["command", "args", "env", "cwd"]),
+    http: new Set(["url", "headers"]),
+    streamable: new Set(["url", "headers", "oauthClientName", "oauthClientId", "oauthClientSecret", "oauthCallbackPort"]),
+};
 const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils"]);
 const PANEL_KEYS = new Set(["dir", "requires"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
@@ -350,6 +356,17 @@ function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
         return;
     }
 
+    if (parsed.mcp !== undefined && !isPlainObject(parsed.mcp)) {
+        push(`${field}.mcp`, "must be an object", "Set mcp to an object with a servers array.");
+    }
+    if (isPlainObject(parsed.mcp)) {
+        for (const key of Object.keys(parsed.mcp)) {
+            if (key !== "servers") {
+                push(`${field}.mcp.${key}`, `unknown mcp key "${key}"`, 'Remove it — the preferred mcp object only supports "servers".');
+            }
+        }
+    }
+
     const mcpServersArray = isPlainObject(parsed.mcp) && Array.isArray((parsed.mcp as Record<string, unknown>).servers)
         ? ((parsed.mcp as Record<string, unknown>).servers as unknown[])
         : undefined;
@@ -370,7 +387,19 @@ function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
             if (typeof entry.name !== "string" || entry.name.length === 0) {
                 push(`${entryField}.name`, "must be a non-empty string", "Set name to a unique server identifier.");
             }
-            if (typeof entry.transport !== "string" || !PREFERRED_MCP_TRANSPORTS.has(entry.transport)) {
+            const transport = typeof entry.transport === "string" && PREFERRED_MCP_TRANSPORTS.has(entry.transport)
+                ? entry.transport
+                : undefined;
+            const allowedKeys = new Set([
+                ...PREFERRED_MCP_COMMON_KEYS,
+                ...(transport ? PREFERRED_MCP_TRANSPORT_KEYS[transport] : Object.values(PREFERRED_MCP_TRANSPORT_KEYS).flatMap((keys) => [...keys])),
+            ]);
+            for (const key of Object.keys(entry)) {
+                if (!allowedKeys.has(key)) {
+                    push(`${entryField}.${key}`, `is not allowed when transport is ${transport ?? JSON.stringify(entry.transport)}`, `Remove "${key}" — allowed fields are: ${[...allowedKeys].join(", ")}.`);
+                }
+            }
+            if (!transport) {
                 push(
                     `${entryField}.transport`,
                     `is required and must be one of ${[...PREFERRED_MCP_TRANSPORTS].join(", ")}`,
@@ -378,19 +407,38 @@ function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
                 );
                 return;
             }
-            if (entry.transport === "stdio") {
+            if (entry.deferLoading !== undefined && typeof entry.deferLoading !== "boolean") {
+                push(`${entryField}.deferLoading`, "must be a boolean", "Set deferLoading to true/false, or omit it.");
+            }
+            if (transport === "stdio") {
                 if (typeof entry.command !== "string" || entry.command.length === 0) {
                     push(`${entryField}.command`, "must be a non-empty string when transport is stdio", "Set command to the stdio server executable.");
                 }
-                if (entry.url !== undefined) {
-                    push(`${entryField}.url`, "is not allowed when transport is stdio", "Remove url or use transport http/streamable.");
+                if (entry.args !== undefined && (!Array.isArray(entry.args) || entry.args.some((arg) => typeof arg !== "string"))) {
+                    push(`${entryField}.args`, "must be an array of strings", "Set args to string arguments, or omit it.");
                 }
-            } else {
-                if (typeof entry.url !== "string" || entry.url.length === 0) {
-                    push(`${entryField}.url`, `must be a non-empty string when transport is ${entry.transport}`, "Set url to the remote MCP endpoint.");
+                if (entry.env !== undefined && (!isPlainObject(entry.env) || Object.values(entry.env).some((value) => typeof value !== "string"))) {
+                    push(`${entryField}.env`, "must be an object with string values", "Set env to string key/value pairs, or omit it.");
                 }
-                if (entry.command !== undefined) {
-                    push(`${entryField}.command`, `is not allowed when transport is ${entry.transport}`, "Remove command or use transport stdio.");
+                if (entry.cwd !== undefined && typeof entry.cwd !== "string") {
+                    push(`${entryField}.cwd`, "must be a string", "Set cwd to a working-directory path, or omit it.");
+                }
+                return;
+            }
+            if (typeof entry.url !== "string" || entry.url.length === 0) {
+                push(`${entryField}.url`, `must be a non-empty string when transport is ${transport}`, "Set url to the remote MCP endpoint.");
+            }
+            if (entry.headers !== undefined && (!isPlainObject(entry.headers) || Object.values(entry.headers).some((value) => typeof value !== "string"))) {
+                push(`${entryField}.headers`, "must be an object with string values", "Set headers to string key/value pairs, or omit it.");
+            }
+            if (transport === "streamable") {
+                for (const key of ["oauthClientName", "oauthClientId", "oauthClientSecret"] as const) {
+                    if (entry[key] !== undefined && typeof entry[key] !== "string") {
+                        push(`${entryField}.${key}`, "must be a string", `Set ${key} to a string, or omit it.`);
+                    }
+                }
+                if (entry.oauthCallbackPort !== undefined && typeof entry.oauthCallbackPort !== "number") {
+                    push(`${entryField}.oauthCallbackPort`, "must be a number", "Set oauthCallbackPort to a port number, or omit it.");
                 }
             }
         });

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -21,6 +21,7 @@ import { MAX_PLUGIN_FILE_SIZE } from "../plugins/types.js";
 export const OVERLAY_SIDECAR_MAX_BYTES = MAX_PLUGIN_FILE_SIZE;
 
 const TOP_LEVEL_KEYS = new Set(["schemaVersion", "services", "agents", "rules", "mcp"]);
+const PREFERRED_MCP_TRANSPORTS = new Set(["stdio", "http", "streamable"]);
 const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils"]);
 const PANEL_KEYS = new Set(["dir", "requires"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
@@ -339,7 +340,9 @@ function validateAgentsOrRules(value: unknown, field: string, packageRoot: strin
  * `mcp.servers` array or the compatibility `mcpServers` object (see
  * extensions/mcp-extension.ts, extensions/mcp/registry.ts). Entries are
  * shape-checked just enough to reject junk while staying compatible with
- * every transport variant those loaders already support.
+ * every transport variant those loaders already support. Preferred entries
+ * must explicitly choose a transport so validation matches the registry;
+ * compatibility entries retain their URL-first inference behavior.
  */
 function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
     if (!isPlainObject(parsed)) {
@@ -361,14 +364,34 @@ function validateMcpShape(parsed: unknown, field: string, push: PushFn): void {
         mcpServersArray.forEach((entry, i) => {
             const entryField = `${field}.servers[${i}]`;
             if (!isPlainObject(entry)) {
-                push(entryField, "must be an object", "Fix this mcp.servers entry to a { name, command|url } object.");
+                push(entryField, "must be an object", "Fix this mcp.servers entry to a { name, transport, command|url } object.");
                 return;
             }
             if (typeof entry.name !== "string" || entry.name.length === 0) {
                 push(`${entryField}.name`, "must be a non-empty string", "Set name to a unique server identifier.");
             }
-            if (typeof entry.command !== "string" && typeof entry.url !== "string") {
-                push(entryField, "must have a string command (stdio) or url (http/streamable)", "Set command for a stdio server, or url for an http/streamable server.");
+            if (typeof entry.transport !== "string" || !PREFERRED_MCP_TRANSPORTS.has(entry.transport)) {
+                push(
+                    `${entryField}.transport`,
+                    `is required and must be one of ${[...PREFERRED_MCP_TRANSPORTS].join(", ")}`,
+                    "Set transport to stdio with command, or http/streamable with url.",
+                );
+                return;
+            }
+            if (entry.transport === "stdio") {
+                if (typeof entry.command !== "string" || entry.command.length === 0) {
+                    push(`${entryField}.command`, "must be a non-empty string when transport is stdio", "Set command to the stdio server executable.");
+                }
+                if (entry.url !== undefined) {
+                    push(`${entryField}.url`, "is not allowed when transport is stdio", "Remove url or use transport http/streamable.");
+                }
+            } else {
+                if (typeof entry.url !== "string" || entry.url.length === 0) {
+                    push(`${entryField}.url`, `must be a non-empty string when transport is ${entry.transport}`, "Set url to the remote MCP endpoint.");
+                }
+                if (entry.command !== undefined) {
+                    push(`${entryField}.command`, `is not allowed when transport is ${entry.transport}`, "Remove command or use transport stdio.");
+                }
             }
         });
     }

--- a/packages/cli/src/package-commands.test.ts
+++ b/packages/cli/src/package-commands.test.ts
@@ -218,6 +218,28 @@ describe("overlay trust integration", () => {
         expect(getGrantedServiceIds("local:" + realpathSync(pkgDir)).size).toBe(0);
     });
 
+    test("install rejects a preferred MCP sidecar without an explicit transport", async () => {
+        const agentDir = join(tmpDir, "agent");
+        const cwd = join(tmpDir, "project");
+        const pkgDir = join(tmpDir, "bad-mcp-pkg");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./mcp.json" });
+        writeFileSync(join(pkgDir, "mcp.json"), JSON.stringify({ mcp: { servers: [{ name: "godmother", command: "godmother" }] } }));
+
+        const originalError = console.error;
+        const errors: string[] = [];
+        console.error = ((...a: unknown[]) => { errors.push(a.join(" ")); }) as typeof console.error;
+        let code: number;
+        try {
+            code = await runPackageCommand(["install", "../bad-mcp-pkg"], cwd, agentDir);
+        } finally {
+            console.error = originalError;
+        }
+
+        expect(code).not.toBe(0);
+        expect(errors.join("\n")).toContain("mcp.servers[0].transport");
+        expect(errors.join("\n")).toContain("pi-native package install may remain");
+    });
+
     // P1: `pizza config grant` must require the normalized identity to exist
     // in DefaultPackageManager.listConfiguredPackages() at USER scope —
     // an arbitrary local directory that merely exists on disk (never

--- a/packages/cli/src/package-commands.test.ts
+++ b/packages/cli/src/package-commands.test.ts
@@ -218,12 +218,14 @@ describe("overlay trust integration", () => {
         expect(getGrantedServiceIds("local:" + realpathSync(pkgDir)).size).toBe(0);
     });
 
-    test("install rejects a preferred MCP sidecar without an explicit transport", async () => {
+    test("install rejects closed preferred MCP transport fields", async () => {
         const agentDir = join(tmpDir, "agent");
         const cwd = join(tmpDir, "project");
         const pkgDir = join(tmpDir, "bad-mcp-pkg");
         writeFixturePackage(pkgDir, { schemaVersion: 1, mcp: "./mcp.json" });
-        writeFileSync(join(pkgDir, "mcp.json"), JSON.stringify({ mcp: { servers: [{ name: "godmother", command: "godmother" }] } }));
+        writeFileSync(join(pkgDir, "mcp.json"), JSON.stringify({ mcp: { servers: [{
+            name: "godmother", transport: "http", url: "https://example.test/mcp", command: "godmother", oauthClientId: "ignored", unexpected: true,
+        }] } }));
 
         const originalError = console.error;
         const errors: string[] = [];
@@ -236,7 +238,9 @@ describe("overlay trust integration", () => {
         }
 
         expect(code).not.toBe(0);
-        expect(errors.join("\n")).toContain("mcp.servers[0].transport");
+        expect(errors.join("\n")).toContain("mcp.servers[0].command");
+        expect(errors.join("\n")).toContain("mcp.servers[0].oauthClientId");
+        expect(errors.join("\n")).toContain("mcp.servers[0].unexpected");
         expect(errors.join("\n")).toContain("pi-native package install may remain");
     });
 

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -41,7 +41,7 @@ Two config formats are supported:
     ```
   </TabItem>
   <TabItem label="mcp.servers (preferred)">
-    The `mcp.servers` format uses an array of server objects, each with an explicit `name` field. PizzaPi treats this as the preferred format internally.
+    The `mcp.servers` format uses an array of server objects, each with explicit `name` and `transport` fields. PizzaPi treats this as the preferred format internally. Use `stdio` with `command`, or `http`/`streamable` with `url`; do not mix command and URL fields.
 
     ```jsonc
     // ~/.pizzapi/config.json
@@ -50,12 +50,14 @@ Two config formats are supported:
         "servers": [
           {
             "name": "tavily",
+            "transport": "stdio",
             "command": "npx",
             "args": ["-y", "@tavily/mcp-server"],
             "env": { "TAVILY_API_KEY": "tvly-..." }
           },
           {
             "name": "filesystem",
+            "transport": "stdio",
             "command": "npx",
             "args": ["-y", "@anthropic/mcp-filesystem"],
             "env": {}

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -94,6 +94,23 @@ STDIO is the most common transport. PizzaPi spawns the MCP server as a child pro
 | `env` | `Record<string, string>` | — | Environment variables set for the child process. These are merged with the current environment. |
 | `cwd` | `string` | — | Working directory for the child process. Defaults to the current project root. |
 
+### Package overlay MCP paths
+
+A package's `pi.pizzapi.mcp` sidecar can use `@PACKAGE_ROOT@` in stdio `command`, `cwd`, string `args` entries, and string `env` values. PizzaPi replaces it with that installed package's confined root before normal variable expansion. It is not available in explicit config files or legacy Claude-plugin `.mcp.json` files, and does not apply to URLs or headers.
+
+For example, the AgentMemory package sidecar should use:
+
+```json
+{
+  "mcpServers": {
+    "godmother": {
+      "command": "@PACKAGE_ROOT@/gm",
+      "args": ["--config", "@PACKAGE_ROOT@/config.json"]
+    }
+  }
+}
+```
+
 ## HTTP / Streamable HTTP Transport
 
 For remote MCP servers, use URL-based configuration instead of spawning a local process.

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -96,7 +96,7 @@ STDIO is the most common transport. PizzaPi spawns the MCP server as a child pro
 
 ### Package overlay MCP paths
 
-A package's `pi.pizzapi.mcp` sidecar can use `@PACKAGE_ROOT@` in stdio `command`, `cwd`, string `args` entries, and string `env` values. PizzaPi replaces it with that installed package's confined root before normal variable expansion. It is not available in explicit config files or legacy Claude-plugin `.mcp.json` files, and does not apply to URLs or headers.
+A package's `pi.pizzapi.mcp` sidecar can use `@PACKAGE_ROOT@` in stdio `command`, `cwd`, string `args` entries, and string `env` values. PizzaPi replaces it with that installed package's confined root after normal variable expansion, so literal variable-shaped text in the installed path stays unchanged. It is not available in explicit config files or legacy Claude-plugin `.mcp.json` files, and does not apply to URL-based definitions (even if they also contain stdio fields), URLs, or headers.
 
 For example, the AgentMemory package sidecar should use:
 

--- a/packages/server/tests/harness/service-announce-package-origin.test.ts
+++ b/packages/server/tests/harness/service-announce-package-origin.test.ts
@@ -119,28 +119,23 @@ describe("package-origin service_announce integration", () => {
                     triggerDefs: [PACKAGE_TRIGGER],
                     sigilDefs: [PACKAGE_SIGIL],
                 });
-                const session = await scenario.addSession({ cwd: "/tmp/test" });
-                runner.emitSessionReady(session.sessionId);
-                // Attach a viewer solely to know the announce has round-tripped
-                // through the server (and therefore been persisted) before we GET.
-                const viewer = await scenario.addViewer(session.sessionId);
-                await new Promise<void>((resolve, reject) => {
-                    const timer = setTimeout(() => reject(new Error("timed out waiting for service_announce")), 8000);
-                    viewer.socket.on("service_announce", (data) => {
-                        if ((data as ServiceAnnounceData).serviceIds.includes(PACKAGE_SERVICE_ID)) {
-                            clearTimeout(timer);
-                            resolve();
+                let body: ServiceAnnounceData | undefined;
+                for (let attempt = 0; attempt < 80; attempt++) {
+                    const res = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/services`);
+                    if (res.status === 200) {
+                        const candidate = await res.json() as ServiceAnnounceData;
+                        if (candidate.serviceIds.includes(PACKAGE_SERVICE_ID)) {
+                            body = candidate;
+                            break;
                         }
-                    });
-                });
+                    }
+                    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+                }
 
-                const res = await server.fetch(`/api/runners/${encodeURIComponent(runner.runnerId)}/services`);
-                expect(res.status).toBe(200);
-                const body = await res.json() as ServiceAnnounceData;
-                expect(body.serviceIds).toContain(PACKAGE_SERVICE_ID);
-                expect(body.panels).toContainEqual(PACKAGE_PANEL);
-                expect(body.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
-                expect(body.sigilDefs).toContainEqual(PACKAGE_SIGIL);
+                expect(body).toBeDefined();
+                expect(body!.panels).toContainEqual(PACKAGE_PANEL);
+                expect(body!.triggerDefs).toContainEqual(PACKAGE_TRIGGER);
+                expect(body!.sigilDefs).toContainEqual(PACKAGE_SIGIL);
             } finally {
                 await scenario.teardown();
                 await cleanupServer(server);


### PR DESCRIPTION
## Summary
- add package-only `@PACKAGE_ROOT@` resolution for `pi.pizzapi.mcp` stdio definitions
- preserve canonical installed roots through ordinary MCP variable expansion
- keep URL-based, explicit-config, and legacy-plugin definitions untouched
- require preferred package MCP entries to use the registry's explicit closed transport schema
- document and test package-root portability, transport precedence, validation, trust, and collision behavior

## Verification
- `bun test packages/cli/src/overlay/manifest.test.ts packages/cli/src/extensions/mcp-overlay.test.ts packages/cli/src/extensions/mcp-extension.test.ts packages/cli/src/extensions/mcp.test.ts packages/cli/src/package-commands.test.ts`
- focused MCP/package/manifest suites: 144 tests passed
- `bun run typecheck`
- docs build
- independent Claude Fable review: LGTM, no P0-P2 findings

Stacked on #659. No stack branches were merged.
