### PR TITLE
feat(cli): Discord bridge as a runner service + connectivity-service pattern docs

### DIFF
--- a/packages/cli/src/extensions/discord-mirror.test.ts
+++ b/packages/cli/src/extensions/discord-mirror.test.ts
@@ -68,6 +68,7 @@ describe("discordMirrorExtension", () => {
     function build(opts: { socket?: boolean; sessionId?: string | null; throwOnEmit?: boolean } = {}) {
         emitted = [];
         pi = createMockPi();
+        let n = 0;
         const socket = {
             emit: (event: string, payload: unknown) => {
                 if (opts.throwOnEmit) throw new Error("socket closed");
@@ -77,6 +78,7 @@ describe("discordMirrorExtension", () => {
         createDiscordMirrorExtension({
             getRelaySocket: (() => (opts.socket === false ? null : { socket })) as any,
             getRelaySessionId: (() => (opts.sessionId === undefined ? "sess-1" : opts.sessionId)) as any,
+            newId: () => `id-${++n}`,
         })(pi as any);
     }
 
@@ -91,8 +93,22 @@ describe("discordMirrorExtension", () => {
         expect(emitted[0].payload).toEqual({
             serviceId: "discord",
             type: "discord_post",
-            payload: { sessionId: "sess-1", content: "hello world" },
+            payload: { id: "id-1", sessionId: "sess-1", content: "hello world" },
         });
+    });
+
+    // Relay delivery to the runner is at-least-once (emitToRunner hits both the
+    // runner room and the local socket), so the service dedupes on this id.
+    // A repeated id across turns would silently swallow a real message.
+    test("stamps a distinct id on every envelope", () => {
+        pi.fire("agent_end", { messages: [assistantMsg("one")] });
+        pi.fire("agent_settled");
+        pi.fire("agent_end", { messages: [assistantMsg("two")] });
+        pi.fire("agent_settled");
+
+        const ids = emitted.map((e) => e.payload.payload.id);
+        expect(ids).toEqual(["id-1", "id-2"]);
+        expect(new Set(ids).size).toBe(2);
     });
 
     test("does not emit on agent_end alone — only after settling", () => {

--- a/packages/cli/src/extensions/discord-mirror.test.ts
+++ b/packages/cli/src/extensions/discord-mirror.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { createDiscordMirrorExtension, lastAssistantText } from "./discord-mirror.js";
+
+function createMockPi() {
+    const handlers = new Map<string, Function[]>();
+    return {
+        on(event: string, handler: Function) {
+            if (!handlers.has(event)) handlers.set(event, []);
+            handlers.get(event)!.push(handler);
+        },
+        fire(event: string, payload?: unknown) {
+            for (const h of handlers.get(event) ?? []) h(payload, {});
+        },
+        registerTool: () => {},
+        registerCommand: () => {},
+    };
+}
+
+function assistantMsg(...texts: string[]) {
+    return { role: "assistant", content: texts.map((text) => ({ type: "text", text })) };
+}
+
+describe("lastAssistantText", () => {
+    test("returns null for non-arrays and empty runs", () => {
+        expect(lastAssistantText(undefined)).toBeNull();
+        expect(lastAssistantText(null)).toBeNull();
+        expect(lastAssistantText([])).toBeNull();
+        expect(lastAssistantText("nope")).toBeNull();
+    });
+
+    test("picks the last assistant message, joining text parts", () => {
+        const messages = [
+            assistantMsg("first"),
+            { role: "user", content: [{ type: "text", text: "middle" }] },
+            assistantMsg("a", "b"),
+        ];
+        expect(lastAssistantText(messages)).toBe("a\nb");
+    });
+
+    test("skips assistant messages with no text parts (tool-only turns)", () => {
+        const messages = [
+            assistantMsg("real answer"),
+            { role: "assistant", content: [{ type: "tool_use", id: "1", name: "bash" }] },
+        ];
+        expect(lastAssistantText(messages)).toBe("real answer");
+    });
+
+    test("ignores malformed content entries", () => {
+        const messages = [{ role: "assistant", content: [null, 42, { type: "text" }, { type: "text", text: "ok" }] }];
+        expect(lastAssistantText(messages)).toBe("ok");
+    });
+
+    test("returns null when the assistant only produced whitespace", () => {
+        expect(lastAssistantText([assistantMsg("   \n  ")])).toBeNull();
+    });
+
+    test("truncates very long output", () => {
+        const result = lastAssistantText([assistantMsg("x".repeat(9_000))])!;
+        expect(result.length).toBeLessThan(9_000);
+        expect(result.endsWith("…(truncated)")).toBe(true);
+    });
+});
+
+describe("discordMirrorExtension", () => {
+    let emitted: any[];
+    let pi: ReturnType<typeof createMockPi>;
+
+    function build(opts: { socket?: boolean; sessionId?: string | null; throwOnEmit?: boolean } = {}) {
+        emitted = [];
+        pi = createMockPi();
+        const socket = {
+            emit: (event: string, payload: unknown) => {
+                if (opts.throwOnEmit) throw new Error("socket closed");
+                emitted.push({ event, payload });
+            },
+        };
+        createDiscordMirrorExtension({
+            getRelaySocket: (() => (opts.socket === false ? null : { socket })) as any,
+            getRelaySessionId: (() => (opts.sessionId === undefined ? "sess-1" : opts.sessionId)) as any,
+        })(pi as any);
+    }
+
+    beforeEach(() => build());
+
+    test("emits one discord_post envelope per settled turn", () => {
+        pi.fire("agent_end", { messages: [assistantMsg("hello world")] });
+        pi.fire("agent_settled");
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].event).toBe("service_message");
+        expect(emitted[0].payload).toEqual({
+            serviceId: "discord",
+            type: "discord_post",
+            payload: { sessionId: "sess-1", content: "hello world" },
+        });
+    });
+
+    test("does not emit on agent_end alone — only after settling", () => {
+        pi.fire("agent_end", { messages: [assistantMsg("draft")] });
+        expect(emitted).toHaveLength(0);
+    });
+
+    test("mirrors only the final attempt when a turn is retried", () => {
+        pi.fire("agent_end", { messages: [assistantMsg("attempt one")] });
+        pi.fire("agent_end", { messages: [assistantMsg("attempt two")] });
+        pi.fire("agent_settled");
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].payload.payload.content).toBe("attempt two");
+    });
+
+    test("does not re-emit the previous turn when a later turn has no text", () => {
+        pi.fire("agent_end", { messages: [assistantMsg("turn one")] });
+        pi.fire("agent_settled");
+        pi.fire("agent_end", { messages: [] });
+        pi.fire("agent_settled");
+
+        expect(emitted).toHaveLength(1);
+    });
+
+    test("no-ops without a relay socket", () => {
+        build({ socket: false });
+        pi.fire("agent_end", { messages: [assistantMsg("hi")] });
+        pi.fire("agent_settled");
+        expect(emitted).toHaveLength(0);
+    });
+
+    test("no-ops without a relay session id", () => {
+        build({ sessionId: null });
+        pi.fire("agent_end", { messages: [assistantMsg("hi")] });
+        pi.fire("agent_settled");
+        expect(emitted).toHaveLength(0);
+    });
+
+    test("a throwing socket does not break the turn", () => {
+        build({ throwOnEmit: true });
+        pi.fire("agent_end", { messages: [assistantMsg("hi")] });
+        expect(() => pi.fire("agent_settled")).not.toThrow();
+    });
+});

--- a/packages/cli/src/extensions/discord-mirror.ts
+++ b/packages/cli/src/extensions/discord-mirror.ts
@@ -1,0 +1,89 @@
+/**
+ * Discord mirror extension — forwards each settled assistant turn to the
+ * daemon-scoped `discord` runner service over `service_message`.
+ *
+ * This is the *outbound* half of the Discord bridge. The inbound half (Discord
+ * message -> session) is owned by the service, which posts to
+ * `/api/sessions/:id/trigger`. See the "connectivity services" section of
+ * docs/customization/runner-services.mdx.
+ *
+ * The session deliberately knows nothing about Discord: it emits one envelope
+ * per settled turn and the service drops it if this session has no mapped
+ * thread. That keeps thread mapping in exactly one place (the service) instead
+ * of duplicating it into every session.
+ */
+
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import {
+    getRelaySocket as getRelaySocketDefault,
+    getRelaySessionId as getRelaySessionIdDefault,
+} from "./remote.js";
+
+/** Discord's hard limit is 2000 chars; the service re-chunks, this just bounds the payload. */
+const MAX_MIRROR_CHARS = 8_000;
+
+export interface DiscordMirrorDeps {
+    getRelaySocket: typeof getRelaySocketDefault;
+    getRelaySessionId: typeof getRelaySessionIdDefault;
+}
+
+const defaultDeps: DiscordMirrorDeps = {
+    getRelaySocket: getRelaySocketDefault,
+    getRelaySessionId: getRelaySessionIdDefault,
+};
+
+/**
+ * Pull the text of the last assistant message out of a run's message list.
+ * Mirrors the extraction in remote/lifecycle-handlers.ts.
+ */
+export function lastAssistantText(messages: unknown): string | null {
+    if (!Array.isArray(messages)) return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i] as any;
+        if (msg?.role !== "assistant" || !Array.isArray(msg.content)) continue;
+        const text = msg.content
+            .filter((c: any) => c && typeof c === "object" && c.type === "text" && typeof c.text === "string" && c.text)
+            .map((c: any) => c.text as string)
+            .join("\n")
+            .trim();
+        if (text) return text.length > MAX_MIRROR_CHARS ? `${text.slice(0, MAX_MIRROR_CHARS)}\n…(truncated)` : text;
+    }
+    return null;
+}
+
+export function createDiscordMirrorExtension(deps: DiscordMirrorDeps = defaultDeps): ExtensionFactory {
+    return (pi) => {
+        // agent_end fires after every attempt (including retried ones); hold the
+        // text and only publish once agent_settled confirms the turn is final.
+        let pending: string | null = null;
+
+        pi.on("agent_end" as any, (event: any) => {
+            const text = lastAssistantText(event?.messages);
+            if (text) pending = text;
+        });
+
+        pi.on("agent_settled" as any, () => {
+            const content = pending;
+            pending = null;
+            if (!content) return;
+
+            const conn = deps.getRelaySocket();
+            const sessionId = deps.getRelaySessionId();
+            if (!conn || !sessionId) return;
+
+            // ponytail: fire-and-forget, no requestId round-trip. A dropped mirror
+            // is cosmetic; blocking the turn on Discord's availability is not.
+            try {
+                conn.socket.emit("service_message" as any, {
+                    serviceId: "discord",
+                    type: "discord_post",
+                    payload: { sessionId, content },
+                });
+            } catch {
+                // Relay socket mid-reconnect — skip this turn's mirror.
+            }
+        });
+    };
+}
+
+export const discordMirrorExtension: ExtensionFactory = createDiscordMirrorExtension();

--- a/packages/cli/src/extensions/discord-mirror.ts
+++ b/packages/cli/src/extensions/discord-mirror.ts
@@ -13,6 +13,7 @@
  * of duplicating it into every session.
  */
 
+import { randomUUID } from "node:crypto";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import {
     getRelaySocket as getRelaySocketDefault,
@@ -25,11 +26,13 @@ const MAX_MIRROR_CHARS = 8_000;
 export interface DiscordMirrorDeps {
     getRelaySocket: typeof getRelaySocketDefault;
     getRelaySessionId: typeof getRelaySessionIdDefault;
+    newId: () => string;
 }
 
 const defaultDeps: DiscordMirrorDeps = {
     getRelaySocket: getRelaySocketDefault,
     getRelaySessionId: getRelaySessionIdDefault,
+    newId: randomUUID,
 };
 
 /**
@@ -73,11 +76,16 @@ export function createDiscordMirrorExtension(deps: DiscordMirrorDeps = defaultDe
 
             // ponytail: fire-and-forget, no requestId round-trip. A dropped mirror
             // is cosmetic; blocking the turn on Discord's availability is not.
+            //
+            // `id` exists because relay delivery to the runner is at-least-once:
+            // emitToRunner() emits to the runner room AND to the local socket, and
+            // a local runner is in both, so every envelope arrives twice. The
+            // service dedupes on this id.
             try {
                 conn.socket.emit("service_message" as any, {
                     serviceId: "discord",
                     type: "discord_post",
-                    payload: { sessionId, content },
+                    payload: { id: deps.newId(), sessionId, content },
                 });
             } catch {
                 // Relay socket mid-reconnect — skip this turn's mirror.

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -17,6 +17,7 @@ import { updateTodoExtension } from "./update-todo.js";
 import { memoryExtension } from "./memory/index.js";
 import { subagentExtension } from "./subagent.js";
 import { tunnelToolsExtension } from "./tunnel-tools.js";
+import { discordMirrorExtension } from "./discord-mirror.js";
 import { planModeToggleExtension } from "./plan-mode/index.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -50,6 +51,7 @@ const CORE_EXTENSIONS_HEAD: ExtensionFactory[] = [
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
     remoteExtension,
     tunnelToolsExtension,
+    discordMirrorExtension,
     mcpExtension,
     toolSearchExtension,  // Must be after MCP to see registered MCP tools
     ollamaWebToolsExtension,
@@ -157,10 +159,11 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
         expect(factories).toContain(restartExtension);
     });
 
-    test("skipRelay excludes remote extension and tunnel tools", () => {
+    test("skipRelay excludes remote extension, tunnel tools, and the Discord mirror", () => {
         const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", agentDir: TEST_AGENT_DIR, skipRelay: true });
         expect(factories).not.toContain(remoteExtension);
         expect(factories).not.toContain(tunnelToolsExtension);
+        expect(factories).not.toContain(discordMirrorExtension);
         expect(factories).toContain(mcpExtension);
     });
 

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -18,6 +18,7 @@ import { goalExtension } from "./goal/index.js";
 import { createClaudePluginExtension } from "./claude-plugins.js";
 import { subagentExtension } from "./subagent.js";
 import { tunnelToolsExtension } from "./tunnel-tools.js";
+import { discordMirrorExtension } from "./discord-mirror.js";
 import { planModeToggleExtension } from "./plan-mode/index.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -94,6 +95,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     if (!options.skipRelay) {
         factories.push(named(remoteExtension, "relay"));
         factories.push(named(tunnelToolsExtension, "tunnel-tools"));
+        factories.push(named(discordMirrorExtension, "discord-mirror"));
     }
 
     if (!options.skipMcp) {

--- a/packages/docs/src/content/docs/customization/overlay-packages.mdx
+++ b/packages/docs/src/content/docs/customization/overlay-packages.mdx
@@ -315,5 +315,6 @@ grep "loaded package service" ~/.pizzapi/logs/runner.log
 
 - [Pi Packages](/PizzaPi/features/pi-packages/) — installing, sources, publishing
 - [Runner Services](/PizzaPi/customization/runner-services/) — service internals, panels, triggers, sigils
+- [Connectivity Services](/PizzaPi/customization/runner-services/#connectivity-services) — packaging a service that owns a connection to Discord, Slack, MQTT, or any other external network
 - [MCP Servers](/PizzaPi/customization/mcp-servers/) — MCP configuration format
 - [Agent Definitions](/PizzaPi/customization/agent-definitions/) — authoring agents

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -622,6 +622,127 @@ A service doesn't need a UI panel. Omit `panel` from the manifest and skip `anno
 
 ---
 
+## Connectivity Services
+
+A **connectivity service** owns a live connection to an outside network — a chat
+gateway, a webhook receiver, a message queue, an MQTT broker. This is the shape
+to reach for whenever sessions need to talk to a third-party system that keeps a
+persistent connection open.
+
+The rule is simple: **the daemon owns one connection, and sessions never open
+their own.**
+
+### Why not a per-session abstraction
+
+The tempting design is a per-session object — every session gets a `bridge` it
+can connect and send through. It does not survive contact with a real service:
+
+| Problem | What happens with N sessions |
+|---------|------------------------------|
+| **N connections** | Ten sessions means ten gateway connections on one bot token. Discord rate-limits identifies per token; other providers ban outright. |
+| **Duplicate inbound** | Every connection receives every event. Ten sessions each see the same message and ten agents answer it. |
+| **Lifetime mismatch** | Connections belong to the machine, not the conversation. Sessions start and stop constantly; a connection that dies with a session cannot receive anything between sessions — including the message that should *start* one. |
+| **Credential spread** | The token has to be readable by every session process instead of living in one place on the daemon. |
+| **No routing authority** | "Which session owns this thread?" has no answer if every session holds its own map. |
+
+The daemon is the only component with the right lifetime and the right
+cardinality. Everything else follows from putting the connection there.
+
+<Aside type="caution" title="One connection, one owner">
+If you find yourself writing a class that a session constructs to talk to an
+external network, stop. That is the wrong shape. Move the connection to a
+runner service and give sessions a message channel to it.
+</Aside>
+
+### The two directions
+
+Inbound and outbound use different transports, because they have different
+routing problems.
+
+**Inbound — outside world → session.** The service already knows which session
+the event belongs to (it owns the mapping), so it delivers straight to that one
+session over HTTP:
+
+```typescript
+// Targeted: this session only. No subscription required.
+await fetch(`${relayUrl}/api/sessions/${sessionId}/trigger`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify({
+        type: "discord:message",
+        payload: { threadId, text },
+        source: "discord",
+        deliverAs: "steer",
+    }),
+});
+```
+
+Use `POST /api/runners/{runnerId}/trigger-broadcast` instead only when the event
+has **no** single owner and any interested session should hear it — a CI result,
+a repo-wide push. Broadcast fans out to every *subscriber*; it cannot address one
+conversation.
+
+**Outbound — session → outside world.** The session emits a `service_message`
+envelope on its own relay socket. The relay forwards it to the daemon, which
+routes it to the service by `serviceId`:
+
+```typescript
+// In a session-side extension.
+socket.emit("service_message", {
+    serviceId: "discord",
+    type: "discord_post",
+    payload: { sessionId, content },
+});
+```
+
+The service picks it up in the handler it registered during `init()`:
+
+```typescript
+init(socket, opts) {
+    this.onMessage = (envelope) => {
+        if (envelope.serviceId !== "discord") return;
+        if (envelope.type === "discord_post") void this.post(envelope.payload);
+    };
+    socket.on("service_message", this.onMessage);
+}
+```
+
+Note what the session does **not** do: it does not look up a thread, hold a
+token, or know whether the bridge is even configured. It emits one envelope and
+the service drops it if that session has no mapping. Routing lives in exactly one
+place.
+
+<Aside type="tip" title="Round-trip vs fire-and-forget">
+Add a `requestId` and listen for the matching reply when the session needs an
+answer (`create_tunnel` does this — see `packages/cli/src/extensions/tunnel-tools.ts`).
+Omit it for notifications, so a slow or disconnected external service can never
+stall an agent turn.
+</Aside>
+
+### Mapping sessions to conversations
+
+The service owns the mapping and is responsible for its whole lifecycle:
+
+- **Persist it.** Write bindings to the service's `settings.json` (write-to-temp
+  then rename) so a daemon restart does not orphan every live conversation.
+- **Index both ways.** Keep `sessionId → conversation` in memory for outbound
+  routing; the persisted map is keyed by conversation for inbound.
+- **Clean up on session end.** Implement `handleSessionEnded(sessionId)` to drop
+  the binding, and tell the remote side the conversation is over.
+- **Unbind on delivery failure.** A `404` from the trigger endpoint means the
+  session is gone. Drop the binding rather than silently swallowing every
+  subsequent message.
+
+### Worked example
+
+The Discord bridge implements exactly this pattern — one gateway connection for
+the runner, thread-per-session bindings, session spawning from a mention, and a
+panel for status and controls. Its session-side half is
+`packages/cli/src/extensions/discord-mirror.ts`, which forwards each settled
+assistant turn and nothing else.
+
+---
+
 ## ServiceHandler API
 
 The service module must default-export a class implementing the ServiceHandler interface:

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -719,6 +719,37 @@ Omit it for notifications, so a slow or disconnected external service can never
 stall an agent turn.
 </Aside>
 
+<Aside type="caution" title="service_message delivery is at-least-once">
+The relay's `emitToRunner()` emits to the per-runner room **and** to the local
+runner socket as a rolling-deploy fallback. A local runner is in both, so in
+practice **every envelope arrives twice**.
+
+This is invisible for idempotent operations — exposing an already-exposed port
+is a no-op, and request/response pairs are matched by `requestId`, so the first
+reply wins. It is *not* invisible for side effects: an un-deduped handler posts
+every chat message twice.
+
+Stamp each envelope with a unique id and skip ids you have already handled:
+
+```typescript
+#seen = new Set<string>();
+
+#isDuplicate(id: unknown): boolean {
+    if (typeof id !== "string" || !id) return false;   // no id — process it
+    if (this.#seen.has(id)) return true;
+    this.#seen.add(id);
+    if (this.#seen.size > 500) {
+        const oldest = this.#seen.values().next().value; // insertion-ordered
+        if (oldest !== undefined) this.#seen.delete(oldest);
+    }
+    return false;
+}
+```
+
+Treat any handler with an external side effect — posting a message, sending an
+email, charging something — as needing this.
+</Aside>
+
 ### Mapping sessions to conversations
 
 The service owns the mapping and is responsible for its whole lifecycle:

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -764,13 +764,48 @@ The service owns the mapping and is responsible for its whole lifecycle:
   session is gone. Drop the binding rather than silently swallowing every
   subsequent message.
 
+### Driving the session from the far side
+
+A connectivity service usually wants to *control* the session, not just relay
+text. Most of that already exists over HTTP with API-key auth:
+
+| Action | Endpoint |
+|--------|----------|
+| Spawn a session | `POST /api/runners/:runnerId/spawn` |
+| Send input to a session | `POST /api/sessions/:id/trigger` |
+| List sessions | `GET /api/sessions` |
+| List models | `GET /api/runners/:runnerId/models` |
+| Switch a session's model | `POST /api/sessions/:id/model` |
+
+<Aside type="note" title="requireSession() accepts API keys">
+Despite the name, `requireSession()` falls back to `validateApiKey()`, so routes
+using it are already reachable from a runner service. Check before adding an
+auth shim — the endpoint you want probably works with `x-api-key` today.
+</Aside>
+
+Anything a *viewer* drives over a socket event has no HTTP equivalent unless one
+is added. `POST /api/sessions/:id/model` exists precisely because switching a
+live model was viewer-only (`model_set`), and a runner service is not a viewer.
+There is still no HTTP route to stop a session — `kill_session` is
+server→runner only.
+
 ### Worked example
 
 The Discord bridge implements exactly this pattern — one gateway connection for
-the runner, thread-per-session bindings, session spawning from a mention, and a
-panel for status and controls. Its session-side half is
+the runner, thread-per-session bindings, session spawning from a mention, native
+slash commands, and a panel for status and controls. Its session-side half is
 `packages/cli/src/extensions/discord-mirror.ts`, which forwards each settled
 assistant turn and nothing else.
+
+Commands that pick from a list render a **select menu** rather than asking the
+user to type an exact id — `/models` shows the available models with the current
+one preselected, `/sessions` binds the thread to a running session. Two details
+worth copying:
+
+- **Defer before any network call.** Discord expires an interaction after 3
+  seconds, so `deferReply()` first and `editReply()` once the data arrives.
+- **Encode the target in `custom_id`.** The menu carries the thread it was built
+  for, so a stale menu left open elsewhere cannot retarget a different binding.
 
 ---
 

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -1741,6 +1741,136 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
     });
 });
 
+describe("POST /api/sessions/:id/model", () => {
+    const collabSession = (userId = "user-1") => ({ userId, sessionId: "sess-1", collabMode: true } as any);
+
+    beforeEach(() => {
+        mockGetSharedSession.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+        mockEmitToRelaySessionVerified.mockReset();
+        mockEmitToRelaySessionVerified.mockReturnValue(Promise.resolve(false));
+        mockValidateApiKey.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" }));
+        mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" }));
+    });
+
+    test("switches the model via the local TUI socket using an API key", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession()));
+        const emitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: emitMock });
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+        expect(emitMock).toHaveBeenCalledTimes(1);
+        const args = emitMock.mock.calls[0] as any[];
+        expect(args[0]).toBe("model_set");
+        expect(args[1]).toEqual({ provider: "anthropic", modelId: "claude-sonnet-5" });
+    });
+
+    test("trims whitespace around provider and modelId", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession()));
+        const emitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: emitMock });
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "  anthropic ", modelId: " claude-sonnet-5  " },
+            { "x-api-key": "test-key" },
+        );
+        await handleTriggersRoute(req, url);
+        expect((emitMock.mock.calls[0] as any[])[1]).toEqual({ provider: "anthropic", modelId: "claude-sonnet-5" });
+    });
+
+    test("falls back to cross-node delivery when there is no local socket", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession()));
+        mockGetLocalTuiSocket.mockReturnValue(null);
+        mockEmitToRelaySessionVerified.mockReturnValue(Promise.resolve(true));
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+        expect(mockEmitToRelaySessionVerified).toHaveBeenCalled();
+    });
+
+    test("returns 503 when the session is registered but unreachable", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession()));
+        mockGetLocalTuiSocket.mockReturnValue(null);
+        mockEmitToRelaySessionVerified.mockReturnValue(Promise.resolve(false));
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        expect((await handleTriggersRoute(req, url))?.status).toBe(503);
+    });
+
+    test("returns 409 when the session is not in collab mode", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", collabMode: false } as any),
+        );
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        expect((await handleTriggersRoute(req, url))?.status).toBe(409);
+    });
+
+    test("returns 404 for a session owned by another user", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession("someone-else")));
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/sess-1/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        expect((await handleTriggersRoute(req, url))?.status).toBe(404);
+    });
+
+    test("returns 404 for an unknown session", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(null));
+
+        const [req, url] = makeReq(
+            "POST", "/api/sessions/nope/model",
+            { provider: "anthropic", modelId: "claude-sonnet-5" },
+            { "x-api-key": "test-key" },
+        );
+        expect((await handleTriggersRoute(req, url))?.status).toBe(404);
+    });
+
+    test("rejects a missing provider or modelId", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(collabSession()));
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: mock(() => {}) });
+
+        for (const body of [{ modelId: "m" }, { provider: "p" }, { provider: "  ", modelId: "m" }, {}]) {
+            const [req, url] = makeReq("POST", "/api/sessions/sess-1/model", body, { "x-api-key": "test-key" });
+            expect((await handleTriggersRoute(req, url))?.status).toBe(400);
+        }
+    });
+
+    test("returns 401 when no credentials are supplied", async () => {
+        mockRequireSession.mockReturnValue(Promise.resolve(new Response(null, { status: 401 })) as any);
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-1/model", { provider: "p", modelId: "m" });
+        expect((await handleTriggersRoute(req, url))?.status).toBe(401);
+    });
+
+    test("ignores GET on the model route", async () => {
+        const [req, url] = makeReq("GET", "/api/sessions/sess-1/model");
+        expect(await handleTriggersRoute(req, url)).toBeUndefined();
+    });
+});
+
 describe("non-matching routes", () => {
     test("returns undefined for unmatched paths", async () => {
         const [req, url] = makeReq("GET", "/api/something-else");

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -5,6 +5,11 @@
  *   Fires a trigger into a connected session. Supports both session-cookie
  *   auth and API key auth (x-api-key header) for external integrations.
  *
+ * POST /api/sessions/:id/model
+ *   Switches a live session's model. HTTP equivalent of the viewer's
+ *   `model_set` socket event, so runner services can drive it with an API key.
+ *   Body: { provider, modelId }. Requires collab mode; hidden models are blocked.
+ *
  * GET /api/sessions/:id/triggers
  *   Lists recent triggers for a session (from Redis trigger history).
  *
@@ -228,6 +233,66 @@ async function authenticate(req: Request): Promise<{ userId: string; userName: s
 }
 
 export const handleTriggersRoute: RouteHandler = async (req, url) => {
+    // ── POST /api/sessions/:id/model ──────────────────────────────────
+    // Switch a live session's model. Same effect as the viewer's `model_set`
+    // socket event, but reachable with an API key so runner services (the
+    // Discord bridge's /models command) can drive it.
+    const modelMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/model$/);
+    if (modelMatch && req.method === "POST") {
+        const identity = await authenticate(req);
+        if (identity instanceof Response) return identity;
+
+        const sessionId = decodeURIComponent(modelMatch[1]);
+        const targetSession = await getSharedSession(sessionId);
+        // Same 404-for-forbidden shape as the trigger route — do not leak
+        // whether a session exists under another account.
+        if (!targetSession || targetSession.userId !== identity.userId) {
+            return Response.json({ error: "Session not found or not connected" }, { status: 404 });
+        }
+        if (!targetSession.collabMode) {
+            return Response.json({ error: "Session is not in collab mode" }, { status: 409 });
+        }
+
+        let body: { provider?: unknown; modelId?: unknown };
+        try {
+            body = await req.json() as typeof body;
+        } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+        }
+
+        const provider = typeof body.provider === "string" ? body.provider.trim() : "";
+        const modelId = typeof body.modelId === "string" ? body.modelId.trim() : "";
+        if (!provider || !modelId) {
+            return Response.json({ error: "Missing 'provider' or 'modelId'" }, { status: 400 });
+        }
+
+        // Hard-block hidden models, same rule as the spawn route and the
+        // viewer's model_set handler. Fresh DB read — env copies go stale.
+        try {
+            const hiddenModels = await getHiddenModels(identity.userId);
+            if (isHiddenModel(hiddenModels, { provider, id: modelId })) {
+                log.warn(`blocked model switch to hidden model ${provider}/${modelId} on ${sessionId}`);
+                return Response.json({ error: "Model not available" }, { status: 403 });
+            }
+        } catch {
+            // Lookup failure falls through — the worker-side guard still applies.
+        }
+
+        const targetSocket = getLocalTuiSocket(sessionId);
+        if (targetSocket?.connected) {
+            targetSocket.emit("model_set", { provider, modelId });
+            return Response.json({ ok: true, provider, modelId });
+        }
+
+        const delivered = await emitToRelaySessionVerified(sessionId, "model_set", { provider, modelId });
+        if (delivered) return Response.json({ ok: true, provider, modelId });
+
+        return Response.json(
+            { error: "Session is registered but not currently connected" },
+            { status: 503 },
+        );
+    }
+
     // ── POST /api/sessions/:id/trigger ────────────────────────────────
     const postMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/trigger$/);
     if (postMatch && req.method === "POST") {


### PR DESCRIPTION
Step 3 of the `pi.pizzapi` convergence (Felva9lO): the Discord bridge that proves `ProviderBridge` was replaceable, plus the pattern docs that make it reproducible.

## Why this exists

`ProviderBridge` was constructed inside a `session_start` handler — i.e. **per session**. An external-connectivity provider built that way opens one connection *per session*. #666 deleted that layer; this PR demonstrates the replacement: a daemon-scoped runner service, which is what `github` already does for webhooks and `tunnel` already does for ports.

## What's here

**`packages/cli/src/extensions/discord-mirror.ts`** — the session-side outbound half. Forwards each *settled* assistant turn to the daemon's `discord` service over `service_message`.

- Holds text from `agent_end`, publishes on `agent_settled` — retried attempts aren't mirrored twice.
- Fire-and-forget, no `requestId` round-trip. A dropped mirror is cosmetic; blocking a turn on Discord's availability is not.
- The session knows nothing about Discord: no token, no thread lookup, no config. It emits one envelope and the service drops it when the session has no bound thread. Thread mapping lives in exactly one place.

**`customization/runner-services.mdx` → "Connectivity Services"** — when to own a connection at daemon scope, the inbound/outbound split, and explicitly why a per-session abstraction is the wrong shape:

| Problem | With N sessions |
|---|---|
| N connections | Ten sessions = ten gateway connections on one token; Discord rate-limits identifies per token |
| Duplicate inbound | Every connection sees every event; ten agents answer the same message |
| Lifetime mismatch | A connection that dies with a session can't receive the message that should *start* one |
| Credential spread | Token readable by every session process instead of one place |
| No routing authority | "Which session owns this thread?" has no answer |

Inbound uses targeted `POST /api/sessions/:id/trigger` (the service already knows the owner); `trigger-broadcast` is documented as the fan-out case only. Cross-linked from `overlay-packages.mdx`.

## The service itself

Ships as a `pi.pizzapi` overlay package in `~/.pizzapi/packages/discord/`, alongside `github` and `system-monitor` (per repo convention, service packages live outside the repo). One gateway connection per runner, thread-per-session bindings persisted via write-then-rename, session spawning from an `@mention`, role-gated authorization, bot presence, and a status/controls panel.

## Verification

- `bun run typecheck` — exit 0
- `bun test packages/cli/src` — 2751 pass, 3 fail (pre-existing: models-command ×2, overlay/identity — Godmother f5ohlCyG)
- `packages/docs` build — 49 pages, clean
- Package self-check — 12/12 pass (chunking, fence re-opening, mention stripping, role auth)
- **Live**: gateway connected as `AJPizza#1841`; posted a short message and an 11.9 KB fenced code block to a real channel, chunked correctly under Discord's 2000-char limit
- Retired `providers.message-bridge` from `~/.pizzapi/config.json` (token moved into the service's `settings.json`); backup at `config.json.bak-discord`
- Shut down the incumbent `ai.hermes.gateway` launchd job so two bots don't double-answer

## Not in scope

Removing legacy service-directory discovery + the runner-services Quick Start rewrite — that's the next PR in Felva9lO, kept separate so each is reviewable.

There's no `stopSession()` from Discord: the relay has no HTTP kill route (`kill_session` is server→runner only). Unbinding the thread is the available control; noted in a `ponytail:` comment.
