### PR TITLE
fix(cli): dispose deleted-plugin services and release their tunnel ports

### DIFF
--- a/packages/cli/src/runner/daemon-legacy-service-removal.test.ts
+++ b/packages/cli/src/runner/daemon-legacy-service-removal.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { PizzaPiSocket, ServiceHandler } from "@pizzapi/extension-sdk";
+import { removeVanishedLegacyServices, type PanelEntry } from "./daemon.js";
+import { ServiceRegistry } from "./service-handler.js";
+import { TunnelService } from "./services/tunnel-service.js";
+
+/**
+ * Lifecycle-level coverage for reconfigure_services against a *live*
+ * ServiceRegistry — the disabled-set parsing tests in daemon-services.test.ts
+ * never caught that a deleted plugin's handler stayed registered and running.
+ */
+
+function createMockSocket() {
+    const listeners = new Map<string, Function[]>();
+    return {
+        emitted: [] as Array<[string, ...unknown[]]>,
+        listeners,
+        emit: mock(function (this: any, ...args: unknown[]) {
+            this.emitted.push(args as [string, ...unknown[]]);
+        }),
+        on: mock((event: string, handler: Function) => {
+            listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+        }),
+        off: mock((event: string, handler: Function) => {
+            listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+        }),
+    };
+}
+
+/** A service that records whether it was disposed, like a real plugin handler. */
+function createFakeService(id: string) {
+    const state = { disposed: 0, initialized: 0 };
+    const handler: ServiceHandler = {
+        id,
+        init(_socket: PizzaPiSocket) {
+            state.initialized += 1;
+        },
+        dispose() {
+            state.disposed += 1;
+        },
+    };
+    return { handler, state };
+}
+
+interface Harness {
+    registry: ServiceRegistry;
+    tunnel: TunnelService;
+    tunnelClient: { exposePort: ReturnType<typeof mock>; unexposePort: ReturnType<typeof mock> };
+    tracked: Set<string>;
+    legacyServiceIds: Set<string>;
+    initializedServiceIds: Set<string>;
+    panelEntries: Map<string, PanelEntry>;
+    sigilServerPorts: Map<string, number>;
+    disposeIncumbent: (id: string, reason: string) => void;
+    releasePort: (port: number) => void;
+}
+
+/** Wire the same collaborators the daemon composes around the removal loop. */
+function createHarness(): Harness {
+    const registry = new ServiceRegistry();
+    const tunnel = new TunnelService();
+    const tunnelClient = { exposePort: mock((_p: number) => {}), unexposePort: mock((_p: number) => {}) };
+    const socket = createMockSocket();
+    tunnel.setTunnelClient(tunnelClient as any);
+    tunnel.init(socket as any, { isShuttingDown: () => false });
+
+    const initializedServiceIds = new Set<string>();
+    const disposeIncumbent = (id: string, _reason: string) => {
+        const svc = registry.get(id);
+        if (!svc) return;
+        svc.dispose();
+        registry.unregister(id);
+        initializedServiceIds.delete(id);
+    };
+
+    return {
+        registry,
+        tunnel,
+        tunnelClient,
+        tracked: new Set<string>(),
+        legacyServiceIds: new Set<string>(),
+        initializedServiceIds,
+        panelEntries: new Map<string, PanelEntry>(),
+        sigilServerPorts: new Map<string, number>(),
+        disposeIncumbent,
+        releasePort: (port: number) => { tunnel.unregisterPort(port); },
+    };
+}
+
+/** Register a legacy service the way the daemon does when it discovers a plugin. */
+function mountLegacyService(h: Harness, id: string, opts: { panelPort?: number; sigilPort?: number } = {}) {
+    const svc = createFakeService(id);
+    h.registry.register(svc.handler);
+    h.initializedServiceIds.add(id);
+    h.tracked.add(id);
+    h.legacyServiceIds.add(id);
+    h.panelEntries.set(id, {
+        serviceId: id,
+        label: id,
+        icon: "square",
+        ...(opts.panelPort !== undefined ? { port: opts.panelPort } : {}),
+    });
+    if (opts.panelPort !== undefined) h.tunnel.registerPort(opts.panelPort, id);
+    if (opts.sigilPort !== undefined) {
+        h.sigilServerPorts.set(id, opts.sigilPort);
+        h.tunnel.registerPort(opts.sigilPort, id);
+    }
+    return svc;
+}
+
+function removeVanished(h: Harness, stillDiscovered: string[], disabled: string[] = [], packageIds: string[] = []) {
+    return removeVanishedLegacyServices({
+        tracked: h.tracked,
+        legacyServiceIds: h.legacyServiceIds,
+        packageServiceIds: new Set(packageIds),
+        disabledIds: new Set(disabled),
+        stillDiscovered: new Set(stillDiscovered),
+        panelEntries: h.panelEntries,
+        sigilServerPorts: h.sigilServerPorts,
+        disposeIncumbent: h.disposeIncumbent,
+        releasePort: h.releasePort,
+    });
+}
+
+describe("removeVanishedLegacyServices (live registry lifecycle)", () => {
+    test("a deleted plugin's service is disposed and unregistered, not just forgotten", () => {
+        const h = createHarness();
+        const svc = mountLegacyService(h, "gone");
+
+        expect(removeVanished(h, [])).toEqual(["gone"]);
+
+        expect(svc.state.disposed).toBe(1);
+        expect(h.registry.has("gone")).toBe(false);
+        expect(h.initializedServiceIds.has("gone")).toBe(false);
+        expect(h.tracked.has("gone")).toBe(false);
+        expect(h.legacyServiceIds.has("gone")).toBe(false);
+    });
+
+    test("a deleted plugin's panel and sigil ports stop being routed", () => {
+        const h = createHarness();
+        mountLegacyService(h, "gone", { panelPort: 4321, sigilPort: 8765 });
+
+        removeVanished(h, []);
+
+        expect(h.tunnelClient.unexposePort).toHaveBeenCalledWith(4321);
+        expect(h.tunnelClient.unexposePort).toHaveBeenCalledWith(8765);
+        expect(h.panelEntries.has("gone")).toBe(false);
+        expect(h.sigilServerPorts.has("gone")).toBe(false);
+    });
+
+    test("a still-discoverable service keeps running and keeps its port", () => {
+        const h = createHarness();
+        const svc = mountLegacyService(h, "kept", { panelPort: 4321 });
+
+        expect(removeVanished(h, ["kept"])).toEqual([]);
+
+        expect(svc.state.disposed).toBe(0);
+        expect(h.registry.has("kept")).toBe(true);
+        expect(h.tunnelClient.unexposePort).not.toHaveBeenCalled();
+    });
+
+    test("a disabled service is left intact so it can be re-enabled", () => {
+        const h = createHarness();
+        const svc = mountLegacyService(h, "off");
+
+        expect(removeVanished(h, [], ["off"])).toEqual([]);
+
+        expect(svc.state.disposed).toBe(0);
+        expect(h.tracked.has("off")).toBe(true);
+    });
+
+    test("a package-origin id is left to the package reconciler", () => {
+        const h = createHarness();
+        const svc = mountLegacyService(h, "pkg");
+
+        expect(removeVanished(h, [], [], ["pkg"])).toEqual([]);
+
+        expect(svc.state.disposed).toBe(0);
+        expect(h.registry.has("pkg")).toBe(true);
+    });
+
+    test("removing one vanished service does not disturb its neighbours", () => {
+        const h = createHarness();
+        const gone = mountLegacyService(h, "gone", { panelPort: 4321 });
+        const kept = mountLegacyService(h, "kept", { panelPort: 5555 });
+
+        expect(removeVanished(h, ["kept"])).toEqual(["gone"]);
+
+        expect(gone.state.disposed).toBe(1);
+        expect(kept.state.disposed).toBe(0);
+        expect(h.registry.has("kept")).toBe(true);
+        expect(h.tunnelClient.unexposePort).toHaveBeenCalledWith(4321);
+        expect(h.tunnelClient.unexposePort).not.toHaveBeenCalledWith(5555);
+    });
+
+    test("a vanished service that never announced a port is still retired cleanly", () => {
+        const h = createHarness();
+        const svc = mountLegacyService(h, "portless");
+
+        expect(removeVanished(h, [])).toEqual(["portless"]);
+
+        expect(svc.state.disposed).toBe(1);
+        expect(h.tunnelClient.unexposePort).not.toHaveBeenCalled();
+    });
+
+    test("removal is idempotent across repeated reconfigure passes", () => {
+        const h = createHarness();
+        mountLegacyService(h, "gone", { panelPort: 4321 });
+
+        expect(removeVanished(h, [])).toEqual(["gone"]);
+        expect(removeVanished(h, [])).toEqual([]);
+        expect(h.tunnelClient.unexposePort).toHaveBeenCalledTimes(1);
+    });
+
+    test("a throwing dispose does not strand the rest of the removal", () => {
+        const h = createHarness();
+        const exploding: ServiceHandler = {
+            id: "boom",
+            init() {},
+            dispose() { throw new Error("dispose failed"); },
+        };
+        h.registry.register(exploding);
+        h.tracked.add("boom");
+        h.legacyServiceIds.add("boom");
+
+        // The daemon's disposeIncumbent swallows dispose errors; assert the
+        // registry still sheds the handler rather than keeping a dead one.
+        const guarded = { ...h, disposeIncumbent: (id: string) => {
+            const svc = h.registry.get(id);
+            if (!svc) return;
+            try { svc.dispose(); } catch { /* daemon logs and continues */ }
+            h.registry.unregister(id);
+        } };
+
+        expect(removeVanished(guarded as Harness, [])).toEqual(["boom"]);
+        expect(h.registry.has("boom")).toBe(false);
+    });
+});

