### PR TITLE
feat(docker): runner container image (ghcr.io/pizzaface/pizzapi-runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,8 +309,8 @@ jobs:
           build-args: |
             VERSION=ci
             GIT_SHA=${{ github.sha }}
-          cache-from: type=gha,scope=runner-image
-          cache-to: type=gha,mode=max,scope=runner-image
+          cache-from: type=gha,scope=runner-image-ci
+          cache-to: type=gha,mode=max,scope=runner-image-ci
 
       - name: Assert — CLI works and image is non-root
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,99 @@ jobs:
           retention-days: 7
 
   # ───────────────────────────────────────────────────────────────
+  # Runner image — hermetic Dockerfile check (linux/amd64 only, --load,
+  # no push). Catches Dockerfile/entrypoint breakage on every PR without
+  # needing a relay. The full relay-backed smoke (registration, spawn,
+  # persistence, stale-lock recovery, sandbox opt-in) lives in
+  # docker/runner/smoke.sh and is run locally against a live relay,
+  # because CI has no provisioned relay/API key.
+  # ───────────────────────────────────────────────────────────────
+  runner-image:
+    name: Runner Image — hermetic check
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Cache Bun artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Stage Docker build context (linux-x64 only)
+        run: bun docker/runner/stage-context.ts --targets linux-x64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build runner image (amd64, load only)
+        uses: docker/build-push-action@v7
+        with:
+          context: packages/cli/dist/runner-image-context
+          file: docker/runner/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: pizzapi/runner-image:ci
+          build-args: |
+            VERSION=ci
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=runner-image
+          cache-to: type=gha,mode=max,scope=runner-image
+
+      - name: Assert — CLI works and image is non-root
+        run: |
+          set -euo pipefail
+          IMG=pizzapi/runner-image:ci
+
+          docker run --rm --entrypoint pizza "$IMG" --version
+
+          docker run --rm --entrypoint sh "$IMG" -c '
+            set -eu
+            [ "$(id -u)" = "1000" ] || { echo "expected uid 1000, got $(id -u)" >&2; exit 1; }
+            for c in bwrap socat rg git ssh tini; do
+              command -v "$c" >/dev/null || { echo "missing $c on PATH" >&2; exit 1; }
+            done
+            SECCOMP_DIR=/usr/lib/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64
+            [ -x "$SECCOMP_DIR/apply-seccomp" ] || { echo "apply-seccomp missing/not executable" >&2; exit 1; }
+            [ -f "$SECCOMP_DIR/unix-block.bpf" ] || { echo "unix-block.bpf missing" >&2; exit 1; }
+            [ "$PIZZAPI_SANDBOX" = "none" ] || { echo "PIZZAPI_SANDBOX default wrong: $PIZZAPI_SANDBOX" >&2; exit 1; }
+            [ "$PIZZAPI_WORKSPACE_ROOTS" = "/workspace" ] || { echo "PIZZAPI_WORKSPACE_ROOTS default wrong: $PIZZAPI_WORKSPACE_ROOTS" >&2; exit 1; }
+            echo "✅ uid, tools, seccomp assets, and env defaults all check out"
+          '
+
+      - name: Assert — healthcheck command fails closed without a daemon
+        run: |
+          set -euo pipefail
+          IMG=pizzapi/runner-image:ci
+
+          set +e
+          docker run --rm --entrypoint pizza "$IMG" runner status
+          CODE=$?
+          set -e
+
+          if [ "$CODE" -ne 1 ]; then
+            echo "::error::expected 'pizza runner status' to exit 1 with no daemon running, got $CODE"
+            exit 1
+          fi
+          echo "✅ pizza runner status correctly exits 1 without a daemon (HEALTHCHECK fails closed)"
+
+  # ───────────────────────────────────────────────────────────────
   # E2E: install flow (`pizzapi web` + register + runner) per distribution
   # ───────────────────────────────────────────────────────────────
   e2e-install-flow:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,94 @@ jobs:
           cache-from: type=gha,scope=ui-image-release
           cache-to: type=gha,mode=max,scope=ui-image-release
 
+  # ─── Build + push versioned Docker runner image ───────────────
+  # Reuses the release-stamped binaries from build-binary instead of
+  # recompiling, so the image contains the exact same bits as the npm
+  # release. needs: publish (which needs: build-binary) guarantees the
+  # binary-linux-* artifacts already exist by the time this job starts.
+  docker-runner:
+    name: Docker Runner — ${{ needs.compute-version.outputs.version }}
+    needs: [compute-version, publish]
+    if: inputs.action != 'pull' && inputs.dry-run != true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download binary artifacts (Linux)
+        uses: actions/download-artifact@v6
+        with:
+          pattern: binary-linux-*
+          path: packages/cli/dist/binaries/
+          merge-multiple: false
+
+      - name: Arrange binary directories
+        run: |
+          # Same layout fix as the publish job's "Arrange binary directories":
+          # download-artifact creates binary-<target>/ dirs; stage-context.ts
+          # expects <target>/ (e.g. linux-x64/, linux-arm64/).
+          cd packages/cli/dist/binaries
+          for dir in ./binary-linux-*; do
+            TARGET="${dir#./binary-}"
+            mv "$dir" "$TARGET"
+            echo "  $dir → $TARGET"
+          done
+          echo ""
+          echo "Binary layout:"
+          ls -la ./*/pizza-* 2>/dev/null || true
+
+      - name: Stage Docker build context (reuse release binaries)
+        run: bun docker/runner/stage-context.ts --skip-build
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          TAGS="ghcr.io/pizzaface/pizzapi-runner:${{ needs.compute-version.outputs.version }}
+          ghcr.io/pizzaface/pizzapi-runner:${{ github.sha }}"
+          if [ "${{ inputs.action }}" = "latest" ]; then
+            TAGS="${TAGS}
+          ghcr.io/pizzaface/pizzapi-runner:latest"
+          fi
+          {
+            echo "value<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push runner image
+        uses: docker/build-push-action@v7
+        with:
+          context: packages/cli/dist/runner-image-context
+          file: docker/runner/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.value }}
+          build-args: |
+            VERSION=${{ needs.compute-version.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=runner-image-release
+          cache-to: type=gha,mode=max,scope=runner-image-release
+
   # ─── Pull (unpublish) a release ──────────────────────────────
   # NOTE: npm OIDC trusted publishing only supports `npm publish`.
   # Unpublish still requires a classic NPM_TOKEN secret.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -521,15 +521,15 @@ jobs:
         id: tags
         run: |
           set -euo pipefail
-          TAGS="ghcr.io/pizzaface/pizzapi-runner:${{ needs.compute-version.outputs.version }}
-          ghcr.io/pizzaface/pizzapi-runner:${{ github.sha }}"
-          if [ "${{ inputs.action }}" = "latest" ]; then
-            TAGS="${TAGS}
-          ghcr.io/pizzaface/pizzapi-runner:latest"
-          fi
+          # One tag per line, no leading whitespace — don't rely on the
+          # build-push-action trimming indentation off each entry.
           {
             echo "value<<EOF"
-            echo "$TAGS"
+            echo "ghcr.io/pizzaface/pizzapi-runner:${{ needs.compute-version.outputs.version }}"
+            echo "ghcr.io/pizzaface/pizzapi-runner:${{ github.sha }}"
+            if [ "${{ inputs.action }}" = "latest" ]; then
+              echo "ghcr.io/pizzaface/pizzapi-runner:latest"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/runner-docker.yml
+++ b/.github/workflows/runner-docker.yml
@@ -1,0 +1,86 @@
+name: Runner Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/runner/**"
+      - "packages/cli/**"
+      - "patches/**"
+      - "bun.lock"
+      - "package.json"
+      - "tsconfig.base.json"
+      - ".github/workflows/runner-docker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve CLI version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="$(python3 -c "import json, pathlib; version=(json.loads(pathlib.Path('packages/cli/package.json').read_text()).get('version') or '').strip(); assert version, 'packages/cli/package.json is missing a semantic version'; print(version)")"
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Cache Bun artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Stage Docker build context (compiles both Linux binaries)
+        run: bun docker/runner/stage-context.ts --targets linux-x64,linux-arm64
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push runner image
+        uses: docker/build-push-action@v7
+        with:
+          context: packages/cli/dist/runner-image-context
+          file: docker/runner/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/pizzaface/pizzapi-runner:main
+            ghcr.io/pizzaface/pizzapi-runner:${{ github.sha }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.value }}
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=runner-image
+          cache-to: type=gha,mode=max,scope=runner-image

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -75,6 +75,13 @@ ENV HOME=/home/pizza \
 WORKDIR /workspace
 USER pizza
 
+# Left as-is for auto-pairing: a fresh container with no credential can sit
+# unhealthy for minutes waiting on a human to approve the printed URL. That's
+# honest, not broken — `pizza runner status` reports "pairing pending" while
+# it waits, and Docker's healthcheck only ever reports status; nothing here
+# restarts or kills the container for being unhealthy. Do not wire an
+# autoheal/restart-on-unhealthy supervisor on top of this image — see
+# "Health, logs, upgrades" in docs/deployment/runner-container.mdx.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
     CMD pizza runner status || exit 1
 

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1
+# PizzaPi runner image — a remote coding machine, not just a daemon wrapper.
+#
+# Build context is the staged directory from stage-context.ts, NOT the repo
+# root (the root .dockerignore excludes packages/cli and docker/). One
+# Dockerfile builds both platforms via buildx; TARGETARCH picks which staged
+# arch directory to install from a `RUN --mount=type=bind` so the *other*
+# arch's ~115MB never lands in an image layer:
+#
+#   bun docker/runner/stage-context.ts
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -f docker/runner/Dockerfile packages/cli/dist/runner-image-context
+#
+# See docs/plans/2026-07-31-runner-container-spike.md for the design.
+FROM debian:trixie-slim
+
+ARG TARGETARCH
+ARG VERSION=0.0.0-dev
+ARG GIT_SHA=unknown
+
+LABEL org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.source="https://github.com/Pizzaface/PizzaPi" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="PizzaPi Runner" \
+      org.opencontainers.image.description="Non-root remote coding runner for PizzaPi: connects to a relay, spawns coding agent sessions against mounted workspaces."
+
+# Only what PizzaPi itself relies on: TLS, git, ssh, the built-in web
+# terminal shell, search/process tools for runner services, bubblewrap+socat
+# for the optional sandbox, curl for debugging, tini as PID 1. setpriv comes
+# from util-linux, already in the base image. No gh, node, python, or
+# compilers — derived images add project toolchains.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        bash \
+        git \
+        openssh-client \
+        ripgrep \
+        findutils \
+        procps \
+        bubblewrap \
+        socat \
+        curl \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the binary + assets for TARGETARCH, and the matching seccomp vendor
+# files (see fact #4 in the container spike) — bind-mounted from the build
+# context so only the selected arch's files end up in an image layer.
+RUN --mount=type=bind,source=.,target=/mnt/ctx \
+    set -eu; \
+    case "$TARGETARCH" in \
+        amd64) arch_dir=linux-x64; seccomp_arch=x64 ;; \
+        arm64) arch_dir=linux-arm64; seccomp_arch=arm64 ;; \
+        *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    seccomp_dir="/usr/lib/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/$seccomp_arch"; \
+    mkdir -p /opt/pizzapi "$seccomp_dir"; \
+    cp -a "/mnt/ctx/$arch_dir/." /opt/pizzapi/; \
+    cp -a "/mnt/ctx/seccomp/$seccomp_arch/." "$seccomp_dir/"; \
+    cp "/mnt/ctx/entrypoint.sh" /usr/local/bin/pizzapi-entrypoint; \
+    ln -s /opt/pizzapi/pizza /usr/local/bin/pizza; \
+    chmod +x /usr/local/bin/pizzapi-entrypoint "$seccomp_dir/apply-seccomp"
+
+RUN groupadd -g 1000 pizza \
+    && useradd -u 1000 -g 1000 -m -d /home/pizza -s /bin/bash pizza \
+    && mkdir -p /home/pizza/.pizzapi /workspace \
+    && chown -R pizza:pizza /home/pizza /workspace
+
+ENV HOME=/home/pizza \
+    PIZZAPI_WORKSPACE_ROOTS=/workspace \
+    PIZZAPI_SANDBOX=none \
+    LANG=C.UTF-8
+
+WORKDIR /workspace
+USER pizza
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+    CMD pizza runner status || exit 1
+
+ENTRYPOINT ["/usr/local/bin/pizzapi-entrypoint"]
+CMD ["runner"]

--- a/docker/runner/README.md
+++ b/docker/runner/README.md
@@ -1,0 +1,12 @@
+# PizzaPi runner image
+
+Build and smoke-test scripts for the `pizzapi-runner` container image. See
+[`docs/plans/2026-07-31-runner-container-spike.md`](../../docs/plans/2026-07-31-runner-container-spike.md)
+for the design and operator-facing docs (Compose, mounts, sandbox posture).
+
+```sh
+bun docker/runner/stage-context.ts                 # build binaries + assemble context
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f docker/runner/Dockerfile packages/cli/dist/runner-image-context
+./docker/runner/smoke.sh                           # end-to-end smoke against a live relay
+```

--- a/docker/runner/README.md
+++ b/docker/runner/README.md
@@ -10,3 +10,21 @@ docker buildx build --platform linux/amd64,linux/arm64 \
   -f docker/runner/Dockerfile packages/cli/dist/runner-image-context
 ./docker/runner/smoke.sh                           # end-to-end smoke against a live relay
 ```
+
+## Model credentials
+
+Pairing authenticates the runner to the *relay*, not to model providers. Log
+those in from inside the container:
+
+```sh
+docker compose exec runner pizza auth            # list providers + what's configured
+docker compose exec runner pizza auth anthropic  # OAuth or API key
+```
+
+The OAuth flows print an authorization URL and accept the final redirect URL
+pasted back, so the browser can be on a different machine than the container
+and no callback port needs publishing. Credentials are written to
+`/home/pizza/.pizzapi/auth.json` in the runner-data volume; new sessions pick
+them up with no restart. `PIZZAPI_AUTH_FILE` remains the non-interactive path
+for automated provisioning.
+

--- a/docker/runner/compose.example.yml
+++ b/docker/runner/compose.example.yml
@@ -12,9 +12,14 @@ services:
     stop_grace_period: 30s
     environment:
       PIZZAPI_RELAY_URL: https://pizza.example.com
-      PIZZAPI_API_KEY: ${PIZZAPI_API_KEY}
       PIZZAPI_RUNNER_NAME: docker-runner
       PIZZAPI_WORKSPACE_ROOTS: /workspace
+      # No PIZZAPI_API_KEY here — first boot with no credential and a known
+      # relay auto-pairs: `docker compose logs -f runner` prints an approval
+      # URL + QR (re-printed every ~60s while pending), you approve it from
+      # an authenticated browser, and the minted key ("runner-docker-runner")
+      # is saved into the runner-data volume below. No restart needed. See
+      # the "Docker/K8s secrets" block further down for the non-pairing path.
       # If the relay is another Compose service instead of a public URL:
       # PIZZAPI_RELAY_URL: http://server:7492
 
@@ -46,5 +51,25 @@ services:
     # environment:
     #   PIZZAPI_SANDBOX: basic
 
+    # --- Alternative to pairing: Docker/K8s secrets ---
+    # Skips the human-approval step; use when provisioning is automated (CI,
+    # fleet rollout) or PIZZAPI_PAIRING=0 is set. `_FILE` vars only expand for
+    # credential-shaped names (*_KEY / *_TOKEN) — populates the bare name from
+    # the trimmed file contents, without ever putting the secret on the
+    # command line or in `docker inspect`'s env list.
+    # environment:
+    #   PIZZAPI_API_KEY_FILE: /run/secrets/pizzapi_api_key
+    #   PIZZAPI_AUTH_FILE: /run/secrets/pizzapi_auth_json   # seeds auth.json once; never clobbers an existing one
+    # secrets:
+    #   - pizzapi_api_key
+    #   - pizzapi_auth_json
+
 volumes:
   runner-data:
+
+# --- Alternative to pairing: Docker/K8s secrets (top-level declaration) ---
+# secrets:
+#   pizzapi_api_key:
+#     file: ./secrets/pizzapi_api_key.txt
+#   pizzapi_auth_json:
+#     file: ./secrets/auth.json

--- a/docker/runner/compose.example.yml
+++ b/docker/runner/compose.example.yml
@@ -1,0 +1,50 @@
+# Example Compose service for the PizzaPi runner image.
+#
+# Copy the `runner:` service (and `volumes:` entry) into your own
+# compose.yml, or run this file directly:
+#   docker compose -f docker/runner/compose.example.yml up -d
+#
+# See docs/plans/2026-07-31-runner-container-spike.md for the full design.
+services:
+  runner:
+    image: ghcr.io/pizzaface/pizzapi-runner:0.5.61
+    restart: unless-stopped
+    stop_grace_period: 30s
+    environment:
+      PIZZAPI_RELAY_URL: https://pizza.example.com
+      PIZZAPI_API_KEY: ${PIZZAPI_API_KEY}
+      PIZZAPI_RUNNER_NAME: docker-runner
+      PIZZAPI_WORKSPACE_ROOTS: /workspace
+      # If the relay is another Compose service instead of a public URL:
+      # PIZZAPI_RELAY_URL: http://server:7492
+
+      # --- Optional: remap the container's `pizza` user to a host uid/gid ---
+      # Useful when ./projects is a bind mount owned by your host user.
+      # PUID: "1000"
+      # PGID: "1000"
+      # PIZZAPI_CHOWN_WORKSPACE: "1"  # also chown workspace roots on start (slow, off by default)
+    volumes:
+      # Required: runner identity, auth, sessions, installed services — treat as secret.
+      - runner-data:/home/pizza/.pizzapi
+      # Workspaces, mounted under PIZZAPI_WORKSPACE_ROOTS.
+      - ./projects:/workspace
+
+      # --- Optional: git identity from the host ---
+      # - ~/.gitconfig:/home/pizza/.gitconfig:ro
+
+      # --- Optional: SSH agent forwarding (preferred over mounting keys) ---
+      # - ${SSH_AUTH_SOCK}:/ssh-agent
+    # environment:
+    #   SSH_AUTH_SOCK: /ssh-agent
+
+    # --- Optional: opt-in nested Bubblewrap sandbox (PIZZAPI_SANDBOX=none by default) ---
+    # This weakens container isolation: it requires disabling Docker's default
+    # seccomp profile for the whole container, not just the sandboxed session.
+    # Only enable this if you understand and accept that tradeoff.
+    # security_opt:
+    #   - seccomp=unconfined
+    # environment:
+    #   PIZZAPI_SANDBOX: basic
+
+volumes:
+  runner-data:

--- a/docker/runner/compose.example.yml
+++ b/docker/runner/compose.example.yml
@@ -28,6 +28,26 @@ services:
       # PUID: "1000"
       # PGID: "1000"
       # PIZZAPI_CHOWN_WORKSPACE: "1"  # also chown workspace roots on start (slow, off by default)
+    # --- Model provider credentials ---
+    # Log providers in from the web UI (Runner Settings → Providers), or inside
+    # the container:
+    #   docker compose exec runner pizza auth            # list providers
+    #   docker compose exec runner pizza auth anthropic  # OAuth / API key login
+    # Credentials land in /home/pizza/.pizzapi/auth.json (the runner-data volume
+    # below); new sessions pick them up without a restart. PIZZAPI_AUTH_FILE
+    # (further down) is the non-interactive alternative.
+    #
+    # Provider OAuth clients hard-code a loopback redirect (Anthropic
+    # localhost:53692, OpenAI Codex localhost:1455) and won't accept the relay's
+    # URL, so the browser is redirected to ITS OWN localhost. Publish the ports
+    # below and a browser on THIS host completes the login with no copy/paste;
+    # from any other device you paste the redirect URL into the login card
+    # instead. Bound to 127.0.0.1: these are one-shot OAuth callbacks, not a
+    # service to expose.
+    # ports:
+    #   - "127.0.0.1:53692:53692"   # Anthropic (Claude Pro/Max)
+    #   - "127.0.0.1:1455:1455"     # OpenAI Codex
+
     volumes:
       # Required: runner identity, auth, sessions, installed services — treat as secret.
       - runner-data:/home/pizza/.pizzapi

--- a/docker/runner/entrypoint.sh
+++ b/docker/runner/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Entrypoint for the PizzaPi runner image.
+#
+# When started as root (e.g. `user: "0:0"` or PUID/PGID set), remaps the
+# baked-in `pizza` user (uid/gid 1000) to the target ids instead of relying
+# on a raw `user:` override. A raw override leaves no /etc/passwd entry for
+# the running uid, which breaks git and shells (see runner-container-spike.md
+# fact #5) — remapping the real `pizza` account keeps that entry intact.
+# The daemon itself never runs as root.
+set -e
+
+log() {
+    echo "[entrypoint] $*" >&2
+}
+
+CURRENT_UID=$(id -u)
+
+if [ "$CURRENT_UID" = "0" ]; then
+    TARGET_UID="${PUID:-1000}"
+    TARGET_GID="${PGID:-1000}"
+    PIZZA_UID=$(id -u pizza)
+    PIZZA_GID=$(id -g pizza)
+
+    if [ "$TARGET_UID" != "$PIZZA_UID" ] || [ "$TARGET_GID" != "$PIZZA_GID" ]; then
+        [ "$TARGET_GID" != "$PIZZA_GID" ] && groupmod -o -g "$TARGET_GID" pizza
+        usermod -o -u "$TARGET_UID" -g "$TARGET_GID" pizza
+    fi
+
+    for dir in "$HOME" "$HOME/.pizzapi"; do
+        if [ -d "$dir" ]; then
+            owner_uid=$(stat -c '%u' "$dir")
+            [ "$owner_uid" != "$TARGET_UID" ] && chown "$TARGET_UID:$TARGET_GID" "$dir"
+        fi
+    done
+
+    if [ "${PIZZAPI_CHOWN_WORKSPACE:-0}" = "1" ] && [ -n "${PIZZAPI_WORKSPACE_ROOTS:-}" ]; then
+        old_ifs=$IFS
+        IFS=,
+        for root in $PIZZAPI_WORKSPACE_ROOTS; do
+            [ -d "$root" ] && chown -R "$TARGET_UID:$TARGET_GID" "$root"
+        done
+        IFS=$old_ifs
+    fi
+
+    log "starting as uid=$TARGET_UID gid=$TARGET_GID (remapped from root), sandbox=${PIZZAPI_SANDBOX:-none}"
+    exec setpriv --reuid="$TARGET_UID" --regid="$TARGET_GID" --init-groups tini -- pizza "$@"
+fi
+
+# Already non-root (the default — no PUID/PGID handling needed or possible).
+if [ ! -d "$HOME/.pizzapi" ]; then
+    log "WARNING: $HOME/.pizzapi does not exist — runner state cannot persist"
+elif [ ! -w "$HOME/.pizzapi" ]; then
+    log "WARNING: $HOME/.pizzapi is not writable by uid $CURRENT_UID — runner state cannot persist"
+fi
+
+log "starting as uid=$CURRENT_UID gid=$(id -g), sandbox=${PIZZAPI_SANDBOX:-none}"
+exec tini -- pizza "$@"

--- a/docker/runner/smoke.sh
+++ b/docker/runner/smoke.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the PizzaPi runner image, against a live relay.
+# Prints a PASS/FAIL/SKIP line per check and always cleans up what it created.
+#
+# Usage: ./docker/runner/smoke.sh
+# Config (env, all optional):
+#   SMOKE_NETWORK      docker network the relay lives on (default: pizzapi-web_default)
+#   SMOKE_RELAY_URL    relay URL reachable from that network (default: http://server:7492)
+#   SMOKE_IMAGE        image tag to build/use (default: pizzapi-runner:smoke)
+#   PIZZAPI_API_KEY    API key; falls back to `apiKey` in ~/.pizzapi/config.json
+#   SMOKE_REBUILD=1    force re-staging/rebuilding even if a context already exists
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_NETWORK="${SMOKE_NETWORK:-pizzapi-web_default}"
+SMOKE_RELAY_URL="${SMOKE_RELAY_URL:-http://server:7492}"
+SMOKE_IMAGE="${SMOKE_IMAGE:-pizzapi-runner:smoke}"
+CONTEXT_DIR="${SMOKE_CONTEXT_DIR:-$REPO_ROOT/packages/cli/dist/runner-image-context}"
+
+RUN_ID="smoke-$(date +%s)-$$"
+CONTAINER="pizzapi-runner-$RUN_ID"
+VOLUME="pizzapi-runner-vol-$RUN_ID"
+TMPDIR_ROOT="$(mktemp -d)"
+WORKSPACE_DIR="$TMPDIR_ROOT/workspace"
+
+RESULTS=()
+
+record() {
+    # record STATUS "check name" "detail"
+    RESULTS+=("$1|$2|$3")
+    printf '[%s] %s%s\n' "$1" "$2" "${3:+ — $3}"
+}
+
+cleanup() {
+    local ec=$?
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker rmi "${SMOKE_IMAGE}-other" >/dev/null 2>&1 || true
+    docker volume rm -f "$VOLUME" >/dev/null 2>&1 || true
+    rm -rf "$TMPDIR_ROOT"
+
+    echo
+    echo "==== SMOKE TEST SUMMARY ===="
+    printf '%-6s  %-52s  %s\n' STATUS CHECK DETAIL
+    local fail=0
+    for r in "${RESULTS[@]}"; do
+        IFS='|' read -r status name detail <<<"$r"
+        printf '%-6s  %-52s  %s\n' "$status" "$name" "$detail"
+        [ "$status" = "FAIL" ] && fail=1
+    done
+    if [ "$ec" != "0" ]; then
+        echo "(script exited early with code $ec — see output above)"
+        fail=1
+    fi
+    exit $fail
+}
+trap cleanup EXIT
+
+# ── Preflight ────────────────────────────────────────────────────────────
+if ! docker network inspect "$SMOKE_NETWORK" >/dev/null 2>&1; then
+    echo "FATAL: docker network '$SMOKE_NETWORK' not found — is the relay dev stack running?" >&2
+    exit 1
+fi
+
+API_KEY="${PIZZAPI_API_KEY:-}"
+if [ -z "$API_KEY" ] && [ -f "$HOME/.pizzapi/config.json" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        API_KEY="$(jq -r '.apiKey // empty' "$HOME/.pizzapi/config.json")"
+    else
+        API_KEY="$(grep -o '"apiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.pizzapi/config.json" | head -1 | sed -E 's/.*"([^"]*)"$/\1/')"
+    fi
+fi
+if [ -z "$API_KEY" ]; then
+    echo "FATAL: no API key (set PIZZAPI_API_KEY or apiKey in ~/.pizzapi/config.json)" >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64) HOST_PLATFORM=linux/amd64; HOST_TARGET=linux-x64; OTHER_PLATFORM=linux/arm64; OTHER_TARGET=linux-arm64 ;;
+    arm64|aarch64) HOST_PLATFORM=linux/arm64; HOST_TARGET=linux-arm64; OTHER_PLATFORM=linux/amd64; OTHER_TARGET=linux-x64 ;;
+    *) echo "FATAL: unsupported host arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+if [ "${SMOKE_REBUILD:-0}" = "1" ] || [ ! -d "$CONTEXT_DIR/$HOST_TARGET" ] || [ ! -d "$CONTEXT_DIR/$OTHER_TARGET" ]; then
+    echo "Staging build context..."
+    (cd "$REPO_ROOT" && bun docker/runner/stage-context.ts)
+fi
+
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+mkdir -p "$WORKSPACE_DIR/smoke-repo"
+git -C "$WORKSPACE_DIR/smoke-repo" init -q
+git -C "$WORKSPACE_DIR/smoke-repo" -c user.email=smoke@pizzapi.local -c user.name=smoke commit --allow-empty -q -m init
+
+wait_healthy() {
+    # wait_healthy CONTAINER TIMEOUT_ITERATIONS(2s each) -> sets HEALTH_STATUS, HEALTH_ELAPSED
+    local c="$1" tries="$2" i
+    for i in $(seq 1 "$tries"); do
+        HEALTH_STATUS="$(docker inspect --format '{{.State.Health.Status}}' "$c" 2>/dev/null || echo unknown)"
+        [ "$HEALTH_STATUS" = "healthy" ] && { HEALTH_ELAPSED=$((i * 2)); return 0; }
+        sleep 2
+    done
+    HEALTH_ELAPSED=$((tries * 2))
+    return 1
+}
+
+runner_id_of() {
+    docker exec "$1" pizza runner status --json 2>/dev/null | { command -v jq >/dev/null 2>&1 && jq -r '.runnerId // empty' || grep -o '"runnerId":"[^"]*"' | head -1 | cut -d'"' -f4; }
+}
+
+spawn_status_code() {
+    # spawn_status_code RUNNER_ID CWD -> prints HTTP status code
+    docker run --rm --network "$SMOKE_NETWORK" curlimages/curl:latest -sS -o /dev/null -w '%{http_code}' \
+        -X POST -H "x-api-key: $API_KEY" -H 'Content-Type: application/json' \
+        -d "{\"runnerId\":\"$1\",\"cwd\":\"$2\"}" \
+        "$SMOKE_RELAY_URL/api/runners/spawn" 2>/dev/null || echo "000"
+}
+
+run_container() {
+    docker run -d --name "$CONTAINER" --network "$SMOKE_NETWORK" \
+        -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+        -e PIZZAPI_API_KEY="$API_KEY" \
+        -e PIZZAPI_RUNNER_NAME="$RUN_ID" \
+        -v "$VOLUME:/home/pizza/.pizzapi" \
+        -v "$WORKSPACE_DIR:/workspace" \
+        "$SMOKE_IMAGE" >/dev/null
+}
+
+# ── 1. Build host-arch image ────────────────────────────────────────────
+if docker buildx build --platform "$HOST_PLATFORM" --load \
+    --build-arg VERSION=smoke --build-arg GIT_SHA="$GIT_SHA" \
+    -t "$SMOKE_IMAGE" -f "$REPO_ROOT/docker/runner/Dockerfile" "$CONTEXT_DIR" \
+    >/tmp/smoke-build-host.log 2>&1; then
+    record PASS "build image ($HOST_PLATFORM)" ""
+else
+    record FAIL "build image ($HOST_PLATFORM)" "see /tmp/smoke-build-host.log"
+    exit 1  # nothing else is possible without the host image
+fi
+
+# ── 1b. Build + run the *other* platform (proves both arches compile) ──
+if docker run --rm --platform "$OTHER_PLATFORM" debian:trixie-slim true >/dev/null 2>&1; then
+    if docker buildx build --platform "$OTHER_PLATFORM" --load \
+        --build-arg VERSION=smoke --build-arg GIT_SHA="$GIT_SHA" \
+        -t "${SMOKE_IMAGE}-other" -f "$REPO_ROOT/docker/runner/Dockerfile" "$CONTEXT_DIR" \
+        >/tmp/smoke-build-other.log 2>&1; then
+        record PASS "build image ($OTHER_PLATFORM)" ""
+        if OUT="$(docker run --rm --platform "$OTHER_PLATFORM" "${SMOKE_IMAGE}-other" --version 2>&1)"; then
+            record PASS "run --version under emulation ($OTHER_PLATFORM)" ""
+        else
+            record FAIL "run --version under emulation ($OTHER_PLATFORM)" "$OUT"
+        fi
+    else
+        record FAIL "build image ($OTHER_PLATFORM)" "see /tmp/smoke-build-other.log"
+    fi
+else
+    record SKIP "build+run image ($OTHER_PLATFORM)" "emulation unavailable (binfmt_misc/qemu not registered)"
+fi
+
+# ── 2. Container starts non-root and registers with the relay ──────────
+run_container
+UID_OUT="$(docker exec "$CONTAINER" id -u 2>/dev/null || echo '?')"
+[ "$UID_OUT" = "1000" ] && record PASS "runs as non-root uid" "uid=$UID_OUT" \
+    || record FAIL "runs as non-root uid" "uid=$UID_OUT"
+
+if wait_healthy "$CONTAINER" 60; then
+    record PASS "registers with relay (healthcheck)" "healthy after ~${HEALTH_ELAPSED}s"
+else
+    record FAIL "registers with relay (healthcheck)" "status=$HEALTH_STATUS after ${HEALTH_ELAPSED}s"
+    docker logs "$CONTAINER" 2>&1 | tail -50
+fi
+
+# ── 3. Workspace enforcement ─────────────────────────────────────────────
+RUNNER_ID="$(runner_id_of "$CONTAINER" || true)"
+if [ -z "$RUNNER_ID" ]; then
+    record FAIL "workspace enforcement rejects cwd=/etc" "could not read runnerId from container"
+    record FAIL "workspace enforcement accepts real repo cwd" "could not read runnerId from container"
+else
+    CODE_ETC="$(spawn_status_code "$RUNNER_ID" /etc)"
+    [ "$CODE_ETC" = "400" ] && record PASS "workspace enforcement rejects cwd=/etc" "http=$CODE_ETC" \
+        || record FAIL "workspace enforcement rejects cwd=/etc" "http=$CODE_ETC"
+
+    CODE_REPO="$(spawn_status_code "$RUNNER_ID" /workspace/smoke-repo)"
+    [ "$CODE_REPO" = "200" ] && record PASS "workspace enforcement accepts real repo cwd" "http=$CODE_REPO" \
+        || record FAIL "workspace enforcement accepts real repo cwd" "http=$CODE_REPO"
+fi
+
+# ── 4. PTY ────────────────────────────────────────────────────────────────
+LDD_OUT="$(docker exec "$CONTAINER" sh -c 'ldd /opt/pizzapi/librust_pty*.so 2>&1' || true)"
+echo "$LDD_OUT" | grep -qi "not found" \
+    && record FAIL "PTY library resolves cleanly (ldd)" "$LDD_OUT" \
+    || record PASS "PTY library resolves cleanly (ldd)" ""
+
+PTY_LOG_ERR="$(docker logs "$CONTAINER" 2>&1 | grep -i pty | grep -iE 'error|fail' || true)"
+[ -z "$PTY_LOG_ERR" ] && record PASS "daemon log shows no PTY/terminal init errors" "" \
+    || record FAIL "daemon log shows no PTY/terminal init errors" "$PTY_LOG_ERR"
+
+# ── 8. Sidecar DNS ────────────────────────────────────────────────────────
+if docker exec "$CONTAINER" curl -sS -o /dev/null -w '%{http_code}' "$SMOKE_RELAY_URL/health" 2>/dev/null | grep -q 200; then
+    record PASS "reaches relay sidecar by service name" "$SMOKE_RELAY_URL/health"
+else
+    record FAIL "reaches relay sidecar by service name" "$SMOKE_RELAY_URL/health unreachable"
+fi
+if docker exec "$CONTAINER" socat -T2 -u /dev/null TCP:redis:6379 >/dev/null 2>&1; then
+    record PASS "reaches redis sidecar by service name (bonus)" "redis:6379"
+else
+    record SKIP "reaches redis sidecar by service name (bonus)" "redis:6379 not reachable (no redis service on $SMOKE_NETWORK?)"
+fi
+
+# ── 9a. Default sandbox posture is logged ───────────────────────────────
+SANDBOX_LOG="$(docker logs "$CONTAINER" 2>&1 | grep -o 'sandbox=[a-z]*' | head -1 || true)"
+[ "$SANDBOX_LOG" = "sandbox=none" ] && record PASS "default sandbox posture logged" "$SANDBOX_LOG" \
+    || record FAIL "default sandbox posture logged" "got '$SANDBOX_LOG'"
+
+# ── 5+6. Stop, remove, recreate on the same volume: identity + shutdown time ─
+STOP_START="$(date +%s)"
+docker stop -t 30 "$CONTAINER" >/dev/null
+STOP_ELAPSED=$(( $(date +%s) - STOP_START ))
+[ "$STOP_ELAPSED" -lt 30 ] && record PASS "clean shutdown (docker stop)" "${STOP_ELAPSED}s" \
+    || record FAIL "clean shutdown (docker stop)" "${STOP_ELAPSED}s (hit grace period)"
+docker rm "$CONTAINER" >/dev/null
+
+run_container
+if wait_healthy "$CONTAINER" 60; then
+    RUNNER_ID_AFTER="$(runner_id_of "$CONTAINER" || true)"
+    if [ -n "$RUNNER_ID_AFTER" ] && [ "$RUNNER_ID_AFTER" = "$RUNNER_ID" ]; then
+        record PASS "identity persists across stop+rm+recreate" "runnerId=$RUNNER_ID_AFTER"
+    else
+        record FAIL "identity persists across stop+rm+recreate" "before=$RUNNER_ID after=$RUNNER_ID_AFTER"
+    fi
+else
+    record FAIL "identity persists across stop+rm+recreate" "container never became healthy after recreate"
+    docker logs "$CONTAINER" 2>&1 | tail -50
+fi
+
+# ── 7. Stale lock recovery after SIGKILL ────────────────────────────────
+docker kill -s SIGKILL "$CONTAINER" >/dev/null
+docker rm "$CONTAINER" >/dev/null
+run_container
+if wait_healthy "$CONTAINER" 60; then
+    KILL_LOGS="$(docker logs "$CONTAINER" 2>&1 || true)"
+    if echo "$KILL_LOGS" | grep -qi "already running"; then
+        record FAIL "stale lock recovery after SIGKILL" "daemon reported a fatal 'already running' lock error"
+    else
+        record PASS "stale lock recovery after SIGKILL" "healthy again after ~${HEALTH_ELAPSED}s"
+    fi
+else
+    record FAIL "stale lock recovery after SIGKILL" "never became healthy again"
+    docker logs "$CONTAINER" 2>&1 | tail -50
+fi
+
+# ── 10. No privileged/hostPID/extra caps/docker socket ──────────────────
+PRIV="$(docker inspect --format '{{.HostConfig.Privileged}}' "$CONTAINER" || true)"
+PIDMODE="$(docker inspect --format '{{.HostConfig.PidMode}}' "$CONTAINER" || true)"
+CAPADD="$(docker inspect --format '{{.HostConfig.CapAdd}}' "$CONTAINER" || true)"
+MOUNTS="$(docker inspect --format '{{range .Mounts}}{{.Source}} {{end}}' "$CONTAINER" || true)"
+if [ "$PRIV" = "false" ] && [ -z "$PIDMODE" ] && { [ "$CAPADD" = "[]" ] || [ "$CAPADD" = "<no value>" ]; } && ! echo "$MOUNTS" | grep -q docker.sock; then
+    record PASS "no --privileged/hostPID/extra caps/docker socket" "privileged=$PRIV pid=$PIDMODE capAdd=$CAPADD"
+else
+    record FAIL "no --privileged/hostPID/extra caps/docker socket" "privileged=$PRIV pid=$PIDMODE capAdd=$CAPADD mounts=$MOUNTS"
+fi
+
+# ── 9b. Opt-in sandbox actually works with the documented flag ─────────
+if docker run --rm --security-opt seccomp=unconfined -e PIZZAPI_SANDBOX=basic --entrypoint bwrap "$SMOKE_IMAGE" \
+    --ro-bind / / --unshare-all true >/dev/null 2>&1; then
+    record PASS "opt-in sandbox works (seccomp=unconfined)" "bwrap --unshare-all succeeded"
+else
+    record FAIL "opt-in sandbox works (seccomp=unconfined)" "bwrap failed even with the opt-in flag"
+fi

--- a/docker/runner/smoke.sh
+++ b/docker/runner/smoke.sh
@@ -24,6 +24,11 @@ TMPDIR_ROOT="$(mktemp -d)"
 WORKSPACE_DIR="$TMPDIR_ROOT/workspace"
 
 RESULTS=()
+# Extra containers/volumes created by the auth checks below — cleaned up
+# alongside the main $CONTAINER/$VOLUME, keyed by suffix off $RUN_ID so
+# nothing collides with a concurrent run.
+EXTRA_CONTAINERS=()
+EXTRA_VOLUMES=()
 
 record() {
     # record STATUS "check name" "detail"
@@ -34,8 +39,10 @@ record() {
 cleanup() {
     local ec=$?
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    for c in "${EXTRA_CONTAINERS[@]:-}"; do [ -n "$c" ] && docker rm -f "$c" >/dev/null 2>&1 || true; done
     docker rmi "${SMOKE_IMAGE}-other" >/dev/null 2>&1 || true
     docker volume rm -f "$VOLUME" >/dev/null 2>&1 || true
+    for v in "${EXTRA_VOLUMES[@]:-}"; do [ -n "$v" ] && docker volume rm -f "$v" >/dev/null 2>&1 || true; done
     rm -rf "$TMPDIR_ROOT"
 
     echo
@@ -104,6 +111,20 @@ wait_healthy() {
 
 runner_id_of() {
     docker exec "$1" pizza runner status --json 2>/dev/null | { command -v jq >/dev/null 2>&1 && jq -r '.runnerId // empty' || grep -o '"runnerId":"[^"]*"' | head -1 | cut -d'"' -f4; }
+}
+
+status_reason_of() {
+    docker exec "$1" pizza runner status --json 2>/dev/null | { command -v jq >/dev/null 2>&1 && jq -r '.reason // empty' || grep -o '"reason":"[^"]*"' | head -1 | cut -d'"' -f4; }
+}
+
+wait_for_log_pattern() {
+    # wait_for_log_pattern CONTAINER FIXED_STRING TIMEOUT_SECONDS(1s each) -> 0 if seen
+    local c="$1" pattern="$2" tries="$3" i
+    for i in $(seq 1 "$tries"); do
+        docker logs "$c" 2>&1 | grep -qF "$pattern" && return 0
+        sleep 1
+    done
+    return 1
 }
 
 spawn_status_code() {
@@ -264,3 +285,184 @@ if docker run --rm --security-opt seccomp=unconfined -e PIZZAPI_SANDBOX=basic --
 else
     record FAIL "opt-in sandbox works (seccomp=unconfined)" "bwrap failed even with the opt-in flag"
 fi
+
+# ── 11. Headless auto-pairing end to end ────────────────────────────────
+PAIR_CONTAINER="$CONTAINER-pair"
+PAIR_VOLUME="$VOLUME-pair"
+EXTRA_CONTAINERS+=("$PAIR_CONTAINER")
+EXTRA_VOLUMES+=("$PAIR_VOLUME")
+
+docker run -d --name "$PAIR_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_RUNNER_NAME="$RUN_ID-pair" \
+    -v "$PAIR_VOLUME:/home/pizza/.pizzapi" \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_for_log_pattern "$PAIR_CONTAINER" 'setup-claim?t=' 30; then
+    record PASS "auto-pairing prints an approval URL (no credential, fresh volume)" ""
+    PAIR_TOKEN="$(docker logs "$PAIR_CONTAINER" 2>&1 | grep -o 'setup-claim?t=[a-f0-9]*' | tail -1 | sed 's/.*t=//')"
+    APPROVE_CODE="$(docker run --rm --network "$SMOKE_NETWORK" curlimages/curl:latest -sS -o /dev/null -w '%{http_code}' \
+        -X POST -H "x-api-key: $API_KEY" "$SMOKE_RELAY_URL/api/setup-claim/$PAIR_TOKEN/approve" 2>/dev/null || echo "000")"
+    [ "$APPROVE_CODE" = "200" ] && record PASS "approve pending claim via x-api-key (requireEnrollmentAuth)" "http=$APPROVE_CODE" \
+        || record FAIL "approve pending claim via x-api-key (requireEnrollmentAuth)" "http=$APPROVE_CODE"
+
+    record SKIP "pairing label round-trips via /api/setup-claim-info" "live relay ($SMOKE_RELAY_URL) is a released build without label/setup-claim-info support (confirmed: that route 404s there) — pairing itself still works"
+
+    if wait_healthy "$PAIR_CONTAINER" 60; then
+        record PASS "runner reaches healthy after approval" "healthy after ~${HEALTH_ELAPSED}s"
+
+        CONFIG_MODE="$(docker exec "$PAIR_CONTAINER" stat -c '%a' /home/pizza/.pizzapi/config.json 2>/dev/null || echo '?')"
+        [ "$CONFIG_MODE" = "600" ] && record PASS "config.json is 0600 after pairing" "mode=$CONFIG_MODE" \
+            || record FAIL "config.json is 0600 after pairing" "mode=$CONFIG_MODE"
+
+        CONFIG_HAS_KEY="$(docker exec "$PAIR_CONTAINER" sh -c "grep -c apiKey /home/pizza/.pizzapi/config.json" 2>/dev/null || echo 0)"
+        [ "${CONFIG_HAS_KEY:-0}" -gt 0 ] 2>/dev/null && record PASS "config.json contains the minted apiKey" "" \
+            || record FAIL "config.json contains the minted apiKey" "grep -c apiKey = ${CONFIG_HAS_KEY:-0}"
+
+        RESTART_MARK="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        docker restart "$PAIR_CONTAINER" >/dev/null
+        if wait_healthy "$PAIR_CONTAINER" 60; then
+            REPAIR_LOG="$(docker logs --since "$RESTART_MARK" "$PAIR_CONTAINER" 2>&1 | grep -iE 'no credentials found|Approve this runner at' || true)"
+            [ -z "$REPAIR_LOG" ] && record PASS "restart does not re-pair (config.json apiKey already satisfies it)" "healthy again after ~${HEALTH_ELAPSED}s" \
+                || record FAIL "restart does not re-pair (config.json apiKey already satisfies it)" "$REPAIR_LOG"
+        else
+            record FAIL "restart does not re-pair (config.json apiKey already satisfies it)" "container never became healthy again"
+            docker logs "$PAIR_CONTAINER" 2>&1 | tail -50
+        fi
+    else
+        record FAIL "runner reaches healthy after approval" "status=$HEALTH_STATUS after ${HEALTH_ELAPSED}s"
+        docker logs "$PAIR_CONTAINER" 2>&1 | tail -50
+    fi
+else
+    record FAIL "auto-pairing prints an approval URL (no credential, fresh volume)" "no setup-claim URL in logs after 30s"
+    docker logs "$PAIR_CONTAINER" 2>&1 | tail -50
+fi
+
+# ── 12. PIZZAPI_PAIRING=0 fails fast instead of hanging ─────────────────
+NOPAIR_CONTAINER="$CONTAINER-nopair"
+EXTRA_CONTAINERS+=("$NOPAIR_CONTAINER")
+docker run -d --name "$NOPAIR_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_PAIRING=0 \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_for_log_pattern "$NOPAIR_CONTAINER" 'Set PIZZAPI_API_KEY' 15; then
+    if docker logs "$NOPAIR_CONTAINER" 2>&1 | grep -qF 'setup-claim?t='; then
+        record FAIL "PIZZAPI_PAIRING=0 fails fast, no auto-pair" "unexpectedly printed a pairing URL despite the opt-out"
+    else
+        record PASS "PIZZAPI_PAIRING=0 fails fast, no auto-pair" "clear error within 15s, no pairing URL printed"
+    fi
+else
+    record FAIL "PIZZAPI_PAIRING=0 fails fast, no auto-pair" "no clear error message within 15s (looks like a hang)"
+    docker logs "$NOPAIR_CONTAINER" 2>&1 | tail -30
+fi
+
+# ── 13. PIZZAPI_API_KEY_FILE registers without the key in docker inspect ─
+APIKEY_FILE_HOST="$TMPDIR_ROOT/api-key-secret.txt"
+printf '%s' "$API_KEY" > "$APIKEY_FILE_HOST"
+FILECRED_CONTAINER="$CONTAINER-filecred"
+FILECRED_VOLUME="$VOLUME-filecred"
+EXTRA_CONTAINERS+=("$FILECRED_CONTAINER")
+EXTRA_VOLUMES+=("$FILECRED_VOLUME")
+
+docker run -d --name "$FILECRED_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_API_KEY_FILE=/run/secrets/pizzapi_api_key \
+    -e PIZZAPI_RUNNER_NAME="$RUN_ID-filecred" \
+    -v "$FILECRED_VOLUME:/home/pizza/.pizzapi" \
+    -v "$APIKEY_FILE_HOST:/run/secrets/pizzapi_api_key:ro" \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_healthy "$FILECRED_CONTAINER" 60; then
+    record PASS "PIZZAPI_API_KEY_FILE registers normally" "healthy after ~${HEALTH_ELAPSED}s"
+else
+    record FAIL "PIZZAPI_API_KEY_FILE registers normally" "status=$HEALTH_STATUS after ${HEALTH_ELAPSED}s"
+    docker logs "$FILECRED_CONTAINER" 2>&1 | tail -50
+fi
+
+INSPECT_ENV="$(docker inspect --format '{{json .Config.Env}}' "$FILECRED_CONTAINER")"
+if echo "$INSPECT_ENV" | grep -q 'PIZZAPI_API_KEY='; then
+    record FAIL "raw API key absent from docker inspect env" "PIZZAPI_API_KEY found in launch env — only _FILE was passed"
+else
+    record PASS "raw API key absent from docker inspect env" "only PIZZAPI_API_KEY_FILE present in launch env"
+fi
+
+# ── 14. PIZZAPI_AUTH_FILE seeds once, never clobbers ────────────────────
+AUTH1_HOST="$TMPDIR_ROOT/auth1.json"
+AUTH2_HOST="$TMPDIR_ROOT/auth2.json"
+echo '{"marker":"auth-file-one"}' > "$AUTH1_HOST"
+echo '{"marker":"auth-file-two-should-not-appear"}' > "$AUTH2_HOST"
+
+AUTHFILE_CONTAINER="$CONTAINER-authfile"
+AUTHFILE_VOLUME="$VOLUME-authfile"
+EXTRA_CONTAINERS+=("$AUTHFILE_CONTAINER")
+EXTRA_VOLUMES+=("$AUTHFILE_VOLUME")
+
+docker run -d --name "$AUTHFILE_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_API_KEY="$API_KEY" \
+    -e PIZZAPI_RUNNER_NAME="$RUN_ID-authfile" \
+    -e PIZZAPI_AUTH_FILE=/run/secrets/auth.json \
+    -v "$AUTHFILE_VOLUME:/home/pizza/.pizzapi" \
+    -v "$AUTH1_HOST:/run/secrets/auth.json:ro" \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_healthy "$AUTHFILE_CONTAINER" 60; then
+    AUTH_MODE="$(docker exec "$AUTHFILE_CONTAINER" stat -c '%a' /home/pizza/.pizzapi/auth.json 2>/dev/null || echo '?')"
+    [ "$AUTH_MODE" = "600" ] && record PASS "PIZZAPI_AUTH_FILE seeds auth.json at 0600 (first boot)" "mode=$AUTH_MODE" \
+        || record FAIL "PIZZAPI_AUTH_FILE seeds auth.json at 0600 (first boot)" "mode=$AUTH_MODE"
+
+    AUTH_CONTENT="$(docker exec "$AUTHFILE_CONTAINER" cat /home/pizza/.pizzapi/auth.json 2>/dev/null || echo '')"
+    echo "$AUTH_CONTENT" | grep -q 'auth-file-one' && record PASS "seeded auth.json has the source file's contents" "" \
+        || record FAIL "seeded auth.json has the source file's contents" "got: $AUTH_CONTENT"
+else
+    record FAIL "PIZZAPI_AUTH_FILE seeds auth.json at 0600 (first boot)" "container never became healthy"
+    docker logs "$AUTHFILE_CONTAINER" 2>&1 | tail -50
+fi
+
+docker stop -t 10 "$AUTHFILE_CONTAINER" >/dev/null 2>&1 || true
+docker rm "$AUTHFILE_CONTAINER" >/dev/null 2>&1 || true
+
+docker run -d --name "$AUTHFILE_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_API_KEY="$API_KEY" \
+    -e PIZZAPI_RUNNER_NAME="$RUN_ID-authfile" \
+    -e PIZZAPI_AUTH_FILE=/run/secrets/auth.json \
+    -v "$AUTHFILE_VOLUME:/home/pizza/.pizzapi" \
+    -v "$AUTH2_HOST:/run/secrets/auth.json:ro" \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_healthy "$AUTHFILE_CONTAINER" 60; then
+    AUTH_CONTENT2="$(docker exec "$AUTHFILE_CONTAINER" cat /home/pizza/.pizzapi/auth.json 2>/dev/null || echo '')"
+    if echo "$AUTH_CONTENT2" | grep -q 'auth-file-one'; then
+        record PASS "PIZZAPI_AUTH_FILE never clobbers an existing auth.json" "still has first seed's contents after a second boot with a different file"
+    else
+        record FAIL "PIZZAPI_AUTH_FILE never clobbers an existing auth.json" "got: $AUTH_CONTENT2"
+    fi
+else
+    record FAIL "PIZZAPI_AUTH_FILE never clobbers an existing auth.json" "container never became healthy on second boot"
+    docker logs "$AUTHFILE_CONTAINER" 2>&1 | tail -50
+fi
+
+# ── 15. A rejected API key is loud and prompt, not a silent hang ───────
+BADKEY_CONTAINER="$CONTAINER-badkey"
+EXTRA_CONTAINERS+=("$BADKEY_CONTAINER")
+BAD_KEY="pizzapi_smoke_invalid_$(date +%s)"
+docker run -d --name "$BADKEY_CONTAINER" --network "$SMOKE_NETWORK" \
+    -e PIZZAPI_RELAY_URL="$SMOKE_RELAY_URL" \
+    -e PIZZAPI_API_KEY="$BAD_KEY" \
+    -e PIZZAPI_RUNNER_NAME="$RUN_ID-badkey" \
+    "$SMOKE_IMAGE" >/dev/null
+
+if wait_for_log_pattern "$BADKEY_CONTAINER" 'rejected our API key' 20; then
+    record PASS "bad API key rejection is loud and prompt" "rejection message appeared within 20s"
+else
+    record FAIL "bad API key rejection is loud and prompt" "no rejection message within 20s (looks like a silent hang)"
+    docker logs "$BADKEY_CONTAINER" 2>&1 | tail -30
+fi
+
+STATUS_REASON="$(status_reason_of "$BADKEY_CONTAINER" || true)"
+case "$STATUS_REASON" in
+    *"relay rejected credentials"*) record PASS "runner status reports the relay-rejected reason (bonus)" "$STATUS_REASON" ;;
+    *) record SKIP "runner status reports the relay-rejected reason (bonus)" "got '${STATUS_REASON:-<empty>}' — may need another connect_error round-trip" ;;
+esac

--- a/docker/runner/smoke.sh
+++ b/docker/runner/smoke.sh
@@ -344,6 +344,30 @@ else
     docker logs "$PAIR_CONTAINER" 2>&1 | tail -50
 fi
 
+# ── 11b. `pizza runner pair` (no --force) refuses on an already-paired container ─
+if docker inspect -f '{{.State.Running}}' "$PAIR_CONTAINER" 2>/dev/null | grep -q true; then
+    CONFIG_BEFORE="$(docker exec "$PAIR_CONTAINER" cat /home/pizza/.pizzapi/config.json 2>/dev/null || echo '')"
+    # `pizza runner pair` legitimately exits non-zero here (refusal) under our
+    # own set -euo pipefail. The `... || true` convention used elsewhere in
+    # this script (e.g. status_reason_of, docker rm -f) discards the exit
+    # code entirely — fine when only the output matters, but here the exit
+    # code IS the thing under test, so capture it via if/else instead.
+    if PAIR_REFUSE_OUT="$(docker exec "$PAIR_CONTAINER" pizza runner pair 2>&1)"; then
+        PAIR_REFUSE_CODE=0
+    else
+        PAIR_REFUSE_CODE=$?
+    fi
+    [ "$PAIR_REFUSE_CODE" -ne 0 ] && record PASS "pizza runner pair (no --force) refuses on an already-paired container" "exit=$PAIR_REFUSE_CODE" \
+        || record FAIL "pizza runner pair (no --force) refuses on an already-paired container" "unexpectedly exited 0: $PAIR_REFUSE_OUT"
+
+    CONFIG_AFTER="$(docker exec "$PAIR_CONTAINER" cat /home/pizza/.pizzapi/config.json 2>/dev/null || echo '')"
+    [ "$CONFIG_BEFORE" = "$CONFIG_AFTER" ] && record PASS "refused pair leaves existing credential untouched" "" \
+        || record FAIL "refused pair leaves existing credential untouched" "config.json changed after refusal"
+else
+    record SKIP "pizza runner pair (no --force) refuses on an already-paired container" "$PAIR_CONTAINER not running (see earlier auto-pairing failures)"
+    record SKIP "refused pair leaves existing credential untouched" "$PAIR_CONTAINER not running"
+fi
+
 # ── 12. PIZZAPI_PAIRING=0 fails fast instead of hanging ─────────────────
 NOPAIR_CONTAINER="$CONTAINER-nopair"
 EXTRA_CONTAINERS+=("$NOPAIR_CONTAINER")

--- a/docker/runner/smoke.sh
+++ b/docker/runner/smoke.sh
@@ -49,11 +49,17 @@ cleanup() {
     echo "==== SMOKE TEST SUMMARY ===="
     printf '%-6s  %-52s  %s\n' STATUS CHECK DETAIL
     local fail=0
-    for r in "${RESULTS[@]}"; do
-        IFS='|' read -r status name detail <<<"$r"
-        printf '%-6s  %-52s  %s\n' "$status" "$name" "$detail"
-        [ "$status" = "FAIL" ] && fail=1
-    done
+    # macOS ships bash 3.2 as /bin/bash, where "${arr[@]}" on an EMPTY array is
+    # an unbound-variable fatal under `set -u` (${#arr[@]} is fine). Without
+    # this guard, exiting at a preflight FATAL — before any record() call — makes
+    # the trap itself die and swallow the actual error message.
+    if [ "${#RESULTS[@]}" -gt 0 ]; then
+        for r in "${RESULTS[@]}"; do
+            IFS='|' read -r status name detail <<<"$r"
+            printf '%-6s  %-52s  %s\n' "$status" "$name" "$detail"
+            [ "$status" = "FAIL" ] && fail=1
+        done
+    fi
     if [ "$ec" != "0" ]; then
         echo "(script exited early with code $ec — see output above)"
         fail=1

--- a/docker/runner/stage-context.ts
+++ b/docker/runner/stage-context.ts
@@ -19,7 +19,7 @@
 
 import { $ } from "bun";
 import { join, dirname } from "path";
-import { existsSync, mkdirSync, cpSync, readdirSync, statSync } from "fs";
+import { existsSync, mkdirSync, cpSync, readdirSync } from "fs";
 
 const SECCOMP_ARCH_MAP: Record<string, "x64" | "arm64"> = {
     "linux-x64": "x64",

--- a/docker/runner/stage-context.ts
+++ b/docker/runner/stage-context.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+/**
+ * Assembles the Docker build context for the PizzaPi runner image.
+ *
+ * The repo-root .dockerignore excludes packages/cli and docker/, so a
+ * root-context build can't see the standalone binaries. This script builds
+ * (or reuses) them via build-binaries.ts and copies just what the runner
+ * Dockerfile needs into a small, self-contained directory:
+ *
+ *   <out>/linux-x64/…      binary (renamed to `pizza`) + libs + assets
+ *   <out>/linux-arm64/…
+ *   <out>/seccomp/x64/{apply-seccomp,unix-block.bpf}
+ *   <out>/seccomp/arm64/{apply-seccomp,unix-block.bpf}
+ *   <out>/entrypoint.sh
+ *
+ * Usage:
+ *   bun docker/runner/stage-context.ts [--targets linux-x64,linux-arm64] [--skip-build] [--out <dir>]
+ */
+
+import { $ } from "bun";
+import { join, dirname } from "path";
+import { existsSync, mkdirSync, cpSync, readdirSync, statSync } from "fs";
+
+const SECCOMP_ARCH_MAP: Record<string, "x64" | "arm64"> = {
+    "linux-x64": "x64",
+    "linux-arm64": "arm64",
+};
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const targetsFlag = args.indexOf("--targets");
+    const outFlag = args.indexOf("--out");
+    const targets = targetsFlag !== -1
+        ? args[targetsFlag + 1].split(",").map((t) => t.trim()).filter(Boolean)
+        : ["linux-x64", "linux-arm64"];
+    for (const t of targets) {
+        if (!(t in SECCOMP_ARCH_MAP)) {
+            console.error(`Unknown target "${t}". Valid targets: ${Object.keys(SECCOMP_ARCH_MAP).join(", ")}`);
+            process.exit(1);
+        }
+    }
+    return {
+        targets,
+        skipBuild: args.includes("--skip-build"),
+        out: outFlag !== -1 ? args[outFlag + 1] : join(import.meta.dirname, "..", "..", "packages", "cli", "dist", "runner-image-context"),
+    };
+}
+
+/**
+ * Resolve @anthropic-ai/sandbox-runtime's package root, the same way
+ * build-binaries.ts resolves pi-coding-agent. It's only a dependency of
+ * packages/tools (not hoisted to the workspace root), so resolve relative
+ * to that package rather than this script's own location.
+ */
+function resolveSandboxRuntimeDir(): string {
+    const fromDir = join(import.meta.dirname, "..", "..", "packages", "tools");
+    const entryPath = Bun.resolveSync("@anthropic-ai/sandbox-runtime/package.json", fromDir);
+    return dirname(entryPath);
+}
+
+async function main() {
+    const { targets, skipBuild, out } = parseArgs();
+    const distBinaries = join(import.meta.dirname, "..", "..", "packages", "cli", "dist", "binaries");
+    const buildBinariesScript = join(import.meta.dirname, "..", "..", "packages", "cli", "build-binaries.ts");
+
+    if (existsSync(out)) {
+        console.log(`Cleaning existing context dir: ${out}`);
+        await $`rm -rf ${out}`;
+    }
+    mkdirSync(out, { recursive: true });
+
+    for (const target of targets) {
+        const srcDir = join(distBinaries, target);
+
+        if (!skipBuild) {
+            console.log(`\n▶ Building ${target}...`);
+            const result = await $`bun ${buildBinariesScript} --target ${target}`.nothrow();
+            if (result.exitCode !== 0) {
+                console.error(`✗ build-binaries.ts failed for ${target}`);
+                process.exit(1);
+            }
+        }
+
+        if (!existsSync(srcDir) || readdirSync(srcDir).length === 0) {
+            console.error(`✗ No artifacts found for "${target}" at ${srcDir}.`);
+            console.error(skipBuild
+                ? `  --skip-build was set — artifacts must already exist (e.g. downloaded by CI).`
+                : `  Build appeared to succeed but produced no output.`);
+            process.exit(1);
+        }
+
+        const destDir = join(out, target);
+        mkdirSync(destDir, { recursive: true });
+        for (const entry of readdirSync(srcDir)) {
+            // Rename the arch-specific exe to a plain `pizza` so the Dockerfile
+            // doesn't need to know the binary name for each TARGETARCH.
+            const dest = entry.startsWith("pizza-linux-") ? "pizza" : entry;
+            cpSync(join(srcDir, entry), join(destDir, dest), { recursive: true });
+        }
+        console.log(`✓ Staged ${target} → ${destDir}`);
+    }
+
+    // Seccomp vendor files (see fact #4 in the container spike): apply-seccomp
+    // + unix-block.bpf let the standalone binary's bundled sandbox-runtime
+    // find seccomp support without node/npm in the image.
+    const sandboxRuntimeDir = resolveSandboxRuntimeDir();
+    for (const target of targets) {
+        const arch = SECCOMP_ARCH_MAP[target];
+        const srcSeccompDir = join(sandboxRuntimeDir, "vendor", "seccomp", arch);
+        if (!existsSync(srcSeccompDir)) {
+            console.error(`✗ Missing seccomp vendor files at ${srcSeccompDir}`);
+            process.exit(1);
+        }
+        const destSeccompDir = join(out, "seccomp", arch);
+        mkdirSync(destSeccompDir, { recursive: true });
+        cpSync(srcSeccompDir, destSeccompDir, { recursive: true });
+        console.log(`✓ Staged seccomp/${arch}`);
+    }
+
+    cpSync(join(import.meta.dirname, "entrypoint.sh"), join(out, "entrypoint.sh"));
+
+    console.log(`\n✅ Build context ready: ${out}`);
+    console.log(`   docker buildx build --platform linux/amd64,linux/arm64 -f docker/runner/Dockerfile ${out}`);
+}
+
+await main();

