### PR TITLE
refactor(cli): generic worker pre-exit shutdown hooks

### DIFF
--- a/packages/cli/src/extensions/__fixtures__/shutdown-hook-signal-harness.ts
+++ b/packages/cli/src/extensions/__fixtures__/shutdown-hook-signal-harness.ts
@@ -1,0 +1,39 @@
+/**
+ * Test fixture: mirrors the worker's shutdown wiring for pre-exit hooks
+ * (see runner/worker.ts `shutdown()`).
+ *
+ * Spawned as a subprocess by shutdown-hooks-signal.test.ts. Installs a SIGTERM
+ * handler that runs runWorkerShutdownHooks — the same in-process path the
+ * worker uses — with a hook that writes a marker file. The parent test SIGTERMs
+ * this process and asserts the marker exists, proving hooks fire across a real
+ * process/signal boundary.
+ *
+ * This is the boundary that matters: pi's `session_shutdown` does not fire when
+ * the daemon SIGTERMs a worker, so a unit test alone would not prove the
+ * capability survives.
+ */
+import { writeFileSync } from "node:fs";
+import { registerWorkerShutdownHook, runWorkerShutdownHooks } from "../shutdown-hooks";
+
+const markerPath = process.env.CLOSE_MARKER_PATH;
+if (!markerPath) {
+    console.error("CLOSE_MARKER_PATH not set");
+    process.exit(1);
+}
+
+registerWorkerShutdownHook("signal-fixture", async (ctx) => {
+    // Async so the test also proves the worker AWAITS the hook rather than
+    // exiting while the flush is still in flight.
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    writeFileSync(markerPath, JSON.stringify({ reason: ctx.reason, sessionId: ctx.sessionId }));
+});
+
+process.on("SIGTERM", () => {
+    void runWorkerShutdownHooks("close")
+        .catch(() => {})
+        .finally(() => process.exit(0));
+});
+
+// Signal readiness and stay alive until SIGTERM.
+console.log("ready");
+setInterval(() => {}, 1_000);

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -5,11 +5,14 @@ import { join } from "node:path";
 import { ProviderBridge } from "../../providers/bridge";
 import type { ProviderContext, SessionCloseResult } from "../../providers/types";
 import { loadGlobalConfig } from "../../config/io";
+import { registerWorkerShutdownHook } from "../shutdown-hooks";
 import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("provider-extension");
 
 let bridge: ProviderBridge | null = null;
+/** Drops this worker's pre-exit registration when the factory re-runs in place. */
+let unregisterShutdownHook: (() => void) | null = null;
 /** Provider instances tracked separately for disposal (bridge doesn't own lifecycle). */
 let providerInstances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
 /** Last-known session identity for close-time context (updated on session_start/turn_end). */