--- a/packages/cli/src/runner/daemon-package-reconcile.test.ts
+++ b/packages/cli/src/runner/daemon-package-reconcile.test.ts
@@ -120,6 +120,38 @@ describe("clearServiceRuntimePorts (final-review port hygiene)", () => {
         expect(panels.get("svc")).toEqual({ serviceId: "svc", label: "Svc", icon: "square" });
         expect(sigilPorts.has("svc")).toBe(false);
     });
+
+    test("releases both the panel port and the sigil-server port back to the tunnel", () => {
+        // Forgetting the port only stops it being announced; the runner keeps
+        // proxying to it unless it is handed back to the tunnel.
+        const panels = new Map<string, PanelEntry>([["svc", { serviceId: "svc", label: "Svc", icon: "square", port: 4321 }]]);
+        const sigilPorts = new Map([["svc", 8765]]);
+        const released: number[] = [];
+
+        clearServiceRuntimePorts("svc", panels, sigilPorts, false, (port) => released.push(port));
+
+        expect(released.sort()).toEqual([4321, 8765]);
+    });
+
+    test("releases ports even when disabled-state metadata is retained", () => {
+        const panels = new Map<string, PanelEntry>([["svc", { serviceId: "svc", label: "Svc", icon: "square", port: 4321 }]]);
+        const sigilPorts = new Map([["svc", 8765]]);
+        const released: number[] = [];
+
+        clearServiceRuntimePorts("svc", panels, sigilPorts, true, (port) => released.push(port));
+
+        expect(released.sort()).toEqual([4321, 8765]);
+        expect(panels.get("svc")?.port).toBeUndefined();
+    });
+
+    test("does not invent a port release for a service that never announced one", () => {
+        const panels = new Map<string, PanelEntry>([["svc", { serviceId: "svc", label: "Svc", icon: "square" }]]);
+        const released: number[] = [];
+
+        clearServiceRuntimePorts("svc", panels, new Map(), false, (port) => released.push(port));
+
+        expect(released).toEqual([]);
+    });
 });
 
 describe("planPackageServiceReconcile (fix #4 + addendum B: reconfigure lifecycle)", () => {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -298,22 +298,68 @@ export function panelEntryFromManifest(
     };
 }
 
-/** Remove ports owned by a stopped handler; optionally retain its disabled-state metadata. */
+/**
+ * Remove ports owned by a stopped handler; optionally retain its disabled-state metadata.
+ *
+ * `releasePort` hands each port back to the tunnel (TunnelService.unregisterPort).
+ * Dropping the port from these maps only stops it being *announced*; without the
+ * release the runner keeps proxying traffic to a port the dead service no longer
+ * owns. Optional so the pure map-hygiene behaviour stays unit-testable.
+ */
 export function clearServiceRuntimePorts(
     serviceId: string,
     panelEntries: Map<string, PanelEntry>,
     sigilServerPorts: Map<string, number>,
     keepMetadata: boolean,
+    releasePort?: (port: number) => void,
 ): void {
+    const sigilPort = sigilServerPorts.get(serviceId);
+    if (sigilPort !== undefined) releasePort?.(sigilPort);
     sigilServerPorts.delete(serviceId);
     const entry = panelEntries.get(serviceId);
     if (!entry) return;
+    if (entry.port !== undefined) releasePort?.(entry.port);
     if (!keepMetadata) {
         panelEntries.delete(serviceId);
         return;
     }
     const { port: _stalePort, ...metadata } = entry;
     panelEntries.set(serviceId, metadata);
+}
+
+/**
+ * Retire legacy (plugin-dir) services that vanished between rediscovery passes.
+ *
+ * A deleted plugin used to have only its *metadata* forgotten, which left the
+ * handler registered, initialized and still serving on its announced port.
+ * Exported so the reconfigure lifecycle is covered by a live-registry test
+ * rather than a mirrored re-implementation of this loop.
+ *
+ * @returns the ids that were retired.
+ */
+export function removeVanishedLegacyServices(opts: {
+    tracked: Set<string>;
+    legacyServiceIds: Set<string>;
+    packageServiceIds: ReadonlySet<string>;
+    disabledIds: ReadonlySet<string>;
+    stillDiscovered: ReadonlySet<string>;
+    panelEntries: Map<string, PanelEntry>;
+    sigilServerPorts: Map<string, number>;
+    disposeIncumbent: (id: string, reason: string) => void;
+    releasePort?: (port: number) => void;
+}): string[] {
+    const removed: string[] = [];
+    for (const id of [...opts.tracked]) {
+        if (opts.packageServiceIds.has(id)) continue; // Package-origin ids reconcile separately
+        if (opts.disabledIds.has(id)) continue;       // Keep disabled services
+        if (opts.stillDiscovered.has(id)) continue;   // Still on disk
+        opts.disposeIncumbent(id, `legacy service "${id}" is no longer discoverable (plugin deleted) — disposing handler`);
+        opts.tracked.delete(id);
+        opts.legacyServiceIds.delete(id);
+        clearServiceRuntimePorts(id, opts.panelEntries, opts.sigilServerPorts, false, opts.releasePort);
+        removed.push(id);
+    }
+    return removed;
 }
 
 /**
@@ -809,6 +855,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         } else {
             registry.register(tunnelService);
         }
+
+        /** Hand a dead service's pinned port back to the tunnel (see clearServiceRuntimePorts). */
+        const releaseServicePort = (port: number): void => {
+            tunnelService.unregisterPort(port);
+        };
 
         const timeService = isServiceDisabled("time") ? null : new TimeService();
         if (timeService) {
@@ -1370,8 +1421,22 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     packageServiceIds.delete(svc.id);
                     legacyServiceIds.delete(svc.id);
                     // Keep disabled-service metadata visible, but never re-announce its dead ports.
-                    clearServiceRuntimePorts(svc.id, panelEntries, sigilServerPorts, true);
+                    clearServiceRuntimePorts(svc.id, panelEntries, sigilServerPorts, true, releaseServicePort);
                 }
+
+                /** Dispose + unregister a running handler so no timers/sockets outlive it. */
+                const disposeIncumbent = (id: string, reason: string) => {
+                    const oldSvc = registry.get(id);
+                    if (!oldSvc) return;
+                    logInfo(`[services] ${reason}`);
+                    try {
+                        oldSvc.dispose();
+                    } catch (err) {
+                        logWarn(`[services] dispose failed for "${id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+                    }
+                    registry.unregister(id);
+                    initializedServiceIds.delete(id);
+                };
 
                 const initAndTrack = (handler: ServiceHandler, kind: "package" | "legacy") => {
                     try {
@@ -1443,8 +1508,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         }
                         packageServiceIds.delete(id);
                         allDiscoveredServiceIds.delete(id);
-                        panelEntries.delete(id);
-                        sigilServerPorts.delete(id);
+                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false, releaseServicePort);
                     }
 
                     // Unchanged winning identity — preserve the running lifecycle,
@@ -1458,19 +1522,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         else panelEntries.delete(id);
                     }
 
-                    const disposeIncumbent = (id: string, reason: string) => {
-                        const oldSvc = registry.get(id);
-                        if (!oldSvc) return;
-                        logInfo(`[services] ${reason}`);
-                        try {
-                            oldSvc.dispose();
-                        } catch (err) {
-                            logWarn(`[services] dispose failed for "${id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
-                        }
-                        registry.unregister(id);
-                        initializedServiceIds.delete(id);
-                    };
-
                     // Same service id, but the package identity that won it changed
                     // underneath it — dispose the incumbent before mounting the new
                     // one so stale handler state/timers never linger alongside it.
@@ -1479,7 +1530,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         const freshIdentity = freshById.get(id)?.source.pluginName ?? id;
                         disposeIncumbent(id, `package service "${id}" identity changed (${existing?.identity} → ${freshIdentity}) — disposing old handler`);
                         packageServiceIds.delete(id);
-                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false);
+                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false, releaseServicePort);
                     }
 
                     // A legacy-origin service currently holds this id from an