--- a/docs/plans/2026-07-31-runner-container-spike.md
+++ b/docs/plans/2026-07-31-runner-container-spike.md
@@ -1,0 +1,213 @@
+# Spike: PizzaPi Runner Container Image
+
+**Status:** scoped; ready for implementation planning  
+**Target:** `ghcr.io/pizzaface/pizzapi-runner:<version>` for `linux/amd64` and `linux/arm64`
+
+## Decision
+
+Ship a small, non-root Linux image that runs the existing standalone PizzaPi binary as:
+
+```text
+tini -- pizza runner
+```
+
+The container is a remote coding machine, not just a daemon wrapper. It must contain the small set of OS tools PizzaPi itself relies on, while project-specific language toolchains remain user-supplied through derived images.
+
+Do not combine the runner with the PizzaPi relay/server image. The runner only needs outbound HTTP/WebSocket access to the relay; it exposes no ports.
+
+## User outcome
+
+A user can move a runner off their host with one Compose service, persist its identity and credentials, mount one or more workspaces, connect it to optional sidecars, and replace the image to upgrade it.
+
+```yaml
+services:
+  runner:
+    image: ghcr.io/pizzaface/pizzapi-runner:0.5.61
+    restart: unless-stopped
+    stop_grace_period: 30s
+    environment:
+      PIZZAPI_RELAY_URL: https://pizza.example.com
+      PIZZAPI_API_KEY: ${PIZZAPI_API_KEY}
+      PIZZAPI_RUNNER_NAME: docker-runner
+      PIZZAPI_WORKSPACE_ROOTS: /workspace
+    volumes:
+      - runner-data:/home/pizza/.pizzapi
+      - ./projects:/workspace
+
+volumes:
+  runner-data:
+```
+
+The relay may be another Compose service:
+
+```yaml
+PIZZAPI_RELAY_URL: http://server:7492
+```
+
+`localhost` always means the runner container itself.
+
+## Image contract
+
+### Base and entrypoint
+
+- Debian slim, matching the standalone binary's glibc target.
+- Run as an unprivileged `pizza` user, default UID/GID 1000.
+- `HOME=/home/pizza`, `WORKDIR=/workspace`.
+- `tini` as PID 1 so signals and orphaned session processes are reaped.
+- `ENTRYPOINT ["tini", "--", "pizza"]`, `CMD ["runner"]`.
+- OCI labels include version, git SHA, source URL, and license.
+- No `EXPOSE`: control and service-tunnel connections are outbound.
+
+### Included runtime tools
+
+Install only tools required for a useful baseline runner:
+
+| Package | Why |
+|---|---|
+| `ca-certificates` | TLS relay/provider connections |
+| `bash` | default web terminal and agent shell |
+| `git` | built-in Git runner service and coding work |
+| `openssh-client` | Git over SSH |
+| `ripgrep`, `findutils` | search tool and sandbox path scanning |
+| `procps` | `ps`/`pgrep` process display and cleanup |
+| `bubblewrap`, `socat` | optional Linux session sandbox |
+| `curl` | baseline network/debug tool |
+| `tini` | PID 1 signal forwarding/reaping |
+
+Do not include GitHub CLI, Docker CLI/socket, compilers, Node, Python, or project language SDKs. Users needing them should build `FROM ghcr.io/pizzaface/pizzapi-runner:<version>` and install exactly what their projects require.
+
+### Build source
+
+Reuse the existing standalone Linux artifacts from `packages/cli/build-binaries.ts`, including:
+
+- `pizza-linux-{x64,arm64}`
+- matching `librust_pty*.so`
+- `package.json`, `theme/`, `export-html/`, `templates/`, and `skills/`
+
+Do not create a second source-based CLI installation path for Docker.
+
+## Storage and mounts
+
+### Required persistent volume
+
+Mount `/home/pizza/.pizzapi` as one persistent volume. It contains a coupled set of runner state:
+
+- `runner.json` identity, secret, and process lock
+- `config.json`, `settings.json`, `models.json`
+- `auth.json` provider credentials
+- session transcripts and attachments
+- usage database/cache
+- installed packages, plugins, agents, skills, providers, and global runner services
+
+Persisting the whole directory is simpler and less error-prone than splitting files. Treat the volume as secret-bearing data. Never bake it into the image.
+
+On an unclean container death, `runner.json` can contain a stale container PID. Existing runner-state validation checks whether that PID belongs to a runner before clearing it; this must be covered by the restart smoke test.
+
+### Workspace mounts
+
+- Mount projects below a stable container path such as `/workspace`.
+- Set `PIZZAPI_WORKSPACE_ROOTS` to the mounted roots. The image should default it to `/workspace` unless the operator overrides it.
+- Spawn requests must use container paths, not host paths.
+- Multiple roots work as comma-separated mounts, for example `/work/client,/work/oss`.
+- Read-only mounts are allowed but agents cannot edit them.
+
+### Optional host integration mounts
+
+| Integration | Recommended mount/config | Notes |
+|---|---|---|
+| Git identity | host `.gitconfig` to `/home/pizza/.gitconfig:ro` | Or configure it inside the persistent volume/user environment |
+| SSH auth | mount an SSH agent socket and set `SSH_AUTH_SOCK` | Prefer this to mounting private keys |
+| GitHub auth | pass `GH_TOKEN` to a derived image containing `gh` | `gh` is not in the base image |
+| Cloud/provider auth | environment secrets or files under persisted `.pizzapi` | macOS Keychain credentials are unavailable in Linux |
+| Extra CA | derived image or mounted CA plus standard CA env/config | Do not disable TLS verification |
+
+Do not recommend mounting the host home directory, `/`, or `/var/run/docker.sock`. The Docker socket is host-root-equivalent and conflicts with the sandbox's Unix-socket restrictions.
+
+## Runner services and sidecars
+
+- Built-in runner services work inside the image: terminal, file explorer, Git, process, memory, time, and tunnel.
+- Global custom services persist under `/home/pizza/.pizzapi/services` and are loaded normally.
+- Project-local `.pizzapi/services` are not part of the image MVP. Although `service-loader.ts` supports `discoverServices({ cwd })`, the current daemon only invokes global discovery; restore that integration separately before promising per-session project services (Godmother follow-up `ZCEJktvF`).
+- Service HTTP ports stay inside the container. PizzaPi's existing `/_tunnel` WebSocket proxies them to the browser, so Compose `ports:` entries are unnecessary.
+- Sidecars (databases, Ollama, MCP HTTP servers, browsers) should share a Compose network and be addressed by service DNS name, such as `postgres:5432` or `ollama:11434`.
+- Stdio MCP servers and custom services must bring their executable dependencies in a derived runner image.
+
+## Credentials
+
+Support both existing paths without adding a container-specific secret system:
+
+1. `PIZZAPI_API_KEY`/provider environment variables, preferably supplied by the orchestrator's secret mechanism.
+2. Existing files in the persistent `/home/pizza/.pizzapi` volume.
+
+Worker sessions inherit daemon environment variables except the existing denylist. This means Compose secrets exposed as environment variables also reach workers unless already denied. Document this; do not promise daemon-only secrecy for arbitrary environment variables.
+
+OAuth login can write to persisted `auth.json`. Host keychain fallback does not cross into the Linux container.
+
+## Sandbox and security posture
+
+A Docker container is the runner's machine boundary; it is not automatically a per-session boundary.
+
+The current Linux sandbox uses nested Bubblewrap. Ordinary Docker configurations may reject its namespace operations, and PizzaPi currently degrades to unsandboxed execution when sandbox initialization fails. Therefore the first image must be explicit rather than silently claiming sandbox support:
+
+- Default the image to `PIZZAPI_SANDBOX=none`.
+- Run the container non-root and mount only intended workspaces/config.
+- Document opt-in testing of `sandbox.enableWeakerNestedSandbox: true` for operators who want nested Bubblewrap. This mode is weaker and must be verified on the target Docker/Podman host.
+- Do not require `--privileged`, host PID namespace, or broad capabilities.
+- Do not expose the web terminal to users who should not have full command execution inside the container; it has the runner user's permissions and no separate sandbox.
+
+A future stronger design may run each worker in its own container. That is a different orchestration feature and not part of this image.
+
+## Operational behavior
+
+- Upgrade by pulling a new immutable version tag and recreating the container; keep the data volume.
+- Publish version tags matching the CLI release, plus `main` for edge builds. Avoid using `latest` in documentation.
+- Use `restart: unless-stopped` and `stop_grace_period: 30s`.
+- Do not add a fake healthcheck based only on the presence of `runner.json`; it cannot prove relay registration. Add a healthcheck only after the CLI exposes a real local runner status/probe command.
+- Container logs are runner stdout/stderr; leave rotation to Docker or the orchestrator.
+- Resource limits are operator-set. Multiple workers and their child processes share the container limits.
+
+## MVP acceptance criteria
+
+1. Both image architectures start as non-root and register with a remote relay.
+2. A session spawned with `cwd=/workspace/<repo>` can read, edit, search, and run Git commands.
+3. The built-in web terminal opens with Bash and the bundled PTY library.
+4. Runner identity, provider auth, transcripts, installed global services, and attachments survive container recreation.
+5. `docker stop` performs a clean shutdown within 30 seconds; restart after forced kill clears a stale state lock.
+6. A runner service panel is reachable through the existing relay tunnel without publishing a container port.
+7. A worker can reach a Compose sidecar by service name.
+8. Requests outside `PIZZAPI_WORKSPACE_ROOTS` are rejected.
+9. The image works without privileged mode or a Docker socket.
+10. Startup/logging states clearly that the session sandbox is disabled by the image default; an opt-in nested-sandbox smoke test documents supported host settings.
+
+## Implementation slices
+
+### 1. Build and smoke the image
+
+Add one runner Dockerfile and a local smoke script/Compose fixture. Build from the existing standalone artifact and verify binary, PTY, signal handling, non-root ownership, and both architectures in CI.
+
+### 2. Publish with releases
+
+Add a GHCR buildx job alongside the existing UI image jobs. Publish version and SHA tags, then add `main` publication after release behavior is proven.
+
+### 3. Document operator contracts
+
+Add a runner-container guide covering Compose, data/workspace mounts, sidecars, derived images, UID/GID ownership, credentials, SSH agent forwarding, sandbox limitations, and upgrades.
+
+Keep these slices separate; no CLI command or Compose generator is needed for MVP.
+
+## Explicit non-goals
+
+- Running the relay/server in the same container.
+- One-container-per-session orchestration.
+- Kubernetes manifests, Helm charts, or a Docker Compose generator.
+- Docker-outside-of-Docker or mounting the host Docker socket.
+- A universal development image containing every language toolchain.
+- Transparent access to host paths, host keychains, host localhost services, or host-installed executables.
+- Changing runner/worker process architecture.
+
+## Open decisions before implementation
+
+1. **Registry name:** confirm `ghcr.io/pizzaface/pizzapi-runner`.
+2. **Base UID/GID:** accept fixed 1000 for MVP, or require runtime UID remapping in the first release.
+3. **Sandbox default:** approve the explicit `PIZZAPI_SANDBOX=none` default versus making weaker nested Bubblewrap a tested default.
+4. **Edge tags:** publish only immutable release tags initially, or also `main` from day one.

