### PR TITLE
docs(runner-services): project-local .pizzapi/services is not loaded

### DIFF
--- a/packages/cli/src/runner/daemon-services.test.ts
+++ b/packages/cli/src/runner/daemon-services.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { resolveAnnouncedDisabledRunnerServices, resolveDisabledRunnerServices, resolveReconfiguredDisabledRunnerServices } from "./daemon.js";
 import { _setGlobalConfigDir, loadGlobalConfig, saveGlobalConfig } from "../config/io.js";
 
@@ -67,6 +68,25 @@ describe("resolveReconfiguredDisabledRunnerServices", () => {
             serviceId: "demo",
             enabled: true,
         })).toEqual(new Set(["nightshift"]));
+    });
+});
+
+describe("legacy service discovery stays runner-global (overlay spec §6.3)", () => {
+    // The daemon owns ONE ServiceRegistry shared by every workspace. Passing a
+    // cwd to discoverServices() would mount the daemon's launch directory as a
+    // runner-global service for unrelated sessions. service-loader still
+    // supports { cwd } as the loader half of a future scoped design, so this
+    // pins the invariant that no production caller actually uses it.
+    test("no discoverServices() call in daemon.ts passes a cwd", () => {
+        const daemonSrc = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "daemon.ts"), "utf-8");
+
+        // Deliberately excludes discoverPackageServices(), which is cwd-scoped by design.
+        const callSites = [...daemonSrc.matchAll(/(?<![A-Za-z])discoverServices\(([\s\S]{0,300}?)\)\s*;/g)];
+
+        expect(callSites.length).toBeGreaterThan(0);
+        for (const [, args] of callSites) {
+            expect(args).not.toMatch(/\bcwd\b/);
+        }
     });
 });
 

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -589,7 +589,21 @@ function isServiceHandler(obj: unknown): obj is ServiceHandler {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 export interface DiscoverServicesOptions {
-    /** Include project-local services from .pizzapi/services/ */
+    /**
+     * Include project-local services from `<cwd>/.pizzapi/services/`.
+     *
+     * ⚠️ Deliberately unset by every production caller. The daemon owns ONE
+     * global ServiceRegistry shared by all workspaces, so passing a cwd here
+     * would mount whichever checkout the daemon happened to start in as a
+     * runner-global service for every unrelated session — precisely the scope
+     * leak §6.3 of docs/specs/pi-pizzapi-overlay.md forbids in schema v1
+     * ("A global grant is not an acceptable shortcut").
+     *
+     * Kept because it is the loader half of a future project-scoped design,
+     * which additionally needs scoped registry instances, canonical project
+     * ownership and lifecycle isolation. Do not wire this into daemon.ts to
+     * "restore" project services — that is the bug, not the fix.
+     */
     cwd?: string;
     /** Additional plugin directories to scan for manifest-declared services */
     pluginDirs?: string[];

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -9,6 +9,14 @@ Runner services are background processes on the runner daemon. They can expose i
 
 ![Service panel showing a System Monitor with CPU, memory, disk, and process information](../../../assets/service-panel-screenshot.png)
 
+<Aside type="caution" title="Runner services are runner-global">
+Services are always runner-wide. A project-local `.pizzapi/services/` directory is **not** loaded, and a package configured at project scope does not mount its services.
+
+The daemon keeps a single service registry shared by every workspace on the machine. Mounting a service found in one checkout would silently activate that project's code for unrelated sessions, so PizzaPi does not do it. Overlay packages that declare services are still installable at project scope — PizzaPi warns that the services stay inactive.
+
+Supporting genuinely project-scoped services needs scoped registry instances and lifecycle isolation, not a global grant. See §6.3 of `docs/specs/pi-pizzapi-overlay.md`.
+</Aside>
+
 ---
 
 ## Quick Start
@@ -764,7 +772,7 @@ Panels render inside an iframe in the PizzaPi web interface. The bottom dock is 
 
 ## How It Works
 
-1. The runner daemon discovers service folders in `~/.pizzapi/services/`, project-local `.pizzapi/services/`, and plugin service declarations
+1. The runner daemon discovers service folders in `~/.pizzapi/services/`, plus plugin and package service declarations
 2. It reads `manifest.json` for panel metadata and trigger definitions
 3. It loads the service module and calls `init(socket, { announcePanel })`
 4. The service starts `Bun.serve()` on port 0 and calls `announcePanel(port)`


### PR DESCRIPTION
Resolves `ZCEJktvF` — which turned out to be a docs bug, not a code bug.

## What the idea claimed

> The completed parent says project-scoped service discovery was wired, and docs claim `.pizzapi/services` loads per session, but current `daemon.ts` only calls `discoverServices({ pluginDirs: globalPluginDirs() })`; no production call passes `cwd`. Verify whether the integration was lost during later daemon changes and restore or correct the docs.

## What's actually true

The integration was never lost — it must not exist. Overlay spec §6.3:

> The runner daemon has one global `ServiceRegistry` across many workspaces, while project packages are cwd-scoped. Mounting project code globally would erase that scope and leak project behavior into unrelated sessions.
> Supporting project-scoped daemon services requires a separate design with scoped registry instances, canonical project ownership, and lifecycle isolation. **A global grant is not an acceptable shortcut.**

The daemon is a single long-lived process with one registry. Passing a `cwd` to `discoverServices()` would mount whichever checkout the daemon happened to start in — here, the PizzaPi repo itself — as a **runner-global** service for every unrelated session on the machine.

So "restore project-local discovery" would have been the bug, not the fix. The docs are what's wrong.

## Changes

- **`runner-services.mdx`** — drop the project-local claim from the discovery list, and add an upfront caution stating services are runner-global and explaining why, so this doesn't keep reading as a missing feature.
- **`service-loader.ts`** — document `DiscoverServicesOptions.cwd` as deliberately unused by production, citing §6.3. Kept rather than deleted because it's the loader half of a future scoped design; the docblock says plainly not to wire it into `daemon.ts`.
- **`daemon-services.test.ts`** — pin the invariant: no `discoverServices()` call in `daemon.ts` may pass a `cwd`. A comment can't enforce this; the test can.

Verified the test catches a violation (adding `cwd: process.cwd()` to a call site fails it), then reverted.

```
bun run typecheck              clean
bun test daemon-services       12 pass
packages/docs build            48 pages, complete
```