@@ -69,9 +72,19 @@ function makeProviderContext(
  * — so the worker stays inside the daemon's SIGTERM→SIGKILL escalation
  * window.
  */
+export interface ProviderSessionCloseOptions {
+  timeoutMs?: number;
+  /** Shared absolute deadline when driven by the worker shutdown window. */
+  deadline?: number;
+  /** Shared abort signal when driven by the worker shutdown window. */
+  signal?: AbortSignal;
+  sessionFile?: string;
+  cwd?: string;
+}
+
 export async function runProviderSessionClose(
   reason: "close" | "error" | "complete",
-  opts?: { timeoutMs?: number },
+  opts?: ProviderSessionCloseOptions,
 ): Promise<SessionCloseResult | null> {
   if (sessionClosePromise) return sessionClosePromise;
   sessionClosePromise = doRunProviderSessionClose(reason, opts);
@@ -80,20 +93,27 @@ export async function runProviderSessionClose(
 
 async function doRunProviderSessionClose(
   reason: "close" | "error" | "complete",
-  opts?: { timeoutMs?: number },
+  opts?: ProviderSessionCloseOptions,
 ): Promise<SessionCloseResult | null> {
   if (!bridge) return null;
   const sessionId = process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown";
-  const sessionFile = currentSessionInfo?.sessionFile ?? sessionId;
-  const cwd = currentSessionInfo?.cwd ?? process.cwd();
-  const timeoutMs = opts?.timeoutMs ?? 2500;
-  const deadline = Date.now() + timeoutMs;
+  const sessionFile = opts?.sessionFile ?? currentSessionInfo?.sessionFile ?? sessionId;
+  const cwd = opts?.cwd ?? currentSessionInfo?.cwd ?? process.cwd();
+  // When the worker shutdown window drives this, adopt ITS deadline rather than
+  // starting a second independent budget — otherwise the two stack and the
+  // worker can outlive the daemon's SIGKILL escalation.
+  const deadline = opts?.deadline ?? Date.now() + (opts?.timeoutMs ?? 2500);
+  const timeoutMs = Math.max(0, deadline - Date.now());
   // Overall deadline is enforced twice: the bridge's own Promise.race stops
   // WAITING on a slow provider, but a well-behaved hook can also watch
   // ctx.signal and cancel its own in-flight work — abort it here so hooks
   // that honor AbortSignal get a chance to clean up rather than being cut off.
   const controller = new AbortController();
   const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+  // An externally-supplied signal (shared window) must still abort us.
+  const externalAbort = () => controller.abort();
+  opts?.signal?.addEventListener("abort", externalAbort, { once: true });
+  if (opts?.signal?.aborted) controller.abort();
   try {
     const result = await bridge.onSessionClose(
       { reason, sessionFile },
@@ -115,6 +135,7 @@ async function doRunProviderSessionClose(
     return null;
   } finally {
     clearTimeout(abortTimer);
+    opts?.signal?.removeEventListener("abort", externalAbort);
     controller.abort();
   }
 }
@@ -126,6 +147,23 @@ export function __setBridgeForTest(b: ProviderBridge | null): void {
 }
 
 export async function providerExtension(pi: ExtensionAPI) {
+  // Close-time flush is driven by the worker's own pre-exit window (pi has no
+  // event that fires on daemon SIGTERM). The provider layer is just one
+  // participant in that window now, not the owner of it.
+  //
+  // Factories re-run when a session is created in place, so drop any previous
+  // registration first — re-registering the same id is expected here and must
+  // not look like the id collision the registry warns about.
+  unregisterShutdownHook?.();
+  unregisterShutdownHook = registerWorkerShutdownHook("providers", async (shutdownCtx) => {
+    await runProviderSessionClose(shutdownCtx.reason, {
+      deadline: shutdownCtx.deadline,
+      signal: shutdownCtx.signal,
+      sessionFile: shutdownCtx.sessionFile,
+      cwd: shutdownCtx.cwd,
+    });
+  });
+
   // ── Session Start: discover and init providers ────────────────
   pi.on("session_start", async (event, ctx) => {
     const { discoverProviders } = await import("../../providers/loader");

--- a/packages/cli/src/extensions/shutdown-hooks-signal.test.ts
+++ b/packages/cli/src/extensions/shutdown-hooks-signal.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Cross-process test for worker pre-exit shutdown hooks.
+ *
+ * pi's `session_shutdown` is awaited but only fires for in-app transitions
+ * (quit/reload/new/resume/fork) — it does NOT fire when the daemon SIGTERMs a
+ * worker. The worker's own signal handler is the injection point, so the
+ * capability is only proven by crossing a real process + signal boundary.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const FIXTURE = join(import.meta.dir, "__fixtures__", "shutdown-hook-signal-harness.ts");
+
+describe("worker shutdown hooks across a process boundary", () => {
+    test("SIGTERM to the worker-like process runs registered hooks before exit", async () => {
+        const tmp = mkdtempSync(join(tmpdir(), "shutdown-hook-signal-"));
+        const markerPath = join(tmp, "close-marker.json");
+        try {
+            const proc = Bun.spawn(["bun", FIXTURE], {
+                cwd: import.meta.dir,
+                env: {
+                    ...process.env,
+                    CLOSE_MARKER_PATH: markerPath,
+                    HOME: tmp, // isolate from any real ~/.pizzapi config
+                    PIZZAPI_SESSION_ID: "sess-fixture",
+                },
+                stdout: "pipe",
+                stderr: "pipe",
+            });
+
+            const reader = proc.stdout.getReader();
+            const deadline = Date.now() + 15_000;
+            let ready = false;
+            let buffered = "";
+            while (!ready && Date.now() < deadline) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                buffered += new TextDecoder().decode(value);
+                if (buffered.includes("ready")) ready = true;
+            }
+            expect(ready).toBe(true);
+
+            proc.kill("SIGTERM");
+            const exitCode = await proc.exited;
+
+            expect(exitCode).toBe(0);
+            // The hook sleeps before writing, so a marker here also proves the
+            // shutdown path awaited it instead of exiting mid-flush.
+            expect(existsSync(markerPath)).toBe(true);
+            const marker = JSON.parse(readFileSync(markerPath, "utf-8"));
+            expect(marker.reason).toBe("close");
+            expect(marker.sessionId).toBe("sess-fixture");
+        } finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    }, 30_000);
+});

--- a/packages/cli/src/extensions/shutdown-hooks.test.ts
+++ b/packages/cli/src/extensions/shutdown-hooks.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+    registerWorkerShutdownHook,
+    registeredShutdownHookIds,
+    runWorkerShutdownHooks,
+    __resetWorkerShutdownHooksForTest,
+    DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    type WorkerShutdownContext,
+} from "./shutdown-hooks.js";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+beforeEach(() => {
+    __resetWorkerShutdownHooksForTest();
+});
+
+describe("registerWorkerShutdownHook", () => {
+    test("registers and unregisters by id", () => {
+        const off = registerWorkerShutdownHook("a", () => {});
+        expect(registeredShutdownHookIds()).toEqual(["a"]);
+        off();
+        expect(registeredShutdownHookIds()).toEqual([]);
+    });
+
+    test("a stale unregister does not drop a later re-registration", () => {
+        const off = registerWorkerShutdownHook("a", () => {});
+        registerWorkerShutdownHook("a", () => {});
+        off(); // closure from the first registration
+        expect(registeredShutdownHookIds()).toEqual(["a"]);
+    });
+});
+
+describe("runWorkerShutdownHooks", () => {
+    test("runs every registered hook with the shutdown reason", async () => {
+        const seen: string[] = [];
+        registerWorkerShutdownHook("a", (ctx) => { seen.push(`a:${ctx.reason}`); });
+        registerWorkerShutdownHook("b", (ctx) => { seen.push(`b:${ctx.reason}`); });
+
+        await runWorkerShutdownHooks("close");
+
+        expect(seen.sort()).toEqual(["a:close", "b:close"]);
+    });
+
+    test("awaits async hooks before resolving", async () => {
+        let flushed = false;
+        registerWorkerShutdownHook("slow", async () => {
+            await sleep(20);
+            flushed = true;
+        });
+
+        await runWorkerShutdownHooks("close");
+
+        expect(flushed).toBe(true);
+    });
+
+    test("is a no-op when nothing is registered", async () => {
+        await runWorkerShutdownHooks("close");
+        expect(registeredShutdownHookIds()).toEqual([]);
+    });
+
+    test("a throwing hook does not prevent the others from running", async () => {
+        const ran: string[] = [];
+        registerWorkerShutdownHook("boom", () => { throw new Error("flush failed"); });
+        registerWorkerShutdownHook("ok", () => { ran.push("ok"); });
+
+        await runWorkerShutdownHooks("close");
+
+        expect(ran).toEqual(["ok"]);
+    });
+
+    test("a rejecting async hook does not prevent the others from running", async () => {
+        const ran: string[] = [];
+        registerWorkerShutdownHook("boom", async () => { throw new Error("flush failed"); });
+        registerWorkerShutdownHook("ok", async () => { ran.push("ok"); });
+
+        await runWorkerShutdownHooks("close");
+
+        expect(ran).toEqual(["ok"]);
+    });
+
+    test("concurrent callers share one run rather than racing", async () => {
+        let calls = 0;
+        registerWorkerShutdownHook("once", async () => {
+            calls += 1;
+            await sleep(20);
+        });
+
+        // The signal handler and the extension shutdownHandler can both fire.
+        await Promise.all([runWorkerShutdownHooks("close"), runWorkerShutdownHooks("complete")]);
+
+        expect(calls).toBe(1);
+    });
+
+    test("a later caller awaits the in-flight run instead of exiting early", async () => {
+        let finished = false;
+        registerWorkerShutdownHook("slow", async () => {
+            await sleep(30);
+            finished = true;
+        });
+
+        const first = runWorkerShutdownHooks("close");
+        // Second caller must not resolve before the first run completes —
+        // otherwise it proceeds to process.exit() mid-flush.
+        await runWorkerShutdownHooks("close");
+        expect(finished).toBe(true);
+        await first;
+    });
+
+    test("ONE deadline bounds N hooks, not N x timeout", async () => {
+        // Four hooks that each outlast the budget. Sequential-with-per-hook
+        // timeouts would take ~4x; the shared window must cap the total.
+        for (const id of ["a", "b", "c", "d"]) {
+            registerWorkerShutdownHook(id, async () => { await sleep(5_000); });
+        }
+
+        const started = Date.now();
+        await runWorkerShutdownHooks("close", { timeoutMs: 100 });
+        const elapsed = Date.now() - started;
+
+        expect(elapsed).toBeLessThan(600);
+    });
+
+    test("aborts the shared signal at the deadline so hooks can cancel their own work", async () => {
+        let abortedDuringRun = false;
+        registerWorkerShutdownHook("watcher", async (ctx) => {
+            await new Promise<void>((resolve) => {
+                if (ctx.signal.aborted) { abortedDuringRun = true; resolve(); return; }
+                ctx.signal.addEventListener("abort", () => { abortedDuringRun = true; resolve(); }, { once: true });
+            });
+        });
+
+        await runWorkerShutdownHooks("close", { timeoutMs: 50 });
+
+        expect(abortedDuringRun).toBe(true);
+    });
+
+    test("passes a shared absolute deadline to every hook", async () => {
+        const deadlines: number[] = [];
+        registerWorkerShutdownHook("a", (ctx) => { deadlines.push(ctx.deadline); });
+        registerWorkerShutdownHook("b", (ctx) => { deadlines.push(ctx.deadline); });
+
+        const before = Date.now();
+        await runWorkerShutdownHooks("close", { timeoutMs: 500 });
+
+        expect(deadlines).toHaveLength(2);
+        expect(deadlines[0]).toBe(deadlines[1]!);
+        expect(deadlines[0]!).toBeGreaterThanOrEqual(before);
+        expect(deadlines[0]!).toBeLessThanOrEqual(before + 500 + 50);
+    });
+
+    test("forwards session identity to hooks", async () => {
+        let received: WorkerShutdownContext | null = null;
+        registerWorkerShutdownHook("capture", (ctx) => { received = ctx; });
+
+        await runWorkerShutdownHooks("error", { sessionFile: "/tmp/session.jsonl", cwd: "/tmp/work" });
+
+        expect(received!.reason).toBe("error");
+        expect(received!.sessionFile).toBe("/tmp/session.jsonl");
+        expect(received!.cwd).toBe("/tmp/work");
+    });
+
+    test("default budget stays inside the daemon SIGKILL escalation window", () => {
+        expect(DEFAULT_SHUTDOWN_TIMEOUT_MS).toBe(2500);
+    });
+});

--- a/packages/cli/src/extensions/shutdown-hooks.ts
+++ b/packages/cli/src/extensions/shutdown-hooks.ts
@@ -1,0 +1,146 @@
+/**
+ * Worker pre-exit shutdown hooks.
+ *
+ * pi has no event for "flush something before the process exits". Its
+ * `session_shutdown` is awaited, but only fires for in-app transitions
+ * (`quit | reload | new | resume | fork`) — when the daemon SIGTERMs a worker,
+ * the worker's own `process.on("SIGTERM")` handler is the only thing that runs.
+ * That signal path is therefore the injection point, and it lives here rather
+ * than inside any one feature's abstraction.
+ *
+ * These hooks MUST run in the worker process. Anything registered from a
+ * session extension is a module-global of that worker, so a daemon-side import
+ * of this module sees an empty registry (a cross-process call would be a
+ * guaranteed no-op — see idea jg017xa4).
+ */
+
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("shutdown-hooks");
+
+/** Default overall budget, sized to stay inside the daemon's SIGTERM→SIGKILL escalation. */
+export const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2500;
+
+export type WorkerShutdownReason = "close" | "error" | "complete";
+
+export interface WorkerShutdownContext {
+    reason: WorkerShutdownReason;
+    sessionId: string;
+    sessionFile?: string;
+    cwd: string;
+    /**
+     * Aborted when the overall deadline expires. Stopping the *wait* is not
+     * enough — a hook that honours this can cancel its own in-flight work
+     * instead of being cut off mid-write.
+     */
+    signal: AbortSignal;
+    /** Absolute epoch-ms deadline shared by every hook in this shutdown. */
+    deadline: number;
+}
+
+export type WorkerShutdownHook = (ctx: WorkerShutdownContext) => void | Promise<void>;
+
+const hooks = new Map<string, WorkerShutdownHook>();
+
+/**
+ * Register an async cleanup to run once, in the worker, before exit.
+ *
+ * @returns an unregister function.
+ */
+export function registerWorkerShutdownHook(id: string, hook: WorkerShutdownHook): () => void {
+    if (hooks.has(id)) {
+        log.warn(`shutdown hook "${id}" was already registered — replacing it`);
+    }
+    hooks.set(id, hook);
+    return () => {
+        // Only remove our own registration; a later re-register under the same
+        // id must not be dropped by a stale unregister closure.
+        if (hooks.get(id) === hook) hooks.delete(id);
+    };
+}
+
+export function registeredShutdownHookIds(): string[] {
+    return [...hooks.keys()];
+}
+
+/**
+ * Cached in-flight/completed run so concurrent shutdown paths (signal handler
+ * and extension-initiated shutdownHandler) share ONE run instead of racing.
+ * The second caller awaits the same promise rather than seeing a "done" flag
+ * and proceeding to process.exit() while the first run is still writing.
+ */
+let inFlight: Promise<void> | null = null;
+
+export async function runWorkerShutdownHooks(
+    reason: WorkerShutdownReason,
+    opts?: { timeoutMs?: number; sessionFile?: string; cwd?: string },
+): Promise<void> {
+    if (inFlight) return inFlight;
+    inFlight = doRunWorkerShutdownHooks(reason, opts);
+    return inFlight;
+}
+
+async function doRunWorkerShutdownHooks(
+    reason: WorkerShutdownReason,
+    opts?: { timeoutMs?: number; sessionFile?: string; cwd?: string },
+): Promise<void> {
+    if (hooks.size === 0) return;
+
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+    const deadline = Date.now() + timeoutMs;
+    const sessionId = process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown";
+
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+
+    const ctx: WorkerShutdownContext = {
+        reason,
+        sessionId,
+        ...(opts?.sessionFile ? { sessionFile: opts.sessionFile } : {}),
+        cwd: opts?.cwd ?? process.cwd(),
+        signal: controller.signal,
+        deadline,
+    };
+
+    // Hooks run concurrently and share ONE deadline, so N hooks are bounded by
+    // timeoutMs rather than N * timeoutMs. Cleanups are independent by
+    // contract; anything needing ordering should sequence itself inside one hook.
+    const entries = [...hooks.entries()];
+    const settled = Promise.allSettled(
+        entries.map(async ([id, hook]) => {
+            try {
+                await hook(ctx);
+            } catch (err) {
+                // A failing cleanup must never block the others or the exit.
+                log.error(`shutdown hook "${id}" failed:`, err);
+            }
+        }),
+    );
+
+    let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race([
+            settled,
+            new Promise<void>((resolve) => {
+                budgetTimer = setTimeout(resolve, timeoutMs);
+            }),
+        ]);
+        const overrun = entries.length && Date.now() >= deadline;
+        if (overrun) {
+            log.warn(`shutdown hooks exceeded ${timeoutMs}ms budget — continuing exit`);
+        }
+    } finally {
+        clearTimeout(abortTimer);
+        if (budgetTimer) clearTimeout(budgetTimer);
+        controller.abort();
+        // Never leave an unhandled rejection behind for hooks still running
+        // past the deadline; we have already stopped waiting on them.
+        void settled.catch(() => {});
+    }
+}
+
+/** Test-only: clear the registry and any cached run. */
+export function __resetWorkerShutdownHooksForTest(): void {
+    hooks.clear();
+    inFlight = null;
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -188,7 +188,7 @@ async function createModelRuntimeWithRetry(authPath: string, modelsPath: string,
 import { forwardCliError } from "../extensions/remote.js";
 import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
 import { armWorkerStartupGate, markWorkerStartupComplete } from "../extensions/worker-startup-gate.js";
-import { runProviderSessionClose } from "../extensions/providers/extension.js";
+import { runWorkerShutdownHooks } from "../extensions/shutdown-hooks.js";
 
 // ── Session metadata / context tracking ──────────────────────────────────
 
@@ -716,10 +716,10 @@ async function main(): Promise<void> {
         commandContextActions: sessionControlActions,
         shutdownHandler: () => {
             // Extension-initiated shutdown (e.g. auto-close after session
-            // completion) — run provider close with "complete" semantics.
+            // completion) — run the pre-exit window with "complete" semantics.
             // ponytail: reason is a heuristic (any ctx.shutdown() maps to
             // "complete"); plumb an explicit reason if a second caller appears.
-            void runProviderSessionClose("complete")
+            void runWorkerShutdownHooks("complete")
                 .catch(() => {})
                 .finally(() => {
                     try {
@@ -805,12 +805,13 @@ async function main(): Promise<void> {
             logWarn("[worker] cleanup did not finish in time; forcing process exit");
             process.exit(0);
         }, hardExitTimeoutMs);
-        // Provider close hooks run first (data flush/archival is the most
-        // valuable cleanup) and in-process — the daemon cannot reach the
-        // provider bridge across the process boundary. Bounded at 2.5s so
-        // close + sandbox cleanup stay inside the daemon's SIGKILL escalation.
+        // Pre-exit hooks run first (data flush/archival is the most valuable
+        // cleanup) and in-process — the daemon cannot reach worker-registered
+        // hooks across the process boundary, and pi's session_shutdown does not
+        // fire for a daemon SIGTERM. Bounded overall so hooks + sandbox cleanup
+        // stay inside the daemon's SIGKILL escalation.
         try {
-            await runProviderSessionClose("close");
+            await runWorkerShutdownHooks("close");
         } catch {}
         try {
             await Promise.race([


### PR DESCRIPTION
Step 1 of retiring `ProviderBridge`. This lands the capability-preserving hook **before** the deletion, so nothing is lost at any point in the sequence.

## The problem

`worker.ts` called `runProviderSessionClose()` directly. That made "flush something before the process exits" a capability of **`ProviderBridge`** rather than of the worker — which blocks deleting the provider layer, because the deletion would take the one lifecycle point pi doesn't offer with it.

## Why pi can't just cover it

`session_shutdown` *is* awaited by pi (`emitSessionShutdownEvent` awaits `extensionRunner.emit`). But it only fires for in-app transitions:

```ts
/** Fired before an extension runtime is torn down due to quit, reload, or session replacement. */
reason: "quit" | "reload" | "new" | "resume" | "fork"
```

When the **daemon SIGTERMs a worker**, that never fires — `process.on("SIGTERM", shutdown)` in `worker.ts` is the only thing that runs. So the signal path is the genuine injection point. It now owns a feature-agnostic registry instead of calling into one feature.

## Changes

- **`extensions/shutdown-hooks.ts`** — register an async cleanup; runs once, bounded, before exit.
- **`worker.ts`** — calls `runWorkerShutdownHooks()` on both shutdown paths.
- **`providerExtension`** — becomes an ordinary participant registering a `"providers"` hook, rather than owning the window.

## Semantics deliberately preserved

These were load-bearing in the provider implementation and are easy to lose in a refactor:

| Behaviour | Why it matters |
|---|---|
| Idempotent shared promise | The signal handler and the extension `shutdownHandler` can both fire. The second caller must **await the first run**, not see a "done" flag and race ahead to `process.exit()` mid-flush. |
| **One** overall deadline | N hooks bounded by `timeoutMs`, not `N × timeoutMs` — the worker must stay inside the daemon's SIGKILL escalation. |
| `AbortSignal` | Stopping the *wait* isn't enough; a hook that honours the signal can cancel its own in-flight work rather than being cut off mid-write. |
| Errors never block exit | One failing cleanup must not strand the others. |

Two fixes fell out while wiring it:

- `runProviderSessionClose` now **adopts the caller's deadline** instead of starting a second independent 2.5s budget. Previously the two would have stacked and could outlive the SIGKILL window.
- `providerExtension` drops its prior registration before re-registering, because factories re-run when a session is created in place (`new session created (in-place)` appears in real runner logs).

Also dropped `SessionCloseResult` from the worker path — **both call sites already discarded it**, so `{ label, jobRef }` was dead API.

## Testing

15 tests. The two that carry the weight:

- **`shutdown-hooks-signal.test.ts`** spawns a worker-like subprocess, SIGTERMs it, and asserts an *async* hook completed — proving the path both fires and is awaited across a real process/signal boundary. A unit test cannot establish this, which is exactly why the original provider close had a subprocess harness too.
- **"ONE deadline bounds N hooks"** registers four hooks that each sleep 5s under a 100ms budget and asserts the whole run finishes in <600ms.

```
bun run typecheck    clean
bun test src/extensions/shutdown-hooks*  15 pass
bun test packages/cli/src                2737 pass, 3 fail
```

Those 3 failures (`models-command` ×2, `overlay/identity`) are **pre-existing**. I verified by running the full suite on a separate worktree with none of these changes: identical 3 failures, 2703 pass. They also pass in isolation — it's cross-test pollution in the single-process run, now tracked as Godmother `f5ohlCyG`.

## Next

With the hook in place, step 2 can delete `providers/{bridge,loader,types}.ts`, `extensions/providers/extension.ts` and the unwired `pi-bridge-adapter.ts` without losing close-time flush.