--- a/packages/cli/src/auth-command.test.ts
+++ b/packages/cli/src/auth-command.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { loginTypes, pickOption } from "./auth-command.js";
+
+describe("pizza auth", () => {
+    test("loginTypes lists only interactive logins", () => {
+        expect(loginTypes({ auth: { oauth: {}, apiKey: { login: () => {} } } })).toEqual(["oauth", "api_key"]);
+        expect(loginTypes({ auth: { oauth: {} } })).toEqual(["oauth"]);
+        // Ambient-only api key (env var / AWS profile) has no login step.
+        expect(loginTypes({ auth: { apiKey: {} } })).toEqual([]);
+        expect(loginTypes(undefined)).toEqual([]);
+    });
+
+    test("pickOption defaults to the first option and is 1-based", () => {
+        const options = [{ id: "oauth" }, { id: "api_key" }];
+        expect(pickOption(options, "").id).toBe("oauth");
+        expect(pickOption(options, "2").id).toBe("api_key");
+        expect(() => pickOption(options, "3")).toThrow();
+    });
+});

--- a/packages/cli/src/auth-command.ts
+++ b/packages/cli/src/auth-command.ts
@@ -1,0 +1,199 @@
+/**
+ * `pizza auth` — model provider login, headless.
+ *
+ * The only way to authenticate a provider used to be `/login` inside the
+ * interactive TUI, which a containerized or SSH-only runner can't reach
+ * comfortably. This drives the same pi flows (ModelRuntime.login) from a
+ * plain terminal, writing to the same `<agentDir>/auth.json` the daemon's
+ * session workers read.
+ *
+ * In Docker:  docker exec -it <container> pizza auth anthropic
+ * The OAuth flows accept a pasted redirect URL, so the browser can live on a
+ * different machine than the runner — no callback port needs publishing.
+ */
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import type { AuthEvent, AuthPrompt, AuthType } from "@earendil-works/pi-ai";
+import { createInterface } from "readline";
+import { join } from "path";
+import { c } from "./cli-colors.js";
+import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
+import { registerOllamaCloudProvider } from "./ollama-cloud-models.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("auth");
+
+const NO_STDIN =
+    "No interactive input: stdin is closed. Attach a terminal, e.g. `docker exec -it <container> pizza auth <provider>`.";
+
+/**
+ * Read one line. `signal` matters: OAuth flows race a "paste the code" prompt
+ * against their loopback callback server and abort the prompt when the
+ * callback wins — without this the CLI would hang after a successful browser
+ * login.
+ *
+ * The EOF path matters just as much: with stdin closed (plain `docker exec`,
+ * a detached service), readline's callback never fires and the process used
+ * to exit silently mid-prompt, dropping the typed line into the parent shell.
+ */
+function ask(message: string, signal?: AbortSignal): Promise<string> {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new Error("Prompt aborted"));
+            return;
+        }
+        const iface = createInterface({ input: process.stdin, output: process.stdout });
+        let settled = false;
+        const finish = (fn: () => void) => {
+            if (settled) return;
+            settled = true;
+            signal?.removeEventListener("abort", onAbort);
+            iface.close();
+            fn();
+        };
+        const onAbort = () => finish(() => reject(new Error("Prompt aborted")));
+        signal?.addEventListener("abort", onAbort, { once: true });
+        iface.on("close", () => finish(() => reject(new Error(NO_STDIN))));
+        process.stdin.on("error", (err) => finish(() => reject(err)));
+        iface.question(message, (answer) => finish(() => resolve(answer.trim())));
+    });
+}
+
+/** Line-based prompt with echo off, for API keys. */
+function askSecret(message: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        process.stdout.write(message);
+        const stdin = process.stdin as NodeJS.ReadStream & { setRawMode?: (mode: boolean) => void };
+        const iface = createInterface({ input: stdin, terminal: false });
+        stdin.setRawMode?.(true);
+        stdin.once("end", () => {
+            stdin.setRawMode?.(false);
+            reject(new Error(NO_STDIN));
+        });
+        let value = "";
+        stdin.on("data", function onData(chunk: Buffer) {
+            for (const char of chunk.toString()) {
+                if (char === "\r" || char === "\n") {
+                    stdin.removeListener("data", onData);
+                    stdin.setRawMode?.(false);
+                    process.stdout.write("\n");
+                    iface.close();
+                    resolve(value.trim());
+                    return;
+                }
+                if (char === "\u0003") {
+                    stdin.setRawMode?.(false);
+                    process.exit(130);
+                }
+                if (char === "\u007f" || char === "\b") value = value.slice(0, -1);
+                else value += char;
+            }
+        });
+    });
+}
+
+function notify(event: AuthEvent): void {
+    if (event.type === "auth_url") {
+        log.info("");
+        log.info(c.dim(event.instructions ?? "Open this URL to authorize:"));
+        log.info(c.accent(event.url));
+        log.info("");
+    } else if (event.type === "device_code") {
+        log.info(`Code ${c.accent(event.userCode)} — enter it at ${c.accent(event.verificationUri)}`);
+    } else if (event.type === "info") {
+        log.info(event.message);
+        for (const link of event.links ?? []) log.info(`  ${link.label ?? ""} ${c.accent(link.url)}`.trim());
+    } else {
+        log.info(c.dim(event.message));
+    }
+}
+
+/** Empty answer = the first option; otherwise a 1-based index. */
+export function pickOption<T extends { id: string }>(options: readonly T[], answer: string): T {
+    const chosen = options[answer ? Number(answer) - 1 : 0];
+    if (!chosen) throw new Error(`Invalid choice: ${answer}`);
+    return chosen;
+}
+
+async function prompt(p: AuthPrompt): Promise<string> {
+    if (p.type === "select") {
+        log.info(p.message);
+        p.options.forEach((opt, i) => log.info(`  ${i + 1}) ${opt.label}${opt.description ? c.dim(` — ${opt.description}`) : ""}`));
+        return pickOption(p.options, await ask("Choice [1]: ", p.signal)).id;
+    }
+    if (p.type === "secret") return askSecret(`${p.message} `);
+    return ask(`${p.message} `, p.signal);
+}
+
+/** Auth types a provider can actually log in with (ambient-only api key has no `login`). */
+export function loginTypes(provider: { auth?: { oauth?: unknown; apiKey?: { login?: unknown } } } | undefined): AuthType[] {
+    const types: AuthType[] = [];
+    if (provider?.auth?.oauth) types.push("oauth");
+    if (provider?.auth?.apiKey?.login) types.push("api_key");
+    return types;
+}
+
+export async function runAuthCommand(args: string[], cwd: string): Promise<number> {
+    const config = loadConfig(cwd);
+    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+    const authPath = join(agentDir, "auth.json");
+
+    if (!process.stdin.isTTY && args.some((a) => !a.startsWith("-"))) {
+        log.warn("stdin is not a terminal — login prompts need one. Re-run with `docker exec -it …` / an interactive shell.");
+    }
+
+    const runtime = await ModelRuntime.create({ authPath, modelsPath: join(agentDir, "models.json") });
+    registerOllamaCloudProvider(runtime);
+
+    const providerId = args.find((a) => !a.startsWith("-"));
+
+    if (!providerId) {
+        const configured = new Set((await runtime.listCredentials()).map((cred) => cred.providerId));
+        log.info("");
+        log.info(c.label("Providers"));
+        for (const provider of runtime.getProviders()) {
+            const types = loginTypes(provider);
+            if (types.length === 0) continue;
+            const mark = configured.has(provider.id) ? c.success("✓") : c.dim("·");
+            log.info(`  ${mark} ${provider.id.padEnd(18)} ${c.dim(types.join(", "))}`);
+        }
+        log.info("");
+        log.info(c.dim(`Credentials: ${authPath}`));
+        log.info(c.dim("Log in with: ") + c.cmd("pizza auth <provider>"));
+        log.info("");
+        return 0;
+    }
+
+    const provider = runtime.getProvider(providerId);
+    if (!provider) {
+        log.error(`Unknown provider "${providerId}". Run ${c.cmd("pizza auth")} to list providers.`);
+        return 1;
+    }
+
+    const types = loginTypes(provider);
+    if (types.length === 0) {
+        log.error(`${providerId} has no interactive login (it reads ambient credentials, e.g. an env var).`);
+        return 1;
+    }
+
+    try {
+        let type = types[0]!;
+        if (types.length > 1) {
+            type = (await prompt({
+                type: "select",
+                message: `How do you want to authenticate with ${provider.name}?`,
+                options: [
+                    { id: "oauth", label: "Sign in (OAuth / subscription)" },
+                    { id: "api_key", label: "Paste an API key" },
+                ],
+            })) as AuthType;
+        }
+        await runtime.login(providerId, type, { prompt, notify });
+    } catch (err) {
+        log.error(`Login failed: ${err instanceof Error ? err.message : String(err)}`);
+        return 1;
+    }
+
+    log.info(`${c.success("✓")} ${provider.name} credentials saved to ${c.dim(authPath)}`);
+    log.info(c.dim("New sessions pick this up automatically; running sessions keep their old credential."));
+    return 0;
+}

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -652,15 +652,24 @@ export function applyProviderSettingsEnv(config: PizzaPiConfig): void {
 // ── Config saving ─────────────────────────────────────────────────────────────
 
 /**
- * Merge fields into ~/.pizzapi/config.json (global config).
+ * Merge fields into <dir>/config.json. Shared by saveGlobalConfig (fixed to
+ * ~/.pizzapi) and callers that need to target a *different* agent dir (e.g.
+ * headless pairing writing into the configured agentDir rather than
+ * assuming ~/.pizzapi — see runner/pairing.ts).
  */
-export function saveGlobalConfig(fields: Partial<PizzaPiConfig>): void {
-    const dir = globalConfigDir();
+export function saveConfigAt(dir: string, fields: Partial<PizzaPiConfig>): void {
     const path = join(dir, "config.json");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
     const existing = readJsonSafe(path);
     writeFileSync(path, JSON.stringify({ ...existing, ...fields }, null, 2), { encoding: "utf-8", mode: 0o600 });
     chmodSync(path, 0o600); // tighten permissions on pre-existing files
+}
+
+/**
+ * Merge fields into ~/.pizzapi/config.json (global config).
+ */
+export function saveGlobalConfig(fields: Partial<PizzaPiConfig>): void {
+    saveConfigAt(globalConfigDir(), fields);
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,6 +60,12 @@ async function main() {
         process.exit(code);
     }
 
+    if (args[0] === "runner" && args[1] === "pair") {
+        const { runPair } = await import("./runner/pair.js");
+        const code = await runPair(args.slice(2));
+        process.exit(code);
+    }
+
     if (args[0] === "runner") {
         const { runSupervisor } = await import("./runner/supervisor.js");
         const code = await runSupervisor(args.slice(1));
@@ -367,6 +373,7 @@ async function main() {
         log.info(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
         log.info(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);
         log.info(`  ${c.cmd("pizza runner status")} ${c.dim("[--json]")}  Health check the runner daemon (exit 0 = healthy)`);
+        log.info(`  ${c.cmd("pizza runner pair")} ${c.dim("[--force]")}   Pair (or re-pair) the runner with a fresh API key`);
         log.info(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
         log.info(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
         log.info(`  ${c.cmd("pizza models")}                List available models`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,12 @@ async function main() {
         process.exit(code);
     }
 
+    if (args[0] === "runner" && args[1] === "status") {
+        const { runStatus } = await import("./runner/status.js");
+        const code = await runStatus(args.slice(2));
+        process.exit(code);
+    }
+
     if (args[0] === "runner") {
         const { runSupervisor } = await import("./runner/supervisor.js");
         const code = await runSupervisor(args.slice(1));
@@ -355,6 +361,7 @@ async function main() {
         log.info(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}           Manage the PizzaPi web hub (Docker)`);
         log.info(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
         log.info(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);
+        log.info(`  ${c.cmd("pizza runner status")} ${c.dim("[--json]")}  Health check the runner daemon (exit 0 = healthy)`);
         log.info(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
         log.info(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
         log.info(`  ${c.cmd("pizza models")}                List available models`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -342,6 +342,12 @@ async function main() {
         process.exit(code);
     }
 
+    if (args[0] === "auth") {
+        const { runAuthCommand } = await import("./auth-command.js");
+        const code = await runAuthCommand(args.slice(1), cwd);
+        process.exit(code);
+    }
+
     if (args[0] === "config" && args[1] === "show") {
         const { runConfigShowCommand } = await import("./config-show.js");
         process.exit(runConfigShowCommand(cwd));
@@ -377,6 +383,7 @@ async function main() {
         log.info(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
         log.info(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
         log.info(`  ${c.cmd("pizza models")}                List available models`);
+        log.info(`  ${c.cmd("pizza auth")} ${c.dim("[provider]")}       Log in to a model provider (headless-friendly)`);
         log.info(`  ${c.cmd("pizza plugins")} ${c.dim("[cmd]")}         Manage Claude Code plugins`);
         log.info(`  ${c.cmd("pizza install")} ${c.dim("<source>")}       Install a pi package (extensions, skills, prompts, themes)`);
         log.info(`  ${c.cmd("pizza remove")} ${c.dim("<source>")}        Remove an installed pi package`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { setRemoteSessionHost } from "./extensions/remote/session-host-ref.js";
 import { runtimeSessionHost } from "./runner/session-host.js";
 import { migrateAgentDir } from "./migrations.js";
 import { runSetup } from "./setup.js";
+import { expandFileBackedEnv } from "./secrets.js";
 import { createLogger, initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 
 const log = createLogger("cli");
@@ -31,6 +32,10 @@ const log = createLogger("cli");
 registerBunOAuthFlows();
 
 async function main() {
+    // Docker/K8s secrets are file-based — populate FOO from FOO_FILE for
+    // credential-shaped env vars before anything reads them.
+    expandFileBackedEnv();
+
     const args = process.argv.slice(2);
     const cwdFlagIdx = args.indexOf("--cwd");
     const cwd = cwdFlagIdx !== -1 && args[cwdFlagIdx + 1] ? args[cwdFlagIdx + 1] : process.cwd();

--- a/packages/cli/src/relay-url.test.ts
+++ b/packages/cli/src/relay-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeLoopbackHost } from "./relay-url.js";
+import { normalizeLoopbackHost, toHttpRelayUrl } from "./relay-url.js";
 
 describe("normalizeLoopbackHost", () => {
     test("rewrites localhost hosts to 127.0.0.1 across schemes", () => {
@@ -29,5 +29,25 @@ describe("normalizeLoopbackHost", () => {
         expect(normalizeLoopbackHost("http://[::1]:7492")).toBe("http://[::1]:7492");
         expect(normalizeLoopbackHost("off")).toBe("off");
         expect(normalizeLoopbackHost("")).toBe("");
+    });
+});
+
+describe("toHttpRelayUrl", () => {
+    test("converts ws:// to http:// — the form a relayUrl round-trips through config.json in after a successful pair", () => {
+        expect(toHttpRelayUrl("ws://localhost:7492")).toBe("http://localhost:7492");
+    });
+
+    test("converts wss:// to https://", () => {
+        expect(toHttpRelayUrl("wss://relay.example.com")).toBe("https://relay.example.com");
+    });
+
+    test("leaves an already-http(s) URL untouched", () => {
+        expect(toHttpRelayUrl("http://localhost:7492")).toBe("http://localhost:7492");
+        expect(toHttpRelayUrl("https://relay.example.com")).toBe("https://relay.example.com");
+    });
+
+    test("defaults a bare hostname (no scheme) to https, matching the daemon's own socket.io resolution", () => {
+        expect(toHttpRelayUrl("relay.example.com")).toBe("https://relay.example.com");
+        expect(toHttpRelayUrl("relay.example.com:5173")).toBe("https://relay.example.com:5173");
     });
 });

--- a/packages/cli/src/relay-url.ts
+++ b/packages/cli/src/relay-url.ts
@@ -19,3 +19,20 @@ export function normalizeLoopbackHost(url: string): string {
         "$1127.0.0.1",
     );
 }
+
+/**
+ * Normalize a relay URL for HTTP(S) REST calls (setup-claim endpoints, any
+ * plain `fetch()`). A relay URL saved to config.json round-trips in ws(s)://
+ * form — that's what the daemon's own socket.io connection wants, and what
+ * pairing persists on success — so anything that later reads it back for a
+ * REST call (a second `pizza runner pair`, auto-pairing after `apiKey` was
+ * cleared but `relayUrl` wasn't) must convert it back. A bare hostname with
+ * no scheme defaults to https, mirroring the daemon's own socket.io URL
+ * resolution.
+ */
+export function toHttpRelayUrl(raw: string): string {
+    if (raw.startsWith("ws://")) return raw.replace(/^ws:\/\//, "http://");
+    if (raw.startsWith("wss://")) return raw.replace(/^wss:\/\//, "https://");
+    if (raw.startsWith("http://") || raw.startsWith("https://")) return raw;
+    return `https://${raw}`;
+}

--- a/packages/cli/src/runner/daemon-handlers/provider-auth.test.ts
+++ b/packages/cli/src/runner/daemon-handlers/provider-auth.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { registerProviderAuthHandlers, type AuthRuntime } from "./provider-auth.js";
+
+/** Socket double: records emits, lets tests fire inbound events. */
+function fakeSocket() {
+    const handlers = new Map<string, (data: any) => void>();
+    const emits: { event: string; data: any }[] = [];
+    return {
+        socket: {
+            on(event: string, fn: (data: any) => void) {
+                handlers.set(event, fn);
+            },
+            emit(event: string, data: any) {
+                emits.push({ event, data });
+            },
+        } as any,
+        fire: (event: string, data: any) => handlers.get(event)?.(data),
+        emits,
+        /** Wait for the reply carrying this requestId. */
+        async reply(requestId: string, timeoutMs = 2000): Promise<any> {
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                const hit = emits.find((e) => e.data?.requestId === requestId);
+                if (hit) return hit.data;
+                await new Promise((r) => setTimeout(r, 5));
+            }
+            throw new Error(`No reply for ${requestId}`);
+        },
+    };
+}
+
+/** Anthropic-shaped flow: emits an auth URL, then waits for a pasted code. */
+function fakeRuntime(): { runtime: AuthRuntime; loggedIn: string[] } {
+    const loggedIn: string[] = [];
+    return {
+        loggedIn,
+        runtime: {
+            getProviders: () => [
+                { id: "anthropic", name: "Anthropic", auth: { oauth: {}, apiKey: { login: () => {} } } },
+                { id: "ambient-only", name: "Ambient", auth: { apiKey: {} } },
+            ],
+            getProvider: (id) => (id === "anthropic" ? { auth: { oauth: {}, apiKey: { login: () => {} } } } : undefined),
+            listCredentials: async () => [{ providerId: "anthropic" }],
+            login: async (providerId, _type, interaction) => {
+                interaction.notify({ type: "auth_url", url: "https://example.test/authorize" });
+                const code = await interaction.prompt({ type: "manual_code", message: "Paste the redirect URL" });
+                if (code !== "the-code") throw new Error("bad code");
+                loggedIn.push(providerId);
+                return {};
+            },
+        },
+    };
+}
+
+describe("provider auth handlers", () => {
+    test("lists only providers with an interactive login", async () => {
+        const { socket, fire, reply } = fakeSocket();
+        const { runtime } = fakeRuntime();
+        registerProviderAuthHandlers(socket, () => false, () => "/tmp/agent", async () => runtime);
+
+        fire("auth_list", { requestId: "r1" });
+        const res = await reply("r1");
+        expect(res.ok).toBe(true);
+        expect(res.providers).toEqual([
+            { id: "anthropic", name: "Anthropic", types: ["oauth", "api_key"], configured: true },
+        ]);
+    });
+
+    test("start returns the auth URL + prompt, submit completes the login", async () => {
+        const { socket, fire, reply } = fakeSocket();
+        const { runtime, loggedIn } = fakeRuntime();
+        registerProviderAuthHandlers(socket, () => false, () => "/tmp/agent", async () => runtime);
+
+        fire("auth_login_start", { requestId: "r2", providerId: "anthropic", authType: "oauth" });
+        const started = await reply("r2");
+        expect(started.ok).toBe(true);
+        expect(started.step.state).toBe("prompt");
+        expect(started.step.authUrl).toBe("https://example.test/authorize");
+        expect(started.step.prompt.message).toContain("Paste");
+
+        fire("auth_login_submit", { requestId: "r3", loginId: started.step.loginId, value: "the-code" });
+        const done = await reply("r3");
+        expect(done.step).toEqual({ state: "done", providerId: "anthropic" });
+        expect(loggedIn).toEqual(["anthropic"]);
+    });
+
+    test("a failed flow reports the error and clears the pending login", async () => {
+        const { socket, fire, reply } = fakeSocket();
+        const { runtime } = fakeRuntime();
+        registerProviderAuthHandlers(socket, () => false, () => "/tmp/agent", async () => runtime);
+
+        fire("auth_login_start", { requestId: "r4", providerId: "anthropic", authType: "oauth" });
+        const started = await reply("r4");
+        fire("auth_login_submit", { requestId: "r5", loginId: started.step.loginId, value: "wrong" });
+        const failed = await reply("r5");
+        expect(failed.step.state).toBe("error");
+        expect(failed.step.message).toContain("bad code");
+
+        // Stale login id is rejected rather than hanging the next request.
+        fire("auth_login_submit", { requestId: "r6", loginId: started.step.loginId, value: "x" });
+        const stale = await reply("r6");
+        expect(stale.ok).toBe(false);
+        expect(stale.message).toContain("No login in progress");
+    });
+
+    test("status poll reports a login the loopback callback finished", async () => {
+        const { socket, fire, reply } = fakeSocket();
+        const { runtime } = fakeRuntime();
+        registerProviderAuthHandlers(socket, () => false, () => "/tmp/agent", async () => runtime);
+
+        fire("auth_login_start", { requestId: "s1", providerId: "anthropic", authType: "oauth" });
+        const started = await reply("s1");
+        const loginId = started.step.loginId;
+
+        // Still waiting on input — nothing to report yet.
+        fire("auth_login_status", { requestId: "s2", loginId });
+        expect((await reply("s2")).step).toEqual({ state: "waiting" });
+
+        // Flow completes without anyone awaiting a step (the callback won).
+        fire("auth_login_submit", { requestId: "s3", loginId, value: "the-code" });
+        await reply("s3");
+
+        fire("auth_login_status", { requestId: "s4", loginId });
+        expect((await reply("s4")).step).toEqual({ state: "done", providerId: "anthropic" });
+    });
+
+    test("rejects a login type the provider does not support", async () => {
+        const { socket, fire, reply } = fakeSocket();
+        const { runtime } = fakeRuntime();
+        registerProviderAuthHandlers(socket, () => false, () => "/tmp/agent", async () => runtime);
+
+        fire("auth_login_start", { requestId: "r7", providerId: "ambient-only", authType: "oauth" });
+        const res = await reply("r7");
+        expect(res.ok).toBe(false);
+    });
+});

--- a/packages/cli/src/runner/daemon-handlers/provider-auth.ts
+++ b/packages/cli/src/runner/daemon-handlers/provider-auth.ts
@@ -1,0 +1,263 @@
+/**
+ * Model provider login over the relay, so credentials can be added from the
+ * web UI (or a phone) instead of a terminal on the runner host.
+ *
+ * pi's OAuth flows are conversational: they emit an authorization URL, then
+ * wait for either their loopback callback or a pasted code/redirect URL. That
+ * conversation is driven here — each request returns the *next* thing the flow
+ * needs, and the UI answers it with `auth_login_submit`.
+ *
+ * ponytail: one login in flight per runner. Logins are seconds-long and
+ * human-driven; a map keyed by login id buys nothing until two people
+ * authenticate the same runner at once.
+ */
+import type { Socket } from "socket.io-client";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import type { AuthEvent, AuthPrompt, AuthType } from "@earendil-works/pi-ai";
+import { registerOllamaCloudProvider } from "../../ollama-cloud-models.js";
+import { logInfo } from "../logger.js";
+
+const LOGIN_TIMEOUT_MS = 10 * 60_000;
+
+/** What the UI must render next. Never carries secrets back out. */
+type LoginStep =
+    | {
+        state: "prompt";
+        loginId: string;
+        prompt: { type: AuthPrompt["type"]; message: string; placeholder?: string; options?: { id: string; label: string }[] };
+        authUrl?: string;
+        info?: string[];
+    }
+    | { state: "done"; providerId: string }
+    | { state: "error"; message: string }
+    /** Status poll only: the flow is still running and nobody needs input. */
+    | { state: "waiting" };
+
+interface PendingLogin {
+    id: string;
+    providerId: string;
+    /** Resolves the flow's pending prompt with the user's answer. */
+    answer?: (value: string) => void;
+    /** Rejects the flow's pending prompt (abort/cancel). */
+    fail?: (err: Error) => void;
+    /** Resolves the in-flight request with the next step. */
+    deliver?: (step: LoginStep) => void;
+    authUrl?: string;
+    info: string[];
+    timer: ReturnType<typeof setTimeout>;
+}
+
+let pending: PendingLogin | null = null;
+
+/**
+ * Last step per login id, kept briefly after the flow ends.
+ *
+ * The provider's loopback callback can win while the UI sits on the paste card
+ * (browser and runner on the same host, or port 53692 published from the
+ * container). Nobody is awaiting a step then, so the outcome is parked here for
+ * `auth_login_status` to report — that's what lets the UI finish on its own.
+ */
+const recentResults = new Map<string, LoginStep>();
+const RESULT_TTL_MS = 120_000;
+
+function rememberResult(loginId: string, step: LoginStep): void {
+    recentResults.set(loginId, step);
+    setTimeout(() => recentResults.delete(loginId), RESULT_TTL_MS).unref?.();
+}
+
+/** Arm the next step handoff before doing anything that can produce one. */
+function nextStep(login: PendingLogin, timeoutMs: number): Promise<LoginStep> {
+    return new Promise((resolve) => {
+        const timer = setTimeout(
+            () => resolve({ state: "error", message: "Timed out waiting for the provider login flow" }),
+            timeoutMs,
+        );
+        login.deliver = (step) => {
+            clearTimeout(timer);
+            login.deliver = undefined;
+            resolve(step);
+        };
+    });
+}
+
+function settle(login: PendingLogin, step: LoginStep): void {
+    clearTimeout(login.timer);
+    if (pending?.id === login.id) pending = null;
+    rememberResult(login.id, step);
+    login.deliver?.(step);
+}
+
+function cancel(reason: string): void {
+    const login = pending;
+    if (!login) return;
+    login.fail?.(new Error(reason));
+    settle(login, { state: "error", message: reason });
+}
+
+/** Minimal slice of ModelRuntime this handler needs — lets tests drive the flow. */
+type ProviderAuthShape = { auth?: { oauth?: unknown; apiKey?: { login?: unknown } } };
+
+export interface AuthRuntime {
+    getProviders(): readonly (ProviderAuthShape & { id: string; name: string })[];
+    getProvider(id: string): ProviderAuthShape | undefined;
+    listCredentials(): Promise<readonly { providerId: string }[]>;
+    login(providerId: string, type: AuthType, interaction: { prompt: (p: AuthPrompt) => Promise<string>; notify: (e: AuthEvent) => void }): Promise<unknown>;
+}
+
+async function createRuntime(agentDir: string): Promise<ModelRuntime> {
+    const runtime = await ModelRuntime.create({
+        authPath: join(agentDir, "auth.json"),
+        modelsPath: join(agentDir, "models.json"),
+    });
+    // Same reason as listConfiguredModels: no extensions load here, so
+    // ollama-cloud is an unknown provider without an explicit registration.
+    registerOllamaCloudProvider(runtime);
+    return runtime;
+}
+
+/** Auth types a provider can interactively log in with. */
+function loginTypes(provider: ProviderAuthShape | undefined): AuthType[] {
+    const types: AuthType[] = [];
+    if (provider?.auth?.oauth) types.push("oauth");
+    if (provider?.auth?.apiKey?.login) types.push("api_key");
+    return types;
+}
+
+export function registerProviderAuthHandlers(
+    socket: Socket,
+    isShuttingDown: () => boolean,
+    resolveAgentDir: () => string,
+    makeRuntime: (agentDir: string) => Promise<AuthRuntime> = createRuntime,
+): void {
+    // Settings/packages already answer on `file_result`; it is the daemon's
+    // generic request/response ack channel, so no new server listener is needed.
+    const reply = (requestId: string | undefined, payload: Record<string, unknown>) =>
+        socket.emit("file_result", { requestId, ...payload });
+
+    socket.on("auth_list", async (data: any) => {
+        if (isShuttingDown()) return;
+        try {
+            const runtime = await makeRuntime(resolveAgentDir());
+            const configured = new Set((await runtime.listCredentials()).map((cred) => cred.providerId));
+            const providers = runtime
+                .getProviders()
+                .map((provider) => ({
+                    id: provider.id,
+                    name: provider.name,
+                    types: loginTypes(provider),
+                    configured: configured.has(provider.id),
+                }))
+                .filter((provider) => provider.types.length > 0);
+            reply(data?.requestId, { ok: true, providers });
+        } catch (err) {
+            reply(data?.requestId, { ok: false, message: err instanceof Error ? err.message : String(err) });
+        }
+    });
+
+    socket.on("auth_login_start", async (data: any) => {
+        if (isShuttingDown()) return;
+        const providerId = typeof data?.providerId === "string" ? data.providerId : "";
+        const type: AuthType = data?.authType === "api_key" ? "api_key" : "oauth";
+        if (!providerId) {
+            reply(data?.requestId, { ok: false, message: "Missing providerId" });
+            return;
+        }
+
+        cancel("Superseded by a new login");
+
+        try {
+            const runtime = await makeRuntime(resolveAgentDir());
+            if (!loginTypes(runtime.getProvider(providerId)).includes(type)) {
+                reply(data?.requestId, { ok: false, message: `${providerId} does not support ${type} login` });
+                return;
+            }
+
+            const login: PendingLogin = {
+                id: randomUUID(),
+                providerId,
+                info: [],
+                timer: setTimeout(() => cancel("Login expired"), LOGIN_TIMEOUT_MS),
+            };
+            pending = login;
+
+            const step = nextStep(login, 30_000);
+
+            const notify = (event: AuthEvent) => {
+                if (event.type === "auth_url") login.authUrl = event.url;
+                else if (event.type === "info") login.info.push(event.message);
+            };
+            const prompt = (p: AuthPrompt) =>
+                new Promise<string>((resolve, reject) => {
+                    login.answer = resolve;
+                    login.fail = reject;
+                    // The flow aborts this prompt if its loopback callback wins.
+                    p.signal?.addEventListener("abort", () => reject(new Error("Prompt aborted")), { once: true });
+                    login.deliver?.({
+                        state: "prompt",
+                        loginId: login.id,
+                        prompt: {
+                            type: p.type,
+                            message: p.message,
+                            placeholder: p.type === "select" ? undefined : p.placeholder,
+                            options: p.type === "select" ? p.options.map((o) => ({ id: o.id, label: o.label })) : undefined,
+                        },
+                        authUrl: login.authUrl,
+                        info: login.info.length ? [...login.info] : undefined,
+                    });
+                });
+
+            runtime
+                .login(providerId, type, { prompt, notify })
+                .then(() => {
+                    logInfo(`provider auth: ${providerId} credentials saved`);
+                    settle(login, { state: "done", providerId });
+                })
+                .catch((err) => settle(login, { state: "error", message: err instanceof Error ? err.message : String(err) }));
+
+            reply(data?.requestId, { ok: true, step: await step });
+        } catch (err) {
+            reply(data?.requestId, { ok: false, message: err instanceof Error ? err.message : String(err) });
+        }
+    });
+
+    socket.on("auth_login_submit", async (data: any) => {
+        if (isShuttingDown()) return;
+        const login = pending;
+        if (!login || login.id !== data?.loginId) {
+            reply(data?.requestId, { ok: false, message: "No login in progress — start again" });
+            return;
+        }
+        const answer = login.answer;
+        if (!answer) {
+            reply(data?.requestId, { ok: false, message: "Login is not waiting for input" });
+            return;
+        }
+        const step = nextStep(login, 60_000);
+        login.answer = undefined;
+        answer(typeof data?.value === "string" ? data.value : "");
+        reply(data?.requestId, { ok: true, step: await step });
+    });
+
+    socket.on("auth_login_status", (data: any) => {
+        if (isShuttingDown()) return;
+        const loginId = data?.loginId;
+        const finished = recentResults.get(loginId);
+        if (finished) {
+            reply(data?.requestId, { ok: true, step: finished });
+            return;
+        }
+        if (pending?.id === loginId) {
+            reply(data?.requestId, { ok: true, step: { state: "waiting" } });
+            return;
+        }
+        reply(data?.requestId, { ok: false, message: "No login in progress — start again" });
+    });
+
+    socket.on("auth_login_cancel", (data: any) => {
+        if (isShuttingDown()) return;
+        if (pending && pending.id === data?.loginId) cancel("Cancelled");
+        reply(data?.requestId, { ok: true });
+    });
+}

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1148,6 +1148,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 socket.disconnect();
                 return;
             }
+            // Reaching "connect" means the auth middleware accepted us — clear any
+            // earlier rejection so `runner status` stops reporting it as stale.
+            patchRunnerState(statePath, { authRejected: false });
             if (tunnelClient && !tunnelClientStarted) {
                 tunnelClientStarted = true;
                 tunnelClient.connect();
@@ -1156,6 +1159,30 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             isFirstConnect = false;
             logInfo(`${verb}. Registering as ${identity.runnerId}…`);
             emitRegister();
+        });
+
+        // A bad API key otherwise looks like a silent hang: the server rejects
+        // with next(new Error("unauthorized")) during the handshake, socket.io
+        // never fires "connect", and (with reconnection on) just retries forever.
+        // Surface it loudly and distinctly from an ordinary network failure, but
+        // rate-limit so a long retry loop can't flood the logs.
+        let lastAuthErrorLoggedAt = 0;
+        const AUTH_ERROR_LOG_INTERVAL_MS = 60_000;
+        socket.on("connect_error", (err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            if (message !== "unauthorized") {
+                logWarn(`[relay] connect error: ${message}`);
+                return;
+            }
+            patchRunnerState(statePath, { authRejected: true });
+            const now = Date.now();
+            if (now - lastAuthErrorLoggedAt < AUTH_ERROR_LOG_INTERVAL_MS) return;
+            lastAuthErrorLoggedAt = now;
+            logError(
+                `[relay] rejected our API key at ${sioUrl}/runner — check PIZZAPI_API_KEY ` +
+                    "(or PIZZAPI_RUNNER_API_KEY / PIZZAPI_API_TOKEN), or re-pair this runner. " +
+                    "Retrying, but it will keep failing until credentials are fixed.",
+            );
         });
 
         socket.on("disconnect", (reason, details) => {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -60,6 +60,7 @@ import { registerUsageHandlers } from "./daemon-handlers/usage.js";
 import { registerSessionAnalysisHandlers } from "./daemon-handlers/session-analysis.js";
 import { registerSettingsHandlers } from "./daemon-handlers/settings.js";
 import { registerPackagesHandlers } from "./daemon-handlers/packages.js";
+import { registerProviderAuthHandlers } from "./daemon-handlers/provider-auth.js";
 
 // Re-export migration from shared module — used on daemon startup
 import { migrateAgentDir } from "../migrations.js";
@@ -1900,6 +1901,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         );
         registerSettingsHandlers(socket, () => isShuttingDown);
         registerPackagesHandlers(socket, () => isShuttingDown);
+        registerProviderAuthHandlers(socket, () => isShuttingDown, () => resolveConfiguredAgentDir());
 
         // ── Error handling ────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -38,6 +38,7 @@ import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } fro
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock, patchRunnerState } from "./runner-state.js";
+import { seedAuthFileIfNeeded } from "../secrets.js";
 import { normalizeLoopbackHost } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
@@ -657,6 +658,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     // reconfigure_services pass.
     const packageDiscoveryCwd = process.cwd();
     const packageDiscoveryAgentDir = resolveConfiguredAgentDir(packageDiscoveryCwd);
+
+    // Seed provider credentials from a mounted secret on first boot (never
+    // clobbers an existing auth.json — OAuth refresh writes back to it).
+    seedAuthFileIfNeeded(packageDiscoveryAgentDir);
 
     // Priority: env var > config.json > default
     const apiKey =

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -39,7 +39,7 @@ import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock, patchRunnerState } from "./runner-state.js";
 import { seedAuthFileIfNeeded } from "../secrets.js";
-import { normalizeLoopbackHost } from "../relay-url.js";
+import { normalizeLoopbackHost, toHttpRelayUrl } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
 import { getWorkspaceRoots } from "./workspace.js";
@@ -688,17 +688,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 .replace(/\/$/, ""),
         );
 
-        // Normalise the relay URL for socket.io-client (needs http(s)://).
-        // If the user supplies a bare hostname (no scheme), default to https://.
-        function normaliseRelayUrl(raw: string): string {
-            if (raw.startsWith("ws://"))      return raw.replace(/^ws:\/\//, "http://");
-            if (raw.startsWith("wss://"))     return raw.replace(/^wss:\/\//, "https://");
-            if (raw.startsWith("http://"))    return raw;
-            if (raw.startsWith("https://"))   return raw;
-            // No scheme — treat as an https host (e.g. "example.com" or "example.com:5173")
-            return `https://${raw}`;
-        }
-
         function toTunnelRelayUrl(raw: string): string {
             if (raw.startsWith("http://")) return `${raw.replace(/^http:\/\//, "ws://")}/_tunnel`;
             if (raw.startsWith("https://")) return `${raw.replace(/^https:\/\//, "wss://")}/_tunnel`;
@@ -706,7 +695,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             return `wss://${raw}/_tunnel`;
         }
 
-        const sioUrl = normaliseRelayUrl(relayRaw);
+        // Normalise the relay URL for socket.io-client (needs http(s)://).
+        // If the user supplies a bare hostname (no scheme), default to https://.
+        const sioUrl = toHttpRelayUrl(relayRaw);
         const tunnelRelayUrl = toTunnelRelayUrl(sioUrl);
 
         const runningSessions = new Map<string, RunnerSession>();

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -37,7 +37,7 @@ import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
-import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
+import { defaultStatePath, acquireStateAndIdentity, releaseStateLock, patchRunnerState } from "./runner-state.js";
 import { normalizeLoopbackHost } from "../relay-url.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
@@ -1161,6 +1161,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 `disconnected (${reason}). Socket.IO will reconnect automatically. `
                 + `transport=${transportName} details=${JSON.stringify(details ?? {})}`,
             );
+            // ponytail: no heartbeat timer here — socket.io's own ping/timeout
+            // already fires "disconnect" on a dead connection, and `runner status`
+            // combines this flag with a PID liveness check. That's sufficient to
+            // answer "is this runner alive AND registered" without extra polling.
+            patchRunnerState(statePath, { connected: false, disconnectedAt: new Date().toISOString() });
         });
 
         // ── Registration confirmation ─────────────────────────────────────
@@ -1176,6 +1181,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     logWarn(`server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`);
                 }
                 logInfo(`registered as ${runnerId}`);
+                patchRunnerState(statePath, {
+                    connected: true,
+                    connectedAt: new Date().toISOString(),
+                    relayUrl: sioUrl,
+                    runnerName,
+                    cliVersion,
+                });
 
                 // Wait for plugin service discovery to finish, then init ALL services
                 // (built-in + plugins) once and announce the full list.

--- a/packages/cli/src/runner/pair.test.ts
+++ b/packages/cli/src/runner/pair.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "bun:test";
+import { decidePairAction, isDaemonRunning, resolveCredentialSource } from "./pair.js";
+
+describe("resolveCredentialSource", () => {
+    test("no credential anywhere", () => {
+        expect(resolveCredentialSource({}, false)).toBeUndefined();
+    });
+
+    test("config only", () => {
+        expect(resolveCredentialSource({}, true)).toBe("config.json");
+    });
+
+    test("PIZZAPI_RUNNER_API_KEY wins over everything, including config", () => {
+        expect(resolveCredentialSource({ PIZZAPI_RUNNER_API_KEY: "x", PIZZAPI_API_KEY: "y", PIZZAPI_API_TOKEN: "z" }, true)).toBe(
+            "PIZZAPI_RUNNER_API_KEY",
+        );
+    });
+
+    test("PIZZAPI_API_KEY wins over PIZZAPI_API_TOKEN and config", () => {
+        expect(resolveCredentialSource({ PIZZAPI_API_KEY: "y", PIZZAPI_API_TOKEN: "z" }, true)).toBe("PIZZAPI_API_KEY");
+    });
+
+    test("PIZZAPI_API_TOKEN wins over config", () => {
+        expect(resolveCredentialSource({ PIZZAPI_API_TOKEN: "z" }, true)).toBe("PIZZAPI_API_TOKEN");
+    });
+});
+
+describe("decidePairAction", () => {
+    test("nothing configured, no --force: proceeds cleanly", () => {
+        const d = decidePairAction(undefined, false);
+        expect(d).toEqual({ proceed: true });
+    });
+
+    test("config-only credential, no --force: refuses", () => {
+        const d = decidePairAction("config.json", false);
+        expect(d.proceed).toBe(false);
+        expect(d.refusalReason).toContain("--force");
+        expect(d.refusalReason).not.toContain("PIZZAPI_"); // no env var involved
+    });
+
+    test("config-only credential, --force: proceeds with no shadow warning", () => {
+        const d = decidePairAction("config.json", true);
+        expect(d).toEqual({ proceed: true });
+    });
+
+    for (const envVar of ["PIZZAPI_RUNNER_API_KEY", "PIZZAPI_API_KEY", "PIZZAPI_API_TOKEN"] as const) {
+        test(`env-shadowed by ${envVar}, no --force: refuses and names the variable`, () => {
+            const d = decidePairAction(envVar, false);
+            expect(d.proceed).toBe(false);
+            expect(d.refusalReason).toContain(envVar);
+            expect(d.refusalReason).toContain("--force");
+        });
+
+        test(`env-shadowed by ${envVar}, --force: proceeds but with a loud warning naming it`, () => {
+            const d = decidePairAction(envVar, true);
+            expect(d.proceed).toBe(true);
+            expect(d.warning).toBeDefined();
+            expect(d.warning).toContain(envVar);
+        });
+    }
+
+    test("refusal message never echoes a key value — only the source label", () => {
+        const d = decidePairAction("PIZZAPI_API_KEY", false);
+        // sanity: message is built purely from the source label, no interpolated secret
+        expect(d.refusalReason).not.toMatch(/[0-9a-f]{16,}/);
+    });
+});
+
+describe("isDaemonRunning", () => {
+    const alive = (_pid: number) => true;
+    const dead = (_pid: number) => false;
+
+    test("no state file: not running", () => {
+        expect(isDaemonRunning(null, alive)).toBe(false);
+    });
+
+    test("state with alive pid: running", () => {
+        expect(isDaemonRunning({ pid: 123 }, alive)).toBe(true);
+    });
+
+    test("state with dead pid: not running", () => {
+        expect(isDaemonRunning({ pid: 123 }, dead)).toBe(false);
+    });
+
+    test("state with pid 0 (released lock): not running", () => {
+        expect(isDaemonRunning({ pid: 0 }, alive)).toBe(false);
+    });
+
+    test("state with no pid field: not running", () => {
+        expect(isDaemonRunning({}, alive)).toBe(false);
+    });
+});

--- a/packages/cli/src/runner/pair.ts
+++ b/packages/cli/src/runner/pair.ts
@@ -1,0 +1,145 @@
+/**
+ * `runner pair [--force]` — mint a fresh headless-paired API key on demand.
+ *
+ * Runs the same device-claim flow `ensureRunnerCredentials()` runs
+ * automatically on a credential-less boot (see pairing.ts), but invokable
+ * any time an operator wants a fresh key — e.g. after revoking a container's
+ * key in the web UI, instead of the old "rm config.json && restart" recipe.
+ *
+ * Two guard rails, both refuse-by-default (require --force to bypass):
+ *  1. An existing credential (env or config) already resolves — don't
+ *     clobber it silently.
+ *  2. One of the three "wins at runtime" env vars is set — pairing would
+ *     write a key to config.json that never takes effect. A prominent
+ *     warn-and-proceed (instead of refusing) risks the exact silent
+ *     failure this command exists to eliminate: an operator scanning for
+ *     "paired successfully" would see it and walk away, never noticing a
+ *     warning line above it. Refusing forces a conscious decision.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+import { c } from "../cli-colors.js";
+import { loadGlobalConfig, resolveAgentDir, saveConfigAt } from "../config.js";
+import { toHttpRelayUrl } from "../relay-url.js";
+import { requestHeadlessPairing } from "../setup.js";
+import { defaultStatePath, isPidRunning, type RunnerState } from "./runner-state.js";
+import { resolveKnownRelayUrl } from "./pairing.js";
+
+export type CredentialSource = "PIZZAPI_RUNNER_API_KEY" | "PIZZAPI_API_KEY" | "PIZZAPI_API_TOKEN" | "config.json";
+
+/**
+ * Pure: mirrors resolveExistingApiKey's priority chain (pairing.ts) but
+ * reports *where* a credential came from instead of its value — callers
+ * must never print the key itself.
+ */
+export function resolveCredentialSource(
+    env: { PIZZAPI_RUNNER_API_KEY?: string; PIZZAPI_API_KEY?: string; PIZZAPI_API_TOKEN?: string },
+    hasConfigApiKey: boolean,
+): CredentialSource | undefined {
+    if (env.PIZZAPI_RUNNER_API_KEY) return "PIZZAPI_RUNNER_API_KEY";
+    if (env.PIZZAPI_API_KEY) return "PIZZAPI_API_KEY";
+    if (env.PIZZAPI_API_TOKEN) return "PIZZAPI_API_TOKEN";
+    return hasConfigApiKey ? "config.json" : undefined;
+}
+
+export interface PairDecision {
+    proceed: boolean;
+    refusalReason?: string;
+    warning?: string;
+}
+
+/**
+ * Pure decision for both guard rails described above, given where (if
+ * anywhere) a credential currently resolves from and whether --force was
+ * passed.
+ */
+export function decidePairAction(existingSource: CredentialSource | undefined, force: boolean): PairDecision {
+    const shadowVar = existingSource && existingSource !== "config.json" ? existingSource : undefined;
+
+    if (existingSource && !force) {
+        return {
+            proceed: false,
+            refusalReason: shadowVar
+                ? `${shadowVar} is already set and resolves ahead of config.json at runtime — pairing now would mint a key that's silently ignored. Unset ${shadowVar} (remove it from Compose's "environment:") and re-run, or pass --force to pair anyway (still prints this warning and proceeds despite the shadow).`
+                : `An API key is already configured (source: config.json). Re-run with --force to replace it.`,
+        };
+    }
+
+    if (shadowVar) {
+        return {
+            proceed: true,
+            warning: `${shadowVar} is set and takes priority over config.json at runtime — the freshly paired key will be ignored until you unset ${shadowVar}.`,
+        };
+    }
+
+    return { proceed: true };
+}
+
+/** Pure: is a runner daemon actively holding the process lock right now? */
+export function isDaemonRunning(state: Partial<Pick<RunnerState, "pid">> | null, isAlive: (pid: number) => boolean): boolean {
+    return typeof state?.pid === "number" && state.pid > 0 && isAlive(state.pid);
+}
+
+function readState(statePath: string): Partial<RunnerState> | null {
+    if (!existsSync(statePath)) return null;
+    try {
+        return JSON.parse(readFileSync(statePath, "utf-8"));
+    } catch {
+        return null;
+    }
+}
+
+export async function runPair(args: string[] = []): Promise<number> {
+    const force = args.includes("--force");
+    const agentDir = resolveAgentDir();
+    const config = loadGlobalConfig();
+
+    const env = {
+        PIZZAPI_RUNNER_API_KEY: process.env.PIZZAPI_RUNNER_API_KEY,
+        PIZZAPI_API_KEY: process.env.PIZZAPI_API_KEY,
+        PIZZAPI_API_TOKEN: process.env.PIZZAPI_API_TOKEN,
+    };
+    const decision = decidePairAction(resolveCredentialSource(env, Boolean(config.apiKey)), force);
+
+    if (!decision.proceed) {
+        console.error(`${c.error("✗ Refusing to pair:")} ${decision.refusalReason}`);
+        return 1;
+    }
+    if (decision.warning) {
+        console.error(`${c.warning("⚠")}  ${decision.warning}`);
+    }
+
+    // Same resolution as the supervisor's auto-pair path — env, then config,
+    // no localhost default (see pairing.ts's own doc comment for why).
+    const knownRelayUrl = resolveKnownRelayUrl(config.relayUrl);
+    if (!knownRelayUrl) {
+        console.error(`${c.error("✗")} No relay URL known. Set PIZZAPI_RELAY_URL and re-run.`);
+        return 1;
+    }
+    const relayUrl = toHttpRelayUrl(knownRelayUrl);
+
+    const label = process.env.PIZZAPI_RUNNER_NAME?.trim() || hostname();
+    console.log(`Pairing with ${c.accent(relayUrl)} as "${label}"…`);
+
+    const result = await requestHeadlessPairing(relayUrl, { label });
+    if ("error" in result) {
+        console.error(`${c.error("✗ Pairing failed:")} ${result.error}`);
+        return 1;
+    }
+
+    // Replace only the credential fields — never touch unrelated config keys.
+    saveConfigAt(agentDir, { apiKey: result.apiKey, relayUrl: result.relayUrl });
+    console.log(`${c.success("✓")} Paired. API key saved to ${join(agentDir, "config.json")}.`);
+
+    const state = readState(defaultStatePath());
+    if (isDaemonRunning(state, isPidRunning)) {
+        console.log(
+            `${c.warning("⚠")}  A runner daemon is already running (pid ${state!.pid}) and is still using the old ` +
+                `credential in memory. Restart it to pick up the new key: ${c.cmd("pizza runner stop")} then start it ` +
+                `again, or ${c.cmd("docker restart <container>")}.`,
+        );
+    }
+
+    return 0;
+}

--- a/packages/cli/src/runner/pairing.test.ts
+++ b/packages/cli/src/runner/pairing.test.ts
@@ -9,7 +9,9 @@ import {
     pairingStatusPath,
     readPairingStatus,
     clearPairingStatus,
+    ensureRunnerCredentials,
 } from "./pairing.js";
+import { _setGlobalConfigDir } from "../config/io.js";
 
 describe("shouldAutoPair", () => {
     test("triggers when nothing is configured but a relay URL is known", () => {
@@ -95,6 +97,73 @@ describe("resolveKnownRelayUrl", () => {
     test("strips a trailing slash", () => {
         process.env.PIZZAPI_RELAY_URL = "http://env:7492/";
         expect(resolveKnownRelayUrl(undefined)).toBe("http://env:7492");
+    });
+});
+
+describe("ensureRunnerCredentials — ws:// relayUrl round-trip regression", () => {
+    // Pins the bug class caught in review: a *second* pairing attempt
+    // (auto-pair re-triggering after apiKey was cleared but relayUrl
+    // wasn't, or any future caller of ensureRunnerCredentials with a
+    // config-sourced relayUrl) must not hand the ws(s):// value straight to
+    // a REST fetch() — it must go through toHttpRelayUrl first (relay-url.ts).
+    let tmpDir: string;
+    const originalFetch = globalThis.fetch;
+    const envKeys = [
+        "PIZZAPI_RUNNER_API_KEY",
+        "PIZZAPI_API_KEY",
+        "PIZZAPI_API_TOKEN",
+        "PIZZAPI_RUNNER_TOKEN",
+        "PIZZAPI_PAIRING",
+        "PIZZAPI_RELAY_URL",
+        "PIZZAPI_RUNNER_NAME",
+    ] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-pairing-regression-test-"));
+        _setGlobalConfigDir(join(tmpDir, ".pizzapi"));
+        for (const k of envKeys) { savedEnv[k] = process.env[k]; delete process.env[k]; }
+    });
+
+    afterEach(() => {
+        _setGlobalConfigDir(null);
+        globalThis.fetch = originalFetch;
+        for (const k of envKeys) {
+            if (savedEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = savedEnv[k];
+        }
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    });
+
+    test("config-sourced ws:// relayUrl still targets http(s) for the setup-claim REST call", async () => {
+        const agentDir = join(tmpDir, ".pizzapi");
+        mkdirSync(agentDir, { recursive: true });
+        writeFileSync(join(agentDir, "config.json"), JSON.stringify({ relayUrl: "ws://localhost:7999" }));
+
+        const requestedUrls: string[] = [];
+        globalThis.fetch = (async (input: RequestInfo | URL) => {
+            const url = input.toString();
+            requestedUrls.push(url);
+            if (url === "http://localhost:7999/api/setup-claim") {
+                return new Response(
+                    JSON.stringify({ token: "tok", expiresAt: new Date(Date.now() + 60_000).toISOString() }),
+                    { status: 200, headers: { "content-type": "application/json" } },
+                );
+            }
+            if (url === "http://localhost:7999/api/setup-claim/tok") {
+                return new Response(JSON.stringify({ status: "approved", apiKey: "a".repeat(64) }), { status: 200 });
+            }
+            throw new Error(`unexpected fetch to ${url}`);
+        }) as typeof fetch;
+
+        const exitCode = await ensureRunnerCredentials(agentDir);
+
+        expect(exitCode).toBeNull(); // pairing succeeded, startup continues
+        expect(requestedUrls.length).toBeGreaterThan(0);
+        for (const url of requestedUrls) {
+            expect(url.startsWith("ws://")).toBe(false);
+            expect(url.startsWith("http://localhost:7999")).toBe(true);
+        }
     });
 });
 

--- a/packages/cli/src/runner/pairing.test.ts
+++ b/packages/cli/src/runner/pairing.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    shouldAutoPair,
+    resolveExistingApiKey,
+    resolveKnownRelayUrl,
+    pairingStatusPath,
+    readPairingStatus,
+    clearPairingStatus,
+} from "./pairing.js";
+
+describe("shouldAutoPair", () => {
+    test("triggers when nothing is configured but a relay URL is known", () => {
+        expect(
+            shouldAutoPair({ hasApiKey: false, hasToken: false, relayUrl: "http://localhost:7492", pairingDisabled: false }),
+        ).toBe(true);
+    });
+
+    test("does not trigger when an API key is already present", () => {
+        expect(
+            shouldAutoPair({ hasApiKey: true, hasToken: false, relayUrl: "http://localhost:7492", pairingDisabled: false }),
+        ).toBe(false);
+    });
+
+    test("does not trigger when a server token is already present", () => {
+        expect(
+            shouldAutoPair({ hasApiKey: false, hasToken: true, relayUrl: "http://localhost:7492", pairingDisabled: false }),
+        ).toBe(false);
+    });
+
+    test("does not trigger when no relay URL is known", () => {
+        expect(
+            shouldAutoPair({ hasApiKey: false, hasToken: false, relayUrl: undefined, pairingDisabled: false }),
+        ).toBe(false);
+    });
+
+    test("does not trigger when pairing is explicitly disabled", () => {
+        expect(
+            shouldAutoPair({ hasApiKey: false, hasToken: false, relayUrl: "http://localhost:7492", pairingDisabled: true }),
+        ).toBe(false);
+    });
+});
+
+describe("resolveExistingApiKey", () => {
+    const originalEnv = { ...process.env };
+    afterEach(() => {
+        for (const k of ["PIZZAPI_RUNNER_API_KEY", "PIZZAPI_API_KEY", "PIZZAPI_API_TOKEN"]) delete process.env[k];
+        Object.assign(process.env, originalEnv);
+    });
+
+    test("prefers PIZZAPI_RUNNER_API_KEY over the rest", () => {
+        process.env.PIZZAPI_RUNNER_API_KEY = "runner-key";
+        process.env.PIZZAPI_API_KEY = "api-key";
+        expect(resolveExistingApiKey("config-key")).toBe("runner-key");
+    });
+
+    test("falls back to config apiKey when nothing else is set", () => {
+        expect(resolveExistingApiKey("config-key")).toBe("config-key");
+    });
+
+    test("returns undefined when nothing is set", () => {
+        expect(resolveExistingApiKey(undefined)).toBeUndefined();
+    });
+});
+
+describe("resolveKnownRelayUrl", () => {
+    const originalEnv = process.env.PIZZAPI_RELAY_URL;
+    afterEach(() => {
+        if (originalEnv === undefined) delete process.env.PIZZAPI_RELAY_URL;
+        else process.env.PIZZAPI_RELAY_URL = originalEnv;
+    });
+
+    test("prefers the env var over config", () => {
+        process.env.PIZZAPI_RELAY_URL = "http://env:7492";
+        expect(resolveKnownRelayUrl("http://config:7492")).toBe("http://env:7492");
+    });
+
+    test("falls back to config when env is unset", () => {
+        delete process.env.PIZZAPI_RELAY_URL;
+        expect(resolveKnownRelayUrl("http://config:7492")).toBe("http://config:7492");
+    });
+
+    test("returns undefined when neither is set — no silent localhost default", () => {
+        delete process.env.PIZZAPI_RELAY_URL;
+        expect(resolveKnownRelayUrl(undefined)).toBeUndefined();
+    });
+
+    test("treats config relayUrl of \"off\" as unset", () => {
+        delete process.env.PIZZAPI_RELAY_URL;
+        expect(resolveKnownRelayUrl("off")).toBeUndefined();
+    });
+
+    test("strips a trailing slash", () => {
+        process.env.PIZZAPI_RELAY_URL = "http://env:7492/";
+        expect(resolveKnownRelayUrl(undefined)).toBe("http://env:7492");
+    });
+});
+
+describe("pairing status file", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-pairing-test-"));
+    });
+    afterEach(() => {
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    });
+
+    test("readPairingStatus returns null when no file exists", () => {
+        expect(readPairingStatus(pairingStatusPath(tmpDir))).toBeNull();
+    });
+
+    test("clearPairingStatus is a no-op when nothing exists", () => {
+        expect(() => clearPairingStatus(pairingStatusPath(tmpDir))).not.toThrow();
+    });
+
+    test("roundtrips a written status file", () => {
+        const path = pairingStatusPath(tmpDir);
+        const status = { claimUrl: "http://x/setup-claim?t=abc", relayUrl: "http://x", startedAt: new Date().toISOString() };
+        mkdirSync(join(path, ".."), { recursive: true });
+        writeFileSync(path, JSON.stringify(status), { mode: 0o600 });
+        expect(readPairingStatus(path)).toEqual(status);
+        clearPairingStatus(path);
+        expect(readPairingStatus(path)).toBeNull();
+    });
+});

--- a/packages/cli/src/runner/pairing.ts
+++ b/packages/cli/src/runner/pairing.ts
@@ -1,0 +1,145 @@
+/**
+ * Headless auto-pairing for `pizza runner`.
+ *
+ * When a container boots with no usable credential, prompting is impossible
+ * (no stdin), so this mints one automatically via the same device-claim flow
+ * `pizza setup --scan` uses \u2014 print an approval URL + QR, wait, persist the
+ * key on approval. Runs in the supervisor, before the daemon (and its
+ * runner.json pid lock) exist, so pairing-pending state lives in its own
+ * small file rather than runner.json (see pairingStatusPath).
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+import { loadGlobalConfig, saveConfigAt } from "../config.js";
+import { requestHeadlessPairing } from "../setup.js";
+import { logError, logInfo, logWarn } from "./logger.js";
+
+const PAIRING_STATUS_FILENAME = "pairing-pending.json";
+
+export interface PairingStatus {
+    claimUrl: string;
+    expiresAt?: string;
+    relayUrl: string;
+    startedAt: string;
+}
+
+export function pairingStatusPath(agentDir: string): string {
+    return join(agentDir, PAIRING_STATUS_FILENAME);
+}
+
+export function readPairingStatus(path: string): PairingStatus | null {
+    if (!existsSync(path)) return null;
+    try {
+        return JSON.parse(readFileSync(path, "utf-8"));
+    } catch {
+        return null;
+    }
+}
+
+function writePairingStatus(path: string, status: PairingStatus): void {
+    try {
+        mkdirSync(join(path, ".."), { recursive: true });
+        writeFileSync(path, JSON.stringify(status, null, 2), { encoding: "utf-8", mode: 0o600 });
+    } catch (err) {
+        logWarn(`Failed to write pairing status: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+export function clearPairingStatus(path: string): void {
+    try { rmSync(path, { force: true }); } catch {}
+}
+
+export interface PairingTriggerInput {
+    hasApiKey: boolean;
+    hasToken: boolean;
+    relayUrl?: string;
+    pairingDisabled: boolean;
+}
+
+/** Pure predicate: should `pizza runner` auto-pair on this boot? */
+export function shouldAutoPair(input: PairingTriggerInput): boolean {
+    if (input.pairingDisabled) return false;
+    if (input.hasApiKey || input.hasToken) return false;
+    return Boolean(input.relayUrl);
+}
+
+/** Mirrors the priority chain daemon.ts uses to resolve a usable API key. */
+export function resolveExistingApiKey(configApiKey?: string): string | undefined {
+    return (
+        process.env.PIZZAPI_RUNNER_API_KEY ??
+        process.env.PIZZAPI_API_KEY ??
+        process.env.PIZZAPI_API_TOKEN ??
+        configApiKey
+    );
+}
+
+/**
+ * Relay URL known from env or config, with no "localhost" default \u2014 unlike
+ * the daemon's own resolution, auto-pairing can't silently fall back to a
+ * default relay: if there isn't an explicit one, we can't prompt for it.
+ */
+export function resolveKnownRelayUrl(configRelayUrl?: string): string | undefined {
+    const raw = (process.env.PIZZAPI_RELAY_URL || configRelayUrl || "").trim();
+    if (!raw || raw === "off") return undefined;
+    return raw.replace(/\/$/, "");
+}
+
+/**
+ * Runs before the daemon subprocess starts. If credentials are already
+ * present (or pairing is explicitly disabled), returns immediately. Otherwise
+ * pairs headlessly, persists the key into `<agentDir>/config.json`, and sets
+ * process.env so the daemon \u2014 spawned with `env: process.env` \u2014 picks it up
+ * without a restart.
+ *
+ * Returns an exit code when startup should abort, or null to continue.
+ */
+export async function ensureRunnerCredentials(agentDir: string): Promise<number | null> {
+    const config = loadGlobalConfig();
+    const hasApiKey = Boolean(resolveExistingApiKey(config.apiKey));
+    const hasToken = Boolean(process.env.PIZZAPI_RUNNER_TOKEN);
+    const pairingDisabled = process.env.PIZZAPI_PAIRING === "0";
+    const relayUrl = resolveKnownRelayUrl(config.relayUrl);
+
+    if (!shouldAutoPair({ hasApiKey, hasToken, relayUrl, pairingDisabled })) {
+        if (!hasApiKey && !hasToken && !pairingDisabled) {
+            // Nothing to pair against and no explicit opt-out — the daemon
+            // would just fail with the same "no credential" message, but we
+            // can't prompt, so fail here with the actionable fix.
+            logError(
+                "No API key configured and no relay URL to auto-pair against. " +
+                    "Set PIZZAPI_RELAY_URL to pair automatically, or set PIZZAPI_API_KEY directly.",
+            );
+            return 1;
+        }
+        return null; // credentials already present, or pairing explicitly disabled
+    }
+
+    const label = process.env.PIZZAPI_RUNNER_NAME?.trim() || hostname();
+    const statusPath = pairingStatusPath(agentDir);
+    logInfo(`no credentials found — pairing with ${relayUrl} as "${label}"…`);
+
+    const result = await requestHeadlessPairing(relayUrl!, {
+        label,
+        onClaim: (info) =>
+            writePairingStatus(statusPath, {
+                claimUrl: info.claimUrl,
+                expiresAt: info.expiresAt,
+                relayUrl: relayUrl!,
+                startedAt: new Date().toISOString(),
+            }),
+    });
+
+    clearPairingStatus(statusPath);
+
+    if ("error" in result) {
+        logError(`Pairing failed: ${result.error}. Set PIZZAPI_API_KEY manually, or retry.`);
+        return 1;
+    }
+
+    saveConfigAt(agentDir, { apiKey: result.apiKey, relayUrl: result.relayUrl });
+    process.env.PIZZAPI_API_KEY = result.apiKey;
+    process.env.PIZZAPI_RELAY_URL = result.relayUrl;
+    logInfo(`paired — API key saved to ${join(agentDir, "config.json")}. Starting runner…`);
+    return null;
+}

--- a/packages/cli/src/runner/pairing.ts
+++ b/packages/cli/src/runner/pairing.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { hostname } from "node:os";
 import { join } from "node:path";
 import { loadGlobalConfig, saveConfigAt } from "../config.js";
+import { toHttpRelayUrl } from "../relay-url.js";
 import { requestHeadlessPairing } from "../setup.js";
 import { logError, logInfo, logWarn } from "./logger.js";
 
@@ -119,13 +120,17 @@ export async function ensureRunnerCredentials(agentDir: string): Promise<number 
     const statusPath = pairingStatusPath(agentDir);
     logInfo(`no credentials found — pairing with ${relayUrl} as "${label}"…`);
 
-    const result = await requestHeadlessPairing(relayUrl!, {
+    // The setup-claim REST endpoints need http(s) — but `relayUrl` here may
+    // already be the ws(s) form a *previous* pairing left in config.json
+    // (apiKey cleared without also clearing relayUrl). See relay-url.ts.
+    const claimRelayUrl = toHttpRelayUrl(relayUrl!);
+    const result = await requestHeadlessPairing(claimRelayUrl, {
         label,
         onClaim: (info) =>
             writePairingStatus(statusPath, {
                 claimUrl: info.claimUrl,
                 expiresAt: info.expiresAt,
-                relayUrl: relayUrl!,
+                relayUrl: claimRelayUrl,
                 startedAt: new Date().toISOString(),
             }),
     });

--- a/packages/cli/src/runner/runner-state.test.ts
+++ b/packages/cli/src/runner/runner-state.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireStateAndIdentity, isPidRunning, releaseStateLock } from "./runner-state.js";
+import { acquireStateAndIdentity, getPidStartTime, isPidReused, isPidRunning, releaseStateLock } from "./runner-state.js";
 
 describe("runner-state", () => {
     let tmpHome: string;
@@ -109,6 +109,64 @@ describe("runner-state", () => {
         }
     });
 
+    test("isPidReused: only says reused when both start times are known and differ", () => {
+        expect(isPidReused("100", "100")).toBe(false); // same process
+        expect(isPidReused("100", "200")).toBe(true); // PID recycled by a newer process
+        expect(isPidReused(undefined, "200")).toBe(false); // no recorded value — can't tell, trust liveness
+        expect(isPidReused("100", null)).toBe(false); // current unreadable — can't tell, trust liveness
+        expect(isPidReused(null, null)).toBe(false);
+    });
+
+    test("getPidStartTime returns a stable, non-empty value for a live process", async () => {
+        const runner = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)", "runner-lock"]);
+        try {
+            expect(runner.pid).toBeDefined();
+            const a = getPidStartTime(runner.pid!);
+            const b = getPidStartTime(runner.pid!);
+            expect(a).toBeString();
+            expect(a).toBe(b as string);
+        } finally {
+            runner.kill("SIGTERM");
+            await new Promise((resolve) => runner.once("exit", resolve));
+        }
+    });
+
+    test("acquireStateAndIdentity clears a lock whose PID was reused by a different process (container restart)", async () => {
+        const statePath = join(tmpHome, ".pizzapi", "runner.json");
+        mkdirSync(join(tmpHome, ".pizzapi"), { recursive: true });
+        const runner = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)", "runner-lock"]);
+
+        try {
+            expect(runner.pid).toBeDefined();
+            writeFileSync(
+                statePath,
+                JSON.stringify(
+                    {
+                        pid: runner.pid,
+                        // Deliberately wrong start time — simulates a stale lock left
+                        // by a different (now-dead) process that happened to reuse
+                        // this exact PID, e.g. across a container restart.
+                        pidStartTime: "not-the-real-start-time",
+                        startedAt: "2024-01-01T00:00:00.000Z",
+                        runnerId: "runner-123",
+                        runnerSecret: "secret-abc",
+                    },
+                    null,
+                    2,
+                ),
+            );
+
+            const identity = acquireStateAndIdentity(statePath);
+            const state = JSON.parse(readFileSync(statePath, "utf-8"));
+
+            expect(identity).toEqual({ runnerId: "runner-123", runnerSecret: "secret-abc" });
+            expect(state.pid).toBe(process.pid);
+        } finally {
+            runner.kill("SIGTERM");
+            await new Promise((resolve) => runner.once("exit", resolve));
+        }
+    });
+
     test("acquireStateAndIdentity exits when a live runner already holds the lock", async () => {
         const statePath = join(tmpHome, ".pizzapi", "runner.json");
         mkdirSync(join(tmpHome, ".pizzapi"), { recursive: true });
@@ -121,6 +179,41 @@ describe("runner-state", () => {
                 JSON.stringify(
                     {
                         pid: runner.pid,
+                        startedAt: "2024-01-01T00:00:00.000Z",
+                        runnerId: "runner-123",
+                        runnerSecret: "secret-abc",
+                    },
+                    null,
+                    2,
+                ),
+            );
+
+            (process as any).exit = (code?: number) => {
+                throw new Error(`process.exit:${code ?? 0}`);
+            };
+
+            expect(() => acquireStateAndIdentity(statePath)).toThrow("process.exit:1");
+        } finally {
+            process.exit = originalExit;
+            runner.kill("SIGTERM");
+            await new Promise((resolve) => runner.once("exit", resolve));
+        }
+    });
+
+    test("acquireStateAndIdentity exits when the recorded start time still matches (genuinely the same live process)", async () => {
+        const statePath = join(tmpHome, ".pizzapi", "runner.json");
+        mkdirSync(join(tmpHome, ".pizzapi"), { recursive: true });
+        const runner = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)", "runner-lock"]);
+        const originalExit = process.exit;
+
+        try {
+            expect(runner.pid).toBeDefined();
+            writeFileSync(
+                statePath,
+                JSON.stringify(
+                    {
+                        pid: runner.pid,
+                        pidStartTime: getPidStartTime(runner.pid!),
                         startedAt: "2024-01-01T00:00:00.000Z",
                         runnerId: "runner-123",
                         runnerSecret: "secret-abc",

--- a/packages/cli/src/runner/runner-state.ts
+++ b/packages/cli/src/runner/runner-state.ts
@@ -14,6 +14,7 @@ import { logInfo, logError, logWarn } from "./logger.js";
 // Schema:
 //   {
 //     "pid": 12345,            // PID of the currently-running daemon (lock)
+//     "pidStartTime": "...",   // OS-reported start time of `pid`, used to detect PID reuse (see getPidStartTime)
 //     "supervisorPid": 12344,  // PID of the outer supervisor process
 //     "startedAt": "<iso>",    // ISO timestamp of that daemon start
 //     "runnerId": "<uuid>",    // stable runner identity (never changes)
@@ -28,6 +29,7 @@ import { logInfo, logError, logWarn } from "./logger.js";
 
 export interface RunnerState {
     pid: number;
+    pidStartTime?: string;
     supervisorPid?: number;
     startedAt: string;
     runnerId: string;
@@ -42,6 +44,61 @@ export interface RunnerState {
 
 export function defaultStatePath(): string {
     return process.env.PIZZAPI_RUNNER_STATE_PATH ?? join(homedir(), ".pizzapi", "runner.json");
+}
+
+/**
+ * Get an OS-reported start time for `pid`, used to detect PID reuse.
+ *
+ * Why this matters: a freshly-started container resets its PID namespace to
+ * 1 every time, and with nothing else running before the daemon, its own
+ * process tree (tini -> supervisor -> daemon) gets the same deterministic
+ * low PIDs on every start. That means a stale lock left by a killed
+ * container's daemon can have the *exact* PID number the next container's
+ * brand-new daemon also gets assigned — PID liveness + cmdline pattern
+ * matching alone can't tell "still the same process" from "coincidentally
+ * reused PID", since both look identical. Start time can: the kernel's
+ * boot-relative clock keeps advancing across container restarts (they share
+ * the host kernel), so a reused PID always has a later start time than the
+ * dead process that had it before.
+ *
+ * Returns null when unavailable or unparseable — callers must treat that as
+ * "can't tell" and fall back to the existing PID+cmdline heuristic.
+ */
+export function getPidStartTime(pid: number): string | null {
+    if (process.platform === "linux") {
+        try {
+            const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+            // Fields after the executable name (in parens, which may itself
+            // contain spaces/parens) are space-separated starting at field 3
+            // (state). The comm field always ends at the LAST ")" on the line.
+            const closeParen = stat.lastIndexOf(")");
+            if (closeParen === -1) return null;
+            const rest = stat.slice(closeParen + 1).trim().split(/\s+/);
+            // rest[0] is field 3 (state), so field 22 (starttime) is rest[19].
+            const starttime = rest[19];
+            return starttime && /^\d+$/.test(starttime) ? starttime : null;
+        } catch {
+            return null;
+        }
+    }
+    try {
+        // macOS/BSD: wall-clock process start time (ticks-since-boot isn't
+        // exposed the same way, but lstart is equally stable across reuse).
+        const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf-8", timeout: 3000 }).trim();
+        return out || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Pure decision: does a matching PID + cmdline actually mean "same process"?
+ * Only says yes (reused) when we have BOTH a recorded and a freshly-read
+ * start time and they disagree — any missing value means "can't tell", which
+ * must fall back to treating the PID as still live (the old, safe behavior).
+ */
+export function isPidReused(recordedStartTime: string | null | undefined, currentStartTime: string | null): boolean {
+    return recordedStartTime != null && currentStartTime != null && currentStartTime !== recordedStartTime;
 }
 
 /**
@@ -74,12 +131,21 @@ export function acquireStateAndIdentity(statePath: string): { runnerId: string; 
             const pid = typeof existing.pid === "number" ? existing.pid : NaN;
             if (Number.isFinite(pid) && pid > 0) {
                 if (isPidRunning(pid)) {
-                    logError(`pizzapi runner already running (pid ${pid}, state: ${statePath}).`);
-                    logError(`   Stop the existing runner process first, e.g.: kill ${pid}`);
-                    process.exit(1);
+                    // Liveness + cmdline alone can be fooled by PID reuse (see
+                    // getPidStartTime). If we recorded a start time last run
+                    // and can read one now, a mismatch means this is a
+                    // different process that just landed on the same PID.
+                    const pidWasReused = isPidReused(existing.pidStartTime, getPidStartTime(pid));
+                    if (!pidWasReused) {
+                        logError(`pizzapi runner already running (pid ${pid}, state: ${statePath}).`);
+                        logError(`   Stop the existing runner process first, e.g.: kill ${pid}`);
+                        process.exit(1);
+                    }
+                    logInfo(`clearing stale lock (pid ${pid} was reused by a different process since state was last written)`);
+                } else {
+                    // PID is gone — stale lock.
+                    logInfo(`clearing stale lock (pid ${pid} is no longer a runner process)`);
                 }
-                // PID is gone or belongs to an unrelated process — stale lock.
-                logInfo(`clearing stale lock (pid ${pid} is no longer a runner process)`);
             }
         }
 
@@ -95,6 +161,7 @@ export function acquireStateAndIdentity(statePath: string): { runnerId: string; 
 
         const state: RunnerState = {
             pid: process.pid,
+            pidStartTime: getPidStartTime(process.pid) ?? undefined,
             supervisorPid: typeof existing.supervisorPid === "number" ? existing.supervisorPid : undefined,
             startedAt: new Date().toISOString(),
             runnerId,

--- a/packages/cli/src/runner/runner-state.ts
+++ b/packages/cli/src/runner/runner-state.ts
@@ -24,7 +24,8 @@ import { logInfo, logError, logWarn } from "./logger.js";
 //     "disconnectedAt": "<iso>", // when the socket last dropped
 //     "relayUrl": "...",       // relay URL the daemon is registered against
 //     "runnerName": "...",     // display name reported at registration
-//     "cliVersion": "..."      // CLI version reported at registration
+//     "cliVersion": "...",     // CLI version reported at registration
+//     "authRejected": false    // true when the relay's last connect attempt rejected our API key
 //   }
 
 export interface RunnerState {
@@ -40,6 +41,8 @@ export interface RunnerState {
     relayUrl?: string;
     runnerName?: string;
     cliVersion?: string;
+    /** True when the relay's last connect attempt rejected our API key (vs. an ordinary network failure). */
+    authRejected?: boolean;
 }
 
 export function defaultStatePath(): string {

--- a/packages/cli/src/runner/runner-state.ts
+++ b/packages/cli/src/runner/runner-state.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { randomBytes, randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { logInfo, logError } from "./logger.js";
+import { logInfo, logError, logWarn } from "./logger.js";
 
 // ── Runner state file (~/.pizzapi/runner.json) ────────────────────────────────
 //
@@ -17,7 +17,13 @@ import { logInfo, logError } from "./logger.js";
 //     "supervisorPid": 12344,  // PID of the outer supervisor process
 //     "startedAt": "<iso>",    // ISO timestamp of that daemon start
 //     "runnerId": "<uuid>",    // stable runner identity (never changes)
-//     "runnerSecret": "<hex>"  // 32-byte secret used to re-authenticate
+//     "runnerSecret": "<hex>", // 32-byte secret used to re-authenticate
+//     "connected": true,       // whether the daemon is currently registered with the relay
+//     "connectedAt": "<iso>",  // when the last successful registration happened
+//     "disconnectedAt": "<iso>", // when the socket last dropped
+//     "relayUrl": "...",       // relay URL the daemon is registered against
+//     "runnerName": "...",     // display name reported at registration
+//     "cliVersion": "..."      // CLI version reported at registration
 //   }
 
 export interface RunnerState {
@@ -26,6 +32,12 @@ export interface RunnerState {
     startedAt: string;
     runnerId: string;
     runnerSecret: string;
+    connected?: boolean;
+    connectedAt?: string;
+    disconnectedAt?: string;
+    relayUrl?: string;
+    runnerName?: string;
+    cliVersion?: string;
 }
 
 export function defaultStatePath(): string {
@@ -120,6 +132,34 @@ export function releaseStateLock(statePath: string) {
         writeFileSync(statePath, JSON.stringify(updated, null, 2), { encoding: "utf-8", mode: 0o600 });
     } catch {
         // Best-effort — ignore errors on shutdown.
+    }
+}
+
+/**
+ * Read-modify-write a partial patch onto the state file, preserving any
+ * fields this process doesn't know about. Used by the daemon to record
+ * relay connection state (connected/connectedAt/...) without racing the
+ * pid-lock fields above.
+ *
+ * Best-effort: never throws. Writes via temp-file + rename in the same
+ * directory so a concurrent `runner status` read never sees a truncated file.
+ */
+export function patchRunnerState(statePath: string, patch: Partial<RunnerState>): void {
+    try {
+        let existing: Partial<RunnerState> = {};
+        if (existsSync(statePath)) {
+            try {
+                existing = JSON.parse(readFileSync(statePath, "utf-8")) as Partial<RunnerState>;
+            } catch {
+                // Corrupt file — overwrite with just the patch below.
+            }
+        }
+        const updated = { ...existing, ...patch };
+        const tmpPath = `${statePath}.tmp-${process.pid}`;
+        writeFileSync(tmpPath, JSON.stringify(updated, null, 2), { encoding: "utf-8", mode: 0o600 });
+        renameSync(tmpPath, statePath);
+    } catch (err: any) {
+        logWarn(`Failed to patch runner state at ${statePath}: ${err?.message ?? String(err)}`);
     }
 }
 

--- a/packages/cli/src/runner/status.test.ts
+++ b/packages/cli/src/runner/status.test.ts
@@ -49,6 +49,17 @@ describe("evaluateRunnerStatus", () => {
         expect(result.reason).toBe("process not running");
     });
 
+    test("unhealthy: relay rejected credentials", () => {
+        const result = evaluateRunnerStatus({ pid: 123, connected: false, authRejected: true }, alive);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("relay rejected credentials — check PIZZAPI_API_KEY / re-pair");
+    });
+
+    test("authRejected is ignored once actually connected", () => {
+        const result = evaluateRunnerStatus({ pid: 123, connected: true, authRejected: true }, alive);
+        expect(result.healthy).toBe(true);
+    });
+
     test("unhealthy: pairing pending (no state file yet)", () => {
         const result = evaluateRunnerStatus(null, alive, {
             claimUrl: "http://relay/setup-claim?t=abc",

--- a/packages/cli/src/runner/status.test.ts
+++ b/packages/cli/src/runner/status.test.ts
@@ -48,6 +48,23 @@ describe("evaluateRunnerStatus", () => {
         expect(result.healthy).toBe(false);
         expect(result.reason).toBe("process not running");
     });
+
+    test("unhealthy: pairing pending (no state file yet)", () => {
+        const result = evaluateRunnerStatus(null, alive, {
+            claimUrl: "http://relay/setup-claim?t=abc",
+            relayUrl: "http://relay",
+            startedAt: "2024-01-01T00:00:00.000Z",
+        });
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toContain("pairing pending");
+        expect(result.pairingUrl).toBe("http://relay/setup-claim?t=abc");
+    });
+
+    test("no state and no pairing file: unchanged generic reason", () => {
+        const result = evaluateRunnerStatus(null, alive, null);
+        expect(result.reason).toBe("no runner state file found");
+        expect(result.pairingUrl).toBeUndefined();
+    });
 });
 
 describe("patchRunnerState", () => {

--- a/packages/cli/src/runner/status.test.ts
+++ b/packages/cli/src/runner/status.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { patchRunnerState } from "./runner-state.js";
+import { evaluateRunnerStatus } from "./status.js";
+
+const alive = (_pid: number) => true;
+const dead = (_pid: number) => false;
+
+describe("evaluateRunnerStatus", () => {
+    test("healthy: state exists, pid alive, connected", () => {
+        const result = evaluateRunnerStatus(
+            { pid: 123, connected: true, startedAt: "2024-01-01T00:00:00.000Z", runnerId: "r1" },
+            alive,
+        );
+        expect(result.healthy).toBe(true);
+        expect(result.reason).toBeUndefined();
+        expect(result.connected).toBe(true);
+    });
+
+    test("unhealthy: no state file", () => {
+        const result = evaluateRunnerStatus(null, alive);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("no runner state file found");
+    });
+
+    test("unhealthy: dead pid", () => {
+        const result = evaluateRunnerStatus({ pid: 123, connected: true }, dead);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("process not running");
+    });
+
+    test("unhealthy: connected false", () => {
+        const result = evaluateRunnerStatus({ pid: 123, connected: false }, alive);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("not registered with relay");
+    });
+
+    test("unhealthy: connected missing entirely (never registered)", () => {
+        const result = evaluateRunnerStatus({ pid: 123 }, alive);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("not registered with relay");
+    });
+
+    test("unhealthy: no pid recorded", () => {
+        const result = evaluateRunnerStatus({ connected: true }, alive);
+        expect(result.healthy).toBe(false);
+        expect(result.reason).toBe("process not running");
+    });
+});
+
+describe("patchRunnerState", () => {
+    let tmpHome: string;
+    let statePath: string;
+
+    beforeEach(() => {
+        tmpHome = mkdtempSync(join(tmpdir(), "runner-status-test-"));
+        mkdirSync(join(tmpHome, ".pizzapi"), { recursive: true });
+        statePath = join(tmpHome, ".pizzapi", "runner.json");
+    });
+
+    afterEach(() => {
+        rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    test("preserves unknown fields while merging the patch", () => {
+        writeFileSync(
+            statePath,
+            JSON.stringify({ pid: 1, runnerId: "r1", runnerSecret: "s1", startedAt: "t0" }, null, 2),
+        );
+
+        patchRunnerState(statePath, { connected: true, connectedAt: "2024-01-01T00:00:00.000Z" });
+
+        const state = JSON.parse(readFileSync(statePath, "utf-8"));
+        expect(state).toMatchObject({
+            pid: 1,
+            runnerId: "r1",
+            runnerSecret: "s1",
+            startedAt: "t0",
+            connected: true,
+            connectedAt: "2024-01-01T00:00:00.000Z",
+        });
+    });
+
+    test("creates the file if it doesn't exist yet", () => {
+        patchRunnerState(statePath, { connected: false });
+        const state = JSON.parse(readFileSync(statePath, "utf-8"));
+        expect(state).toEqual({ connected: false });
+    });
+
+    test("never throws on an unwritable path", () => {
+        expect(() => patchRunnerState(join(tmpHome, "no-such-dir", "runner.json"), { connected: true })).not.toThrow();
+    });
+});

--- a/packages/cli/src/runner/status.ts
+++ b/packages/cli/src/runner/status.ts
@@ -12,7 +12,9 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { c } from "../cli-colors.js";
+import { resolveAgentDir } from "../config.js";
 import { defaultStatePath, isPidRunning, type RunnerState } from "./runner-state.js";
+import { pairingStatusPath, readPairingStatus, type PairingStatus } from "./pairing.js";
 import { formatDuration } from "./services/time-utils.js";
 
 export interface RunnerStatusResult {
@@ -25,6 +27,8 @@ export interface RunnerStatusResult {
     pid?: number;
     startedAt?: string;
     cliVersion?: string;
+    /** Set only while an auto-pairing claim is pending approval. */
+    pairingUrl?: string;
 }
 
 /**
@@ -34,8 +38,20 @@ export interface RunnerStatusResult {
 export function evaluateRunnerStatus(
     state: Partial<RunnerState> | null,
     isAlive: (pid: number) => boolean,
+    pairing?: PairingStatus | null,
 ): RunnerStatusResult {
     if (!state) {
+        // Auto-pairing runs before the daemon (and its state file) exist, so a
+        // pending claim is the only thing that can explain "no state" without
+        // it just meaning "never started".
+        if (pairing) {
+            return {
+                healthy: false,
+                reason: `pairing pending — approve at ${pairing.claimUrl}`,
+                connected: false,
+                pairingUrl: pairing.claimUrl,
+            };
+        }
         return { healthy: false, reason: "no runner state file found", connected: false };
     }
 
@@ -73,7 +89,8 @@ export async function runStatus(args: string[] = []): Promise<number> {
     const asJson = args.includes("--json");
     const statePath = defaultStatePath();
     const state = readState(statePath);
-    const result = evaluateRunnerStatus(state, isPidRunning);
+    const pairing = state ? null : readPairingStatus(pairingStatusPath(resolveAgentDir()));
+    const result = evaluateRunnerStatus(state, isPidRunning, pairing);
 
     if (asJson) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/runner/status.ts
+++ b/packages/cli/src/runner/status.ts
@@ -1,0 +1,102 @@
+/**
+ * `runner status [--json]` — health probe for the running PizzaPi runner daemon.
+ *
+ * Answers "is this runner alive AND registered with the relay?" by combining
+ * a PID liveness check with the `connected` flag the daemon patches into the
+ * state file on register/disconnect (see runner-state.ts / daemon.ts).
+ *
+ * Exit 0 = healthy, exit 1 = not — this is what a Docker HEALTHCHECK
+ * consumes, so this command stays fast and dependency-light: no relay
+ * round-trip, no config/model loading, no dynamic import of the daemon.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { c } from "../cli-colors.js";
+import { defaultStatePath, isPidRunning, type RunnerState } from "./runner-state.js";
+import { formatDuration } from "./services/time-utils.js";
+
+export interface RunnerStatusResult {
+    healthy: boolean;
+    reason?: string;
+    runnerId?: string;
+    runnerName?: string;
+    relayUrl?: string;
+    connected: boolean;
+    pid?: number;
+    startedAt?: string;
+    cliVersion?: string;
+}
+
+/**
+ * Pure decision logic, factored out so tests don't need real processes.
+ * `isAlive` is injected (normally `isPidRunning`) for the same reason.
+ */
+export function evaluateRunnerStatus(
+    state: Partial<RunnerState> | null,
+    isAlive: (pid: number) => boolean,
+): RunnerStatusResult {
+    if (!state) {
+        return { healthy: false, reason: "no runner state file found", connected: false };
+    }
+
+    const pid = typeof state.pid === "number" ? state.pid : 0;
+    const base: RunnerStatusResult = {
+        healthy: false,
+        runnerId: state.runnerId,
+        runnerName: state.runnerName,
+        relayUrl: state.relayUrl,
+        connected: state.connected === true,
+        pid: pid || undefined,
+        startedAt: state.startedAt,
+        cliVersion: state.cliVersion,
+    };
+
+    if (!pid || !isAlive(pid)) {
+        return { ...base, reason: "process not running" };
+    }
+    if (state.connected !== true) {
+        return { ...base, reason: "not registered with relay" };
+    }
+    return { ...base, healthy: true };
+}
+
+function readState(statePath: string): Partial<RunnerState> | null {
+    if (!existsSync(statePath)) return null;
+    try {
+        return JSON.parse(readFileSync(statePath, "utf-8"));
+    } catch {
+        return null;
+    }
+}
+
+export async function runStatus(args: string[] = []): Promise<number> {
+    const asJson = args.includes("--json");
+    const statePath = defaultStatePath();
+    const state = readState(statePath);
+    const result = evaluateRunnerStatus(state, isPidRunning);
+
+    if (asJson) {
+        console.log(JSON.stringify(result, null, 2));
+        return result.healthy ? 0 : 1;
+    }
+
+    if (!state) {
+        console.log(c.error("Runner not running.") + c.dim(` (${result.reason})`));
+        return 1;
+    }
+
+    const uptime = result.startedAt
+        ? formatDuration(Date.now() - new Date(result.startedAt).getTime())
+        : c.dim("unknown");
+    console.log(`${c.bold(result.runnerName ?? "runner")} ${c.dim(result.runnerId ?? "unknown")}`);
+    console.log(`  ${c.dim("relay")}      ${result.relayUrl ?? c.dim("unknown")}`);
+    console.log(`  ${c.dim("connected")}  ${result.connected ? c.success("true") : c.error("false")}`);
+    console.log(`  ${c.dim("uptime")}     ${uptime}`);
+    console.log(`  ${c.dim("pid")}        ${result.pid ?? c.dim("unknown")}`);
+    console.log(`  ${c.dim("version")}    ${result.cliVersion ?? c.dim("unknown")}`);
+    if (!result.healthy) {
+        console.log(c.warning(`unhealthy: ${result.reason}`));
+    }
+
+    return result.healthy ? 0 : 1;
+}

--- a/packages/cli/src/runner/status.ts
+++ b/packages/cli/src/runner/status.ts
@@ -71,6 +71,9 @@ export function evaluateRunnerStatus(
         return { ...base, reason: "process not running" };
     }
     if (state.connected !== true) {
+        if (state.authRejected) {
+            return { ...base, reason: "relay rejected credentials — check PIZZAPI_API_KEY / re-pair" };
+        }
         return { ...base, reason: "not registered with relay" };
     }
     return { ...base, healthy: true };

--- a/packages/cli/src/runner/supervisor.ts
+++ b/packages/cli/src/runner/supervisor.ts
@@ -29,11 +29,21 @@ import { fileURLToPath } from "node:url";
 import { defaultStatePath } from "./runner-state.js";
 import { setLogComponent, logInfo, logError } from "./logger.js";
 import { forceKillTree, SHUTDOWN_MESSAGE } from "./process-kill.js";
+import { resolveAgentDir } from "../config.js";
+import { ensureRunnerCredentials } from "./pairing.js";
 
 const RESTART_DELAY_BASE = 2_000;  // 2 s
 const RESTART_DELAY_MAX  = 60_000; // 60 s
 
 export async function runSupervisor(_args: string[] = []): Promise<number> {
+    setLogComponent("supervisor");
+
+    // Auto-pair before the daemon (and its runner.json pid lock) ever exist —
+    // if no usable credential is configured, this blocks here printing a QR /
+    // approval URL instead of the daemon failing fast after acquiring the lock.
+    const pairingExitCode = await ensureRunnerCredentials(resolveAgentDir());
+    if (pairingExitCode !== null) return pairingExitCode;
+
     // Resolve the CLI entry point so we can re-spawn it with `_daemon`.
     // Works from TypeScript source, compiled dist, and standalone binaries.
     // Detect compiled Bun single-file binary.
@@ -109,7 +119,6 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
         // Best-effort — the daemon will create the file if it doesn't exist.
     }
 
-    setLogComponent("supervisor");
     logInfo("starting runner daemon as subprocess…");
 
     while (true) {

--- a/packages/cli/src/secrets.test.ts
+++ b/packages/cli/src/secrets.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expandFileBackedEnv, seedAuthFileIfNeeded } from "./secrets.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-secrets-test-"));
+});
+
+afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("expandFileBackedEnv", () => {
+    test("populates a credential-shaped var from its _FILE path", () => {
+        const path = join(tmpDir, "key");
+        writeFileSync(path, "  secret-value  \n");
+        const env: NodeJS.ProcessEnv = { ANTHROPIC_API_KEY_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.ANTHROPIC_API_KEY).toBe("secret-value");
+    });
+
+    test("handles GH_TOKEN_FILE (ends in _TOKEN)", () => {
+        const path = join(tmpDir, "token");
+        writeFileSync(path, "ghp_abc123\n");
+        const env: NodeJS.ProcessEnv = { GH_TOKEN_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.GH_TOKEN).toBe("ghp_abc123");
+    });
+
+    test("handles the explicit PizzaPi names", () => {
+        const path = join(tmpDir, "pizzapikey");
+        writeFileSync(path, "pk-123");
+        const env: NodeJS.ProcessEnv = { PIZZAPI_API_KEY_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.PIZZAPI_API_KEY).toBe("pk-123");
+    });
+
+    test("leaves a non-credential *_FILE var alone", () => {
+        const path = join(tmpDir, "auth.db");
+        writeFileSync(path, "binary-ish-content");
+        const env: NodeJS.ProcessEnv = { NTFY_AUTH_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.NTFY_AUTH).toBeUndefined();
+    });
+
+    test("an already-set var wins over its _FILE counterpart", () => {
+        const path = join(tmpDir, "key");
+        writeFileSync(path, "from-file");
+        const env: NodeJS.ProcessEnv = { ANTHROPIC_API_KEY: "from-env", ANTHROPIC_API_KEY_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.ANTHROPIC_API_KEY).toBe("from-env");
+    });
+
+    test("an empty string counts as unset and still gets expanded", () => {
+        const path = join(tmpDir, "key");
+        writeFileSync(path, "from-file");
+        const env: NodeJS.ProcessEnv = { ANTHROPIC_API_KEY: "", ANTHROPIC_API_KEY_FILE: path };
+        expandFileBackedEnv(env);
+        expect(env.ANTHROPIC_API_KEY).toBe("from-file");
+    });
+
+    test("unreadable file is skipped without throwing", () => {
+        const env: NodeJS.ProcessEnv = { OPENAI_API_KEY_FILE: join(tmpDir, "does-not-exist") };
+        expect(() => expandFileBackedEnv(env)).not.toThrow();
+        expect(env.OPENAI_API_KEY).toBeUndefined();
+    });
+});
+
+describe("seedAuthFileIfNeeded", () => {
+    test("seeds auth.json when missing", () => {
+        const src = join(tmpDir, "src-auth.json");
+        writeFileSync(src, JSON.stringify({ anthropic: { key: "x" } }));
+        const agentDir = join(tmpDir, "agent");
+        mkdirSync(agentDir, { recursive: true });
+
+        seedAuthFileIfNeeded(agentDir, { PIZZAPI_AUTH_FILE: src });
+
+        const dest = join(agentDir, "auth.json");
+        expect(readFileSync(dest, "utf-8")).toBe(readFileSync(src, "utf-8"));
+    });
+
+    test("keeps an existing auth.json (never clobbers)", () => {
+        const src = join(tmpDir, "src-auth.json");
+        writeFileSync(src, JSON.stringify({ anthropic: { key: "new" } }));
+        const agentDir = join(tmpDir, "agent");
+        mkdirSync(agentDir, { recursive: true });
+        const dest = join(agentDir, "auth.json");
+        writeFileSync(dest, JSON.stringify({ anthropic: { key: "existing-refreshed" } }));
+
+        seedAuthFileIfNeeded(agentDir, { PIZZAPI_AUTH_FILE: src });
+
+        expect(readFileSync(dest, "utf-8")).toContain("existing-refreshed");
+    });
+
+    test("no-op when PIZZAPI_AUTH_FILE is unset", () => {
+        const agentDir = join(tmpDir, "agent");
+        mkdirSync(agentDir, { recursive: true });
+        seedAuthFileIfNeeded(agentDir, {});
+        expect(() => readFileSync(join(agentDir, "auth.json"), "utf-8")).toThrow();
+    });
+});

--- a/packages/cli/src/secrets.ts
+++ b/packages/cli/src/secrets.ts
@@ -1,0 +1,74 @@
+/**
+ * File-backed secrets for container/K8s deployments.
+ *
+ * Docker/K8s secrets are mounted as files, not env vars \u2014 these two helpers
+ * bridge that gap without ever logging a credential value:
+ *
+ *   1. `expandFileBackedEnv` \u2014 `FOO_FILE=/path` \u2192 `FOO=<trimmed file contents>`,
+ *      restricted to credential-shaped names so an unrelated `*_FILE` var
+ *      (e.g. NTFY_AUTH_FILE pointing at a binary DB) is never touched.
+ *   2. `seedAuthFileIfNeeded` \u2014 copies `PIZZAPI_AUTH_FILE` into the agent
+ *      dir's auth.json on first boot, without ever clobbering an existing
+ *      one (OAuth refresh writes back to it).
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("secrets");
+
+/** `<NAME>_FILE` is only expanded when `<NAME>` looks like a credential. */
+function isCredentialShaped(name: string): boolean {
+    return name.endsWith("_KEY") || name.endsWith("_TOKEN");
+}
+
+/**
+ * Expand `<NAME>_FILE` env vars into `<NAME>` for credential-shaped names
+ * (ends in `_API_KEY` / `_TOKEN` / `_KEY`, e.g. ANTHROPIC_API_KEY_FILE,
+ * GH_TOKEN_FILE, PIZZAPI_API_KEY_FILE). Skips a name that's already set
+ * (env wins) and any file that can't be read. Never logs values.
+ */
+export function expandFileBackedEnv(env: NodeJS.ProcessEnv = process.env): void {
+    for (const key of Object.keys(env)) {
+        if (!key.endsWith("_FILE")) continue;
+        const name = key.slice(0, -"_FILE".length);
+        if (!isCredentialShaped(name)) continue;
+        if (env[name]) continue; // already set — wins
+        const path = env[key];
+        if (!path) continue;
+        try {
+            const contents = readFileSync(path, "utf-8").trim();
+            if (!contents) continue;
+            env[name] = contents;
+            log.info(`${name} populated from ${path}`);
+        } catch (err) {
+            log.warn(`Could not read ${key}=${path}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+}
+
+/**
+ * Seed `<agentDir>/auth.json` from `PIZZAPI_AUTH_FILE` on first boot.
+ * Never overwrites an existing auth.json — OAuth refresh writes back to it,
+ * so clobbering on every restart would destroy refreshed tokens.
+ */
+export function seedAuthFileIfNeeded(agentDir: string, env: NodeJS.ProcessEnv = process.env): void {
+    const src = env.PIZZAPI_AUTH_FILE;
+    if (!src) return;
+    const dest = join(agentDir, "auth.json");
+    if (existsSync(dest)) {
+        log.info(`auth.json already exists at ${dest} — keeping existing credentials (PIZZAPI_AUTH_FILE ignored)`);
+        return;
+    }
+    if (!existsSync(src)) {
+        log.warn(`PIZZAPI_AUTH_FILE=${src} is not readable — skipping seed`);
+        return;
+    }
+    try {
+        mkdirSync(agentDir, { recursive: true });
+        writeFileSync(dest, readFileSync(src, "utf-8"), { encoding: "utf-8", mode: 0o600 });
+        log.info(`seeded auth.json from ${src}`);
+    } catch (err) {
+        log.warn(`Failed to seed auth.json from ${src}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -2,8 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runQrSetup, qrCodeUrl, requestHeadlessPairing } from "./setup.js";
-import qrcode from "qrcode";
+import { runQrSetup, qrCodeUrl, renderQrCode, requestHeadlessPairing } from "./setup.js";
 import { _setGlobalConfigDir } from "./config/io.js";
 
 const originalHome = process.env.HOME;
@@ -27,12 +26,19 @@ describe("QR setup", () => {
         expect(url).toBe("http://localhost:7492/setup-claim?t=abc123");
     });
 
-    test("qrcode terminal renderer produces non-empty output for setup URL", async () => {
+    test("renderQrCode emits one line per module row with a 4-module quiet zone", async () => {
         const url = qrCodeUrl("http://localhost:7492", "test-token-123");
-        const rendered = await qrcode.toString(url, { type: "terminal", small: true });
-        expect(rendered.length).toBeGreaterThan(10);
-        // Terminal QR codes contain unicode block characters.
-        expect(rendered).toMatch(/[\u2580-\u259f█\s]+/);
+        const rendered = await renderQrCode(url);
+        const rows = rendered.split("\n");
+        // No half-block glyphs: every module row is its own line, so log viewers
+        // with line spacing can't slice a row in half.
+        expect(rendered).not.toMatch(/[\u2580-\u259f]/);
+        // 3 padded rows on each side + the renderer's own 1-module border.
+        expect(rows.slice(0, 3).every((r) => !r.includes("\x1b[40m"))).toBe(true);
+        expect(rows.slice(-3).every((r) => !r.includes("\x1b[40m"))).toBe(true);
+        // All rows are the same width in modules.
+        const widths = new Set(rows.map((r) => r.split("\x1b[0m").length));
+        expect(widths.size).toBe(1);
     });
 
     test("runQrSetup creates claim, prints QR, and saves config on approval", async () => {

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runQrSetup, qrCodeUrl } from "./setup.js";
+import { runQrSetup, qrCodeUrl, requestHeadlessPairing } from "./setup.js";
 import qrcode from "qrcode";
 import { _setGlobalConfigDir } from "./config/io.js";
 
@@ -100,6 +100,72 @@ describe("QR setup", () => {
         try {
             const ok = await runQrSetup(relayUrl, 10);
             expect(ok).toBe(false);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("requestHeadlessPairing sends the label, reports the claim URL, and resolves on approval", async () => {
+        const relayUrl = "http://localhost:7999";
+        const token = "headless-token";
+        const apiKey = "1".repeat(64);
+        let sentBody: any = null;
+        let pollCount = 0;
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = input.toString();
+            if (url === `${relayUrl}/api/setup-claim`) {
+                sentBody = JSON.parse(init?.body as string);
+                return new Response(JSON.stringify({ token, expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString() }), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                });
+            }
+            if (url === `${relayUrl}/api/setup-claim/${token}`) {
+                pollCount++;
+                if (pollCount < 2) return new Response(JSON.stringify({ status: "pending" }), { status: 200 });
+                return new Response(JSON.stringify({ status: "approved", apiKey }), { status: 200 });
+            }
+            return originalFetch(input, init);
+        }) as typeof fetch;
+
+        try {
+            let claimSeen: { claimUrl: string; expiresAt: string } | null = null;
+            const result = await requestHeadlessPairing(relayUrl, {
+                label: "my-runner",
+                pollIntervalMs: 5,
+                onClaim: (info) => { claimSeen = info; },
+            });
+            expect(sentBody).toEqual({ relayUrl, label: "my-runner" });
+            expect(claimSeen).not.toBeNull();
+            expect(claimSeen!.claimUrl).toBe(`${relayUrl}/setup-claim?t=${token}`);
+            expect(result).toEqual({ apiKey, relayUrl: "ws://localhost:7999" });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("requestHeadlessPairing never touches saveGlobalConfig or process.env — persistence is the caller's job", async () => {
+        const relayUrl = "http://localhost:7999";
+        const token = "headless-token-2";
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (input: RequestInfo | URL) => {
+            const url = input.toString();
+            if (url === `${relayUrl}/api/setup-claim`) {
+                return new Response(JSON.stringify({ token, expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString() }), { status: 200 });
+            }
+            if (url === `${relayUrl}/api/setup-claim/${token}`) {
+                return new Response(JSON.stringify({ status: "expired" }), { status: 200 });
+            }
+            return originalFetch(input);
+        }) as typeof fetch;
+
+        try {
+            delete process.env.PIZZAPI_API_KEY;
+            const result = await requestHeadlessPairing(relayUrl, { pollIntervalMs: 5 });
+            expect("error" in result).toBe(true);
+            expect(process.env.PIZZAPI_API_KEY).toBeUndefined();
         } finally {
             globalThis.fetch = originalFetch;
         }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -118,6 +118,36 @@ export function qrCodeUrl(relayUrl: string, token: string): string {
     return `${relayUrl}/setup-claim?t=${encodeURIComponent(token)}`;
 }
 
+const WHITE_MODULE = "\x1b[47m  \x1b[0m";
+
+/**
+ * Render a scannable terminal QR.
+ *
+ * ponytail: full-size renderer (one log line per module row) instead of
+ * `small: true` — the half-block glyphs pack two module rows into one text
+ * line, so any log viewer with line spacing (docker logs in the web UI)
+ * slices every row in half and nothing scans. Also pads the 1-module border
+ * out to the spec's 4-module quiet zone, since the surrounding terminal
+ * background is dark and would otherwise read as QR data.
+ */
+export async function renderQrCode(url: string): Promise<string> {
+    const rendered = await qrcode.toString(url, { type: "terminal", errorCorrectionLevel: "L" });
+    const rows = rendered.split("\n").filter((line) => line.length > 0);
+    const modulesWide = (rows[0]?.split("\x1b[0m").length ?? 1) - 1;
+    const side = WHITE_MODULE.repeat(3);
+    const blank = WHITE_MODULE.repeat(modulesWide + 6);
+    return [blank, blank, blank, ...rows.map((r) => side + r + side), blank, blank, blank].join("\n");
+}
+
+/** Write raw to stdout: log prefixes/timestamps would shift the first row. */
+async function printQrCode(url: string): Promise<void> {
+    try {
+        process.stdout.write(`\n${await renderQrCode(url)}\n\n`);
+    } catch (err) {
+        log.warn("Could not render QR code; use the URL below.", err instanceof Error ? err.message : String(err));
+    }
+}
+
 export async function runQrSetup(relayUrl: string, pollIntervalMs = 2000): Promise<boolean> {
     const configPath = join(homedir(), ".pizzapi", "config.json");
 
@@ -134,13 +164,7 @@ export async function runQrSetup(relayUrl: string, pollIntervalMs = 2000): Promi
     const wsRelayUrl = relayUrl.replace(/^http/, "ws");
 
     log.info("Scan this QR code with an authenticated PizzaPi web browser:");
-    log.info("");
-    try {
-        const qr = await qrcode.toString(claimUrl, { type: "terminal", small: true });
-        log.info(qr);
-    } catch (err) {
-        log.warn("Could not render QR code; use the URL below.", err instanceof Error ? err.message : String(err));
-    }
+    await printQrCode(claimUrl);
     log.info(c.dim("Or open:"), c.accent(claimUrl));
     log.info("");
     log.info(c.dim("Waiting for approval… (expires in 10 minutes)"));
@@ -215,13 +239,7 @@ export async function requestHeadlessPairing(
     };
 
     log.info("Scan this QR code with an authenticated PizzaPi web browser, or open the URL below:");
-    log.info("");
-    try {
-        const qr = await qrcode.toString(claimUrl, { type: "terminal", small: true });
-        log.info(qr);
-    } catch (err) {
-        log.warn("Could not render QR code; use the URL below.", err instanceof Error ? err.message : String(err));
-    }
+    await printQrCode(claimUrl);
     printUrl();
     log.info(c.dim("Waiting for approval\u2026 (expires in 10 minutes)"));
 

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -78,12 +78,15 @@ async function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function createSetupClaim(relayUrl: string): Promise<{ token: string; expiresAt: string } | { error: string }> {
+async function createSetupClaim(relayUrl: string, label?: string): Promise<{ token: string; expiresAt: string } | { error: string }> {
     try {
         const res = await fetch(`${relayUrl}/api/setup-claim`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ relayUrl }),
+            // `label` is a newer field (identifies the runner on the approval page
+            // and the minted key) — omit it when unset so older relays that don't
+            // know about it still get the exact same request body as before.
+            body: JSON.stringify(label ? { relayUrl, label } : { relayUrl }),
         });
         const json = (await res.json()) as { token?: string; expiresAt?: string; error?: string };
         if (!res.ok || !json.token) return { error: json.error ?? `HTTP ${res.status}` };
@@ -173,6 +176,82 @@ export async function runQrSetup(relayUrl: string, pollIntervalMs = 2000): Promi
     log.info("");
     log.error("Setup claim expired before approval. Please try again.\n");
     return false;
+}
+
+/**
+ * Non-interactive claim + poll flow, for contexts where readline prompts
+ * aren't usable (e.g. `pizza runner` auto-pairing in a container). Reuses
+ * the same `/api/setup-claim` endpoints as the interactive QR flow but
+ * never touches stdin, and leaves persistence to the caller — unlike
+ * `runQrSetup`, which saves straight to ~/.pizzapi/config.json, a headless
+ * runner may need to save into a different (configured) agent dir.
+ *
+ * Prints the QR code once and the approval URL immediately, then re-prints
+ * just the URL every `reprintIntervalMs` (~1 min) so it's visible again to
+ * an operator who runs `docker logs --tail` after the fact.
+ */
+export async function requestHeadlessPairing(
+    relayUrl: string,
+    opts: {
+        label?: string;
+        pollIntervalMs?: number;
+        maxWaitMs?: number;
+        reprintIntervalMs?: number;
+        /** Fired once the claim exists, before the wait loop starts. */
+        onClaim?: (info: { claimUrl: string; expiresAt: string }) => void;
+    } = {},
+): Promise<{ apiKey: string; relayUrl: string } | { error: string }> {
+    const claim = await createSetupClaim(relayUrl, opts.label);
+    if ("error" in claim) {
+        return { error: `Could not create setup claim: ${claim.error}` };
+    }
+
+    const claimUrl = qrCodeUrl(relayUrl, claim.token);
+    const wsRelayUrl = relayUrl.replace(/^http/, "ws");
+    opts.onClaim?.({ claimUrl, expiresAt: claim.expiresAt });
+
+    const printUrl = () => {
+        log.info(`${c.dim("Approve this runner at:")} ${c.accent(claimUrl)}`);
+    };
+
+    log.info("Scan this QR code with an authenticated PizzaPi web browser, or open the URL below:");
+    log.info("");
+    try {
+        const qr = await qrcode.toString(claimUrl, { type: "terminal", small: true });
+        log.info(qr);
+    } catch (err) {
+        log.warn("Could not render QR code; use the URL below.", err instanceof Error ? err.message : String(err));
+    }
+    printUrl();
+    log.info(c.dim("Waiting for approval\u2026 (expires in 10 minutes)"));
+
+    const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+    const maxWaitMs = opts.maxWaitMs ?? 10 * 60 * 1000;
+    const reprintIntervalMs = opts.reprintIntervalMs ?? 60_000;
+    const startedAt = Date.now();
+    let lastPrint = startedAt;
+
+    while (Date.now() - startedAt < maxWaitMs) {
+        await sleep(pollIntervalMs);
+        if (Date.now() - lastPrint >= reprintIntervalMs) {
+            printUrl();
+            lastPrint = Date.now();
+        }
+        const result = await pollSetupClaim(relayUrl, claim.token);
+        if ("error" in result) {
+            log.warn(`Poll failed: ${result.error}`);
+            continue;
+        }
+        if (result.status === "approved" && result.apiKey) {
+            log.info(`${c.success("\u2713")} Device approved\n`);
+            return { apiKey: result.apiKey, relayUrl: wsRelayUrl };
+        }
+        if (result.status === "expired" || result.status === "redeemed") {
+            return { error: `Setup claim ${result.status}` };
+        }
+    }
+
+    return { error: "Setup claim expired before approval" };
 }
 
 /**

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
                     label: "Deployment",
                     items: [
                         { label: "Self-Hosting", slug: "deployment/self-hosting" },
+                        { label: "Runner Container", slug: "deployment/runner-container" },
                         { label: "Tailscale HTTPS", slug: "deployment/tailscale" },
                         { label: "macOS Service", slug: "deployment/mac-setup" },
                     ],

--- a/packages/docs/src/content/docs/deployment/runner-container.mdx
+++ b/packages/docs/src/content/docs/deployment/runner-container.mdx
@@ -159,14 +159,20 @@ That key shows up individually in the relay's Settings → API Keys, labeled by 
 
 Opt out with `PIZZAPI_PAIRING=0` if you'd rather the container fail fast with an actionable error than sit there waiting for a human to click a link (e.g. for the secrets-file path below, or any automated provisioning where no one will be watching the logs).
 
-**Re-pairing after revoking a key.** Revoking the minted key in the web UI doesn't make the runner forget it — the stale key is only in `config.json` in the data volume. To force a fresh pairing, remove the stored credential and restart (this assumes the pairing-first setup above, with no `PIZZAPI_API_KEY` env var set on the service — if you also have `PIZZAPI_API_KEY` in the environment, that still wins over the now-revoked value in `config.json`; remove it from Compose too):
+**Re-pairing after revoking a key.** Revoking the minted key in the web UI doesn't make the runner forget it — the stale key sits in `config.json` in the data volume until something replaces it. Run the same headless flow on demand instead of hand-editing the volume:
+
+```bash
+docker compose exec runner pizza runner pair --force
+```
+
+This prints a fresh approval URL + QR to the container's stdout (`docker compose logs -f runner` to see it if you're not attached), waits for approval, and overwrites `apiKey`/`relayUrl` in `config.json` on success. Without `--force` it refuses — non-zero exit, existing credential untouched — so it's safe to run speculatively to check what's configured. It also warns (and, without `--force`, refuses outright) if `PIZZAPI_API_KEY` or another credential env var is set on the service, since that would keep shadowing the freshly-paired key at runtime — remove it from Compose's `environment:` in that case. **A currently-running daemon keeps using its old credential in memory** even after a successful pair; the command says so and tells you to `docker compose restart runner` (or `pizza runner stop` + start again) to pick up the new key. See [`pizza runner pair`](/PizzaPi/running/cli-reference/#pizzapi-runner-pair) for the full flag/exit-code reference.
+
+The old manual fallback (remove `config.json` from the volume, then restart so auto-pairing kicks in) still works if you'd rather not run a command inside the container:
 
 ```bash
 docker compose exec runner rm /home/pizza/.pizzapi/config.json
 docker compose restart runner
 ```
-
-(If you've also persisted `auth.json`/provider credentials you want to keep, don't remove the whole volume — just `config.json`, which is what holds `apiKey`/`relayUrl`.)
 
 ### Docker/K8s secrets (alternative)
 

--- a/packages/docs/src/content/docs/deployment/runner-container.mdx
+++ b/packages/docs/src/content/docs/deployment/runner-container.mdx
@@ -18,9 +18,7 @@ Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your C
 ## Quick start
 
 <Steps>
-1. **Get a runner token.** Open your relay's web UI → Settings → **Runner Tokens** card → create one. It gives you the `PIZZAPI_RELAY_URL` and `PIZZAPI_API_KEY` values to copy.
-
-2. **Start the container** with Compose:
+1. **Start the container** with Compose — no API key needed yet:
 
    ```yaml
    # compose.yml
@@ -31,7 +29,6 @@ Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your C
        stop_grace_period: 30s
        environment:
          PIZZAPI_RELAY_URL: https://pizza.example.com
-         PIZZAPI_API_KEY: ${PIZZAPI_API_KEY}
          PIZZAPI_RUNNER_NAME: docker-runner
        volumes:
          - runner-data:/home/pizza/.pizzapi
@@ -51,12 +48,19 @@ Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your C
    docker run -d --name pizzapi-runner \
      --restart unless-stopped --stop-timeout 30 \
      -e PIZZAPI_RELAY_URL=https://pizza.example.com \
-     -e PIZZAPI_API_KEY="$PIZZAPI_API_KEY" \
      -e PIZZAPI_RUNNER_NAME=docker-runner \
      -v runner-data:/home/pizza/.pizzapi \
      -v "$(pwd)/projects:/workspace" \
      ghcr.io/pizzaface/pizzapi-runner:0.5.61
    ```
+
+2. **Approve it.** A container with no resolvable credential and a known relay URL auto-pairs on boot: it prints an approval URL + QR code to its logs (re-printed roughly every 60s while it waits) and polls for approval.
+
+   ```bash
+   docker compose logs -f runner
+   ```
+
+   Open the printed URL in a browser where you're already signed in to the relay, and approve. The runner then saves the minted key into the data volume and continues starting — no restart needed.
 
 3. **Confirm it registered:**
 
@@ -66,8 +70,10 @@ Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your C
    docker exec pizzapi-runner pizza runner status
    ```
 
-   Or check the relay's web UI — the runner shows up under its display name (`PIZZAPI_RUNNER_NAME`, defaulting to the container's hostname).
+   Or check the relay's web UI — the runner shows up under its display name (`PIZZAPI_RUNNER_NAME`, defaulting to the container's hostname), and the key it used shows up in Settings → API Keys as `runner-<name>`, individually revocable.
 </Steps>
+
+Prefer to skip the approval step entirely — automated provisioning, fleet rollout, `PIZZAPI_PAIRING=0` — see [Credentials](#credentials) below for the Docker/K8s-secrets alternative.
 
 If your relay is itself a Compose service, point at it by service name instead of a public URL:
 
@@ -145,15 +151,58 @@ The entrypoint detects it's running as uid 0, remaps the baked-in `pizza` accoun
 
 ## Credentials
 
-Two credential paths, same as bare-metal:
+### Pairing (recommended)
 
-1. **Environment variables** — `PIZZAPI_API_KEY`, provider keys (`ANTHROPIC_API_KEY`, etc.), ideally from your orchestrator's secret store.
-2. **Persisted `auth.json`** in the data volume — written by `pizza setup` / OAuth login run inside the container, survives recreation.
+A container with no resolvable relay credential and a known `PIZZAPI_RELAY_URL` auto-pairs on boot instead of failing: it mints a device-claim token, prints an approval URL + QR code to stdout (re-printed roughly every 60s while pending), and polls the relay. Approving it from an already-authenticated browser mints a fresh, dedicated API key — named `runner-<name>`, where `<name>` is `PIZZAPI_RUNNER_NAME` or the container's hostname if unset — and the runner saves it (plus the relay URL) into `config.json` in the data volume and continues starting, no restart required.
 
-macOS Keychain-stored credentials do **not** cross into the container — it's Linux. If you relied on keychain fallback on your Mac, you need an explicit env var or `auth.json` entry instead.
+That key shows up individually in the relay's Settings → API Keys, labeled by name, and can be revoked on its own without touching any other runner's credentials — unlike a hand-copied token shared across machines.
+
+Opt out with `PIZZAPI_PAIRING=0` if you'd rather the container fail fast with an actionable error than sit there waiting for a human to click a link (e.g. for the secrets-file path below, or any automated provisioning where no one will be watching the logs).
+
+**Re-pairing after revoking a key.** Revoking the minted key in the web UI doesn't make the runner forget it — the stale key is only in `config.json` in the data volume. To force a fresh pairing, remove the stored credential and restart (this assumes the pairing-first setup above, with no `PIZZAPI_API_KEY` env var set on the service — if you also have `PIZZAPI_API_KEY` in the environment, that still wins over the now-revoked value in `config.json`; remove it from Compose too):
+
+```bash
+docker compose exec runner rm /home/pizza/.pizzapi/config.json
+docker compose restart runner
+```
+
+(If you've also persisted `auth.json`/provider credentials you want to keep, don't remove the whole volume — just `config.json`, which is what holds `apiKey`/`relayUrl`.)
+
+### Docker/K8s secrets (alternative)
+
+For automated provisioning where pairing's human-approval step doesn't fit — CI, fleet rollout — mount credentials as files and point env vars at them instead:
+
+| Variable | Behavior |
+|---|---|
+| `<NAME>_FILE` (e.g. `PIZZAPI_API_KEY_FILE`, `ANTHROPIC_API_KEY_FILE`, `GH_TOKEN_FILE`) | Populates `<NAME>` from the trimmed contents of the file at that path, but **only** for credential-shaped names — ones ending in `_KEY` or `_TOKEN` (which covers `_API_KEY`). An already-set `<NAME>` wins over its `_FILE` counterpart. Any other `*_FILE` var (e.g. an app's own `NTFY_AUTH_FILE`) is left completely alone. |
+| `PIZZAPI_AUTH_FILE` | Seeds `<data volume>/auth.json` (mode `0600`) from the file at that path, but **only when `auth.json` doesn't already exist**. It never overwrites an existing one — OAuth refresh writes back to `auth.json` on every token refresh, so clobbering it on every restart would destroy already-refreshed credentials. |
+
+The deliberate `_KEY`/`_TOKEN` scoping matters: a blanket `*_FILE` → bare-name expansion would silently repurpose any unrelated app's own `FOO_FILE` convention (pointing at a config path, a binary DB, whatever) the moment it happened to share a name with something the runner reads — restricting it to credential-shaped suffixes keeps the behavior predictable.
+
+```yaml
+services:
+  runner:
+    environment:
+      PIZZAPI_API_KEY_FILE: /run/secrets/pizzapi_api_key
+      PIZZAPI_AUTH_FILE: /run/secrets/pizzapi_auth_json
+    secrets:
+      - pizzapi_api_key
+      - pizzapi_auth_json
+secrets:
+  pizzapi_api_key:
+    file: ./secrets/pizzapi_api_key.txt
+  pizzapi_auth_json:
+    file: ./secrets/auth.json
+```
+
+### Other notes
+
+macOS Keychain-stored credentials do **not** cross into the container — it's Linux. If you relied on keychain fallback on your Mac, you need an explicit env var, `_FILE` secret, or `auth.json` entry instead.
 
 <Aside type="caution" title="Worker sessions inherit almost all of the daemon's environment">
   Every env var set on the runner container — including Compose secrets meant for something else entirely — is forwarded to spawned agent sessions, except a small denylist: `PIZZAPI_RUNNER_TOKEN`, `PIZZAPI_RUNNER_API_KEY`, `PIZZAPI_SESSION_PROVIDER`, `NODE_OPTIONS`, `BUN_OPTIONS`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `DYLD_FORCE_FLAT_NAMESPACE`. There's no daemon-only secrecy for arbitrary env vars — if a sidecar's `DATABASE_URL` is on the runner's environment, an agent session can read it (`process.env`) and could put it in a file or shell command. Keep secrets a session shouldn't see out of the **runner's** environment; put them on the sidecar's environment instead.
+
+  This includes the runner's own relay key: the daemon passes its resolved `PIZZAPI_API_KEY` into every worker session's environment (`packages/cli/src/runner/session-spawner.ts`), because worker sessions connect to the relay themselves. **Pairing does not change this.** It shrinks the blast radius of a leak — a dedicated, individually revocable key instead of a master token shared across every runner — but any agent code running in the container can still read that key via `process.env` and do whatever a valid API key can do. Pairing is not session isolation; it's damage-limitation for the credential's scope and lifecycle.
 </Aside>
 
 ---
@@ -280,13 +329,14 @@ docker exec pizzapi-runner pizza runner status --json
 }
 ```
 
-When unhealthy, `reason` explains why (`"no runner state file found"`, `"process not running"`, or `"not registered with relay"`) — see the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status).
+When unhealthy, `reason` explains why — `"no runner state file found"`, `"process not running"`, `"not registered with relay"`, a pending-pairing message with the approval URL, or `"relay rejected credentials — check PIZZAPI_API_KEY / re-pair"` — see the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status).
 
 Other operational notes:
 
 - `restart: unless-stopped` + `stop_grace_period: 30s` — `docker stop` sends SIGTERM to `tini` (PID 1), which forwards it through the supervisor to the daemon, the same clean-shutdown path as running `pizza runner stop`. Give it the full 30s window to disconnect and release its lock before Docker sends SIGKILL.
 - Logs are the runner's stdout/stderr (`docker logs pizzapi-runner`). Rotation is Docker's/your logging driver's job, not the image's.
 - **Relay restarts are survivable and need no action.** If the relay goes away, the runner reconnects with backoff, re-registers under the same identity, and preserves its already-initialized runner services rather than tearing them down. Expect the container to report `unhealthy` for a healthcheck interval or two while that happens — don't wire an external supervisor to restart it on the first failed check.
+- **A fresh container waiting on pairing approval is also legitimately `unhealthy`**, for however long it takes a human to click the approval link — minutes, potentially, not one healthcheck interval. This is intentional: the `HEALTHCHECK` (`--start-period=45s --retries=3`) is left as-is rather than widened for pairing, because Docker's healthcheck only ever reports status here — nothing in this image restarts or kills the container for failing it, so a long unhealthy window costs nothing. Don't wire an autoheal/restart-on-unhealthy supervisor on top of this image; the moment one exists, an unattended pairing window turns into a restart loop instead of a runner patiently waiting for a click.
 - Resource limits (`mem_limit`, `cpus`, ...) apply to the whole container — every session and its child processes share them. Size for your heaviest concurrent session load, not one session.
 - **Upgrade** by pulling a new version tag and recreating the container; the data volume carries identity, auth, and transcripts forward:
 
@@ -302,7 +352,8 @@ Other operational notes:
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Container unhealthy | Unreachable relay, or wrong `PIZZAPI_RELAY_URL` scheme | `docker exec <ctr> pizza runner status` for the exact `reason`; check the URL scheme matches the relay's actual setup |
-| Logs stop after `connecting to relay at ...` and never say `registered as ...`; status shows `connected false` / `not registered with relay` | Invalid `PIZZAPI_API_KEY`. The socket connects before the key is validated, so a bad key looks like a hang rather than an auth error | Check the **relay's** logs for `Failed to validate API key`, then issue a fresh runner token. Note an `apiKey` in a host `config.json` is not automatically the one your shell has in `PIZZAPI_API_KEY` — confirm which one you're passing |
+| Logs show `[relay] rejected our API key at ... — check PIZZAPI_API_KEY ... or re-pair this runner`; status shows `connected false` / `relay rejected credentials — check PIZZAPI_API_KEY / re-pair` | Invalid or revoked `PIZZAPI_API_KEY` (or a stale key left in `config.json` from a prior pairing). The daemon watches for socket.io's `unauthorized` connect error and logs this loudly and immediately (rate-limited to once/~60s during retries), rather than the old silent hang | Issue a fresh key — re-pair (see [Credentials](#credentials)) if you're using auto-pairing, or a new runner token otherwise. Note an `apiKey` in a host `config.json` is not automatically the one your shell has in `PIZZAPI_API_KEY` — confirm which one you're passing |
+| Container sits `unhealthy` right after a fresh start, with an approval URL in the logs | Expected — auto-pairing is waiting for a human to approve it | Open the printed URL (or re-run `docker compose logs -f runner` to see it again); see [Credentials → Pairing](#pairing-recommended). Not a bug, and nothing should be restarting the container for this |
 | `Permission denied` writing to `/home/pizza/.pizzapi` | Bind-mounted (not named) volume owned by a different host UID | Use a named volume, chown the host dir to `1000:1000`, or use the `PUID`/`PGID` remap path |
 | Spawn request rejected: "outside allowed workspace root(s)" | `cwd` isn't under any `PIZZAPI_WORKSPACE_ROOTS` entry, or you passed a host path instead of a container path | Use the container-side mount path; add the missing root to `PIZZAPI_WORKSPACE_ROOTS` |
 | `command not found` for a language toolchain, `gh`, etc. | Base image intentionally excludes it | Build a [derived image](#sidecars--derived-images) |

--- a/packages/docs/src/content/docs/deployment/runner-container.mdx
+++ b/packages/docs/src/content/docs/deployment/runner-container.mdx
@@ -1,0 +1,313 @@
+---
+title: Runner Container
+description: Run the PizzaPi runner in Docker — data volume, workspace mounts, UID/GID remapping, credentials, sidecars, and sandbox posture.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+The runner container image (`ghcr.io/pizzaface/pizzapi-runner`) packages the standalone `pizza runner` binary as a small, non-root Debian image. It's a **remote coding machine** — it dials out to a relay over HTTP/WebSocket and spawns agent sessions against mounted workspaces. It exposes no inbound ports.
+
+<Aside type="caution">
+  This is **not** the relay/server image. To self-host the relay + web UI, see [Self-Hosting](/PizzaPi/deployment/self-hosting/). This page only covers the runner.
+</Aside>
+
+Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your CLI/relay version. A `:latest` tag exists but isn't reproducible; don't use it in a config you expect to stay stable across upgrades.
+
+---
+
+## Quick start
+
+<Steps>
+1. **Get a runner token.** Open your relay's web UI → Settings → **Runner Tokens** card → create one. It gives you the `PIZZAPI_RELAY_URL` and `PIZZAPI_API_KEY` values to copy.
+
+2. **Start the container** with Compose:
+
+   ```yaml
+   # compose.yml
+   services:
+     runner:
+       image: ghcr.io/pizzaface/pizzapi-runner:0.5.61
+       restart: unless-stopped
+       stop_grace_period: 30s
+       environment:
+         PIZZAPI_RELAY_URL: https://pizza.example.com
+         PIZZAPI_API_KEY: ${PIZZAPI_API_KEY}
+         PIZZAPI_RUNNER_NAME: docker-runner
+       volumes:
+         - runner-data:/home/pizza/.pizzapi
+         - ./projects:/workspace
+
+   volumes:
+     runner-data:
+   ```
+
+   ```bash
+   docker compose up -d
+   ```
+
+   Or the equivalent `docker run`:
+
+   ```bash
+   docker run -d --name pizzapi-runner \
+     --restart unless-stopped --stop-timeout 30 \
+     -e PIZZAPI_RELAY_URL=https://pizza.example.com \
+     -e PIZZAPI_API_KEY="$PIZZAPI_API_KEY" \
+     -e PIZZAPI_RUNNER_NAME=docker-runner \
+     -v runner-data:/home/pizza/.pizzapi \
+     -v "$(pwd)/projects:/workspace" \
+     ghcr.io/pizzaface/pizzapi-runner:0.5.61
+   ```
+
+3. **Confirm it registered:**
+
+   ```bash
+   docker compose exec runner pizza runner status
+   # or, for the docker run form:
+   docker exec pizzapi-runner pizza runner status
+   ```
+
+   Or check the relay's web UI — the runner shows up under its display name (`PIZZAPI_RUNNER_NAME`, defaulting to the container's hostname).
+</Steps>
+
+If your relay is itself a Compose service, point at it by service name instead of a public URL:
+
+```yaml
+environment:
+  PIZZAPI_RELAY_URL: http://server:7492
+```
+
+`localhost` inside the container always means the **container itself** — not your host, and not the relay (the relay is never this same container).
+
+---
+
+## Data volume
+
+Mount `/home/pizza/.pizzapi` as one persistent volume — everything that makes the runner *this* runner lives there:
+
+- `runner.json` — runner identity (`runnerId`) and secret (`runnerSecret`) used to re-authenticate with the relay, plus the process lock
+- `config.json`, `settings.json`, `models.json`
+- `auth.json` — provider credentials (OAuth tokens, saved API keys)
+- session transcripts and attachments
+- the usage database/cache
+- installed packages, plugins, agents, skills, and global runner services
+
+Persist the whole directory, not a subset — it's one coupled unit. Treat it as **secret-bearing**: it holds `runnerSecret` and provider tokens. Never bake it into an image or commit it.
+
+If you don't persist it: every container recreation gets a **new** `runnerId` (the relay sees a brand-new runner registering, not the same one reconnecting), all provider auth is gone (re-run `pizza setup` / OAuth login inside the container), and every session transcript and attachment is lost.
+
+---
+
+## Workspaces
+
+Mount project directories under `/workspace` (or wherever `PIZZAPI_WORKSPACE_ROOTS` points — the image defaults it to `/workspace`):
+
+```yaml
+volumes:
+  - ./projects/client-a:/workspace/client-a
+  - ./projects/client-b:/workspace/client-b:ro
+```
+
+- `PIZZAPI_WORKSPACE_ROOTS` is comma-separated: `/workspace/client-a,/workspace/client-b`.
+- Spawn requests (`spawn_session`, the web UI's session picker) must use **container paths** — `/workspace/client-a`, not the host path you mounted from.
+- Read-only mounts (`:ro`) work, but agents can't edit those files.
+- A spawn request with a `cwd` outside every configured root is rejected: `Requested cwd is outside allowed workspace root(s): <path>`.
+- If you unset `PIZZAPI_WORKSPACE_ROOTS` entirely, the runner is **unscoped** — any path on the container filesystem is allowed. Don't do this in a shared container.
+
+---
+
+## UID/GID ownership
+
+The image runs as a fixed non-root user, `pizza` (uid/gid `1000:1000`), by default. Named volumes (like `runner-data` above) pick up that ownership automatically the first time Docker populates them from the image. Bind mounts are the common failure case: if `./projects` on the host is owned by a different UID than 1000, the container's `pizza` user can't write to it.
+
+To match a host UID/GID, run the container **as root** and let the entrypoint remap and drop privileges — don't just set a raw `user:` override:
+
+```yaml
+services:
+  runner:
+    image: ghcr.io/pizzaface/pizzapi-runner:0.5.61
+    user: "0:0"          # required — the entrypoint needs root to remap, then drops it
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      PIZZAPI_CHOWN_WORKSPACE: "1"   # recursively chown mounted workspace roots to PUID:PGID
+    volumes:
+      - runner-data:/home/pizza/.pizzapi
+      - ./projects:/workspace
+```
+
+The entrypoint detects it's running as uid 0, remaps the baked-in `pizza` account to `PUID`/`PGID`, chowns `$HOME` and `.pizzapi`, optionally chowns the workspace roots (`PIZZAPI_CHOWN_WORKSPACE=1` — a recursive `chown`, can be slow on large repos), then drops privileges via `setpriv` before exec'ing `tini -- pizza runner`. The daemon itself never runs as root.
+
+<Aside type="caution">
+  Don't set `user: "5000:5000"` directly without `PUID`/`PGID` and running as root first. A raw uid override leaves no `/etc/passwd` entry for that uid — verified: `whoami` fails and `git` operations break, since git refuses to resolve a committer identity for an unknown uid. This is exactly why the remap path exists; use it instead of a bare `user:` override.
+</Aside>
+
+---
+
+## Credentials
+
+Two credential paths, same as bare-metal:
+
+1. **Environment variables** — `PIZZAPI_API_KEY`, provider keys (`ANTHROPIC_API_KEY`, etc.), ideally from your orchestrator's secret store.
+2. **Persisted `auth.json`** in the data volume — written by `pizza setup` / OAuth login run inside the container, survives recreation.
+
+macOS Keychain-stored credentials do **not** cross into the container — it's Linux. If you relied on keychain fallback on your Mac, you need an explicit env var or `auth.json` entry instead.
+
+<Aside type="caution" title="Worker sessions inherit almost all of the daemon's environment">
+  Every env var set on the runner container — including Compose secrets meant for something else entirely — is forwarded to spawned agent sessions, except a small denylist: `PIZZAPI_RUNNER_TOKEN`, `PIZZAPI_RUNNER_API_KEY`, `PIZZAPI_SESSION_PROVIDER`, `NODE_OPTIONS`, `BUN_OPTIONS`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `DYLD_FORCE_FLAT_NAMESPACE`. There's no daemon-only secrecy for arbitrary env vars — if a sidecar's `DATABASE_URL` is on the runner's environment, an agent session can read it (`process.env`) and could put it in a file or shell command. Keep secrets a session shouldn't see out of the **runner's** environment; put them on the sidecar's environment instead.
+</Aside>
+
+---
+
+## Sidecars & derived images
+
+Sidecars (databases, Ollama, MCP HTTP servers) share the Compose network and get addressed by service DNS name:
+
+```yaml
+services:
+  runner:
+    environment:
+      DATABASE_URL: postgres://user:pass@postgres:5432/app
+      OLLAMA_HOST: http://ollama:11434
+  postgres:
+    image: postgres:16
+  ollama:
+    image: ollama/ollama
+```
+
+The base image deliberately ships **no** `gh`, Node, Python, or compilers — only what PizzaPi itself needs (git, ssh, ripgrep, bash, bubblewrap, curl, tini). Add a toolchain in a derived image:
+
+```dockerfile
+# Dockerfile
+FROM ghcr.io/pizzaface/pizzapi-runner:0.5.61
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        nodejs npm gh \
+    && rm -rf /var/lib/apt/lists/*
+USER pizza
+```
+
+Stdio MCP servers and custom runner services need their executable dependencies (interpreters, CLIs) baked into a derived image the same way — the base image won't have them.
+
+---
+
+## Runner services & tunnels
+
+Built-in runner services — terminal, file explorer, git, process, memory, time, tunnel — run inside the container unmodified. Their ports stay internal to the container; the browser reaches them through the relay's existing `/_tunnel` WebSocket proxy (the same mechanism [`create_tunnel`](/PizzaPi/features/tunnels/) uses for dev-server previews). You don't need any `ports:` entries in Compose for this to work.
+
+---
+
+## SSH & git identity
+
+Prefer forwarding an SSH agent socket over mounting private keys:
+
+```yaml
+services:
+  runner:
+    environment:
+      SSH_AUTH_SOCK: /ssh-agent
+    volumes:
+      - ${SSH_AUTH_SOCK}:/ssh-agent:ro
+```
+
+For git identity, either mount your host config read-only:
+
+```yaml
+volumes:
+  - ~/.gitconfig:/home/pizza/.gitconfig:ro
+```
+
+or point git's own `GIT_CONFIG_GLOBAL` at a file inside the persisted volume so identity survives recreation without a host mount:
+
+```yaml
+environment:
+  GIT_CONFIG_GLOBAL: /home/pizza/.pizzapi/gitconfig
+```
+
+then run `git config --global user.name "..." && git config --global user.email "..."` once inside the container. The default `/home/pizza/.gitconfig` location is **not** part of the persisted `.pizzapi` volume and won't survive a recreation unless you use one of the two options above.
+
+---
+
+## Sandbox posture
+
+The container is the machine boundary, not a per-session boundary — every session in the container shares its filesystem and process namespace unless PizzaPi's own sandbox is enabled and configured.
+
+The image defaults to `PIZZAPI_SANDBOX=none`. That's not a convenience default: bubblewrap (the Linux sandbox backend) can't create user namespaces under Docker's default seccomp profile, even running as root. Verified on Docker 29.5.3.
+
+To opt in to the nested-bubblewrap sandbox:
+
+```yaml
+services:
+  runner:
+    security_opt:
+      - "seccomp=unconfined"
+    environment:
+      PIZZAPI_SANDBOX: basic
+```
+
+This is a trade, not a free win: `seccomp=unconfined` widens the syscalls available to everything in the container, weakening the container's own isolation from the host in exchange for the nested sandbox being able to isolate sessions from each other inside it. Verify it on your actual host before relying on it — see [Agent Sandbox](/PizzaPi/security/sandbox/) for what `basic` mode actually restricts.
+
+<Aside type="caution">
+  The web terminal has full runner-user (`pizza`) permissions inside the container and no separate sandbox of its own. Don't expose a runner container's web terminal to anyone who shouldn't have a shell on that box.
+</Aside>
+
+---
+
+## Health, logs, upgrades
+
+The image ships a `HEALTHCHECK` that runs `pizza runner status` every 30s (5s timeout, 45s start period, 3 retries). Exit 0 means the process is alive **and** registered with the relay — not just alive:
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' pizzapi-runner
+
+# for scripting / your own monitoring
+docker exec pizzapi-runner pizza runner status --json
+```
+
+```json
+{
+  "healthy": true,
+  "runnerId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "runnerName": "docker-runner",
+  "relayUrl": "https://pizza.example.com",
+  "connected": true,
+  "pid": 47,
+  "startedAt": "2025-01-15T10:30:00.000Z",
+  "cliVersion": "0.5.61"
+}
+```
+
+When unhealthy, `reason` explains why (`"no runner state file found"`, `"process not running"`, or `"not registered with relay"`) — see the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status).
+
+Other operational notes:
+
+- `restart: unless-stopped` + `stop_grace_period: 30s` — `docker stop` sends SIGTERM to `tini` (PID 1), which forwards it through the supervisor to the daemon, the same clean-shutdown path as running `pizza runner stop`. Give it the full 30s window to disconnect and release its lock before Docker sends SIGKILL.
+- Logs are the runner's stdout/stderr (`docker logs pizzapi-runner`). Rotation is Docker's/your logging driver's job, not the image's.
+- Resource limits (`mem_limit`, `cpus`, ...) apply to the whole container — every session and its child processes share them. Size for your heaviest concurrent session load, not one session.
+- **Upgrade** by pulling a new version tag and recreating the container; the data volume carries identity, auth, and transcripts forward:
+
+  ```bash
+  docker compose pull runner
+  docker compose up -d runner
+  ```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Container unhealthy | Bad `PIZZAPI_API_KEY`, unreachable relay, or wrong `PIZZAPI_RELAY_URL` scheme | `docker exec <ctr> pizza runner status` for the exact `reason`; check the URL scheme matches the relay's actual setup |
+| `Permission denied` writing to `/home/pizza/.pizzapi` | Bind-mounted (not named) volume owned by a different host UID | Use a named volume, chown the host dir to `1000:1000`, or use the `PUID`/`PGID` remap path |
+| Spawn request rejected: "outside allowed workspace root(s)" | `cwd` isn't under any `PIZZAPI_WORKSPACE_ROOTS` entry, or you passed a host path instead of a container path | Use the container-side mount path; add the missing root to `PIZZAPI_WORKSPACE_ROOTS` |
+| `command not found` for a language toolchain, `gh`, etc. | Base image intentionally excludes it | Build a [derived image](#sidecars--derived-images) |
+| Sandbox not active despite `PIZZAPI_SANDBOX=basic` | Missing `security_opt: ["seccomp=unconfined"]` | Add the `security_opt` (see [Sandbox posture](#sandbox-posture)) — and re-check the trade-off before you do |
+
+---
+
+## What this image is not
+
+- Not the relay/server — that's a separate image; see [Self-Hosting](/PizzaPi/deployment/self-hosting/).
+- Not one container per session — one runner container hosts many concurrent sessions.
+- No Docker socket, no Docker-outside-of-Docker — the runner never needs `/var/run/docker.sock`.
+- No host path, host keychain, or host `localhost` access — everything the container sees is what you explicitly mounted or networked in.
+- No universal language-toolchain image — bring what your project needs via a derived image.

--- a/packages/docs/src/content/docs/deployment/runner-container.mdx
+++ b/packages/docs/src/content/docs/deployment/runner-container.mdx
@@ -225,6 +225,10 @@ environment:
 
 then run `git config --global user.name "..." && git config --global user.email "..."` once inside the container. The default `/home/pizza/.gitconfig` location is **not** part of the persisted `.pizzapi` volume and won't survive a recreation unless you use one of the two options above.
 
+<Aside type="caution">
+  Set an identity before letting agents commit. With no git identity configured, commits made inside the container are attributed to the agent's placeholder identity (`Pi Agent <pi-agent@example.com>`) rather than to you — and that lands in your repo history.
+</Aside>
+
 ---
 
 ## Sandbox posture
@@ -282,6 +286,7 @@ Other operational notes:
 
 - `restart: unless-stopped` + `stop_grace_period: 30s` — `docker stop` sends SIGTERM to `tini` (PID 1), which forwards it through the supervisor to the daemon, the same clean-shutdown path as running `pizza runner stop`. Give it the full 30s window to disconnect and release its lock before Docker sends SIGKILL.
 - Logs are the runner's stdout/stderr (`docker logs pizzapi-runner`). Rotation is Docker's/your logging driver's job, not the image's.
+- **Relay restarts are survivable and need no action.** If the relay goes away, the runner reconnects with backoff, re-registers under the same identity, and preserves its already-initialized runner services rather than tearing them down. Expect the container to report `unhealthy` for a healthcheck interval or two while that happens — don't wire an external supervisor to restart it on the first failed check.
 - Resource limits (`mem_limit`, `cpus`, ...) apply to the whole container — every session and its child processes share them. Size for your heaviest concurrent session load, not one session.
 - **Upgrade** by pulling a new version tag and recreating the container; the data volume carries identity, auth, and transcripts forward:
 
@@ -296,7 +301,8 @@ Other operational notes:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Container unhealthy | Bad `PIZZAPI_API_KEY`, unreachable relay, or wrong `PIZZAPI_RELAY_URL` scheme | `docker exec <ctr> pizza runner status` for the exact `reason`; check the URL scheme matches the relay's actual setup |
+| Container unhealthy | Unreachable relay, or wrong `PIZZAPI_RELAY_URL` scheme | `docker exec <ctr> pizza runner status` for the exact `reason`; check the URL scheme matches the relay's actual setup |
+| Logs stop after `connecting to relay at ...` and never say `registered as ...`; status shows `connected false` / `not registered with relay` | Invalid `PIZZAPI_API_KEY`. The socket connects before the key is validated, so a bad key looks like a hang rather than an auth error | Check the **relay's** logs for `Failed to validate API key`, then issue a fresh runner token. Note an `apiKey` in a host `config.json` is not automatically the one your shell has in `PIZZAPI_API_KEY` — confirm which one you're passing |
 | `Permission denied` writing to `/home/pizza/.pizzapi` | Bind-mounted (not named) volume owned by a different host UID | Use a named volume, chown the host dir to `1000:1000`, or use the `PUID`/`PGID` remap path |
 | Spawn request rejected: "outside allowed workspace root(s)" | `cwd` isn't under any `PIZZAPI_WORKSPACE_ROOTS` entry, or you passed a host path instead of a container path | Use the container-side mount path; add the missing root to `PIZZAPI_WORKSPACE_ROOTS` |
 | `command not found` for a language toolchain, `gh`, etc. | Base image intentionally excludes it | Build a [derived image](#sidecars--derived-images) |

--- a/packages/docs/src/content/docs/deployment/runner-container.mdx
+++ b/packages/docs/src/content/docs/deployment/runner-container.mdx
@@ -11,7 +11,7 @@ The runner container image (`ghcr.io/pizzaface/pizzapi-runner`) packages the sta
   This is **not** the relay/server image. To self-host the relay + web UI, see [Self-Hosting](/PizzaPi/deployment/self-hosting/). This page only covers the runner.
 </Aside>
 
-Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your CLI/relay version. A `:latest` tag exists but isn't reproducible; don't use it in a config you expect to stay stable across upgrades.
+Pin a version tag — `ghcr.io/pizzaface/pizzapi-runner:0.5.61`, matching your CLI/relay version. A `:latest` tag exists but isn't reproducible; don't use it in a config you expect to stay stable across upgrades. Version tags begin with the first release that shipped this image, so check the [package's tag list](https://github.com/Pizzaface/PizzaPi/pkgs/container/pizzapi-runner) and pin one that exists (the version numbers in the examples below are illustrative).
 
 ---
 

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -7,6 +7,10 @@ import { Tabs, TabItem, Steps, Aside } from "@astrojs/starlight/components";
 
 Self-hosting gives you full control over your data, no rate limits, and the ability to customize the server. The default Docker stack includes **Redis** (event buffer), a **UI sidecar** (GHCR UI assets), and the **PizzaPi server** (relay API + web UI).
 
+<Aside type="tip">
+  This page covers the relay/server. Looking to run the **runner** (the agent host that connects out to a relay) in Docker instead? See [Runner Container](/PizzaPi/deployment/runner-container/).
+</Aside>
+
 ---
 
 ## Quickest: `pizza web`

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -25,6 +25,7 @@ Commands:
   pizza runner [args]         Manage the background runner daemon
   pizza runner stop           Stop the runner daemon
   pizza runner status [--json]  Health check the runner daemon (exit 0 = healthy)
+  pizza runner pair [--force]   Pair (or re-pair) the runner with a fresh API key
   pizza setup                 Run first-time setup
   pizza usage [provider]      Show API usage stats
   pizza models                List available models
@@ -218,6 +219,30 @@ pizzapi runner status --json   # machine-readable, for scripting/monitoring
 | `startedAt` | state file exists | ISO timestamp of the daemon's last start |
 
 This is the command the [runner container image](/PizzaPi/deployment/runner-container/)'s Docker `HEALTHCHECK` runs.
+
+---
+
+### `pizzapi runner pair`
+
+Mint a fresh headless-paired API key on demand — the same device-claim flow the daemon runs automatically on a credential-less boot ([Runner Container → Credentials](/PizzaPi/deployment/runner-container/#credentials)), but invokable any time. Useful after revoking a runner's key in the web UI, instead of hand-editing the data volume.
+
+```bash
+pizzapi runner pair            # refuses if a credential already resolves
+pizzapi runner pair --force    # pairs and overwrites any existing credential
+```
+
+Prints an approval URL + QR code (re-printed periodically while waiting), polls until approved or expired, then writes `apiKey`/`relayUrl` into `config.json` in the resolved agent dir, replacing only those two fields.
+
+**Exit code:** `0` on a successful pair. Non-zero if refused, if the claim expires, or on any pairing failure.
+
+Two guard rails, both bypassed only with `--force`:
+
+- **Refuses to clobber an existing credential.** If an API key already resolves (env var or `config.json`), it prints where it came from (never the key itself) and exits non-zero telling you to re-run with `--force`.
+- **Refuses when an env var would shadow the result.** The runtime resolution order is `PIZZAPI_RUNNER_API_KEY` → `PIZZAPI_API_KEY` → `PIZZAPI_API_TOKEN` → config `apiKey`. If any of those three env vars is set, a freshly paired key written to `config.json` would be silently ignored at runtime — pairing would "succeed" while nothing actually changes. This refuses outright by default (naming the offending variable and telling you to unset it) rather than just warning, because a warning line is easy to miss when the operator is scanning for a success message. Even with `--force`, the same warning still prints before proceeding, since forcing past the refusal doesn't make the shadow go away.
+
+If a runner daemon is already running when pairing succeeds, the daemon keeps using its old credential in memory — the command prints a reminder to restart it (`pizzapi runner stop` then start again, or `docker restart <container>`) rather than restarting anything itself.
+
+If no relay URL is known (neither `PIZZAPI_RELAY_URL` nor a configured one), it fails immediately with an actionable message — it never prompts or guesses a default.
 
 ---
 

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -210,7 +210,8 @@ pizzapi runner status --json   # machine-readable, for scripting/monitoring
 | Field | Present when | Description |
 |---|---|---|
 | `healthy` | always | `true` only if the process is alive and `connected` is `true` |
-| `reason` | unhealthy | `"no runner state file found"`, `"process not running"`, or `"not registered with relay"` |
+| `reason` | unhealthy | `"no runner state file found"`, `"pairing pending — approve at <url>"` (auto-pairing is waiting on approval), `"process not running"`, `"relay rejected credentials — check PIZZAPI_API_KEY / re-pair"` (the relay rejected the key — distinct from an ordinary connectivity problem), or `"not registered with relay"` |
+| `pairingUrl` | pairing pending | The approval URL to open, when `reason` is a pending-pairing message |
 | `runnerId`, `runnerName`, `relayUrl`, `cliVersion` | state file exists | Copied from `~/.pizzapi/runner.json` |
 | `connected` | always | Whether the daemon's last-known state is registered with the relay |
 | `pid` | a pid was recorded | The daemon process's own PID (not the supervisor's) |

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -24,6 +24,7 @@ Commands:
   pizza web [flags]           Manage the PizzaPi web hub (Docker)
   pizza runner [args]         Manage the background runner daemon
   pizza runner stop           Stop the runner daemon
+  pizza runner status [--json]  Health check the runner daemon (exit 0 = healthy)
   pizza setup                 Run first-time setup
   pizza usage [provider]      Show API usage stats
   pizza models                List available models
@@ -177,6 +178,45 @@ Send a stop signal to the currently running runner daemon.
 ```bash
 pizzapi runner stop
 ```
+
+---
+
+### `pizzapi runner status`
+
+Health check for the runner daemon — answers "is this runner alive **and** registered with the relay?" by combining a PID liveness check with the daemon's last-known relay connection state. Fast and dependency-light: no relay round-trip, no config/model loading.
+
+```bash
+pizzapi runner status          # human-readable summary
+pizzapi runner status --json   # machine-readable, for scripting/monitoring
+```
+
+**Exit code:** `0` if healthy (process running and `connected: true`), `1` otherwise.
+
+`--json` prints:
+
+```json
+{
+  "healthy": true,
+  "runnerId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "runnerName": "docker-runner",
+  "relayUrl": "https://pizza.example.com",
+  "connected": true,
+  "pid": 12345,
+  "startedAt": "2025-01-15T10:30:00.000Z",
+  "cliVersion": "0.5.61"
+}
+```
+
+| Field | Present when | Description |
+|---|---|---|
+| `healthy` | always | `true` only if the process is alive and `connected` is `true` |
+| `reason` | unhealthy | `"no runner state file found"`, `"process not running"`, or `"not registered with relay"` |
+| `runnerId`, `runnerName`, `relayUrl`, `cliVersion` | state file exists | Copied from `~/.pizzapi/runner.json` |
+| `connected` | always | Whether the daemon's last-known state is registered with the relay |
+| `pid` | a pid was recorded | The daemon process's own PID (not the supervisor's) |
+| `startedAt` | state file exists | ISO timestamp of the daemon's last start |
+
+This is the command the [runner container image](/PizzaPi/deployment/runner-container/)'s Docker `HEALTHCHECK` runs.
 
 ---
 

--- a/packages/docs/src/content/docs/running/runner-daemon.mdx
+++ b/packages/docs/src/content/docs/running/runner-daemon.mdx
@@ -190,7 +190,7 @@ pizzapi runner status          # human-readable
 pizzapi runner status --json   # machine-readable
 ```
 
-Exits `0` if the process is alive **and** currently registered with the relay, `1` otherwise (dead process, or alive but disconnected). This is what the [runner container image](/PizzaPi/deployment/runner-container/)'s Docker `HEALTHCHECK` runs. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status) for the JSON field reference.
+Exits `0` if the process is alive **and** currently registered with the relay, `1` otherwise (dead process, alive but disconnected, waiting on pairing approval, or rejected by the relay — `reason` distinguishes these). This is what the [runner container image](/PizzaPi/deployment/runner-container/)'s Docker `HEALTHCHECK` runs. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status) for the JSON field reference, and [Runner Container → Credentials](/PizzaPi/deployment/runner-container/#credentials) for what auto-pairing does when no `PIZZAPI_API_KEY` is set.
 
 ---
 

--- a/packages/docs/src/content/docs/running/runner-daemon.mdx
+++ b/packages/docs/src/content/docs/running/runner-daemon.mdx
@@ -194,6 +194,17 @@ Exits `0` if the process is alive **and** currently registered with the relay, `
 
 ---
 
+## Re-pairing On Demand
+
+```bash
+pizzapi runner pair            # refuses if a credential already resolves
+pizzapi runner pair --force    # pairs and overwrites any existing credential
+```
+
+Runs the same headless device-claim flow the daemon runs automatically on a credential-less boot, but on demand — useful after revoking a runner's API key in the web UI. Refuses without `--force` if a credential already resolves (env var or `config.json`), and refuses (or, with `--force`, warns loudly) if `PIZZAPI_RUNNER_API_KEY` / `PIZZAPI_API_KEY` / `PIZZAPI_API_TOKEN` is set, since that would keep shadowing the freshly paired key at runtime. If a daemon is already running, pairing still writes the new credential but the daemon keeps using the old one in memory until you restart it — the command tells you so. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-pair) for the full guard-rail and exit-code reference.
+
+---
+
 ## Session Linking & Triggers
 
 When sessions are spawned via `spawn_session`, the runner daemon automatically **links them as parent-child**. This enables the conversation trigger system. See the [Multi-Agent Sessions](/PizzaPi/features/multi-agent/) guide for the full list of trigger types, response actions, and delivery semantics.

--- a/packages/docs/src/content/docs/running/runner-daemon.mdx
+++ b/packages/docs/src/content/docs/running/runner-daemon.mdx
@@ -167,6 +167,10 @@ pm2 save
 pm2 startup   # generate startup script
 ```
 
+### Docker
+
+To run the runner as a container instead of a host process, see the dedicated [Runner Container](/PizzaPi/deployment/runner-container/) guide — it covers the Compose service, the persistent data volume, workspace mounts, UID/GID remapping, and sandbox posture.
+
 ---
 
 ## Stopping the Runner
@@ -176,6 +180,17 @@ pizzapi runner stop
 ```
 
 This sends SIGTERM to the supervisor and polls for up to 10 seconds, then force-kills with SIGKILL if it has not exited. The daemon disconnects from the relay and releases its lock immediately; workers are independent processes that may continue running or be reaped by the system.
+
+---
+
+## Checking Status
+
+```bash
+pizzapi runner status          # human-readable
+pizzapi runner status --json   # machine-readable
+```
+
+Exits `0` if the process is alive **and** currently registered with the relay, `1` otherwise (dead process, or alive but disconnected). This is what the [runner container image](/PizzaPi/deployment/runner-container/)'s Docker `HEALTHCHECK` runs. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-runner-status) for the JSON field reference.
 
 ---
 

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -504,6 +504,38 @@ export interface RunnerServerToClientEvents {
     source?: string;
   }) => void;
 
+  /** Model provider auth: list providers that support interactive login */
+  auth_list: (data: {
+    requestId?: string;
+  }) => void;
+
+  /** Model provider auth: begin a login; replies with the flow's first step */
+  auth_login_start: (data: {
+    requestId?: string;
+    providerId: string;
+    /** "oauth" (default) or "api_key" */
+    authType?: string;
+  }) => void;
+
+  /** Model provider auth: answer the flow's pending prompt (code, key, choice) */
+  auth_login_submit: (data: {
+    requestId?: string;
+    loginId: string;
+    value: string;
+  }) => void;
+
+  /** Model provider auth: poll a login (its loopback callback may have won) */
+  auth_login_status: (data: {
+    requestId?: string;
+    loginId: string;
+  }) => void;
+
+  /** Model provider auth: abandon an in-flight login */
+  auth_login_cancel: (data: {
+    requestId?: string;
+    loginId: string;
+  }) => void;
+
   /** Full snapshot of active trigger subscriptions for this runner's sessions.
    *  Sent after runner_registered so the runner can rebuild subscription state. */
   trigger_subscriptions_snapshot: (data: TriggerSubscriptionsSnapshot) => void;

--- a/packages/server/src/api-key-auth.test.ts
+++ b/packages/server/src/api-key-auth.test.ts
@@ -71,4 +71,43 @@ describe("API-key auth fallback", () => {
             expect(identity).toBeInstanceOf(Response);
         });
     });
+
+    // Regression: these go through the ROUTE, not straight to validateApiKey.
+    // better-auth's api-key plugin hooks session resolution, so a malformed
+    // key makes getSession() throw before our explicit validation runs — which
+    // surfaced as a 500 "Internal server error" on every session-authenticated
+    // route for any client holding a stale key. The direct-call test above
+    // passed the whole time precisely because it skipped getSession().
+    test("a malformed x-api-key yields 401, not 500, on a requireSession route", async () => {
+        await runWithAuthContext(authContext, async () => {
+            for (const bad of ["invalid", "0".repeat(64), "pzpe_not_a_real_key"]) {
+                const req = new Request("http://localhost:7492/api/me", {
+                    headers: { "x-api-key": bad },
+                });
+                const res = await handleApi(req, new URL(req.url));
+                expect(res).not.toBeUndefined();
+                expect(res!.status).toBe(401);
+            }
+        });
+    });
+
+    test("a malformed x-api-key yields 401, not 500, on the enrollment approve route", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const create = new Request("http://localhost:7492/api/setup-claim", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ relayUrl: "http://localhost:7492" }),
+            });
+            const createRes = await handleApi(create, new URL(create.url));
+            const { token } = (await createRes!.json()) as { token: string };
+
+            const req = new Request(`http://localhost:7492/api/setup-claim/${token}/approve`, {
+                method: "POST",
+                headers: { "x-api-key": "0".repeat(64) },
+            });
+            const res = await handleApi(req, new URL(req.url));
+            expect(res).not.toBeUndefined();
+            expect(res!.status).toBe(401);
+        });
+    });
 });

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -176,6 +176,8 @@ export interface SetupClaimTable {
     expiresAt: string;
     approvedAt: string | null;
     redeemedAt: string | null;
+    /** Operator-facing name for the device/runner being paired (e.g. "docker-demo-runner"). */
+    label: string | null;
 }
 
 export interface MobileLinkTable {

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -1,10 +1,36 @@
 import { getAuth, getKysely } from "./auth.js";
 
+/**
+ * better-auth's api-key plugin hooks session resolution, so an invalid or
+ * malformed `x-api-key` header makes `getSession` THROW rather than return
+ * null. Unguarded, that surfaced as a 500 "Internal server error" on every
+ * session-authenticated route whenever a client presented a stale key — the
+ * one case where the answer is unambiguously 401. Swallow it and let the
+ * explicit API-key path produce the real status, matching what
+ * routes/tunnel-ws.ts and ws/namespaces/auth.ts already do.
+ */
+async function trySession(req: Request) {
+    try {
+        return await getAuth().api.getSession({ headers: req.headers });
+    } catch {
+        return null;
+    }
+}
+
+/** Same rationale as trySession: a malformed key throws instead of returning invalid. */
+async function tryVerifyApiKey(key: string) {
+    try {
+        return await getAuth().api.verifyApiKey({ body: { key } });
+    } catch {
+        return null;
+    }
+}
+
 /** Returns the session+user or a 401 Response. Falls back to API-key auth. */
 export async function requireSession(
     req: Request,
 ): Promise<{ userId: string; userName: string } | Response> {
-    const session = await getAuth().api.getSession({ headers: req.headers });
+    const session = await trySession(req);
     if (session?.user?.id) {
         return { userId: session.user.id, userName: session.user.name ?? session.user.id };
     }
@@ -33,14 +59,14 @@ export interface EnrollmentAuth {
  * is allowed to live (see EnrollmentAuth.maxMintTtlSeconds).
  */
 export async function requireEnrollmentAuth(req: Request): Promise<EnrollmentAuth | Response> {
-    const session = await getAuth().api.getSession({ headers: req.headers });
+    const session = await trySession(req);
     if (session?.user?.id) {
         return { userId: session.user.id, userName: session.user.name ?? session.user.id, maxMintTtlSeconds: null };
     }
     const key = req.headers.get("x-api-key");
     if (!key) return new Response("Unauthorized", { status: 401 });
-    const result = await getAuth().api.verifyApiKey({ body: { key } });
-    if (!result.valid || !result.key?.userId) {
+    const result = await tryVerifyApiKey(key);
+    if (!result?.valid || !result.key?.userId) {
         return new Response("Invalid or expired API key", { status: 401 });
     }
     const userId = result.key.userId;
@@ -64,8 +90,8 @@ export async function validateApiKey(
     if (!key) {
         return new Response("Missing API key (x-api-key header)", { status: 401 });
     }
-    const result = await getAuth().api.verifyApiKey({ body: { key } });
-    if (!result.valid || !result.key?.userId) {
+    const result = await tryVerifyApiKey(key);
+    if (!result?.valid || !result.key?.userId) {
         return new Response("Invalid or expired API key", { status: 401 });
     }
     const userId = result.key.userId;

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -22,6 +22,7 @@ import { handleAttachmentsRoute } from "./attachments.js";
 import { handlePushRoute } from "./push.js";
 import { handleSettingsRoute } from "./settings.js";
 import { handleRunnerSettingsRoute } from "./runner-settings.js";
+import { handleRunnerAuthRoute } from "./runner-auth.js";
 import { handlePackagesRoute } from "./packages.js";
 import { handleMcpOAuthRoute } from "./mcp-oauth.js";
 import { handleTunnelRoute } from "./tunnel.js";
@@ -40,6 +41,7 @@ const routers: RouteHandler[] = [
     handleMobileLinksRoute, // Android app pairing lifecycle
     handleMobileOtaRoute,   // Self-hosted OTA bundle for the mobile app (unauthenticated)
     handleTunnelRoute,     // Before runners — /api/tunnel/* is session-scoped, not runner-scoped
+    handleRunnerAuthRoute,  // Before runners — /api/runners/:id/providers/*
     handleRunnersRoute,
     handleRunnerSettingsRoute,
     handlePackagesRoute,

--- a/packages/server/src/routes/runner-auth.test.ts
+++ b/packages/server/src/routes/runner-auth.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+afterAll(() => mock.restore());
+
+const mockRequireSession = mock((_req: Request) => Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+mock.module("../middleware.js", () => ({ requireSession: mockRequireSession }));
+
+const mockGetRunnerData = mock((_runnerId: string) => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+mock.module("../ws/sio-registry.js", () => ({ getRunnerData: mockGetRunnerData }));
+
+const mockSendRunnerCommand = mock((_runnerId: string, _command: Record<string, unknown>, _timeout?: number) =>
+    Promise.resolve({ ok: true } as any),
+);
+mock.module("../ws/namespaces/runner.js", () => ({ sendRunnerCommand: mockSendRunnerCommand }));
+
+const { handleRunnerAuthRoute } = await import("./runner-auth.js");
+
+function makeReq(method: string, path: string, body?: object): [Request, URL] {
+    const url = new URL(`http://localhost${path}`);
+    const init: RequestInit = { method, headers: { "content-type": "application/json" } };
+    if (body) init.body = JSON.stringify(body);
+    return [new Request(url.toString(), init), url];
+}
+
+describe("handleRunnerAuthRoute", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+        mockSendRunnerCommand.mockReset();
+        mockSendRunnerCommand.mockReturnValue(Promise.resolve({ ok: true } as any));
+    });
+
+    test("routes list / start / submit / cancel to the right runner commands", async () => {
+        await handleRunnerAuthRoute(...makeReq("GET", "/api/runners/runner-A/providers"));
+        await handleRunnerAuthRoute(...makeReq("POST", "/api/runners/runner-A/providers/login", { providerId: "anthropic" }));
+        await handleRunnerAuthRoute(...makeReq("POST", "/api/runners/runner-A/providers/login/submit", { loginId: "L", value: "v" }));
+        await handleRunnerAuthRoute(...makeReq("POST", "/api/runners/runner-A/providers/login/cancel", { loginId: "L" }));
+        await handleRunnerAuthRoute(...makeReq("GET", "/api/runners/runner-A/providers/login/status?loginId=L"));
+
+        expect(mockSendRunnerCommand.mock.calls.map((call) => (call[1] as any).type)).toEqual([
+            "auth_list",
+            "auth_login_start",
+            "auth_login_submit",
+            "auth_login_cancel",
+            "auth_login_status",
+        ]);
+        // Unknown auth types must not reach the runner as-is.
+        expect((mockSendRunnerCommand.mock.calls[1][1] as any).authType).toBe("oauth");
+    });
+
+    test("another user's runner is forbidden", async () => {
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "someone-else", runnerId: "runner-A" } as any));
+        const res = await handleRunnerAuthRoute(...makeReq("GET", "/api/runners/runner-A/providers"));
+        expect(res?.status).toBe(403);
+        expect(mockSendRunnerCommand).not.toHaveBeenCalled();
+    });
+
+    test("start requires a providerId", async () => {
+        const res = await handleRunnerAuthRoute(...makeReq("POST", "/api/runners/runner-A/providers/login", {}));
+        expect(res?.status).toBe(400);
+        expect(mockSendRunnerCommand).not.toHaveBeenCalled();
+    });
+
+    test("ignores unrelated runner paths", async () => {
+        expect(await handleRunnerAuthRoute(...makeReq("GET", "/api/runners/runner-A/settings"))).toBeUndefined();
+    });
+});

--- a/packages/server/src/routes/runner-auth.ts
+++ b/packages/server/src/routes/runner-auth.ts
@@ -1,0 +1,93 @@
+/**
+ * Model provider auth router — log providers in from the web UI.
+ *
+ * Endpoints:
+ *   GET  /api/runners/:id/providers               — providers that support login
+ *   POST /api/runners/:id/providers/login         — start a login {providerId, authType}
+ *   POST /api/runners/:id/providers/login/submit  — answer the flow {loginId, value}
+ *   POST /api/runners/:id/providers/login/cancel  — abandon an in-flight login
+ *
+ * The runner owns the login conversation (see daemon-handlers/provider-auth.ts);
+ * this router is a thin authenticated pass-through. `value` can carry an API
+ * key, so responses never echo submitted input back.
+ */
+
+import { getRunnerData } from "../ws/sio-registry.js";
+import { sendRunnerCommand } from "../ws/namespaces/runner.js";
+import { requireSession } from "../middleware.js";
+import type { RouteHandler } from "./types.js";
+
+const PROVIDERS_RE = /^\/api\/runners\/([^/]+)\/providers(\/login(\/submit|\/cancel|\/status)?)?$/;
+
+export const handleRunnerAuthRoute: RouteHandler = async (req, url) => {
+    const match = url.pathname.match(PROVIDERS_RE);
+    if (!match) return undefined;
+
+    const runnerId = decodeURIComponent(match[1]);
+    const sub = match[3] ?? match[2] ?? "";
+
+    const identity = await requireSession(req);
+    if (identity instanceof Response) return identity;
+
+    const runner = await getRunnerData(runnerId);
+    if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
+    if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+    const run = async (command: Record<string, unknown>, timeoutMs?: number) => {
+        try {
+            const result = (await sendRunnerCommand(runnerId, command, timeoutMs)) as Record<string, unknown>;
+            if (result && result.ok === false) {
+                return Response.json({ error: result.message ?? "Runner rejected the request" }, { status: 502 });
+            }
+            return Response.json(result);
+        } catch (err) {
+            return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 502 });
+        }
+    };
+
+    if (req.method === "GET" && sub === "") {
+        return run({ type: "auth_list" });
+    }
+
+    // Polled while a login card is open: the provider's loopback callback can
+    // complete the flow without the user pasting anything.
+    if (req.method === "GET" && sub === "/status") {
+        const loginId = url.searchParams.get("loginId");
+        if (!loginId) return Response.json({ error: "Missing 'loginId'" }, { status: 400 });
+        return run({ type: "auth_login_status", loginId });
+    }
+
+    if (req.method !== "POST") return undefined;
+
+    let body: any;
+    try {
+        body = await req.json();
+    } catch {
+        return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (sub === "/login") {
+        if (typeof body?.providerId !== "string" || !body.providerId) {
+            return Response.json({ error: "Missing 'providerId'" }, { status: 400 });
+        }
+        const authType = body.authType === "api_key" ? "api_key" : "oauth";
+        // Login waits on a human in a browser; give the runner room to reply.
+        return run({ type: "auth_login_start", providerId: body.providerId, authType }, 45_000);
+    }
+
+    if (sub === "/submit") {
+        if (typeof body?.loginId !== "string" || typeof body?.value !== "string") {
+            return Response.json({ error: "Missing 'loginId' or 'value'" }, { status: 400 });
+        }
+        return run({ type: "auth_login_submit", loginId: body.loginId, value: body.value }, 90_000);
+    }
+
+    if (sub === "/cancel") {
+        if (typeof body?.loginId !== "string") {
+            return Response.json({ error: "Missing 'loginId'" }, { status: 400 });
+        }
+        return run({ type: "auth_login_cancel", loginId: body.loginId });
+    }
+
+    return undefined;
+};

--- a/packages/server/src/routes/setup-claims.test.ts
+++ b/packages/server/src/routes/setup-claims.test.ts
@@ -3,7 +3,9 @@
  *
  * These exist specifically to catch routing regressions that store-level
  * tests can't see: GET /api/setup-claim/:token is a one-shot redeem for the
- * CLI, and GET /api/setup-claim/:token/info must never fall through to it.
+ * CLI, and GET /api/setup-claim-info/:token must never fall through to it, and must
+ * live outside the /api/setup-claim/ prefix so older relays (which parse the
+ * poll token with split("/")[0]) can't mis-route it into the consuming handler.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
@@ -33,7 +35,7 @@ function get(path: string): { req: Request; url: URL } {
 }
 
 describe("setup-claim routes", () => {
-    test("GET .../info never consumes the one-shot key, and the CLI poll route still redeems afterwards", async () => {
+    test("GET /api/setup-claim-info/:token never consumes the one-shot key, and the CLI poll route still redeems afterwards", async () => {
         await runWithAuthContext(authContext, async () => {
             const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
             const approve = await approveSetupClaim(token, "user-route", "Route");
@@ -42,7 +44,7 @@ describe("setup-claim routes", () => {
             // Simulate the browser re-opening the confirm screen after approval
             // (deep link revisited, StrictMode double-invoke, etc.) — hit /info twice.
             for (let i = 0; i < 2; i++) {
-                const { req, url } = get(`/api/setup-claim/${token}/info`);
+                const { req, url } = get(`/api/setup-claim-info/${token}`);
                 const res = await handleSetupClaimsRoute(req, url);
                 expect(res).toBeDefined();
                 const body = (await res!.json()) as { status: string; label?: string; apiKey?: string };
@@ -67,13 +69,44 @@ describe("setup-claim routes", () => {
         });
     });
 
-    test("GET .../token (no /info) is still the one-shot redeem for a pending claim", async () => {
+    test("GET .../token (no info route) is still the one-shot redeem for a pending claim", async () => {
         await runWithAuthContext(authContext, async () => {
             const { token } = await createSetupClaim("http://localhost:7492");
             const { req, url } = get(`/api/setup-claim/${token}`);
             const res = await handleSetupClaimsRoute(req, url);
             const body = (await res!.json()) as { status: string };
             expect(body.status).toBe("pending");
+        });
+    });
+
+    // Cross-version safety. The UI ships as its own image and will meet older
+    // relays, which resolve the poll token as
+    // `pathname.slice("/api/setup-claim/".length).split("/")[0]` — meaning a
+    // NESTED `/api/setup-claim/:token/info` arrives at their consuming handler
+    // with a valid token and silently redeems an approved claim. Keeping the
+    // info route under its own prefix is what prevents that, so pin it here:
+    // if someone "tidies" the path back under /api/setup-claim/, this fails.
+    test("the info route lives outside the /api/setup-claim/ prefix (old relays would mis-route a nested path)", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            await approveSetupClaim(token, "user-route", "Route");
+
+            // The nested path must NOT be served as an info read here either —
+            // this server answers it with the redeem handler, exactly as an old
+            // relay would, which is precisely why the UI must not request it.
+            const nested = get(`/api/setup-claim/${token}/info`);
+            const nestedRes = await handleSetupClaimsRoute(nested.req, nested.url);
+            const nestedBody = (await nestedRes!.json()) as { status?: string; apiKey?: string };
+            expect(nestedBody.apiKey).toBeDefined(); // consumed — proves the hazard is real
+
+            // ...and the dedicated prefix is the safe read that the UI uses.
+            const { token: token2 } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            await approveSetupClaim(token2, "user-route", "Route");
+            const info = get(`/api/setup-claim-info/${token2}`);
+            const infoRes = await handleSetupClaimsRoute(info.req, info.url);
+            const infoBody = (await infoRes!.json()) as { status: string; apiKey?: string };
+            expect(infoBody.apiKey).toBeUndefined();
+            expect(infoBody.status).toBe("approved");
         });
     });
 });

--- a/packages/server/src/routes/setup-claims.test.ts
+++ b/packages/server/src/routes/setup-claims.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Route-level tests for setup-claim endpoints.
+ *
+ * These exist specifically to catch routing regressions that store-level
+ * tests can't see: GET /api/setup-claim/:token is a one-shot redeem for the
+ * CLI, and GET /api/setup-claim/:token/info must never fall through to it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTestAuthContext, runWithAuthContext } from "../auth.js";
+import { runAllMigrations } from "../migrations.js";
+import { createSetupClaim, approveSetupClaim } from "../setup-claims.js";
+import { handleSetupClaimsRoute } from "./setup-claims.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-setup-claims-routes-"));
+const dbPath = join(tmpDir, "test.db");
+const authContext = createTestAuthContext({ dbPath, baseURL: "http://localhost:7492" });
+
+beforeAll(async () => {
+    await runAllMigrations(authContext);
+});
+
+afterAll(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+function get(path: string): { req: Request; url: URL } {
+    const url = new URL(`http://localhost:7492${path}`);
+    return { req: new Request(url, { method: "GET" }), url };
+}
+
+describe("setup-claim routes", () => {
+    test("GET .../info never consumes the one-shot key, and the CLI poll route still redeems afterwards", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            const approve = await approveSetupClaim(token, "user-route", "Route");
+            expect(approve).not.toBeNull();
+
+            // Simulate the browser re-opening the confirm screen after approval
+            // (deep link revisited, StrictMode double-invoke, etc.) — hit /info twice.
+            for (let i = 0; i < 2; i++) {
+                const { req, url } = get(`/api/setup-claim/${token}/info`);
+                const res = await handleSetupClaimsRoute(req, url);
+                expect(res).toBeDefined();
+                const body = (await res!.json()) as { status: string; label?: string; apiKey?: string };
+                expect(body.status).toBe("approved");
+                expect(body.label).toBe("docker-demo-runner");
+                expect(body.apiKey).toBeUndefined();
+            }
+
+            // The CLI's plain poll route must still redeem successfully: first
+            // call returns the key, second call reports redeemed.
+            const { req: pollReq1, url: pollUrl1 } = get(`/api/setup-claim/${token}`);
+            const pollRes1 = await handleSetupClaimsRoute(pollReq1, pollUrl1);
+            const pollBody1 = (await pollRes1!.json()) as { status: string; apiKey?: string };
+            expect(pollBody1.status).toBe("approved");
+            expect(pollBody1.apiKey).toBe(approve!.apiKey);
+
+            const { req: pollReq2, url: pollUrl2 } = get(`/api/setup-claim/${token}`);
+            const pollRes2 = await handleSetupClaimsRoute(pollReq2, pollUrl2);
+            const pollBody2 = (await pollRes2!.json()) as { status: string; apiKey?: string };
+            expect(pollBody2.status).toBe("redeemed");
+            expect(pollBody2.apiKey).toBeUndefined();
+        });
+    });
+
+    test("GET .../token (no /info) is still the one-shot redeem for a pending claim", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492");
+            const { req, url } = get(`/api/setup-claim/${token}`);
+            const res = await handleSetupClaimsRoute(req, url);
+            const body = (await res!.json()) as { status: string };
+            expect(body.status).toBe("pending");
+        });
+    });
+});

--- a/packages/server/src/routes/setup-claims.ts
+++ b/packages/server/src/routes/setup-claims.ts
@@ -3,7 +3,15 @@
  *
  * - POST /api/setup-claim              — unauthenticated; creates a pending claim.
  * - GET  /api/setup-claim/:token       — unauthenticated; poll/redeem a claim (one-shot key delivery, CLI only).
- * - GET  /api/setup-claim/:token/info  — unauthenticated; non-consuming status/label read for the approval UI.
+ * - GET  /api/setup-claim-info/:token  — unauthenticated; non-consuming status/label read for the approval UI.
+ *
+ * The info route deliberately sits OUTSIDE the /api/setup-claim/ prefix. Older
+ * relays parse the poll route's token as
+ * `pathname.slice("/api/setup-claim/".length).split("/")[0]`, so a nested
+ * `/api/setup-claim/:token/info` request would hit their *consuming* poll
+ * handler with a valid token and silently redeem an approved claim. The UI is
+ * shipped as a separately versioned image from the server, so a newer UI WILL
+ * meet an older server in the wild. A distinct prefix 404s there instead.
  * - POST /api/setup-claim/:token/approve — authenticated; approve and attach API key.
  */
 
@@ -33,8 +41,8 @@ export const handleSetupClaimsRoute: RouteHandler = async (req, url) => {
 
     // Non-consuming status/label read for the web approval UI (checked before the
     // poll/redeem route below — must NEVER fall through to the one-shot redeem).
-    if (url.pathname.startsWith("/api/setup-claim/") && url.pathname.endsWith("/info") && req.method === "GET") {
-        const token = url.pathname.slice("/api/setup-claim/".length, -"/info".length);
+    if (url.pathname.startsWith("/api/setup-claim-info/") && req.method === "GET") {
+        const token = url.pathname.slice("/api/setup-claim-info/".length).split("/")[0];
         if (!token) {
             return Response.json({ error: "Missing claim token" }, { status: 400 });
         }

--- a/packages/server/src/routes/setup-claims.ts
+++ b/packages/server/src/routes/setup-claims.ts
@@ -14,9 +14,11 @@ export const handleSetupClaimsRoute: RouteHandler = async (req, url) => {
     // Create a pending claim (called by the CLI during `pizzapi setup --scan`).
     if (url.pathname === "/api/setup-claim" && req.method === "POST") {
         let relayUrl = "";
+        let label: string | undefined;
         try {
-            const body = (await req.json()) as { relayUrl?: string };
+            const body = (await req.json()) as { relayUrl?: string; label?: string };
             relayUrl = typeof body.relayUrl === "string" ? body.relayUrl.trim() : "";
+            label = typeof body.label === "string" ? body.label : undefined;
         } catch {
             relayUrl = "";
         }
@@ -24,7 +26,7 @@ export const handleSetupClaimsRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Missing required field: relayUrl" }, { status: 400 });
         }
 
-        const { token, expiresAt } = await createSetupClaim(relayUrl);
+        const { token, expiresAt } = await createSetupClaim(relayUrl, label);
         return Response.json({ token, expiresAt });
     }
 

--- a/packages/server/src/routes/setup-claims.ts
+++ b/packages/server/src/routes/setup-claims.ts
@@ -1,13 +1,14 @@
 /**
  * Setup-claim routes — QR-code device enrollment.
  *
- * - POST /api/setup-claim         — unauthenticated; creates a pending claim.
- * - GET  /api/setup-claim/:token  — unauthenticated; poll/redeem a claim.
+ * - POST /api/setup-claim              — unauthenticated; creates a pending claim.
+ * - GET  /api/setup-claim/:token       — unauthenticated; poll/redeem a claim (one-shot key delivery, CLI only).
+ * - GET  /api/setup-claim/:token/info  — unauthenticated; non-consuming status/label read for the approval UI.
  * - POST /api/setup-claim/:token/approve — authenticated; approve and attach API key.
  */
 
 import { requireEnrollmentAuth } from "../middleware.js";
-import { createSetupClaim, pollSetupClaim, approveSetupClaim } from "../setup-claims.js";
+import { createSetupClaim, pollSetupClaim, approveSetupClaim, getSetupClaimInfo } from "../setup-claims.js";
 import type { RouteHandler } from "./types.js";
 
 export const handleSetupClaimsRoute: RouteHandler = async (req, url) => {
@@ -28,6 +29,20 @@ export const handleSetupClaimsRoute: RouteHandler = async (req, url) => {
 
         const { token, expiresAt } = await createSetupClaim(relayUrl, label);
         return Response.json({ token, expiresAt });
+    }
+
+    // Non-consuming status/label read for the web approval UI (checked before the
+    // poll/redeem route below — must NEVER fall through to the one-shot redeem).
+    if (url.pathname.startsWith("/api/setup-claim/") && url.pathname.endsWith("/info") && req.method === "GET") {
+        const token = url.pathname.slice("/api/setup-claim/".length, -"/info".length);
+        if (!token) {
+            return Response.json({ error: "Missing claim token" }, { status: 400 });
+        }
+        const info = await getSetupClaimInfo(token);
+        if (!info) {
+            return Response.json({ error: "Unknown or expired claim" }, { status: 404 });
+        }
+        return Response.json(info);
     }
 
     // Poll/redeem a claim (called by the CLI every few seconds).

--- a/packages/server/src/setup-claims.test.ts
+++ b/packages/server/src/setup-claims.test.ts
@@ -9,6 +9,7 @@ import {
     pollSetupClaim,
     approveSetupClaim,
     sweepExpiredSetupClaims,
+    getSetupClaimInfo,
 } from "./setup-claims.js";
 import { runWithAuthContext } from "./auth.js";
 
@@ -211,6 +212,57 @@ describe("setup-claims store", () => {
             const second = await pollSetupClaim(token);
             expect(second!.status).toBe("redeemed");
             expect(second!.label).toBe("docker-demo-runner");
+        });
+    });
+
+    // Regression: the web UI reads label/status via getSetupClaimInfo (the
+    // /info route), which must be safe to call after approval without
+    // disturbing the CLI's one-shot redeem via pollSetupClaim.
+    test("getSetupClaimInfo never leaks the key and never redeems an approved claim", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            const approve = await approveSetupClaim(token, "user-info", "Info");
+            expect(approve).not.toBeNull();
+
+            const info = await getSetupClaimInfo(token);
+            expect(info).not.toBeNull();
+            expect(info!.status).toBe("approved");
+            expect(info!.label).toBe("docker-demo-runner");
+            expect((info as unknown as { apiKey?: string }).apiKey).toBeUndefined();
+
+            // The CLI's poll must still work: first call redeems and returns the key,
+            // second call reports redeemed. getSetupClaimInfo must not have consumed it.
+            const firstPoll = await pollSetupClaim(token);
+            expect(firstPoll!.status).toBe("approved");
+            expect(firstPoll!.apiKey).toBe(approve!.apiKey);
+
+            const secondPoll = await pollSetupClaim(token);
+            expect(secondPoll!.status).toBe("redeemed");
+            expect(secondPoll!.apiKey).toBeUndefined();
+        });
+    });
+
+    test("repeated getSetupClaimInfo reads on an approved claim never redeem it", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492");
+            await approveSetupClaim(token, "user-repeat", "Repeat");
+
+            for (let i = 0; i < 5; i++) {
+                const info = await getSetupClaimInfo(token);
+                expect(info!.status).toBe("approved");
+            }
+
+            // Still approved (not redeemed) after all those reads — the CLI poll
+            // is the only thing allowed to consume it.
+            const info = await getSetupClaimInfo(token);
+            expect(info!.status).toBe("approved");
+        });
+    });
+
+    test("getSetupClaimInfo returns null for an unknown token", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const info = await getSetupClaimInfo("definitely-not-a-token");
+            expect(info).toBeNull();
         });
     });
 });

--- a/packages/server/src/setup-claims.test.ts
+++ b/packages/server/src/setup-claims.test.ts
@@ -127,4 +127,90 @@ describe("setup-claims store", () => {
             expect(second).toBeNull();
         });
     });
+
+    test("label is trimmed, persisted, and returned on poll", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "  docker-demo-runner  ");
+            const status = await pollSetupClaim(token);
+            expect(status!.label).toBe("docker-demo-runner");
+        });
+    });
+
+    test("hostile label input is stripped to a safe charset and truncated", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const hostile = "<script>alert(1)</script>\x00\x07" + "a".repeat(100);
+            const { token } = await createSetupClaim("http://localhost:7492", hostile);
+            const status = await pollSetupClaim(token);
+            expect(status!.label).toBeDefined();
+            expect(status!.label!.length).toBeLessThanOrEqual(64);
+            // Only letters, digits, space, -, _, . may survive.
+            expect(status!.label!).toMatch(/^[a-zA-Z0-9 _.-]*$/);
+        });
+    });
+
+    test("whitespace-only label is treated as no label", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "   ");
+            const status = await pollSetupClaim(token);
+            expect(status!.label).toBeUndefined();
+        });
+    });
+
+    test("no label still behaves exactly as before (relayUrl-only call)", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token, expiresAt } = await createSetupClaim("http://localhost:7492");
+            expect(new Date(expiresAt).getTime()).toBeGreaterThan(Date.now());
+            const status = await pollSetupClaim(token);
+            expect(status!.label).toBeUndefined();
+
+            const approve = await approveSetupClaim(token, "user-nolabel", "NoLabel");
+            expect(approve).not.toBeNull();
+
+            const { getKysely } = await import("./auth.js");
+            const row = await getKysely()
+                .selectFrom("apikey")
+                .select(["name"])
+                .where("name", "=", `setup-claim-${token.slice(0, 8)}`)
+                .executeTakeFirst();
+            expect(row).toBeTruthy();
+
+            const firstPoll = await pollSetupClaim(token);
+            expect(firstPoll!.status).toBe("approved");
+            expect(firstPoll!.apiKey).toBe(approve!.apiKey);
+
+            const redeemed = await pollSetupClaim(token);
+            expect(redeemed!.status).toBe("redeemed");
+        });
+    });
+
+    test("approving a labeled claim names the minted key after the label", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            const approve = await approveSetupClaim(token, "user-label", "Labelled");
+            expect(approve).not.toBeNull();
+
+            const { getKysely } = await import("./auth.js");
+            const row = await getKysely()
+                .selectFrom("apikey")
+                .select(["name"])
+                .where("name", "=", "runner-docker-demo-runner")
+                .executeTakeFirst();
+            expect(row).toBeTruthy();
+        });
+    });
+
+    test("label survives the approve -> poll -> redeem cycle", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492", "docker-demo-runner");
+            await approveSetupClaim(token, "user-cycle", "Cycle");
+
+            const first = await pollSetupClaim(token);
+            expect(first!.status).toBe("approved");
+            expect(first!.label).toBe("docker-demo-runner");
+
+            const second = await pollSetupClaim(token);
+            expect(second!.status).toBe("redeemed");
+            expect(second!.label).toBe("docker-demo-runner");
+        });
+    });
 });

