### PR TITLE
fix(bash): track, persist, and surface background shells

### DIFF
--- a/packages/cli/src/extensions/background-bash.test.ts
+++ b/packages/cli/src/extensions/background-bash.test.ts
@@ -1,8 +1,18 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds } from "./background-bash.js";
+import { sessionJobsFilePath } from "../runner/session-procs.js";
 
-// Keep the auto-background window out of the way unless a test opts in.
-beforeAll(() => { process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "30"; });
+// Keep the auto-background window out of the way unless a test opts in, and
+// never write to the real session's proc/jobs files (inherited when tests run
+// under a PizzaPi worker).
+beforeAll(() => {
+    process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "30";
+    delete process.env.PIZZAPI_SESSION_PROC_FILE;
+});
 afterAll(() => { delete process.env.PIZZAPI_BASH_BACKGROUND_SECONDS; });
 
 function mockPi() {
@@ -175,9 +185,121 @@ describe("bash override with backgrounding", () => {
         expect(again.content[0].text).toContain("already");
     });
 
-    test("shortcut and /background command are registered", () => {
+    test("shortcut, /background, and /shells commands are registered", () => {
         const { pi } = getTool();
         expect(pi.shortcuts.has("ctrl+shift+b")).toBe(true);
         expect(pi.commands.has("background")).toBe(true);
+        expect(pi.commands.has("shells")).toBe(true);
+    });
+});
+
+describe("process tracking and lifecycle", () => {
+    function withProcFile(): { dir: string; procFile: string; jobsFile: string; cleanup: () => void } {
+        const dir = mkdtempSync(join(tmpdir(), "bgbash-"));
+        const procFile = join(dir, "s.pids");
+        process.env.PIZZAPI_SESSION_PROC_FILE = procFile;
+        return {
+            dir,
+            procFile,
+            jobsFile: sessionJobsFilePath(procFile),
+            cleanup: () => {
+                delete process.env.PIZZAPI_SESSION_PROC_FILE;
+                rmSync(dir, { recursive: true, force: true });
+            },
+        };
+    }
+
+    /** Spawn-and-reap a process to get a pid that is definitely dead. */
+    async function deadPid(): Promise<number> {
+        const p = spawn("true");
+        await new Promise((r) => p.on("close", r));
+        return p.pid!;
+    }
+
+    test("records the command's group-leader pid into the session proc file", async () => {
+        const { procFile, cleanup } = withProcFile();
+        try {
+            const { tool } = getTool();
+            await run(tool, { command: "echo hi", title: "hi" });
+            const pids = readFileSync(procFile, "utf8").trim().split("\n").map(Number);
+            expect(pids.length).toBe(1);
+            expect(pids[0]).toBeGreaterThan(0);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test("persists backgrounded jobs and marks their exit", async () => {
+        const { jobsFile, cleanup } = withProcFile();
+        try {
+            const { tool } = getTool();
+            const res = await run(tool, { command: "sleep 0.3; exit 5", title: "Flaky", run_in_background: true });
+            const pid = Number(res.content[0].text.match(/pid (\d+)/)![1]);
+
+            const persisted = JSON.parse(readFileSync(jobsFile, "utf8"));
+            const rec = persisted.find((j: any) => j.pid === pid);
+            expect(rec.title).toBe("Flaky");
+            expect(rec.endedAt).toBeUndefined();
+
+            await Bun.sleep(800);
+            const after = JSON.parse(readFileSync(jobsFile, "utf8")).find((j: any) => j.pid === pid);
+            expect(after.exitCode).toBe(5);
+            expect(after.endedAt).toBeGreaterThan(0);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test("recovers persisted jobs on startup; dead ones marked lost, log still readable", async () => {
+        const { dir, jobsFile, cleanup } = withProcFile();
+        try {
+            const pid = await deadPid();
+            const logPath = join(dir, "dev.log");
+            writeFileSync(logPath, "old output here");
+            writeFileSync(
+                jobsFile,
+                JSON.stringify([{ pid, command: "npm run dev", title: "Dev server", logPath, startedAt: Date.now() - 5000, readOffset: 0 }]),
+            );
+
+            const { pi } = getTool(); // factory runs loadJobs()
+            const bashOutput = pi.tools.get("bash_output")!;
+            const listing = await bashOutput.execute("id", {});
+            expect(listing.content[0].text).toContain("npm run dev");
+            expect(listing.content[0].text).toContain("lost to a worker restart");
+
+            const out = await bashOutput.execute("id", { pid });
+            expect(out.content[0].text).toContain("old output here");
+        } finally {
+            cleanup();
+        }
+    });
+
+    test("/new reset kills running shells, silences completions, removes logs", async () => {
+        const { pi, tool } = getTool();
+        const res = await run(tool, { command: "sleep 30", title: "Server", run_in_background: true });
+        const pid = Number(res.content[0].text.match(/pid (\d+)/)![1]);
+        const logPath = res.content[0].text.match(/goes to (\S+)\./)![1];
+
+        pi.emit("session_switch", { reason: "new" });
+
+        const listing = await pi.tools.get("bash_output")!.execute("id", {});
+        expect(listing.content[0].text).toBe("No background shells.");
+        expect(existsSync(logPath)).toBe(false);
+
+        await Bun.sleep(300);
+        expect(pi.messages.length).toBe(0); // completion suppressed — old conversation is gone
+        expect(() => process.kill(pid, 0)).toThrow(); // actually dead
+    });
+
+    test("session_shutdown kills running shells without notifying", async () => {
+        const { pi, tool } = getTool();
+        const res = await run(tool, { command: "sleep 30", title: "Server", run_in_background: true });
+        const pid = Number(res.content[0].text.match(/pid (\d+)/)![1]);
+
+        pi.emit("session_shutdown");
+
+        await Bun.sleep(300);
+        expect(pi.messages.length).toBe(0);
+        expect(() => process.kill(pid, 0)).toThrow();
     });
 });

--- a/packages/cli/src/extensions/background-bash.ts
+++ b/packages/cli/src/extensions/background-bash.ts
@@ -1,10 +1,12 @@
 import { spawn } from "node:child_process";
-import { createWriteStream, openSync, readSync, closeSync, statSync, unlinkSync } from "node:fs";
+import { createWriteStream, openSync, readSync, closeSync, statSync, unlinkSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { createBashToolDefinition } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "../config.js";
+import { SHELL_PROC_CAPTURE_PREFIX, sessionJobsFilePath, readSessionJobs } from "../runner/session-procs.js";
+export { tailFile } from "../runner/session-procs.js";
 
 /**
  * Bash override with auto-backgrounding.
@@ -26,7 +28,6 @@ import { loadConfig } from "../config.js";
  * and this override keeps the name "bash".
  */
 
-const TAIL_BYTES = 4000;
 const DEFAULT_BACKGROUND_AFTER_SECONDS = 15;
 const DELIVERY_RETRY_MS = 10_000;
 const MAX_DELIVERY_ATTEMPTS = 3;
@@ -66,11 +67,59 @@ interface BackgroundJob {
     endedAt?: number;
     /** Byte offset of the last bash_output read — next read returns only new output. */
     readOffset: number;
+    /** Loaded from disk after a worker restart — no exit notification possible. */
+    recovered?: boolean;
+    /** Found dead on recovery — exit status was lost with the old worker. */
+    lost?: boolean;
 }
 
 /** Backgrounded jobs (running or exited), keyed by pid. Kept for bash_output/kill_shell. */
 // ponytail: unbounded per-session map of tiny records (output lives on disk) — prune if sessions ever run thousands of background jobs.
+// ponytail: keyed by OS pid — pid reuse within one session would overwrite an exited record; harmless enough to ignore.
 const jobs = new Map<number, BackgroundJob>();
+
+/** Persisted registry path (worker mode only — unset in TUI, where nothing reads it). */
+function jobsFilePath(): string | undefined {
+    const procFile = process.env.PIZZAPI_SESSION_PROC_FILE;
+    return procFile ? sessionJobsFilePath(procFile) : undefined;
+}
+
+/** Persist the jobs registry so the daemon's Processes panel and a restarted worker can see it. */
+function saveJobs(): void {
+    const path = jobsFilePath();
+    if (!path) return;
+    try {
+        if (jobs.size === 0) rmSync(path, { force: true });
+        else writeFileSync(path, JSON.stringify([...jobs.values()]));
+    } catch {
+        // best-effort
+    }
+}
+
+function isAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Recover persisted jobs after a worker restart. Exit notifications are gone with the old worker. */
+function loadJobs(): void {
+    const path = jobsFilePath();
+    if (!path) return;
+    for (const j of readSessionJobs(path)) {
+        if (jobs.has(j.pid)) continue;
+        const job: BackgroundJob = { ...j, readOffset: j.readOffset ?? 0, recovered: true };
+        if (job.endedAt === undefined && !isAlive(job.pid)) {
+            job.endedAt = Date.now();
+            job.lost = true;
+        }
+        jobs.set(j.pid, job);
+    }
+    saveJobs();
+}
 
 /** Read a file from `offset` to EOF. */
 function readFrom(path: string, offset: number): { text: string; newOffset: number } {
@@ -91,7 +140,8 @@ function readFrom(path: string, offset: number): { text: string; newOffset: numb
 }
 
 function jobStatus(job: BackgroundJob): string {
-    if (job.endedAt === undefined) return "running";
+    if (job.endedAt === undefined) return job.recovered ? "running (recovered — no exit notification, poll bash_output)" : "running";
+    if (job.lost) return "ended (exit status lost to a worker restart)";
     if (job.signal) return `killed by ${job.signal}`;
     return `exited ${job.exitCode}`;
 }
@@ -99,7 +149,10 @@ function jobStatus(job: BackgroundJob): string {
 function listJobsText(): string {
     if (jobs.size === 0) return "No background shells.";
     return [...jobs.values()]
-        .map((j) => `pid ${j.pid} [${jobStatus(j)}] ${j.title} — ${j.command} (log: ${j.logPath})`)
+        .map((j) => {
+            const runtime = Math.round(((j.endedAt ?? Date.now()) - j.startedAt) / 1000);
+            return `pid ${j.pid} [${jobStatus(j)}, ${runtime}s] ${j.title} — ${j.command} (log: ${j.logPath})`;
+        })
         .join("\n");
 }
 
@@ -119,25 +172,6 @@ export function backgroundPendingJobs(): string[] {
     return commands;
 }
 
-/** Last `maxBytes` of a file, as text. */
-export function tailFile(path: string, maxBytes = TAIL_BYTES): string {
-    let fd: number | undefined;
-    try {
-        const size = statSync(path).size;
-        const start = Math.max(0, size - maxBytes);
-        const len = size - start;
-        if (len === 0) return "";
-        const buf = Buffer.allocUnsafe(len);
-        fd = openSync(path, "r");
-        readSync(fd, buf, 0, len, start);
-        return (start > 0 ? `…(truncated, full log at ${path})\n` : "") + buf.toString("utf8");
-    } catch {
-        return "";
-    } finally {
-        if (fd !== undefined) closeSync(fd);
-    }
-}
-
 export function formatCompletion(
     title: string,
     code: number | null,
@@ -150,6 +184,8 @@ export function formatCompletion(
 }
 
 function killTree(pid: number): void {
+    // pid <= 0 would signal init's group (-pid) or every user process (kill(-1)).
+    if (!Number.isInteger(pid) || pid <= 0) return;
     try {
         // Detached on POSIX → child is its own group leader; kill the group.
         process.platform === "win32" ? process.kill(pid) : process.kill(-pid);
@@ -200,11 +236,49 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
         }
     }
 
-    pi.on("agent_start" as any, () => { streaming = true; });
+    pi.on("agent_start" as any, (_event: any, ctx: any) => {
+        streaming = true;
+        if (ctx?.ui) ui = ctx.ui;
+    });
     pi.on("agent_settled" as any, () => { streaming = false; sweep(); });
     pi.on("message_start" as any, (event: any) => {
         const deliveryId = event?.message?.details?.deliveryId;
         if (deliveryId) undelivered.delete(deliveryId);
+    });
+
+    // ── lifecycle: recover persisted jobs, kill on shutdown / /new reset ─────
+    let ui: { setStatus?: (key: string, text: string | undefined) => void; notify?: (msg: string, level?: string) => void } | undefined;
+    const updateStatus = () => {
+        const running = [...jobs.values()].filter((j) => j.endedAt === undefined).length;
+        ui?.setStatus?.("bg-shells", running > 0 ? `${running} bg shell${running === 1 ? "" : "s"}` : undefined);
+    };
+
+    loadJobs();
+
+    /** Kill running jobs, drop their logs, and forget everything — session is over or reset. */
+    const cleanupJobs = () => {
+        for (const job of jobs.values()) {
+            if (job.endedAt === undefined) killTree(job.pid);
+            try { unlinkSync(job.logPath); } catch { /* best effort */ }
+        }
+        jobs.clear();
+        saveJobs();
+        undelivered.clear();
+        if (sweeper) {
+            clearInterval(sweeper);
+            sweeper = undefined;
+        }
+        updateStatus();
+    };
+    pi.on("session_shutdown" as any, async () => { cleanupJobs(); });
+    pi.on("session_start" as any, (_event: any, ctx: any) => {
+        if (ctx?.ui) ui = ctx.ui;
+        updateStatus();
+    });
+    // /new resets the conversation in place — old shells (and their completions)
+    // must not bleed into it. Other switches keep jobs: same worker, same user.
+    pi.on("session_switch" as any, (event: any) => {
+        if (event?.reason === "new") cleanupJobs();
     });
 
     const notifyExit = (title: string, command: string, code: number | null, sig: string | null, ms: number, logPath: string, pid: number | undefined) => {
@@ -239,9 +313,13 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
         const logPath = join(tmpdir(), `pizzapi-bash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.log`);
         const log = createWriteStream(logPath);
         const startedAt = Date.now();
+        // Record this command's detached group-leader PID for the daemon's
+        // process tracking (Processes panel + end-of-session reaping). The
+        // prefix is self-guarded on $PIZZAPI_SESSION_PROC_FILE — no-op in TUI.
+        const spawnCommand = process.platform === "win32" ? command : `${SHELL_PROC_CAPTURE_PREFIX}\n${command}`;
         // ponytail: shell:true instead of pi's getShellConfig — loses custom
         // shellPath/windows stdin transport; wire pi's shell utils if that bites.
-        const child = spawn(command, {
+        const child = spawn(spawnCommand, {
             shell: true,
             cwd,
             env,
@@ -271,6 +349,8 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
                 job.exitCode = r.code;
                 job.signal = r.sig;
                 job.endedAt = Date.now();
+                saveJobs();
+                updateStatus();
             }
             await new Promise<void>((res) => log.end(res));
             return r;
@@ -293,7 +373,7 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
         try {
             const bg = new Promise<"bg">((resolve) => {
                 if (runInBackground) return resolve("bg");
-                waiting.set(pid, { command, backgroundNow: () => resolve("bg") });
+                if (pid > 0) waiting.set(pid, { command, backgroundNow: () => resolve("bg") });
                 // Auto-background once the foreground streaming window elapses.
                 const after = backgroundAfterSeconds();
                 bgTimer = setTimeout(() => resolve("bg"), after * 1000);
@@ -313,7 +393,11 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
             // Backgrounded: stop streaming, let it run, notify on exit.
             backgrounded = true;
             waiting.delete(pid);
-            jobs.set(pid, { pid, command, title, logPath, startedAt, readOffset: 0 });
+            if (pid > 0) {
+                jobs.set(pid, { pid, command, title, logPath, startedAt, readOffset: 0 });
+                saveJobs();
+                updateStatus();
+            }
             onData(Buffer.from(
                 `\n[Still running: "${title}" (pid ${pid}). Output now goes to ${logPath}. ` +
                 `A message will arrive in this session when it exits — do NOT use sleep or poll for it. ` +
@@ -321,6 +405,9 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
             ));
             void exited.then(({ code, sig }) => {
                 if (timer) clearTimeout(timer);
+                // Cleaned up in the meantime (shutdown or /new)? Stay quiet — the
+                // conversation this shell belonged to is gone.
+                if (pid > 0 && !jobs.has(pid)) return;
                 notifyExit(title, command, code, sig, Date.now() - startedAt, logPath, child.pid);
             });
             return { exitCode: 0 };
@@ -391,7 +478,10 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
                 };
             }
             const { text, newOffset } = readFrom(job.logPath, job.readOffset);
-            job.readOffset = newOffset;
+            if (newOffset !== job.readOffset) {
+                job.readOffset = newOffset;
+                saveJobs();
+            }
             const runtime = Math.round(((job.endedAt ?? Date.now()) - job.startedAt) / 1000);
             const header = `[pid ${job.pid}, ${jobStatus(job)}, ${runtime}s] ${job.command}`;
             return {
@@ -454,5 +544,10 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
     pi.registerCommand("background", {
         description: "Send the running bash command to the background",
         handler: async (_args: string, ctx: any) => { backgroundNow(ctx?.ui); },
+    });
+
+    pi.registerCommand("shells", {
+        description: "List background shells and their status",
+        handler: async (_args: string, ctx: any) => { ctx?.ui?.notify?.(listJobsText(), "info"); },
     });
 };

--- a/packages/cli/src/runner/services/process-service.test.ts
+++ b/packages/cli/src/runner/services/process-service.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parsePsLine, ProcessService } from "./process-service.js";
 import { killSessionProcessGroup } from "../session-spawner.js";
+import { sessionJobsFilePath } from "../session-procs.js";
 
 describe("parsePsLine", () => {
     test("parses a normal ps line", () => {
@@ -103,6 +104,66 @@ describe("ProcessService", () => {
         expect(sent[1].type).toBe("process_list_result");
 
         killSessionProcessGroup(groupPid, "SIGKILL");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("reports background shells with liveness and serves log tails", async () => {
+        const live = spawn("sh", ["-c", "sleep 30"], { detached: true, stdio: "ignore" });
+        const livePid = live.pid!;
+        const dead = spawn("true");
+        await new Promise((r) => dead.on("close", r));
+        await new Promise((r) => setTimeout(r, 100));
+
+        const dir = mkdtempSync(join(tmpdir(), "procsvc-"));
+        const procFile = join(dir, "s3.pids");
+        const logPath = join(dir, "dev.log");
+        writeFileSync(logPath, "hello log");
+        writeFileSync(
+            sessionJobsFilePath(procFile),
+            JSON.stringify([
+                { pid: livePid, command: "sleep 30", title: "Server", logPath, startedAt: Date.now() },
+                { pid: dead.pid!, command: "npm run dev", title: "Crashed", logPath, startedAt: Date.now() - 5000 },
+            ]),
+        );
+
+        const service = new ProcessService(() => null, () => procFile);
+        const sent: Array<{ type: string; payload: any }> = [];
+        (service as any).socket = { on() {}, off() {}, emit: (_e: string, env: any) => sent.push(env) };
+
+        await (service as any).handleList({ serviceId: "process", type: "process_list", sessionId: "s3", payload: {} });
+        const shells = sent[0].payload.shells;
+        expect(shells.find((s: any) => s.pid === livePid).running).toBe(true);
+        expect(shells.find((s: any) => s.pid === dead.pid).running).toBe(false); // stale record, re-checked
+
+        await (service as any).handleTail({ serviceId: "process", type: "process_tail", sessionId: "s3", payload: { pid: livePid } });
+        expect(sent[1].type).toBe("process_tail_result");
+        expect(sent[1].payload.text).toContain("hello log");
+
+        await (service as any).handleTail({ serviceId: "process", type: "process_tail", sessionId: "s3", payload: { pid: 999999 } });
+        expect(sent[2].type).toBe("process_error");
+
+        killSessionProcessGroup(livePid, "SIGKILL");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("kill of a recorded group leader takes the whole group down", async () => {
+        const child = spawn("sh", ["-c", "sleep 30 & sleep 30"], { detached: true, stdio: "ignore" });
+        const groupPid = child.pid!;
+        await new Promise((r) => setTimeout(r, 100));
+
+        const dir = mkdtempSync(join(tmpdir(), "procsvc-"));
+        const procFile = join(dir, "s4.pids");
+        writeFileSync(procFile, `${groupPid}\n`);
+
+        const service = new ProcessService(() => null, () => procFile);
+        const sent: Array<{ type: string; payload: any }> = [];
+        (service as any).socket = { on() {}, off() {}, emit: (_e: string, env: any) => sent.push(env) };
+
+        await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s4", payload: { pid: groupPid } });
+        await new Promise((r) => setTimeout(r, 200));
+        // The whole group is gone — grandchild `sleep 30 &` included.
+        expect(killSessionProcessGroup(groupPid, "SIGKILL")).toBe(false);
+
         rmSync(dir, { recursive: true, force: true });
     });
 });

--- a/packages/cli/src/runner/services/process-service.ts
+++ b/packages/cli/src/runner/services/process-service.ts
@@ -5,16 +5,26 @@ import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../ser
 import { logInfo } from "../logger.js";
 import {
     sessionProcFilePath,
+    sessionJobsFilePath,
     readRecordedGroupPids,
+    readSessionJobs,
     pruneProcFile,
     selectGroupProcesses,
     parsePsFullLine,
+    tailFile,
     type SessionProcess,
+    type PersistedShellJob,
 } from "../session-procs.js";
 
 const execFileAsync = promisify(execFile);
 
 export type { SessionProcess };
+
+/** A background shell as reported to the Processes panel. */
+export interface ShellInfo extends PersistedShellJob {
+    /** Liveness re-checked by the daemon — the persisted record can be stale after a worker crash. */
+    running: boolean;
+}
 
 /** Parse one `ps -o pid=,etime=,rss=,command=` output line (legacy helper). */
 export function parsePsLine(line: string): SessionProcess | null {
@@ -57,6 +67,9 @@ export class ProcessService implements ServiceHandler {
                     break;
                 case "process_kill":
                     void this.handleKill(envelope);
+                    break;
+                case "process_tail":
+                    void this.handleTail(envelope);
                     break;
             }
         };
@@ -142,11 +155,43 @@ export class ProcessService implements ServiceHandler {
         return typeof payload?.sessionId === "string" ? payload.sessionId : null;
     }
 
+    /** Background shells persisted by the worker's bash override, with liveness re-checked. */
+    private listShells(sessionId: string): ShellInfo[] {
+        const jobsPath = sessionJobsFilePath(this.getProcFilePath(sessionId));
+        return readSessionJobs(jobsPath).map((j) => {
+            let running = j.endedAt === undefined;
+            if (running) {
+                try {
+                    process.kill(j.pid, 0);
+                } catch {
+                    running = false; // stale record — worker died before it could mark the exit
+                }
+            }
+            return { ...j, running };
+        });
+    }
+
     private async handleList(envelope: ServiceEnvelope): Promise<void> {
         const sessionId = this.resolveSessionId(envelope);
         const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
         const processes = sessionId ? await this.listProcesses(sessionId, workerPid) : [];
-        this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
+        const shells = sessionId ? this.listShells(sessionId) : [];
+        this.emit("process_list_result", { workerPid, processes, shells }, envelope.requestId);
+    }
+
+    /** Tail of a background shell's log file. Only paths from the worker-written registry are readable. */
+    private async handleTail(envelope: ServiceEnvelope): Promise<void> {
+        const sessionId = this.resolveSessionId(envelope);
+        const payload = envelope.payload as { pid?: number } | undefined;
+        const pid = typeof payload?.pid === "number" ? payload.pid : NaN;
+        const job = sessionId
+            ? readSessionJobs(sessionJobsFilePath(this.getProcFilePath(sessionId))).find((j) => j.pid === pid)
+            : undefined;
+        if (!job) {
+            this.emit("process_error", { error: `No background shell with pid ${payload?.pid}` }, envelope.requestId);
+            return;
+        }
+        this.emit("process_tail_result", { pid: job.pid, text: tailFile(job.logPath, 8192) }, envelope.requestId);
     }
 
     private async handleKill(envelope: ServiceEnvelope): Promise<void> {
@@ -173,7 +218,18 @@ export class ProcessService implements ServiceHandler {
         }
 
         try {
-            process.kill(pid, "SIGTERM");
+            // Recorded bash-command group leader? Kill the whole group so
+            // grandchildren (dev servers a command spawned) go with it.
+            const { groups } = this.sessionGroups(sessionId, workerPid);
+            if (groups.has(pid) && pid !== workerPid && process.platform !== "win32") {
+                try {
+                    process.kill(-pid, "SIGTERM");
+                } catch {
+                    process.kill(pid, "SIGTERM");
+                }
+            } else {
+                process.kill(pid, "SIGTERM");
+            }
             logInfo(`[process] killed pid ${pid} in session ${sessionId}`);
         } catch {
             // Already exited — fall through to refreshed list

--- a/packages/cli/src/runner/session-procs.ts
+++ b/packages/cli/src/runner/session-procs.ts
@@ -19,7 +19,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, rmSync, openSync, readSync, closeSync, statSync } from "node:fs";
 
 /** Directory holding per-session recorded-group pid files. */
 export function sessionProcDir(): string {
@@ -90,12 +90,68 @@ export function parseRecordedGroupPids(content: string): number[] {
     return [...seen];
 }
 
-/** Delete a session's pid file (best-effort). */
+/** Delete a session's pid file and persisted shell registry (best-effort). */
 export function removeSessionProcFile(sessionId: string): void {
     try {
         rmSync(sessionProcFilePath(sessionId), { force: true });
+        rmSync(sessionJobsFilePath(sessionProcFilePath(sessionId)), { force: true });
     } catch {
         // best-effort
+    }
+}
+
+/** Path of the persisted background-shell registry next to a session's pid file. */
+export function sessionJobsFilePath(procFilePath: string): string {
+    return procFilePath.replace(/\.pids$/, "") + ".jobs.json";
+}
+
+/**
+ * A background shell record persisted by the worker's bash override
+ * (extensions/background-bash.ts) so the daemon's process service can show
+ * shells in the Processes panel and a restarted worker can recover handles.
+ */
+export interface PersistedShellJob {
+    pid: number;
+    command: string;
+    title: string;
+    logPath: string;
+    startedAt: number;
+    exitCode?: number | null;
+    signal?: string | null;
+    endedAt?: number;
+    readOffset?: number;
+}
+
+/** Read the persisted background-shell registry (worker-written, best-effort). */
+export function readSessionJobs(jobsPath: string): PersistedShellJob[] {
+    try {
+        const raw = JSON.parse(readFileSync(jobsPath, "utf8"));
+        if (!Array.isArray(raw)) return [];
+        return raw.filter(
+            (j): j is PersistedShellJob =>
+                j && Number.isInteger(j.pid) && j.pid > 0 && typeof j.logPath === "string" && typeof j.command === "string",
+        );
+    } catch {
+        return []; // missing or corrupt — nothing persisted
+    }
+}
+
+/** Last `maxBytes` of a file, as text (shared by bash_output and the panel's log tail). */
+export function tailFile(path: string, maxBytes = 4000): string {
+    let fd: number | undefined;
+    try {
+        const size = statSync(path).size;
+        const start = Math.max(0, size - maxBytes);
+        const len = size - start;
+        if (len === 0) return "";
+        const buf = Buffer.allocUnsafe(len);
+        fd = openSync(path, "r");
+        readSync(fd, buf, 0, len, start);
+        return (start > 0 ? `…(truncated, full log at ${path})\n` : "") + buf.toString("utf8");
+    } catch {
+        return "";
+    } finally {
+        if (fd !== undefined) closeSync(fd);
     }
 }
 

--- a/packages/docs/src/content/docs/features/slash-commands.mdx
+++ b/packages/docs/src/content/docs/features/slash-commands.mdx
@@ -47,6 +47,7 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 | `/rewind` | Rewind the conversation to a previous user message (forks the session). `/fork` is an alias. |
 | `/stop` | Abort the current generation. |
 | `/background` | Send the currently running bash command to the background (also `ctrl+shift+b` in the TUI). |
+| `/shells` | List background shells with status, runtime, and log path. |
 | `/restart` | Restart the underlying CLI process. |
 
 ### Session history

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -37,6 +37,7 @@ The following commands are always available in the chat input:
 | `/copy` | Copy the last assistant message to clipboard. |
 | `/stop` | Abort the currently running agent generation. |
 | `/background` | Send the currently running bash command to the background. The agent gets a notification with the exit code and output when it finishes. |
+| `/shells` | List background shells with status, runtime, and log path. Background shells also appear in the Processes panel with live output and a kill button. |
 | `/restart` | Restart the underlying CLI process — useful if the agent is stuck or needs a fresh start. |
 | `/sandbox` | Show current sandbox status (mode, platform, recent violations) if a runner is connected. |
 | `/sandbox status` | Show current sandbox status (default). |

--- a/packages/ui/src/components/ProcessPanel.tsx
+++ b/packages/ui/src/components/ProcessPanel.tsx
@@ -1,13 +1,27 @@
 import { useState, useEffect, useCallback } from "react";
 import { useServiceChannel } from "@/hooks/useServiceChannel";
 import { reportError } from "@/lib/frontend-log";
-import { RefreshCw, X } from "lucide-react";
+import { RefreshCw, X, ChevronRight, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface SessionProcess {
     pid: number;
     etime: string;
     rssKb: number;
     command: string;
+}
+
+/** Background shell record from the worker's bash override (see process-service.ts ShellInfo). */
+interface ShellInfo {
+    pid: number;
+    command: string;
+    title: string;
+    logPath: string;
+    startedAt: number;
+    exitCode?: number | null;
+    signal?: string | null;
+    endedAt?: number;
+    running: boolean;
 }
 
 interface ProcessPanelProps {
@@ -21,20 +35,43 @@ function formatRss(rssKb: number): string {
     return `${rssKb} KB`;
 }
 
+function formatRuntime(shell: ShellInfo): string {
+    const ms = (shell.endedAt ?? Date.now()) - shell.startedAt;
+    const s = Math.round(ms / 1000);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+}
+
+function shellStatus(shell: ShellInfo): { label: string; className: string } {
+    if (shell.running) return { label: "running", className: "bg-primary/15 text-primary" };
+    if (shell.endedAt === undefined) return { label: "ended", className: "bg-muted text-muted-foreground" };
+    if (shell.signal) return { label: shell.signal, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" };
+    if (shell.exitCode === 0) return { label: "exit 0", className: "bg-muted text-muted-foreground" };
+    return { label: `exit ${shell.exitCode}`, className: "bg-destructive/15 text-destructive" };
+}
+
 const POLL_MS = 3000;
 
 export function ProcessPanel({ sessionId }: ProcessPanelProps) {
     const [processes, setProcesses] = useState<SessionProcess[]>([]);
+    const [shells, setShells] = useState<ShellInfo[]>([]);
     const [workerPid, setWorkerPid] = useState<number | null>(null);
     const [loaded, setLoaded] = useState(false);
+    const [expandedPid, setExpandedPid] = useState<number | null>(null);
+    const [tails, setTails] = useState<Record<number, string>>({});
 
     const { send, available } = useServiceChannel<unknown, unknown>("process", {
         onMessage: (type, payload) => {
             const p = payload as Record<string, unknown>;
             if (type === "process_list_result") {
                 setProcesses((p.processes as SessionProcess[]) ?? []);
+                setShells((p.shells as ShellInfo[]) ?? []);
                 setWorkerPid((p.workerPid as number | null) ?? null);
                 setLoaded(true);
+            } else if (type === "process_tail_result") {
+                const pid = p.pid as number;
+                setTails((t) => ({ ...t, [pid]: (p.text as string) || "(no output yet)" }));
             } else if (type === "process_error") {
                 reportError("process", (p.error as string) || "Process operation failed");
             }
@@ -48,6 +85,7 @@ export function ProcessPanel({ sessionId }: ProcessPanelProps) {
     useEffect(() => {
         if (!available) {
             setProcesses([]);
+            setShells([]);
             setLoaded(false);
             return;
         }
@@ -56,13 +94,24 @@ export function ProcessPanel({ sessionId }: ProcessPanelProps) {
         return () => clearInterval(interval);
     }, [available, refresh]);
 
+    // Keep the expanded shell's log tail fresh alongside the list poll.
+    useEffect(() => {
+        if (!available || expandedPid === null) return;
+        send("process_tail", { sessionId, pid: expandedPid });
+        const interval = setInterval(() => send("process_tail", { sessionId, pid: expandedPid }), POLL_MS);
+        return () => clearInterval(interval);
+    }, [available, expandedPid, send, sessionId]);
+
     if (!available) return null;
+
+    const toggleExpand = (pid: number) => setExpandedPid((cur) => (cur === pid ? null : pid));
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0">
                 <span className="text-xs text-muted-foreground">
                     {processes.length} process{processes.length === 1 ? "" : "es"}
+                    {shells.length > 0 && ` · ${shells.length} shell${shells.length === 1 ? "" : "s"}`}
                     {workerPid ? ` · group ${workerPid}` : ""}
                 </span>
                 <div className="flex-1" />
@@ -77,7 +126,66 @@ export function ProcessPanel({ sessionId }: ProcessPanelProps) {
             </div>
 
             <div className="flex-1 overflow-y-auto">
-                {processes.length === 0 ? (
+                {shells.length > 0 && (
+                    <div className="border-b border-border">
+                        <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                            Background shells
+                        </div>
+                        {shells.map((shell) => {
+                            const status = shellStatus(shell);
+                            const expanded = expandedPid === shell.pid;
+                            return (
+                                <div key={shell.pid} className="border-b border-border/50 last:border-b-0">
+                                    <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-accent/30">
+                                        <button
+                                            type="button"
+                                            onClick={() => toggleExpand(shell.pid)}
+                                            className="text-muted-foreground hover:text-foreground"
+                                            aria-expanded={expanded}
+                                            aria-label={expanded ? "Hide output" : "Show output"}
+                                        >
+                                            {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                                        </button>
+                                        <span
+                                            className={cn(
+                                                "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+                                                status.className,
+                                            )}
+                                        >
+                                            {status.label}
+                                        </span>
+                                        <span className="min-w-0 flex-1 truncate" title={shell.command}>
+                                            <span className="font-medium">{shell.title || shell.command}</span>
+                                            {shell.title && (
+                                                <span className="ml-1.5 font-mono text-muted-foreground">{shell.command}</span>
+                                            )}
+                                        </span>
+                                        <span className="shrink-0 font-mono text-muted-foreground">{formatRuntime(shell)}</span>
+                                        <span className="shrink-0 font-mono text-muted-foreground">pid {shell.pid}</span>
+                                        {shell.running && (
+                                            <button
+                                                type="button"
+                                                onClick={() => send("process_kill", { sessionId, pid: shell.pid })}
+                                                className="text-muted-foreground hover:text-destructive"
+                                                title={`Kill ${shell.pid}`}
+                                                aria-label={`Kill shell ${shell.pid}`}
+                                            >
+                                                <X size={11} />
+                                            </button>
+                                        )}
+                                    </div>
+                                    {expanded && (
+                                        <pre className="mx-3 mb-2 max-h-48 overflow-y-auto rounded bg-muted/40 p-2 text-[11px] leading-snug whitespace-pre-wrap break-all">
+                                            {tails[shell.pid] ?? "Loading…"}
+                                        </pre>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+
+                {processes.length === 0 && shells.length === 0 ? (
                     <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
                         {loaded
                             ? workerPid

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -157,6 +157,28 @@ export const SessionMessageItem = React.memo(
               {isCustomMessage && message.customType && (
                 <span className="normal-case font-mono">• {message.customType}</span>
               )}
+              {isCustomMessage &&
+                message.customType === "background-bash" &&
+                (() => {
+                  const d = message.details as
+                    | { exitCode?: number | null; signal?: string | null }
+                    | undefined;
+                  if (!d || (d.exitCode === undefined && !d.signal)) return null;
+                  const label = d.signal ? d.signal : `exit ${d.exitCode}`;
+                  const ok = !d.signal && d.exitCode === 0;
+                  return (
+                    <span
+                      className={cn(
+                        "normal-case rounded px-1.5 py-0.5 text-[10px] font-medium tracking-normal",
+                        ok
+                          ? "bg-primary/15 text-primary"
+                          : "bg-destructive/15 text-destructive",
+                      )}
+                    >
+                      {label}
+                    </span>
+                  );
+                })()}
               {message.toolName && <span>• {message.toolName}</span>}
               {message.timestamp && (
                 <span>• {new Date(message.timestamp).toLocaleTimeString()}</span>


### PR DESCRIPTION
## Problem

Audit of `/background` + session-started bash process tracking found that **#628 regressed #612**: the bash override (`background-bash.ts`) builds its own tool definition without `commandPrefix`, so `SHELL_PROC_CAPTURE_PREFIX` never ran and the session-procs pid file stayed empty for every agent bash call. Downstream, the Processes panel was blind to bash-spawned processes, end-of-session group reaping killed nothing (background dev servers leaked forever), and the panel's kill trust-boundary refused bash pids.

On top of that: no `session_shutdown` cleanup, in-memory-only jobs registry (worker restart orphaned all handles), `/new` bled old completions into fresh conversations, and humans had no way to see or kill background shells from either UI.

## Fixes

**Tracking (P1 regression)**
- The override's `exec` now prepends `SHELL_PROC_CAPTURE_PREFIX` (POSIX; self-guarded on `$PIZZAPI_SESSION_PROC_FILE`), restoring pid-file recording → Processes panel visibility + end-of-session reaping.
- `killTree` refuses `pid <= 0` — previously a spawn failure (`pid = -1`) plus timeout could fall through to `process.kill(-1)` (SIGTERM to every user process).

**Lifecycle**
- `session_shutdown` and `session_switch(reason: "new")` kill running shells, unlink their logs, clear the registry, and suppress their completion notifications.
- Jobs registry persists to `~/.pizzapi/session-procs/<id>.jobs.json`. A restarted worker recovers handles: `bash_output`/`kill_shell` keep working; dead jobs are listed as "exit status lost to a worker restart". The daemon removes the file with the pid file at true session termination.

**Daemon (`ProcessService`)**
- `process_list_result` now includes `shells[]` (title, command, status, runtime, log path) with liveness re-checked by the daemon.
- `process_kill` on a recorded bash group leader kills the whole group (grandchildren included).
- New `process_tail` returns the log tail for a registered shell (only worker-registered log paths are readable).

**Web UI**
- Processes panel gains a **Background Shells** section: status badge (running / exit N / signal), runtime, pid, kill button, and an expandable auto-refreshing log tail.
- `background-bash` completion messages render an exit-code badge instead of a bare custom-message bullet.

**TUI**
- `/shells` lists background shells (status, runtime, log path).
- Footer status shows `N bg shells` while any are running.

## Tests

- `background-bash.test.ts`: pid recording, jobs persistence + exit marking, crash recovery (lost status + readable log), `/new` and shutdown kill/silence/log-removal. Tests now clear `PIZZAPI_SESSION_PROC_FILE` inherited from a parent worker.
- `process-service.test.ts`: `shells[]` liveness re-check, `process_tail` (incl. unknown-pid rejection), whole-group kill of recorded leaders.
- Full `bun test packages/cli/src`: 2627 pass; the 4 failures (ollama-cloud models, packageIdentity) reproduce on clean main with no diff applied (env-dependent, pre-existing).

GM: fBMDks5m, rdSSbqq4, xSsqW6UQ