@@ -1490,7 +1541,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         disposeIncumbent(id, `package service "${id}" supersedes legacy incumbent — disposing legacy handler`);
                         legacyServiceIds.delete(id);
                         allDiscoveredServiceIds.delete(id);
-                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false);
+                        clearServiceRuntimePorts(id, panelEntries, sigilServerPorts, false, releaseServicePort);
                     }
 
                     for (const id of [...plan.replaceIdentitySwap, ...plan.evictLegacyThenRegister, ...plan.registerNew]) {
@@ -1511,15 +1562,17 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
                 // Remove legacy services that are no longer discoverable (plugin
                 // deleted) and not disabled. Package-origin ids are reconciled above.
-                for (const id of [...allDiscoveredServiceIds]) {
-                    if (packageServiceIds.has(id)) continue;
-                    if (newDisabledServices.has(id)) continue; // Keep disabled services
-                    if (discoveredServices.some(s => s.handler.id === id)) continue; // Still exists
-                    allDiscoveredServiceIds.delete(id);
-                    legacyServiceIds.delete(id);
-                    panelEntries.delete(id);
-                    sigilServerPorts.delete(id);
-                }
+                removeVanishedLegacyServices({
+                    tracked: allDiscoveredServiceIds,
+                    legacyServiceIds,
+                    packageServiceIds: new Set(packageServiceIds.keys()),
+                    disabledIds: newDisabledServices,
+                    stillDiscovered: new Set(discoveredServices.map(s => s.handler.id)),
+                    panelEntries,
+                    sigilServerPorts,
+                    disposeIncumbent,
+                    releasePort: releaseServicePort,
+                });
 
                 for (const { handler, source, manifest } of discoveredServices) {
                     if (legacyServiceIds.has(handler.id) && registry.has(handler.id)) continue; // unchanged — preserve lifecycle

--- a/packages/cli/src/runner/services/tunnel-service.test.ts
+++ b/packages/cli/src/runner/services/tunnel-service.test.ts
@@ -96,6 +96,83 @@ describe("TunnelService", () => {
         ]);
     });
 