--- a/packages/server/src/setup-claims.ts
+++ b/packages/server/src/setup-claims.ts
@@ -146,6 +146,31 @@ export async function pollSetupClaim(token: string): Promise<SetupClaimStatus | 
     return { status: row.status, relayUrl: row.relayUrl, label: row.label ?? undefined };
 }
 
+export interface SetupClaimInfo {
+    status: SetupClaimTable["status"] | "expired";
+    label?: string;
+}
+
+/**
+ * Non-consuming read of a claim's status/label, for the web approval UI to
+ * show "what am I approving" before the user clicks. Unlike `pollSetupClaim`
+ * (the CLI's one-shot redeem), this NEVER mutates the row and NEVER returns
+ * the API key — it's safe to call any number of times, including after the
+ * claim has been approved, without disturbing the CLI's pending redemption.
+ */
+export async function getSetupClaimInfo(token: string): Promise<SetupClaimInfo | null> {
+    const row = await getKysely()
+        .selectFrom("setup_claim")
+        .select(["status", "expiresAt", "label"])
+        .where("id", "=", token)
+        .executeTakeFirst();
+
+    if (!row) return null;
+
+    const expired = row.status !== "redeemed" && new Date(row.expiresAt) < new Date();
+    return { status: expired ? "expired" : row.status, label: row.label ?? undefined };
+}
+
 /**
  * Approve a pending claim. Creates an API key for the approving user and stores
  * it on the claim so the polling CLI can redeem it.

--- a/packages/server/src/setup-claims.ts
+++ b/packages/server/src/setup-claims.ts
@@ -44,6 +44,17 @@ export async function ensureSetupClaimsTable(): Promise<void> {
         .addColumn("approvedAt", "text")
         .addColumn("redeemedAt", "text")
         .execute();
+
+    // Migration: add label column for naming the runner/device being paired
+    // (older rows/deployments simply have a null label).
+    try {
+        await getKysely().schema.alterTable("setup_claim").addColumn("label", "text").execute();
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes("duplicate column name")) {
+            throw err;
+        }
+    }
 }
 
 function claimExpiry(): string {
@@ -54,7 +65,22 @@ function generateToken(): string {
     return crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
 }
 
-export async function createSetupClaim(relayUrl: string): Promise<{ token: string; expiresAt: string }> {
+const LABEL_MAX_LENGTH = 64;
+// Letters, digits, space, dash, underscore, dot. Rendered as text in the web UI
+// and folded into a minted API key name, so nothing else survives.
+const LABEL_SAFE_CHARS = /[^a-zA-Z0-9 _.-]/g;
+
+/** Sanitize an attacker-controlled label: trim, strip unsafe chars, cap length. */
+function sanitizeLabel(label: unknown): string | null {
+    if (typeof label !== "string") return null;
+    const cleaned = label.trim().replace(LABEL_SAFE_CHARS, "").slice(0, LABEL_MAX_LENGTH).trim();
+    return cleaned || null;
+}
+
+export async function createSetupClaim(
+    relayUrl: string,
+    label?: string | null,
+): Promise<{ token: string; expiresAt: string }> {
     const token = generateToken();
     const now = new Date().toISOString();
     const expiresAt = claimExpiry();
@@ -71,6 +97,7 @@ export async function createSetupClaim(relayUrl: string): Promise<{ token: strin
             expiresAt,
             approvedAt: null,
             redeemedAt: null,
+            label: sanitizeLabel(label),
         })
         .execute();
     return { token, expiresAt };
