### PR TITLE
ci: fix docs deploy failing on redis-memory-server postinstall

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,10 @@ jobs:
 
       - name: Install docs dependencies
         working-directory: packages/docs
-        run: bun install
+        # ponytail: --ignore-scripts skips redis-memory-server's postinstall (compiles
+        # Redis from source, fails on ubuntu-latest). Docs only need astro + sharp,
+        # neither of which has an install script. Drop it if docs ever gain one.
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build docs
         working-directory: packages/docs


### PR DESCRIPTION
## Problem

The last 4 runs of **Deploy Docs to GitHub Pages** failed at the `Install docs dependencies` step:

```
make: *** [Makefile:109: build] Error 1
error: postinstall script from "redis-memory-server" exited with 1
```

`bun install` from `packages/docs` resolves the whole workspace, so `redis-memory-server`'s postinstall runs and tries to compile Redis (+ redistimeseries) from source on `ubuntu-latest`, which fails. `ci.yml` survives this only because it caches `node_modules` and `~/.bun/install/cache`; the docs job has no cache.

## Fix

```yaml
run: bun install --frozen-lockfile --ignore-scripts
```

Docs need `astro` + `sharp` only. sharp 0.33 ships prebuilt binaries via optionalDependencies and has no install script, so nothing the docs build needs is skipped.

## Verification

Ran locally in `packages/docs`:

- `bun install --frozen-lockfile --ignore-scripts` → exit 0
- `bun run build` → `48 page(s) built in 5.85s`, images optimized, pagefind index built, exit 0

Skipped adding a bun cache to the docs job — worth doing if install time starts to matter.
