### PR TITLE
fix(runner): kill spawned sessions when the runner dies

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -44,7 +44,7 @@ import { normalizeLoopbackHost } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
 import { getWorkspaceRoots } from "./workspace.js";
-import { type RunnerSession, spawnSession, killSessionProcessGroup } from "./session-spawner.js";
+import { type RunnerSession, spawnSession, killSessionProcessGroup, notifyWorkersOfRestart } from "./session-spawner.js";
 import { pruneSessionCloseMetadata, type SessionCloseMetadata } from "./session-close-metadata.js";
 
 import { scanGlobalSkills } from "../skills.js";
@@ -1096,6 +1096,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const shutdown = async (code: number) => {
             if (isShuttingDown) return;
             isShuttingDown = true;
+            // Workers exit when our IPC channel closes (see worker.ts "disconnect").
+            // On an intentional restart (42) tell them to stay alive so the next
+            // daemon re-adopts them; every other exit takes its sessions with it.
+            if (code === 42) await notifyWorkersOfRestart(runningSessions);
             clearInterval(stopFilePoll);
             clearInterval(endedSessionSweep);
             clearInterval(sessionCloseMetadataSweep);

--- a/packages/cli/src/runner/session-spawner-detach.test.ts
+++ b/packages/cli/src/runner/session-spawner-detach.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { notifyWorkersOfRestart, type RunnerSession } from "./session-spawner.js";
+
+function session(id: string, child: { connected: boolean; send: (...args: any[]) => boolean } | null): RunnerSession {
+    return { sessionId: id, child: child as unknown as ChildProcess | null, startedAt: 0 };
+}
+
+describe("notifyWorkersOfRestart", () => {
+    test("sends detach only to connected children and waits for the flush", async () => {
+        const sent: unknown[] = [];
+        const connected = {
+            connected: true,
+            send: (msg: unknown, cb: () => void) => { sent.push(msg); setTimeout(cb, 5); return true; },
+        };
+        const map = new Map<string, RunnerSession>([
+            ["a", session("a", connected)],
+            ["b", session("b", { connected: false, send: () => { throw new Error("should not send"); } })],
+            ["c", session("c", null)], // adopted session, no handle
+        ]);
+
+        await notifyWorkersOfRestart(map);
+
+        expect(sent).toEqual([{ type: "detach" }]);
+    });
+
+    test("does not hang when a child never acknowledges", async () => {
+        const map = new Map<string, RunnerSession>([
+            ["a", session("a", { connected: true, send: () => true })], // callback never fires
+        ]);
+
+        const start = Date.now();
+        await notifyWorkersOfRestart(map, 50);
+        expect(Date.now() - start).toBeLessThan(1_000);
+    });
+
+    test("survives a child that throws on send", async () => {
+        const map = new Map<string, RunnerSession>([
+            ["a", session("a", { connected: true, send: () => { throw new Error("EPIPE"); } })],
+        ]);
+        await notifyWorkersOfRestart(map, 50);
+    });
+});

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -46,6 +46,32 @@ export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.
     }
 }
 
+/**
+ * Tell every live worker that the daemon is restarting on purpose, so they do
+ * not exit when the IPC channel closes.  Waits for the sends to flush (bounded)
+ * because the daemon exits right after this returns.
+ */
+export async function notifyWorkersOfRestart(
+    runningSessions: Map<string, RunnerSession>,
+    timeoutMs = 1_000,
+): Promise<void> {
+    const sends = Array.from(runningSessions.values())
+        .map((s) => s.child)
+        .filter((c): c is ChildProcess => !!c?.connected)
+        .map((child) => new Promise<void>((resolve) => {
+            try {
+                child.send({ type: "detach" }, () => resolve());
+            } catch {
+                resolve();
+            }
+        }));
+    if (sends.length === 0) return;
+    await Promise.race([
+        Promise.all(sends),
+        new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
+}
+
 /** Is this process running inside a compiled Bun single-file binary? */
 // Detect compiled Bun single-file binary.
 // - Unix: import.meta.url contains "$bunfs"

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -827,12 +827,27 @@ async function main(): Promise<void> {
 
     process.on("SIGTERM", shutdown);
     process.on("SIGINT", shutdown);
+    // Set when the daemon is restarting intentionally: the IPC channel closes but
+    // the next daemon re-adopts us, so we must NOT exit.
+    let detached = false;
     // Windows: the daemon can't deliver a catchable SIGTERM (kill() there is an
     // immediate TerminateProcess) — it sends a shutdown request over IPC instead.
     process.on("message", (msg: unknown) => {
-        if (typeof msg === "object" && msg !== null && (msg as Record<string, unknown>).type === "shutdown") {
-            void shutdown();
+        if (typeof msg !== "object" || msg === null) return;
+        const type = (msg as Record<string, unknown>).type;
+        if (type === "shutdown") void shutdown();
+        if (type === "detach") detached = true;
+    });
+
+    // Daemon died (crash, SIGKILL, or clean exit) — the IPC channel closes.
+    // Sessions do not outlive their runner unless it told us it's coming back.
+    process.on("disconnect", () => {
+        if (detached) {
+            logInfo("[worker] daemon detached for restart; staying alive");
+            return;
         }
+        logInfo("[worker] daemon gone; shutting down");
+        void shutdown();
     });
 
     // Keep the process alive; work happens via relay/websocket events.


### PR DESCRIPTION
Sessions spawned by a runner outlived it: when the daemon crashed or was SIGKILLed, worker processes kept running (and kept their relay connections), so you'd accumulate orphaned sessions.

Workers already get an IPC channel (`stdio: [..., "ipc"]`), so parent death is detectable for free.

## Changes

- **`worker.ts`** — `process.on("disconnect")` runs the existing graceful `shutdown()` (provider close hooks, sandbox cleanup, session dispose). Fires on daemon crash, SIGKILL, or clean exit.
- **`daemon.ts` / `session-spawner.ts`** — intentional restarts (`shutdown(42)`) send `{type:"detach"}` to every live worker first, so they stay alive and the next daemon re-adopts them via the existing `existingSessions` path. The send is flushed with a 1s bound since the daemon exits right after.

Same pattern `terminal-worker.ts` already uses ("If the parent dies, so should we").

## Not done

- Adopted sessions (`child: null`) aren't signalled — they belong to a prior daemon and already died with it.
- No spawn-a-real-daemon E2E; the disconnect handler is process-coupled, like the `SIGTERM` path next to it. `notifyWorkersOfRestart` is unit-tested (connected-only filtering, no-ack timeout, throwing `send`).

## Verification

- `bun run typecheck` — clean
- `bun test src/runner/session-spawner-detach.test.ts src/runner/session-spawner.test.ts` — 4 pass