@@ -80,6 +107,7 @@ export interface SetupClaimStatus {
     status: SetupClaimTable["status"];
     relayUrl: string;
     apiKey?: string;
+    label?: string;
 }
 
 /**
@@ -103,7 +131,7 @@ export async function pollSetupClaim(token: string): Promise<SetupClaimStatus | 
                 .where("id", "=", token)
                 .execute();
         }
-        return { status: "expired", relayUrl: row.relayUrl };
+        return { status: "expired", relayUrl: row.relayUrl, label: row.label ?? undefined };
     }
 
     if (row.status === "approved" && row.apiKey) {
@@ -112,10 +140,10 @@ export async function pollSetupClaim(token: string): Promise<SetupClaimStatus | 
             .set({ status: "redeemed", redeemedAt: new Date().toISOString() })
             .where("id", "=", token)
             .execute();
-        return { status: "approved", relayUrl: row.relayUrl, apiKey: row.apiKey };
+        return { status: "approved", relayUrl: row.relayUrl, apiKey: row.apiKey, label: row.label ?? undefined };
     }
 
-    return { status: row.status, relayUrl: row.relayUrl };
+    return { status: row.status, relayUrl: row.relayUrl, label: row.label ?? undefined };
 }
 
 /**
@@ -144,7 +172,8 @@ export async function approveSetupClaim(
     const ttl = maxTtlSeconds == null
         ? SETUP_CLAIM_API_KEY_TTL_SECONDS
         : Math.min(SETUP_CLAIM_API_KEY_TTL_SECONDS, maxTtlSeconds);
-    const apiKey = await mintEphemeralApiKey(userId, `setup-claim-${token.slice(0, 8)}`, ttl);
+    const keyName = row.label ? `runner-${row.label}`.slice(0, LABEL_MAX_LENGTH + 7) : `setup-claim-${token.slice(0, 8)}`;
+    const apiKey = await mintEphemeralApiKey(userId, keyName, ttl);
 
     await getKysely()
         .updateTable("setup_claim")

--- a/packages/ui/src/components/DeviceSetupScanner.test.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.test.tsx
@@ -7,15 +7,17 @@ mock.module("@/lib/utils", () => ({
     cn: (...classes: Array<string | undefined | null | false>) => classes.filter(Boolean).join(" "),
 }));
 
-const approveMock = mock().mockResolvedValue({ error: null });
 mock.module("@/lib/auth-client", () => ({
-    authClient: { $fetch: approveMock },
     useSession: () => ({ data: { session: null }, isPending: false }),
 }));
 
 // Capture the html5-qrcode success callback so tests can simulate a decode.
 let decodeCallback: ((text: string) => void) | null = null;
+// Whether the preview container was visible at the moment start() measured it.
+let readerHiddenAtStart: boolean | null = null;
 const startMock = mock().mockImplementation(async (_cameraId: unknown, _config: unknown, onDecode: (text: string) => void) => {
+    const reader = document.querySelector('[id$="-qr-reader"]');
+    readerHiddenAtStart = reader ? reader.hasAttribute("hidden") : null;
     decodeCallback = onDecode;
 });
 const stopMock = mock().mockResolvedValue(undefined);
@@ -57,8 +59,8 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
     cleanup();
     decodeCallback = null;
-    approveMock.mockClear();
     startMock.mockClear();
+    readerHiddenAtStart = null;
     stopMock.mockClear();
     clearMock.mockClear();
     getCamerasMock.mockClear();
@@ -74,6 +76,10 @@ describe("DeviceSetupScanner", () => {
 
         await waitFor(() => expect(getCamerasMock).toHaveBeenCalledTimes(1));
         expect(startMock).toHaveBeenCalledTimes(1);
+        // Must request the rear lens: cameras[0] is the selfie camera on Android.
+        expect(startMock.mock.calls[0][0]).toEqual({ facingMode: "environment" });
+        // A display:none container measures 0x0 and the preview renders black.
+        expect(readerHiddenAtStart).toBe(false);
     });
 
     test("scanning a QR requires explicit confirmation before approving", async () => {
@@ -84,15 +90,20 @@ describe("DeviceSetupScanner", () => {
         await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
         expect(decodeCallback).not.toBeNull();
 
+        const fetchMock = mock().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+        const approveCalls = () => fetchMock.mock.calls.filter((c: unknown[]) => String(c[0]).includes("/approve"));
+
         // A decoded QR must NOT auto-approve; it shows a confirmation step.
         decodeCallback!(`http://localhost/?t=${token}`);
         await waitFor(() => expect(getByText("Approve this device")).toBeDefined());
-        expect(approveMock).not.toHaveBeenCalled();
+        expect(approveCalls()).toHaveLength(0);
 
         // Only an explicit click approves.
         fireEvent.click(getByText("Approve this device"));
-        await waitFor(() => expect(approveMock).toHaveBeenCalledTimes(1));
-        expect(approveMock.mock.calls[0][0]).toContain(`/api/setup-claim/${token}/approve`);
+        await waitFor(() => expect(approveCalls()).toHaveLength(1));
+        // Exact path: an auth-client baseURL prefix (/api/auth/...) 404s here.
+        expect(approveCalls()[0][0]).toBe(`/api/setup-claim/${token}/approve`);
         expect(queryByText("Cancel")).toBeNull();
     });
 
@@ -127,6 +138,24 @@ describe("DeviceSetupScanner", () => {
         await waitFor(() => expect(getByText("Approve this device")).toBeDefined());
         expect(queryByText("undefined")).toBeNull();
         expect(container.textContent).not.toContain("undefined");
+    });
+
+    test("unmounting before the scanner starts does not throw", async () => {
+        // html5-qrcode throws a bare string synchronously, which a .catch() on
+        // the returned promise would never see.
+        stopMock.mockImplementationOnce(() => {
+            throw "Cannot stop, scanner is not running or paused.";
+        });
+        clearMock.mockImplementationOnce(() => {
+            throw "Cannot clear while scan is ongoing, close it first.";
+        });
+
+        const { getByText, unmount } = render(<DeviceSetupScanner onClose={() => {}} />);
+        fireEvent.click(getByText("Allow Camera & Scan"));
+        await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+
+        expect(() => unmount()).not.toThrow();
+        await waitFor(() => expect(stopMock).toHaveBeenCalled());
     });
 
     test("initialToken pre-fills the manual approve input", () => {

--- a/packages/ui/src/components/DeviceSetupScanner.test.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.test.tsx
@@ -52,6 +52,8 @@ beforeAll(() => {
     /* eslint-enable @typescript-eslint/no-explicit-any */
 });
 
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
     cleanup();
     decodeCallback = null;