+    test("unregisterPort releases a pinned port and unexposes it", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+        socket.emitted.length = 0;
+
+        expect(service.unregisterPort(3000)).toBe(true);
+        expect(tunnelClient.unexposePort).toHaveBeenCalledWith(3000);
+        expect(socket.emitted).toEqual([
+            ["service_message", { serviceId: "tunnel", type: "tunnel_removed", payload: { port: 3000 } }],
+        ]);
+    });
+
+    test("unregisterPort is a no-op for a port that was never pinned", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        expect(service.unregisterPort(9999)).toBe(false);
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalled();
+    });
+
+    test("double unregisterPort cannot drive the refcount below zero", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+
+        expect(service.unregisterPort(3000)).toBe(true);
+        expect(service.unregisterPort(3000)).toBe(false);
+        expect(tunnelClient.unexposePort).toHaveBeenCalledTimes(1);
+    });
+
+    test("re-registering the same pinned port does not leak a refcount", () => {
+        // Services re-invoke announcePanel on every restart; if that double-counted,
+        // a later unregisterPort would decrement to 1 and never actually unexpose.
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+        service.registerPort(3000, "Panel (restarted)");
+
+        expect(service.unregisterPort(3000)).toBe(true);
+        expect(tunnelClient.unexposePort).toHaveBeenCalledWith(3000);
+    });
+
+    test("releasing a pinned port keeps a session-scoped exposure of the same port alive", () => {
+        const service = new TunnelService();
+        const socket = createMockSocket();
+        const tunnelClient = createMockTunnelClient();
+
+        service.setTunnelClient(tunnelClient as any);
+        service.init(socket as any, { isShuttingDown: () => false });
+        service.registerPort(3000, "Panel");
+        exposeViaMessage(socket, "sess-a", 3000);
+
+        expect(service.unregisterPort(3000)).toBe(true);
+        // The session still owns a ref, so the port must stay exposed.
+        expect(tunnelClient.unexposePort).not.toHaveBeenCalled();
+
+        unexposeViaMessage(socket, "sess-a", 3000);
+        expect(tunnelClient.unexposePort).toHaveBeenCalledWith(3000);
+    });
+
     test("service_message tunnel_expose and tunnel_unexpose sync the tunnel client", () => {
         const service = new TunnelService();
         const socket = createMockSocket();

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -80,11 +80,34 @@ export class TunnelService implements ServiceHandler {
             url: `/tunnel/${port}`,
             pinned: true,
         };
+        // Services re-invoke announcePanel/announceSigilServer every time they
+        // (re)start their HTTP server, so the same pinned port can be registered
+        // more than once. Only the first registration takes a ref — otherwise the
+        // count never drains and unregisterPort() can't actually unexpose.
+        const alreadyPinned = this.pinnedTunnels.has(port);
         this.pinnedTunnels.set(port, info);
-        this.incRef(port);
+        if (!alreadyPinned) this.incRef(port);
         this.tunnelClient?.exposePort(port);
         logInfo(`[tunnel] auto-registered panel port ${port}${name ? ` (${name})` : ""}`);
         this.emitTunnelRegistered(info);
+    }
+
+    /**
+     * Release a pinned port previously taken by {@link registerPort}.
+     *
+     * Counterpart to registerPort: without this, a service that is disabled,
+     * revoked, superseded, or whose plugin was deleted leaves the runner routing
+     * traffic to a port it no longer owns. Session-scoped exposures of the same
+     * port survive — decRef only unexposes once the last owner releases it.
+     *
+     * @returns true if the port was pinned and has now been released.
+     */
+    unregisterPort(port: number): boolean {
+        if (!this.pinnedTunnels.has(port)) return false;
+        this.pinnedTunnels.delete(port);
+        this.decRef(port);
+        logInfo(`[tunnel] released pinned port ${port}`);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Closes the remaining half of `ST2qvLCs` and all of `b7ZxKxmd` — they turned out to be the same ten-line loop in `daemon.ts`.

## The bug

When `reconfigure_services` found that a legacy plugin had been deleted, it dropped the service's *metadata* and stopped there:

```ts
allDiscoveredServiceIds.delete(id);
legacyServiceIds.delete(id);
panelEntries.delete(id);
sigilServerPorts.delete(id);
```

No `dispose()`, no `registry.unregister()`. The handler stayed registered, initialized and announced — a deleted plugin's service kept running, kept its timers and sockets, and kept being served to viewers.

The port half is the same story: `TunnelService` exposed `registerPort()` with no counterpart, so dropping `sigilServerPorts` only stopped the port being *announced*. The runner carried on proxying traffic to a port the dead service no longer owned.

## The fix

- **`TunnelService.unregisterPort()`** — the missing counterpart. Guarded against double-release, and `decRef` means a session-scoped exposure of the same port survives a pinned release.
- **`registerPort` is now idempotent.** Services re-invoke `announcePanel`/`announceSigilServer` every time they restart their HTTP server, so the same port got registered repeatedly; the double `incRef` meant the count could never drain and `unregisterPort` would have been unable to actually unexpose.
- **`clearServiceRuntimePorts()` releases ports.** Putting the release in the shared helper fixes the leak on *every* teardown path — disable, revoke, identity swap, legacy eviction — not just plugin deletion.
- **`disposeIncumbent` hoisted** so the legacy path reuses the existing dispose → unregister → forget sequence rather than growing a third copy.

## Testing

`ST2qvLCs` explicitly asked for lifecycle tests "around the live registry, not only disabled-set parsing" — the existing `daemon-services.test.ts` is entirely parsing tests, which is why this survived.

So `removeVanishedLegacyServices()` is extracted and exported, and the new `daemon-legacy-service-removal.test.ts` drives it against a **real `ServiceRegistry` and a real `TunnelService`**. The test exercises production code rather than mirroring the loop — the repo already has a `ponytail:` note about mirrored characterization tests drifting.

Verified the tests actually catch the regression: reverting the loop to its previous behaviour fails 6 of them.

```
bun run typecheck   clean
bun test src/runner 476 pass, 0 fail
```

## Note

`registerPort` being non-idempotent is a latent refcount leak that exists on `main` today, independent of plugin deletion — any service that restarts its panel server leaks a ref. Worth a look during review.