@@ -60,6 +62,7 @@ afterEach(() => {
     stopMock.mockClear();
     clearMock.mockClear();
     getCamerasMock.mockClear();
+    globalThis.fetch = originalFetch;
 });
 
 describe("DeviceSetupScanner", () => {
@@ -91,6 +94,39 @@ describe("DeviceSetupScanner", () => {
         await waitFor(() => expect(approveMock).toHaveBeenCalledTimes(1));
         expect(approveMock.mock.calls[0][0]).toContain(`/api/setup-claim/${token}/approve`);
         expect(queryByText("Cancel")).toBeNull();
+    });
+
+    test("shows the claim's label on the confirmation screen when present", async () => {
+        globalThis.fetch = mock().mockResolvedValue(
+            new Response(JSON.stringify({ status: "pending", relayUrl: "http://x", label: "docker-demo-runner" }), { status: 200 }),
+        ) as unknown as typeof fetch;
+
+        const token = "c".repeat(64);
+        const { getByText } = render(<DeviceSetupScanner onClose={() => {}} />);
+
+        fireEvent.click(getByText("Allow Camera & Scan"));
+        await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+
+        decodeCallback!(`http://localhost/?t=${token}`);
+        await waitFor(() => expect(getByText("Approve this device")).toBeDefined());
+        await waitFor(() => expect(getByText("docker-demo-runner")).toBeDefined());
+    });
+
+    test("confirmation screen is unaffected when the claim has no label", async () => {
+        globalThis.fetch = mock().mockResolvedValue(
+            new Response(JSON.stringify({ status: "pending", relayUrl: "http://x" }), { status: 200 }),
+        ) as unknown as typeof fetch;
+
+        const token = "d".repeat(64);
+        const { getByText, queryByText, container } = render(<DeviceSetupScanner onClose={() => {}} />);
+
+        fireEvent.click(getByText("Allow Camera & Scan"));
+        await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+
+        decodeCallback!(`http://localhost/?t=${token}`);
+        await waitFor(() => expect(getByText("Approve this device")).toBeDefined());
+        expect(queryByText("undefined")).toBeNull();
+        expect(container.textContent).not.toContain("undefined");
     });
 
     test("initialToken pre-fills the manual approve input", () => {

--- a/packages/ui/src/components/DeviceSetupScanner.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.tsx
@@ -33,13 +33,19 @@ function extractToken(decodedText: string): string | null {
 
 /**
  * Best-effort label lookup for the confirmation screen; never blocks approval.
- * Hits the non-consuming /info route — the plain /api/setup-claim/:token route
- * is a one-shot redeem for the CLI and must never be called from here (doing
- * so would silently burn the approved key out from under the CLI's poll).
+ * Hits the non-consuming /api/setup-claim-info/:token route — the plain
+ * /api/setup-claim/:token route is a one-shot redeem for the CLI and must
+ * never be called from here (doing so would silently burn the approved key
+ * out from under the CLI's poll).
+ *
+ * Note the separate prefix rather than a nested /info path: older relays parse
+ * the poll route's token with split("/")[0], so a nested path would reach
+ * their consuming handler with a valid token. This UI ships as its own image
+ * and will meet older servers; there it simply 404s and the label is omitted.
  */
 async function fetchClaimLabel(token: string): Promise<string | undefined> {
     try {
-        const res = await fetch(`/api/setup-claim/${token}/info`);
+        const res = await fetch(`/api/setup-claim-info/${token}`);
         if (!res.ok) return undefined;
         const data = (await res.json()) as { label?: string };
         return typeof data.label === "string" && data.label ? data.label : undefined;

--- a/packages/ui/src/components/DeviceSetupScanner.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 // ponytail: type-only — the 330KB html5-qrcode lib is dynamically imported on scan start
 import type { Html5Qrcode } from "html5-qrcode";
-import { authClient } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -54,17 +53,47 @@ async function fetchClaimLabel(token: string): Promise<string | undefined> {
     }
 }
 
+/**
+ * ponytail: plain fetch, not authClient.$fetch — the auth client prefixes its
+ * baseURL (`<origin>/api/auth`), which turned this into a 404 at
+ * /api/auth/api/setup-claim/:token/approve. The route accepts the browser
+ * session cookie, and the mobile fetch patch adds x-api-key for the bundled app.
+ */
 async function approveClaim(token: string): Promise<{ ok: boolean; error?: string }> {
     try {
-        const { error } = await authClient.$fetch(`/api/setup-claim/${token}/approve`, {
+        const res = await fetch(`/api/setup-claim/${token}/approve`, {
             method: "POST",
+            credentials: "include",
         });
-        if (error) {
-            return { ok: false, error: (error as any)?.message ?? "Approval failed" };
+        if (!res.ok) {
+            const body = (await res.json().catch(() => null)) as { error?: string } | null;
+            return { ok: false, error: body?.error ?? `Approval failed (HTTP ${res.status})` };
         }
         return { ok: true };
     } catch (e) {
         return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+    }
+}
+
+/**
+ * Stop + clear without ever throwing.
+ *
+ * ponytail: html5-qrcode throws a bare *string* synchronously from stop()/clear()
+ * when the scanner isn't in the state it expects ("Cannot stop, scanner is not
+ * running or paused."). A .catch() on the returned promise never sees that, so
+ * it escaped the unmount cleanup and tripped the app's error boundary whenever
+ * the panel closed before start() finished.
+ */
+async function teardownScanner(scanner: Html5Qrcode): Promise<void> {
+    try {
+        await scanner.stop();
+    } catch {
+        // Not scanning (or already stopped) — nothing to stop.
+    }
+    try {
+        scanner.clear();
+    } catch {
+        // Nothing rendered to clear.
     }
 }
 
@@ -79,16 +108,8 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
 
     React.useEffect(() => {
         return () => {
-            if (scannerRef.current) {
-                scannerRef.current
-                    .stop()
-                    .catch(() => {
-                        // Ignore stop errors during unmount.
-                    })
-                    .finally(() => {
-                        scannerRef.current?.clear();
-                    });
-            }
+            const scanner = scannerRef.current;
+            if (scanner) void teardownScanner(scanner);
         };
     }, []);
 
@@ -153,7 +174,13 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
 
         try {
             await scanner.start(
-                cameras[0].id,
+                // ponytail: a facingMode constraint, not cameras[0].id — the first
+                // enumerated device is the selfie camera on Android, so scanning
+                // opened the wrong lens. Bare string, not { ideal } (html5-qrcode
+                // rejects that) and not { exact } (hard-fails on a front-camera-only
+                // laptop); getUserMedia treats a bare string as "ideal". getCameras()
+                // above stays: it drives the permission prompt and no-camera message.
+                { facingMode: "environment" },
                 { fps: 10, qrbox: { width: 250, height: 250 } },
                 async (decodedText) => {
                     const token = extractToken(decodedText);
@@ -263,10 +290,18 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
                             <p className="text-center text-xs text-muted-foreground">Point your camera at the QR code on the new device.</p>
                         )}
 
+                        {/*
+                          * Visible from "requesting" on, not just "scanning":
+                          * html5-qrcode measures this element inside start(), and a
+                          * hidden (display:none) container measures 0×0 — the camera
+                          * opens but the preview renders as a black square. The two
+                          * awaits in startScanning (dynamic import, getCameras) give
+                          * React time to flush this before start() runs.
+                          */}
                         <div
                             id={readerId}
                             className="mx-auto aspect-square w-full max-w-[300px] overflow-hidden rounded-md border bg-black"
-                            hidden={state.kind !== "scanning"}
+                            hidden={state.kind !== "scanning" && state.kind !== "requesting"}
                         />
 
                         {state.kind === "error" && (

--- a/packages/ui/src/components/DeviceSetupScanner.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.tsx
@@ -31,10 +31,15 @@ function extractToken(decodedText: string): string | null {
     return null;
 }
 
-/** Best-effort label lookup for the confirmation screen; never blocks approval. */
+/**
+ * Best-effort label lookup for the confirmation screen; never blocks approval.
+ * Hits the non-consuming /info route — the plain /api/setup-claim/:token route
+ * is a one-shot redeem for the CLI and must never be called from here (doing
+ * so would silently burn the approved key out from under the CLI's poll).
+ */
 async function fetchClaimLabel(token: string): Promise<string | undefined> {
     try {
-        const res = await fetch(`/api/setup-claim/${token}`);
+        const res = await fetch(`/api/setup-claim/${token}/info`);
         if (!res.ok) return undefined;
         const data = (await res.json()) as { label?: string };
         return typeof data.label === "string" && data.label ? data.label : undefined;

--- a/packages/ui/src/components/DeviceSetupScanner.tsx
+++ b/packages/ui/src/components/DeviceSetupScanner.tsx
@@ -14,6 +14,8 @@ interface ScannerState {
     message?: string;
     /** Decoded token awaiting explicit user confirmation (kind === "confirm"). */
     token?: string;
+    /** Operator-facing name of the device/runner asking for approval, if the claim has one. */
+    label?: string;
 }
 
 function extractToken(decodedText: string): string | null {
@@ -27,6 +29,18 @@ function extractToken(decodedText: string): string | null {
     const raw = decodedText.trim();
     if (/^[0-9a-f]{64}$/i.test(raw)) return raw;
     return null;
+}
+
+/** Best-effort label lookup for the confirmation screen; never blocks approval. */
+async function fetchClaimLabel(token: string): Promise<string | undefined> {
+    try {
+        const res = await fetch(`/api/setup-claim/${token}`);
+        if (!res.ok) return undefined;
+        const data = (await res.json()) as { label?: string };
+        return typeof data.label === "string" && data.label ? data.label : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 async function approveClaim(token: string): Promise<{ ok: boolean; error?: string }> {
@@ -75,6 +89,16 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
         } else {
             setState({ kind: "error", message: result.error });
         }
+    }, []);
+
+    // Show the confirm screen immediately, then fill in the label once it
+    // arrives — never block or fail the confirmation on the label lookup.
+    const requestConfirmation = React.useCallback((token: string) => {
+        setState({ kind: "confirm", token });
+        void fetchClaimLabel(token).then((label) => {
+            if (!label) return;
+            setState((prev) => (prev.kind === "confirm" && prev.token === token ? { ...prev, label } : prev));
+        });
     }, []);
 
     const startScanning = React.useCallback(async () => {
@@ -130,7 +154,7 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
                     }
                     // Require an explicit confirmation click before approving — a QR
                     // that merely lands in frame must not auto-approve a device.
-                    setState({ kind: "confirm", token });
+                    requestConfirmation(token);
                 },
                 () => {
                     // Scan failures are frequent and noisy; ignore them.
@@ -142,7 +166,7 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
             setCameraError(`Could not start camera: ${detail}`);
             setState({ kind: "idle" });
         }
-    }, [handleApprove]);
+    }, [requestConfirmation]);
 
     const handleManualSubmit = React.useCallback(
         async (e: React.FormEvent) => {
@@ -176,6 +200,9 @@ export function DeviceSetupScanner({ initialToken, onClose }: { initialToken?: s
                         <p className="text-center text-xs text-muted-foreground">
                             Only approve if you started this setup. Approving grants the device an API key for your account.
                         </p>
+                        {state.label && (
+                            <p className="text-center text-sm font-semibold">{state.label}</p>
+                        )}
                         <code className="max-w-full break-all rounded bg-muted px-2 py-1 text-xs font-mono">{state.token}</code>
                         <div className="mt-2 flex gap-2">
                             <Button variant="outline" onClick={() => setState({ kind: "idle" })}>

--- a/packages/ui/src/components/runner-settings/ProviderAuthSettings.tsx
+++ b/packages/ui/src/components/runner-settings/ProviderAuthSettings.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2, ExternalLink, KeyRound, Loader2, LogIn, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import type { SectionProps } from "./RunnerSettingsPanel";
+
+interface ProviderRow {
+    id: string;
+    name: string;
+    types: ("oauth" | "api_key")[];
+    configured: boolean;
+}
+
+type LoginStep =
+    | { state: "waiting" }
+    | {
+        state: "prompt";
+        loginId: string;
+        prompt: { type: "text" | "secret" | "select" | "manual_code"; message: string; placeholder?: string; options?: { id: string; label: string }[] };
+        authUrl?: string;
+        info?: string[];
+    }
+    | { state: "done"; providerId: string }
+    | { state: "error"; message: string };
+
+async function api(path: string, init?: RequestInit): Promise<any> {
+    const res = await fetch(path, { credentials: "include", headers: { "Content-Type": "application/json" }, ...init });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(body?.error ?? `HTTP ${res.status}`);
+    return body;
+}
+
+export default function ProviderAuthSettings({ runnerId }: SectionProps) {
+    const base = `/api/runners/${encodeURIComponent(runnerId)}/providers`;
+    const [providers, setProviders] = useState<ProviderRow[] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [step, setStep] = useState<LoginStep | null>(null);
+    const [answer, setAnswer] = useState("");
+    const [busy, setBusy] = useState(false);
+
+    const load = useCallback(async () => {
+        setError(null);
+        try {
+            const body = await api(base);
+            setProviders(body.providers ?? []);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }, [base]);
+
+    useEffect(() => {
+        void load();
+    }, [load]);
+
+    /**
+     * While a prompt is on screen, the provider's own loopback callback may
+     * complete the login (browser on the runner's host, or 53692 published from
+     * the container) — nothing submits in that case, so poll for the outcome.
+     */
+    useEffect(() => {
+        if (step?.state !== "prompt") return;
+        const loginId = step.loginId;
+        const timer = setInterval(async () => {
+            try {
+                const body = await api(`${base}/login/status?loginId=${encodeURIComponent(loginId)}`);
+                if (body.step?.state === "done" || body.step?.state === "error") applyStep(body.step);
+            } catch {
+                // Transient relay/runner hiccup — the next tick retries.
+            }
+        }, 2500);
+        return () => clearInterval(timer);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [step, base]);
+
+    /** Both start and submit return the same "what's next" step. */
+    function applyStep(next: LoginStep) {
+        setAnswer("");
+        if (next.state === "waiting") {
+            return;
+        }
+        if (next.state === "done") {
+            setStep(null);
+            setNotice(`${next.providerId} is now authenticated.`);
+            void load();
+        } else if (next.state === "error") {
+            setStep(null);
+            setError(next.message);
+        } else {
+            setStep(next);
+        }
+    }
+
+    async function start(providerId: string, authType: "oauth" | "api_key") {
+        setBusy(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const body = await api(`${base}/login`, { method: "POST", body: JSON.stringify({ providerId, authType }) });
+            applyStep(body.step);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function submit(value: string) {
+        if (!step || step.state !== "prompt") return;
+        setBusy(true);
+        setError(null);
+        try {
+            const body = await api(`${base}/login/submit`, {
+                method: "POST",
+                body: JSON.stringify({ loginId: step.loginId, value }),
+            });
+            applyStep(body.step);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setStep(null);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function cancel() {
+        const loginId = step?.state === "prompt" ? step.loginId : null;
+        setStep(null);
+        setAnswer("");
+        if (loginId) {
+            await api(`${base}/login/cancel`, { method: "POST", body: JSON.stringify({ loginId }) }).catch(() => {});
+        }
+    }
+
+    return (
+        <div className="p-4 space-y-4">
+            <div className="flex items-start justify-between gap-3">
+                <div>
+                    <h3 className="text-sm font-medium">Model providers</h3>
+                    <p className="text-xs text-muted-foreground mt-1">
+                        Credentials are stored on the runner in <code>auth.json</code>. New sessions pick them up
+                        immediately.
+                    </p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => void load()} disabled={busy}>
+                    <RefreshCw className="h-3.5 w-3.5 mr-1" />
+                    Refresh
+                </Button>
+            </div>
+
+            {error && <ErrorAlert>{error}</ErrorAlert>}
+            {notice && (
+                <div className="flex items-center gap-2 text-xs text-emerald-600 dark:text-emerald-400">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    {notice}
+                </div>
+            )}
+
+            {step?.state === "prompt" && (
+                <div className="rounded-md border p-3 space-y-3">
+                    {step.authUrl && (
+                        <div className="space-y-2">
+                            <p className="text-xs text-muted-foreground">
+                                Open the authorization page, finish signing in, then paste the URL you land on back
+                                here. It can be a browser on any device.
+                            </p>
+                            <Button asChild size="sm" variant="secondary">
+                                <a href={step.authUrl} target="_blank" rel="noreferrer">
+                                    <ExternalLink className="h-3.5 w-3.5 mr-1" />
+                                    Open authorization page
+                                </a>
+                            </Button>
+                        </div>
+                    )}
+                    {step.info?.map((line) => (
+                        <p key={line} className="text-xs text-muted-foreground">
+                            {line}
+                        </p>
+                    ))}
+
+                    {step.prompt.type === "select" ? (
+                        <div className="space-y-2">
+                            <Label className="text-xs">{step.prompt.message}</Label>
+                            <div className="flex flex-wrap gap-2">
+                                {step.prompt.options?.map((option) => (
+                                    <Button key={option.id} size="sm" variant="outline" disabled={busy} onClick={() => void submit(option.id)}>
+                                        {option.label}
+                                    </Button>
+                                ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <form
+                            className="space-y-2"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                void submit(answer);
+                            }}
+                        >
+                            <Label className="text-xs" htmlFor="provider-auth-answer">
+                                {step.prompt.message}
+                            </Label>
+                            <div className="flex gap-2">
+                                <Input
+                                    id="provider-auth-answer"
+                                    autoFocus
+                                    type={step.prompt.type === "secret" ? "password" : "text"}
+                                    placeholder={step.prompt.placeholder}
+                                    value={answer}
+                                    onChange={(e) => setAnswer(e.target.value)}
+                                    disabled={busy}
+                                />
+                                <Button type="submit" size="sm" disabled={busy || !answer.trim()}>
+                                    {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Submit"}
+                                </Button>
+                            </div>
+                        </form>
+                    )}
+
+                    <Button variant="ghost" size="sm" onClick={() => void cancel()}>
+                        Cancel
+                    </Button>
+                </div>
+            )}
+
+            {providers === null ? (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Loading providers…
+                </div>
+            ) : (
+                <div className="divide-y rounded-md border">
+                    {providers.map((provider) => (
+                        <div key={provider.id} className="flex items-center justify-between gap-3 p-2.5">
+                            <div className="min-w-0">
+                                <div className="text-sm truncate">
+                                    {provider.name}
+                                    {provider.configured && (
+                                        <span className="ml-2 text-[11px] text-emerald-600 dark:text-emerald-400">signed in</span>
+                                    )}
+                                </div>
+                                <div className="text-[11px] text-muted-foreground truncate">{provider.id}</div>
+                            </div>
+                            <div className="flex gap-2 shrink-0">
+                                {provider.types.includes("oauth") && (
+                                    <Button size="sm" variant="outline" disabled={busy} onClick={() => void start(provider.id, "oauth")}>
+                                        <LogIn className="h-3.5 w-3.5 mr-1" />
+                                        Sign in
+                                    </Button>
+                                )}
+                                {provider.types.includes("api_key") && (
+                                    <Button size="sm" variant="ghost" disabled={busy} onClick={() => void start(provider.id, "api_key")}>
+                                        <KeyRound className="h-3.5 w-3.5 mr-1" />
+                                        API key
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
+++ b/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
@@ -16,10 +16,12 @@ const ProviderOverridesSettings = React.lazy(() => import("./ProviderOverridesSe
 const TuiPrefsSettings = React.lazy(() => import("./TuiPrefsSettings"));
 const FastModelSettings = React.lazy(() => import("./FastModelSettings"));
 const PackagesSettings = React.lazy(() => import("./PackagesSettings"));
+const ProviderAuthSettings = React.lazy(() => import("./ProviderAuthSettings"));
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export type SettingsSection =
+    | "providerAuth"
     | "models"
     | "webSearch"
     | "toolSearch"
@@ -50,6 +52,7 @@ export interface SectionProps {
 // ── Sub-tab definitions ───────────────────────────────────────────────────────
 
 const SETTINGS_TABS: { key: SettingsSection; label: string }[] = [
+    { key: "providerAuth", label: "Providers" },
     { key: "models", label: "Models" },
     { key: "goal", label: "Fast Model" },
     { key: "webSearch", label: "Web Search" },
@@ -177,6 +180,9 @@ export function RunnerSettingsPanel({ runnerId }: RunnerSettingsPanelProps) {
             break;
         case "packages":
             content = <PackagesSettings {...sectionProps} />;
+            break;
+        case "providerAuth":
+            content = <ProviderAuthSettings {...sectionProps} />;
             break;
     }
 


### PR DESCRIPTION
Implements the runner container image per the approved spike (`docs/plans/2026-07-31-runner-container-spike.md`), covering all three slices of Godmother epic `dQR5hwwdI2kSP7AxPsSUq` plus the CLI health probe the spike said was a prerequisite.

`ghcr.io/pizzaface/pizzapi-runner` is a **remote coding machine**, not a daemon wrapper: Debian slim, non-root `pizza` (1000:1000), `tini` as PID 1, built from the existing standalone Linux binaries. It dials out to a relay and exposes no inbound ports.

## What's here

| Area | Change |
|---|---|
| Image | `docker/runner/Dockerfile` — one arch-generic Dockerfile, `linux/amd64` + `linux/arm64` via `TARGETARCH` |
| Entrypoint | `docker/runner/entrypoint.sh` — non-root by default; optional `PUID`/`PGID` remap with privilege drop via `setpriv` |
| Build | `docker/runner/stage-context.ts` — compiles/reuses the standalone binaries and assembles a minimal build context |
| Smoke | `docker/runner/smoke.sh` — 17 checks end-to-end against a live relay |
| Compose | `docker/runner/compose.example.yml` — operator-facing example |
| CLI | `pizza runner status [--json]` — real health probe (alive **and** relay-registered), backs the image `HEALTHCHECK` |
| CLI fix | Stale-lock check now detects PID reuse (found by the smoke test — see below) |
| CI | GHCR publish on release + edge publish on `main` + hermetic Dockerfile check on every PR |
| Docs | `deployment/runner-container.mdx` operator guide + `pizza runner status` in the CLI reference |

## Decisions made

- **Registry:** `ghcr.io/pizzaface/pizzapi-runner`. Release publishes `:<version>` + `:<sha>`, and `:latest` **only** for `latest` releases (never beta/dev). Pushes to `main` publish `:main` + `:<sha>`.
- **UID/GID:** non-root `pizza` 1000 by default (a fresh named volume inherits that ownership automatically). Operators whose bind mounts are owned by another UID run the container as root with `PUID`/`PGID`; the entrypoint remaps the *existing* `pizza` account and drops privileges. This is deliberately not a raw `user:` override — a raw override leaves no `/etc/passwd` entry for the UID (verified: `whoami` fails), which breaks git and shells.
- **Sandbox:** image defaults to `PIZZAPI_SANDBOX=none`. Bubblewrap cannot create user namespaces under Docker's default seccomp profile — verified on Docker 29.5.3, it fails even as root, while `--security-opt seccomp=unconfined` makes it succeed. Rather than ship a silently-degraded sandbox, the default is explicit and the opt-in path is **tested** (smoke check 17) and documented as the isolation trade it actually is.
- **Sandbox assets:** `@anthropic-ai/sandbox-runtime` resolves its `vendor/seccomp/<arch>` helpers relative to its own module dir, which doesn't exist inside a bun-compiled binary. The image stages them at `/usr/lib/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/<arch>/`, one of srt's global fallback locations — so the sandbox works from a standalone binary with **no node/npm in the image**.
- **Healthcheck:** the spike deferred this pending a real probe, so the probe was built. `pizza runner status` exits 0 only when the daemon PID is alive *and* registered with the relay; no relay round-trip, no config/model loading, cheap enough for a 30s interval.

## Bug found and fixed

The smoke test caught a real, reproducible bug outside the image itself. A fresh container resets its PID namespace to 1, so the daemon's process tree gets the same deterministic low PIDs on every start. After `docker kill -9` + recreate on the same volume, the new daemon saw *its own PID number* in the stale lock file and refused to start with a fatal `already running`, self-healing ~2s later only because the supervisor blindly retries. PID liveness + `ps` cmdline matching cannot distinguish "same process still alive" from "brand-new process that reused the PID".

Fixed in `runner-state.ts` by recording the OS-reported process start time alongside the PID (`/proc/<pid>/stat` field 22 on Linux, `ps -o lstart=` elsewhere) and only trusting a lock when both match. Missing or unparseable start times fall back to the previous behaviour, so this is strictly an additional discriminator. Godmother: `Uoe0ItIe`.

## Verification

Smoke run against a live relay (`docker network pizzapi-web_default`, relay at `server:7492`) — **17/17 PASS, 0 FAIL, 0 SKIP**, reproduced across 4 independent runs:

- both arches build; foreign-arch binary runs under emulation
- starts as uid 1000 non-root and reaches Docker `healthy` (~8s) via the real healthcheck
- workspace enforcement: `cwd=/etc` rejected (400), real repo under `/workspace` accepted (200)
- PTY library resolves cleanly; no terminal/PTY errors in the daemon log
- reaches Compose sidecars by DNS name (`server:7492`, `redis:6379`)
- `docker stop` shuts down cleanly in 0–1s (well inside the 30s grace period)
- runner identity survives stop + `rm` + recreate on the same volume
- stale-lock recovery after SIGKILL — healthy again with no fatal error
- no `--privileged`, no host PID namespace, no added capabilities, no Docker socket
- opt-in sandbox verified: with `seccomp=unconfined`, `bwrap --unshare-all` succeeds inside the container

Also: `bun run typecheck` clean; `bun test packages/cli/src` → 2638 pass. The 3 remaining failures are pre-existing and unrelated — `origin/main` at equal path depth fails 4 in the same suite on this machine (models-command + computePackageIdentity, environment/pollution sensitive). `bun run --cwd packages/docs build` → exit 0, 49 pages.

Image size: 341MB arm64, 318MB amd64.

## Notes for review

- CI's image job is **hermetic** (single-arch, `--load`, no push) and asserts the CLI runs, uid is 1000, `pizza runner status` fails closed with no daemon, required tools are on PATH, seccomp assets are staged, and env defaults are right. The relay-backed smoke stays in `docker/runner/smoke.sh` because CI has no provisioned relay or API key.
- The release job **reuses the release-stamped binaries** from the `build-binary` matrix rather than recompiling, so the image ships the same bits as the npm release.
- A QEMU setup step was added to the new release job; the existing `docker-ui` job builds multi-arch without one, which may be a latent gap there (left untouched — out of scope).

Closes `ncNx1zxm`, `iQ6y7fgP`, `oOwIFNPU`, `pcBd0QmU`.
