### PR TITLE
Fix chunked conversation hydration races

### DIFF
--- a/packages/cli/src/extensions/remote/chunked-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.test.ts
@@ -14,6 +14,9 @@ import {
     emitSessionActive,
     buildLiveSessionAnalysis,
     readQueuedFollowUps,
+    recordInFlightMessageState,
+    finishInFlightMessageState,
+    _resetChunkedDeliveryStateForTesting,
 } from "./chunked-delivery.js";
 import type { RelayContext } from "../remote-types.js";
 import { resetSessionAnalysis, sessionAnalysisExtension } from "../session-analysis.js";
@@ -24,6 +27,7 @@ afterEach(() => {
     if (originalSessionId == null) delete process.env.PIZZAPI_SESSION_ID;
     else process.env.PIZZAPI_SESSION_ID = originalSessionId;
     resetSessionAnalysis("test-session");
+    _resetChunkedDeliveryStateForTesting();
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -156,9 +160,7 @@ function createFakePi() {
 
 describe("messagesChangedSinceLastEmit", () => {
     beforeEach(() => {
-        // Reset module-level state by recording a fresh baseline with no messages.
-        // We use a dummy context with no leafId and empty messages so that
-        // subsequent tests start from a known state.
+        _resetChunkedDeliveryStateForTesting();
     });
 
     test("returns true when no baseline has been recorded yet", () => {
@@ -192,6 +194,40 @@ describe("messagesChangedSinceLastEmit", () => {
 
         expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
         expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
+        expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
+    });
+
+    test("does not mark a real chunked refresh complete when delivery fails", async () => {
+        const ctx = makeContext({
+            leafId: "large-message",
+            entries: [{
+                type: "message",
+                id: "large-message",
+                parentId: null,
+                timestamp: new Date(0).toISOString(),
+                message: { role: "user", content: "x".repeat(4_800_000), timestamp: Date.now() },
+            }],
+        });
+
+        emitSessionActive(ctx);
+        expect((ctx.emitted[0] as any).state.chunked).toBe(true);
+        expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(messagesChangedSinceLastEmit(ctx)).toBe(true);
+    });
+
+    test("suppresses duplicate heartbeat refreshes while a chunk stream is in flight", () => {
+        const ctx = makeContext({ leafId: "leaf-chunking" });
+        const leafId = recordInFlightMessageState(ctx);
+
+        expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
+
+        finishInFlightMessageState(ctx, leafId, false);
+        expect(messagesChangedSinceLastEmit(ctx)).toBe(true);
+
+        recordInFlightMessageState(ctx);
+        finishInFlightMessageState(ctx, leafId, true);
         expect(messagesChangedSinceLastEmit(ctx)).toBe(false);
     });
 });

--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -217,7 +217,13 @@ export function computeChunkBoundaries(messages: unknown[], sizes?: number[]): A
  * Each chunk carries a `snapshotId` that matches the session_active event,
  * so the UI can discard stale chunks from a previous snapshot stream.
  */
-function sendChunkedMessages(rctx: RelayContext, rawMessages: unknown[], snapshotId: string, rawSizes?: number[]): void {
+function sendChunkedMessages(
+    rctx: RelayContext,
+    rawMessages: unknown[],
+    snapshotId: string,
+    onComplete: (delivered: boolean) => void,
+    rawSizes?: number[],
+): void {
     const initialSizes = rawSizes ?? computeMessageSizes(rawMessages);
     const { messages, sizes } = capOversizedMessagesInternal(rawMessages, initialSizes);
     const chunks = computeChunkBoundariesInternal(messages, sizes);
@@ -231,10 +237,14 @@ function sendChunkedMessages(rctx: RelayContext, rawMessages: unknown[], snapsho
     let chunkIndex = 0;
 
     function sendNextChunk() {
-        if (!rctx.relay || !rctx.sioSocket?.connected) return; // disconnected mid-stream
-        if (chunkIndex >= totalChunks) return;
-        // A newer emitSessionActive() superseded this sender — stop.
+        // A newer emitSessionActive() superseded this sender — stop before any
+        // cleanup, because the newer sender owns the in-flight marker.
         if (activeChunkedSnapshotId !== snapshotId) return;
+        if (!rctx.relay || !rctx.sioSocket?.connected) {
+            onComplete(false);
+            return;
+        }
+        if (chunkIndex >= totalChunks) return;
 
         const [start, end] = chunks[chunkIndex];
         const isFinal = chunkIndex === totalChunks - 1;
@@ -251,7 +261,9 @@ function sendChunkedMessages(rctx: RelayContext, rawMessages: unknown[], snapsho
 
         chunkIndex++;
 
-        if (chunkIndex < totalChunks) {
+        if (isFinal) {
+            onComplete(true);
+        } else if (chunkIndex < totalChunks) {
             // Yield the event loop so Socket.IO can process pings/acks between chunks
             setImmediate(sendNextChunk);
         }
@@ -276,6 +288,7 @@ interface LastEmittedMessageState {
     leafId: string | null;
 }
 let lastEmittedMessageState: LastEmittedMessageState | null = null;
+let inFlightMessageLeafId: string | null = null;
 
 function getLiveModel(rctx: RelayContext, fallback: unknown | (() => unknown)) {
     const liveModel = rctx.latestCtx?.model;
@@ -351,10 +364,36 @@ export function buildLiveSessionAnalysis(rctx: RelayContext): SessionAnalysis | 
  * Record the current message state as "last emitted" after a full session_active.
  * Exported for unit testing.
  */
-export function recordEmittedMessageState(rctx: RelayContext): void {
+export function recordEmittedMessageState(rctx: RelayContext, leafId?: string | null): void {
     lastEmittedMessageState = {
-        leafId: rctx.latestCtx?.sessionManager.getLeafId() ?? null,
+        leafId: leafId === undefined
+            ? rctx.latestCtx?.sessionManager.getLeafId() ?? null
+            : leafId,
     };
+}
+
+/** Mark a chunked checkpoint as actively draining without claiming success. */
+export function recordInFlightMessageState(rctx: RelayContext): string | null {
+    inFlightMessageLeafId = rctx.latestCtx?.sessionManager.getLeafId() ?? null;
+    return inFlightMessageLeafId;
+}
+
+/** Complete the current chunk sender; failed sends remain eligible for refresh. */
+export function finishInFlightMessageState(
+    rctx: RelayContext,
+    leafId: string | null,
+    delivered: boolean,
+): void {
+    if (inFlightMessageLeafId !== leafId) return;
+    inFlightMessageLeafId = null;
+    if (delivered) recordEmittedMessageState(rctx, leafId);
+}
+
+/** @internal — reset module state between tests. */
+export function _resetChunkedDeliveryStateForTesting(): void {
+    activeChunkedSnapshotId = null;
+    lastEmittedMessageState = null;
+    inFlightMessageLeafId = null;
 }
 
 /**
@@ -369,8 +408,9 @@ export function recordEmittedMessageState(rctx: RelayContext): void {
  * Exported for unit testing.
  */
 export function messagesChangedSinceLastEmit(rctx: RelayContext): boolean {
-    if (!lastEmittedMessageState) return true; // no baseline yet
     const currentLeafId = rctx.latestCtx?.sessionManager.getLeafId() ?? null;
+    if (inFlightMessageLeafId !== null && currentLeafId === inFlightMessageLeafId) return false;
+    if (!lastEmittedMessageState) return true;
     return currentLeafId !== lastEmittedMessageState.leafId;
 }
 
@@ -413,6 +453,7 @@ export function emitSessionActive(rctx: RelayContext, recoveryNonce?: string): v
         const snapshotId = randomUUID();
         // Cancel any in-flight chunked sender from a previous call.
         activeChunkedSnapshotId = snapshotId;
+        const snapshotLeafId = recordInFlightMessageState(rctx);
         rctx.forwardEvent({
             type: "session_active",
             ...(recoveryNonce !== undefined ? { recoveryNonce } : {}),
@@ -424,13 +465,19 @@ export function emitSessionActive(rctx: RelayContext, recoveryNonce?: string): v
                 totalMessages: messages.length,
             },
         });
-        recordEmittedMessageState(rctx);
-        sendChunkedMessages(rctx, messages, snapshotId, messageSizes);
+        sendChunkedMessages(
+            rctx,
+            messages,
+            snapshotId,
+            (delivered) => finishInFlightMessageState(rctx, snapshotLeafId, delivered),
+            messageSizes,
+        );
     } else {
         // Small session — single event (original path).
         // Cancel any in-flight chunked sender since we're replacing with a full snapshot.
         // Still cap individual oversized messages to avoid transport failures.
         activeChunkedSnapshotId = null;
+        inFlightMessageLeafId = null;
         rctx.forwardEvent({
             type: "session_active",
             ...(recoveryNonce !== undefined ? { recoveryNonce } : {}),

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -58,6 +58,27 @@ describe("enqueueSessionEvent", () => {
 
         errorSpy.mockRestore();
     });
+
+    test("returned promise drains earlier events before lifecycle cleanup", async () => {
+        const order: string[] = [];
+        let release!: () => void;
+        const blocked = new Promise<void>((resolve) => { release = resolve; });
+
+        enqueueSessionEvent("session-1", async () => {
+            await blocked;
+            order.push("chunk-finalized");
+        });
+        const cleanup = enqueueSessionEvent("session-1", async () => {
+            order.push("cleanup");
+        });
+
+        await Promise.resolve();
+        expect(order).toEqual([]);
+        release();
+        await cleanup;
+
+        expect(order).toEqual(["chunk-finalized", "cleanup"]);
+    });
 });
 
 describe("chunked snapshot assembly", () => {

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -168,7 +168,7 @@ export async function finalizeChunkedSnapshot(
 // scrambling the viewer's message assembly.
 export const sessionEventQueues = new Map<string, Promise<void>>();
 
-export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): void {
+export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): Promise<void> {
     const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
     const next = prev
         .then(fn, fn) // always chain, even on prior rejection
@@ -184,6 +184,7 @@ export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>):
             sessionEventQueues.delete(sessionId);
         }
     });
+    return next;
 }
 
 /**

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -77,7 +77,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         // pendingChunkedStates immediately, any chunks still queued in
         // enqueueSessionEvent() would wake up, find no pending state, and
         // skip final assembly — leaving the session with a stale snapshot.
-        enqueueSessionEvent(sessionId, async () => {
+        await enqueueSessionEvent(sessionId, async () => {
             pendingChunkedStates.delete(sessionId);
         });
         void clearPushPendingQuestion(sessionId);
@@ -123,7 +123,11 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             }
 
             clearThinkingMaps(sessionId);
-            pendingChunkedStates.delete(sessionId);
+            // Drain chunk handlers before deleting their assembly state or the
+            // last queued chunk can lose the durable checkpoint on disconnect.
+            await enqueueSessionEvent(sessionId, async () => {
+                pendingChunkedStates.delete(sessionId);
+            });
             void clearPushPendingQuestion(sessionId);
             // NOTE: We intentionally do NOT remove the child from the
             // parent's children set here.  Doing so races with

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -14,6 +14,7 @@ import {
     onViewerConnectedSignal,
     onViewerReadyForRunnerSignal,
     isViewerSwitchCurrent,
+    shouldAvoidSnapshotFallback,
     forwardRecoveryConnectedSignal,
     withHubMetaSource,
     withMetaViaHubHint,
@@ -154,6 +155,14 @@ describe("isViewerSwitchCurrent", () => {
 
     test("rejects stale generations", () => {
         expect(isViewerSwitchCurrent(4, 3)).toBe(false);
+    });
+});
+
+describe("shouldAvoidSnapshotFallback", () => {
+    test("blocks stale snapshots for seq cache misses and chunk assembly", () => {
+        expect(shouldAvoidSnapshotFallback(12, null)).toBe(true);
+        expect(shouldAvoidSnapshotFallback(undefined, { snapshotId: "snap-1" })).toBe(true);
+        expect(shouldAvoidSnapshotFallback(undefined, null)).toBe(false);
     });
 });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -147,6 +147,11 @@ export function withLivenessOnlyHint<T extends Record<string, unknown>>(event: T
 }
 
 /** @internal — exported for unit tests only */
+export function shouldAvoidSnapshotFallback(requestedLastSeq: number | undefined, pending: unknown): boolean {
+    return requestedLastSeq !== undefined || (pending !== null && pending !== undefined);
+}
+
+/** @internal — exported for unit tests only */
 export function isViewerSwitchCurrent(currentGeneration: number | undefined, requestedGeneration?: number): boolean {
     return requestedGeneration === undefined || currentGeneration === requestedGeneration;
 }
@@ -492,13 +497,14 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 } catch {}
             }
 
-            // If a chunked delivery is in-flight, lastState is stale (chunked
-            // session_active intentionally skips updating it). Emitting the old
-            // non-chunked snapshot here would overwrite the chunked header the
-            // viewer already received via the room broadcast, clear chunk-tracking
-            // in App.tsx, and cause remaining chunks to be dropped. Skip it and
-            // let the runner's fresh chunked delivery hydrate the viewer instead.
-            if (freshSession.lastState && !chunkedPending) {
+            // A seq cache miss must recover from the runner; an unsequenced
+            // snapshot can rewind a client that already has newer events. The
+            // same applies while a chunked checkpoint is still assembling.
+            if (shouldAvoidSnapshotFallback(requestedLastSeq, chunkedPending)) {
+                return;
+            }
+
+            if (freshSession.lastState) {
                 try {
                     socket.emit("event", {
                         event: withMetaViaHubHint({ type: "session_active", state: JSON.parse(freshSession.lastState) }),
@@ -506,13 +512,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                         generation,
                     });
                 } catch {}
-            } else if (!chunkedPending) {
-                // No in-memory state — fall back to event cache.
-                // Don't send partial chunked snapshots here — they'd arrive as
-                // non-chunked SA events, set lastCompletedSnapshotRef, and cause
-                // the UI to reject subsequent chunks from the active stream.
-                // The runner re-emits a fresh snapshot on the "connected" event
-                // above, which will properly restart chunked delivery.
+            } else {
                 await sendLatestSnapshotFromCache(socket, nextSessionId, generation);
             }
         };
@@ -548,20 +548,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("resync", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
-            // If a chunked delivery is in-flight on this node, skip
-            // sendSnapshotToViewer() entirely — that helper unconditionally
-            // emits lastState (the previous completed non-chunked snapshot),
-            // which would clear chunkedDeliveryRef on the client and cause all
-            // remaining session_messages_chunk events from the active stream to
-            // be dropped.  Ask the runner for a fresh chunked delivery instead;
-            // it will arrive in-order via the room broadcast.
+            // Never answer an in-flight chunk resync with lastState: it is the
+            // previous completed checkpoint until server assembly finishes.
+            // The client keeps the last good transcript visible and retries on
+            // an incomplete final chunk, after finalization is durable.
             //
-            // Note: getPendingChunkedSnapshot() reads node-local in-memory state.
-            // In a multi-node deployment this returns null when the delivery is
-            // managed by a different server node.  In that case we fall through to
-            // sendSnapshotToViewer(), which is the same behaviour as before this
-            // guard was added — a degraded-but-safe fallback for a deployment
-            // topology PizzaPi doesn't formally support.
+            // getPendingChunkedSnapshot() is node-local. Multi-node deployments
+            // still need sticky routing or shared pending state for this guard.
             const requestedLastSeq = typeof data?.lastSeq === "number" && Number.isFinite(data.lastSeq) ? data.lastSeq : undefined;
             const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
             if (requestedLastSeq !== undefined && !resyncChunkedPending) {
@@ -573,22 +566,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     return;
                 }
             }
-            if (resyncChunkedPending) {
-                // A chunked delivery is in-flight on this node.  DON'T request
-                // a room-wide re-emit via emitToRelaySession("connected") —
-                // that triggers emitSessionActive() on the runner which
-                // broadcasts to ALL viewers, resetting every watcher's
-                // transcript even though only this one viewer needed recovery.
-                //
-                // Fall through to sendSnapshotToViewer() below instead.  This
-                // sends the previous completed (non-chunked) lastState — it's
-                // slightly stale but gives the viewer a complete transcript.
-                // The non-chunked SA will set lastCompletedSnapshotRef on the
-                // client, which rejects remaining chunks from the in-flight
-                // delivery.  That's acceptable: the viewer has a working
-                // transcript, and the next session_active (from normal agent
-                // activity or a later resync after the chunked delivery
-                // finishes) will bring them fully up to date.
+            if (shouldAvoidSnapshotFallback(requestedLastSeq, resyncChunkedPending)) {
+                // Cache miss with a client cursor requires a newly sequenced
+                // runner snapshot; stale lastState cannot safely fill the gap.
+                if (requestedLastSeq !== undefined && !resyncChunkedPending) {
+                    forwardRecoveryConnectedSignal(currentSessionId);
+                }
+                return;
             }
 
             await sendSnapshotToViewer(currentSessionId, socket);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -130,7 +130,6 @@ import {
   augmentThinkingDurations,
   normalizeModelList,
   normalizeCommandList,
-  mergeChunkSnapshot,
   buildStreamingPartialMessage,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
@@ -145,9 +144,10 @@ import {
   registerChunkIndex,
   shouldAllowOutOfOrderSnapshotDuringHydration,
   shouldDeferEventForHydration,
+  shouldRequestChunkRecovery,
 } from "@/lib/session-seq";
 import { createLogger } from "@pizzapi/tools";
-import { isActiveViewerSessionPayload, matchesViewerGeneration } from "@/lib/viewer-switch";
+import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration } from "@/lib/viewer-switch";
 
 // Lazy-loaded low-frequency surfaces. Auth, session sidebar/viewer, banners,
 // and loading/error UI remain eager so critical paths stay fast.
@@ -845,6 +845,9 @@ export function App() {
   // chunks from a previous stream are discarded (e.g. if a new viewer
   // connects mid-stream and triggers a fresh emitSessionActive).
   // (Owned by lifecycleRefs.chunked / lifecycleRefs.lastCompletedSnapshot.)
+  // Live deltas that arrive while the historical snapshot is loading are
+  // replayed after the snapshot is installed so the current turn is not lost.
+  const deferredChunkEventsRef = React.useRef<unknown[]>([]);
 
   // Mobile layout
   const {
@@ -1049,6 +1052,7 @@ export function App() {
     lastSeqRef.current = null;
     renderedMcpReportTsRef.current = null;
     injectedMessagesRef.current = [];
+    deferredChunkEventsRef.current = [];
     // Single atomic reset — all session-scoped fields defined in SessionState
     // are cleared together. New fields added to SessionState are automatically
     // included; nothing can be accidentally left stale between sessions.
@@ -1680,21 +1684,16 @@ export function App() {
       onSnapshotStarted({});
     }
 
-    // While awaiting the initial snapshot OR during chunked hydration, skip
-    // streaming delta events.  They'd render briefly and then be replaced
-    // when the snapshot arrives, causing visible "jumping".  During chunked
-    // delivery, live events can interleave with historical chunks and produce
-    // an out-of-order transcript.  This also covers tool execution events —
-    // without this guard, tool_execution_update partials can write synthetic
-    // toolResult messages into state before the snapshot hydrates the real
-    // conversation, producing orphan/duplicate tool output on reconnect.
-    if (lifecycleRefs.awaitingSnapshot.current || lifecycleRefs.chunked.current) {
-      if (
-        type === "message_update" || type === "message_start" || type === "message_end" || type === "turn_end" ||
-        type === "tool_execution_start" || type === "tool_execution_update" || type === "tool_execution_end"
-      ) {
-        return;
-      }
+    // Deltas cannot be applied on top of a half-loaded snapshot. Drop them
+    // before the header, but retain them during chunking for replay after the
+    // atomic swap. The same helper also rejects chunks seen before their header.
+    if (shouldDeferEventForHydration(
+      type,
+      lifecycleRefs.awaitingSnapshot.current,
+      !!lifecycleRefs.chunked.current,
+    )) {
+      if (lifecycleRefs.chunked.current) deferredChunkEventsRef.current.push(event);
+      return;
     }
 
     if (type === "heartbeat") {
@@ -1864,6 +1863,9 @@ export function App() {
       const isChunked = !!state?.chunked;
       const snapshotId = typeof state?.snapshotId === "string" ? state.snapshotId : "";
       const totalMessages = typeof state?.totalMessages === "number" ? state.totalMessages : rawMessages.length;
+      // A newer snapshot supersedes both the old chunks and any deltas buffered
+      // against them. Those deltas are already represented in this snapshot.
+      deferredChunkEventsRef.current = [];
       onSnapshotStarted({ chunked: isChunked, snapshotId, totalMessages });
 
       const stateModel = normalizeModel(state?.model);
@@ -1879,15 +1881,17 @@ export function App() {
       }
 
       // Flush any queued streaming-delta RAF before replacing state so stale
-      // partials can't be re-inserted on top of the fresh snapshot.
+      // partials can't be re-inserted on top of the fresh snapshot. Chunked
+      // snapshots remain off-screen until complete, preserving the last good
+      // transcript instead of flashing an empty conversation on every refresh.
       cancelPendingDeltas();
-      // Re-append locally-injected messages (e.g. MCP auth banners) that
-      // aren't part of the server-side state snapshot.
-      const injected = injectedMessagesRef.current;
-      setMessages(injected.length > 0 ? [...normalizedMessages, ...injected] : normalizedMessages);
-      const serverHasMore = state?.hasMore === true;
-      const oldestLoadedIndex = typeof state?.oldestLoadedIndex === "number" ? state.oldestLoadedIndex : 0;
-      paginationStateRef.current = { totalMessages, hasMore: serverHasMore, oldestLoadedIndex };
+      if (!isChunked) {
+        const injected = injectedMessagesRef.current;
+        setMessages(injected.length > 0 ? [...normalizedMessages, ...injected] : normalizedMessages);
+        const serverHasMore = state?.hasMore === true;
+        const oldestLoadedIndex = typeof state?.oldestLoadedIndex === "number" ? state.oldestLoadedIndex : 0;
+        paginationStateRef.current = { totalMessages, hasMore: serverHasMore, oldestLoadedIndex };
+      }
       if (!metaViaHub) {
         setActiveModel(stateModel);
         if (hasSessionName) {
@@ -1976,7 +1980,7 @@ export function App() {
         setTodoList(stateTodos);
 
         patchSessionCache({
-          messages: normalizedMessages,
+          ...(!isChunked ? { messages: normalizedMessages } : {}),
           activeModel: stateModel,
           ...(hasSessionName ? { sessionName: nextSessionName } : {}),
           availableModels: stateModels,
@@ -1988,7 +1992,7 @@ export function App() {
         });
       } else {
         patchSessionCache({
-          messages: normalizedMessages,
+          ...(!isChunked ? { messages: normalizedMessages } : {}),
           availableModels: stateModels,
           ...(hasStateCommands ? { availableCommands: stateCommands } : {}),
           ...(hasStateAnalysis ? { analysis: stateAnalysis ?? null } : {}),
@@ -2070,6 +2074,15 @@ export function App() {
         chunkState.totalChunks,
       );
 
+      if (shouldRequestChunkRecovery(isFinal, readyToFinalize)) {
+        // The relay finalizes its durable snapshot before broadcasting the
+        // final chunk. A resync now can therefore recover the complete state
+        // without replaying the stale pre-chunk checkpoint.
+        // Omit lastSeq: delta-only replay cannot repair a missing historical
+        // chunk and would leave hydration stuck if newer deltas are cached.
+        viewerWsRef.current?.emit("resync", {});
+      }
+
       if (readyToFinalize) {
         // Assemble all buffered chunks in chunkIndex order so the resulting
         // transcript matches the original server-side ordering regardless of
@@ -2089,30 +2102,28 @@ export function App() {
           .filter((m): m is RelayMessage => m !== null);
         const finalMessages = deduplicateMessages(convertedOrdered);
 
-        lifecycleRefs.lastCompletedSnapshot.current = chunkSnapshotId || null;
-        lifecycleRefs.chunked.current = null;
-        lifecycleRefs.hydrated.current = true;
-        // Flush any MCP startup report that arrived before hydration completed
+        const injected = injectedMessagesRef.current;
+        const completedMessages = injected.length > 0 ? [...finalMessages, ...injected] : finalMessages;
+        const deferredEvents = deferredChunkEventsRef.current;
+        deferredChunkEventsRef.current = [];
+
+        setMessages(completedMessages);
+        setActiveToolCalls(detectInFlightTools(finalMessages));
+        paginationStateRef.current = { totalMessages, hasMore: false, oldestLoadedIndex: 0 };
+        patchSessionCache({ messages: completedMessages });
+        onSnapshotComplete();
+
+        // Queue updates above are applied in order, so replayed functional
+        // message updates land on the completed snapshot rather than the old
+        // visible transcript.
+        for (const deferredEvent of deferredEvents) {
+          handleRelayEvent(deferredEvent);
+        }
+
         if (pendingMcpReportRef.current) {
           applyMcpReport(pendingMcpReportRef.current);
           pendingMcpReportRef.current = null;
         }
-        onSnapshotComplete();
-
-        // Capture the merged result inside the updater so patchSessionCache
-        // receives the same value that setMessages commits — including any
-        // injected banners or system messages that are in prev but not in
-        // the snapshot.  Using a plain variable here mirrors the mcpNext
-        // pattern used in applyMcpReport; React calls functional updaters
-        // synchronously when enqueuing the update so mergedMessages is
-        // populated before patchSessionCache runs.
-        let mergedMessages: RelayMessage[] = finalMessages;
-        setMessages((prev) => {
-          mergedMessages = mergeChunkSnapshot(finalMessages, prev);
-          return mergedMessages;
-        });
-        setActiveToolCalls(detectInFlightTools(finalMessages));
-        patchSessionCache({ messages: mergedMessages });
       }
       return;
     }
@@ -3206,6 +3217,7 @@ export function App() {
     renderedMcpReportTsRef.current = null;
     pendingMcpReportRef.current = null;
     injectedMessagesRef.current = [];
+    deferredChunkEventsRef.current = [];
     metaSourceHubRef.current = false;
     paginationStateRef.current = null;
     setLoadingOlderMessages(false);
@@ -3350,31 +3362,26 @@ export function App() {
         }
         const { event: rawEvent, seq: envelopeSeq, deltaReplay, generation } = envelope.value;
 
-        // During session switch, only accept events that explicitly match our generation.
-        // This prevents events without generation tags from old sessions being processed
-        // while we're awaiting the snapshot for the new session.
-        if (lifecycleRefs.awaitingSnapshot.current) {
-          if (generation !== lifecycleRefs.generation.current) {
-            return;
-          }
-        } else if (!matchesViewerGeneration(lifecycleRefs.generation.current, generation)) {
-          return;
-        }
-        if (!lifecycleRefs.activeSessionId.current) return;
-        lastViewerEventAtRef.current = Date.now();
-
         const eventType =
           rawEvent && typeof rawEvent === "object" && typeof (rawEvent as Record<string, unknown>).type === "string"
             ? (rawEvent as Record<string, unknown>).type as string
             : "";
 
-        if (shouldDeferEventForHydration(
+        // Direct hydration events carry the switch generation. A cache-miss
+        // recovery snapshot is instead broadcast through the new session room,
+        // so its session_active header has no generation. The server has already
+        // removed this socket from the old room before joining the new one; accept
+        // only that state-setting header while awaiting hydration.
+        if (!matchesHydrationGeneration(
+          lifecycleRefs.generation.current,
+          generation,
           eventType,
           lifecycleRefs.awaitingSnapshot.current,
-          !!lifecycleRefs.chunked.current,
         )) {
           return;
         }
+        if (!lifecycleRefs.activeSessionId.current) return;
+        lastViewerEventAtRef.current = Date.now();
 
         const seq = envelopeSeq ?? null;
         if (seq !== null) {

--- a/packages/ui/src/lib/message-helpers.test.ts
+++ b/packages/ui/src/lib/message-helpers.test.ts
@@ -8,7 +8,6 @@ import {
   augmentThinkingDurations,
   normalizeModelList,
   normalizeCommandList,
-  mergeChunkSnapshot,
   buildStreamingPartialMessage,
 } from "./message-helpers";
 import { extractTextFromToolContent, hasVisibleContent } from "@/components/session-viewer/utils";
@@ -464,88 +463,6 @@ describe("normalizeCommandList", () => {
   test("handles missing optional fields", () => {
     const result = normalizeCommandList([{ name: "test" }]);
     expect(result).toEqual([{ name: "test", description: undefined, source: undefined }]);
-  });
-});
-
-// ── mergeChunkSnapshot ────────────────────────────────────────────────────────
-
-describe("mergeChunkSnapshot", () => {
-  test("returns snapshot messages unchanged when prev is empty", () => {
-    const snap = [assistantMsg({ key: "snapshot-0" }), assistantMsg({ key: "snapshot-1" })];
-    expect(mergeChunkSnapshot(snap, [])).toEqual(snap);
-  });
-
-  test("returns snapshot messages unchanged when all prev keys are covered by snapshot", () => {
-    const snap = [assistantMsg({ key: "snapshot-0" }), assistantMsg({ key: "snapshot-1" })];
-    const prev = [assistantMsg({ key: "snapshot-0" }), assistantMsg({ key: "snapshot-1" })];
-    expect(mergeChunkSnapshot(snap, prev)).toEqual(snap);
-  });
-
-  test("preserves injected messages not present in snapshot", () => {
-    const snap = [assistantMsg({ key: "snapshot-0" }), assistantMsg({ key: "snapshot-1" })];
-    const injected = assistantMsg({ key: "mcp-banner-abc" });
-    const prev = [...snap, injected];
-
-    const result = mergeChunkSnapshot(snap, prev);
-
-    expect(result).toHaveLength(3);
-    // Snapshot messages come first
-    expect(result[0].key).toBe("snapshot-0");
-    expect(result[1].key).toBe("snapshot-1");
-    // Injected banner is preserved at the end
-    expect(result[2].key).toBe("mcp-banner-abc");
-  });
-
-  test("snapshot messages take precedence over matching prev messages", () => {
-    const snapMsg = { ...assistantMsg({ key: "snapshot-0" }), content: "new-content" };
-    const prevMsg = { ...assistantMsg({ key: "snapshot-0" }), content: "old-content" };
-
-    const result = mergeChunkSnapshot([snapMsg], [prevMsg]);
-
-    expect(result).toHaveLength(1);
-    expect((result[0] as { content: string }).content).toBe("new-content");
-  });
-
-  test("multiple injected messages are all preserved after snapshot", () => {
-    const snap = [assistantMsg({ key: "snapshot-0" })];
-    const banner1 = assistantMsg({ key: "banner-1" });
-    const banner2 = assistantMsg({ key: "banner-2" });
-    const prev = [assistantMsg({ key: "snapshot-0" }), banner1, banner2];
-
-    const result = mergeChunkSnapshot(snap, prev);
-
-    expect(result).toHaveLength(3);
-    expect(result[0].key).toBe("snapshot-0");
-    expect(result.map((m) => m.key)).toContain("banner-1");
-    expect(result.map((m) => m.key)).toContain("banner-2");
-  });
-
-  // ── session-cache correctness ────────────────────────────────────────────
-  // patchSessionCache must receive the *merged* result from mergeChunkSnapshot,
-  // not the raw finalMessages from the server.  Using finalMessages directly
-  // would drop injected banners (e.g. MCP startup messages) from the cache,
-  // causing them to disappear on session switch / page reload.
-  test("merged result preserves injected banners that the raw snapshot would drop", () => {
-    const finalMessages = [
-      assistantMsg({ key: "snapshot-0" }),
-      assistantMsg({ key: "snapshot-1" }),
-    ];
-    const mcpBanner = assistantMsg({ key: "mcp_startup:1700000000000" });
-    const triggerBanner = assistantMsg({ key: "trigger:abc123" });
-    // Simulate the rendered state that contains both snapshot messages and
-    // injected banners added since the last hydration.
-    const prevMessages = [...finalMessages, mcpBanner, triggerBanner];
-
-    const merged = mergeChunkSnapshot(finalMessages, prevMessages);
-
-    // The merged result (what should go into the session cache) keeps both
-    // injected keys even though they are absent from finalMessages.
-    expect(merged.map((m) => m.key)).toContain("mcp_startup:1700000000000");
-    expect(merged.map((m) => m.key)).toContain("trigger:abc123");
-
-    // Storing finalMessages directly in the cache would silently drop them.
-    expect(finalMessages.find((m) => m.key === "mcp_startup:1700000000000")).toBeUndefined();
-    expect(finalMessages.find((m) => m.key === "trigger:abc123")).toBeUndefined();
   });
 });
 

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -152,23 +152,6 @@ export function deduplicateMessages(messages: RelayMessage[]): RelayMessage[] {
 }
 
 /**
- * Merge a finalized chunk snapshot with the previous message state.
- *
- * The assembled snapshot takes precedence for every message ID it covers, but
- * any messages already in `prev` whose keys are *not* present in the snapshot
- * (e.g. MCP auth banners, local system messages injected during hydration) are
- * preserved by appending them after the snapshot messages.
- */
-export function mergeChunkSnapshot(
-  snapshotMessages: RelayMessage[],
-  prev: RelayMessage[],
-): RelayMessage[] {
-  const snapshotKeys = new Set(snapshotMessages.map((m) => m.key));
-  const preserved = prev.filter((m) => !snapshotKeys.has(m.key));
-  return preserved.length > 0 ? [...snapshotMessages, ...preserved] : snapshotMessages;
-}
-
-/**
  * Build a synthetic streaming-partial `RelayMessage` from a `tool_execution_update`
  * event's `partialResult`. The shape produced here MUST match the shape of the
  * final tool result delivered via `message_end` so the rendering pipeline

--- a/packages/ui/src/lib/session-lifecycle.ts
+++ b/packages/ui/src/lib/session-lifecycle.ts
@@ -129,7 +129,7 @@ export type SessionLifecycleAction =
   | { type: "DISCONNECTED"; reason: string; isRestarting?: boolean; stopReconnect?: boolean }
   | { type: "RECONNECTING" }
   | { type: "RESTART_PENDING_CLEARED" }
-  | { type: "SNAPSHOT_STARTED"; chunked?: boolean; snapshotId?: string; totalMessages?: number }
+  | { type: "SNAPSHOT_STARTED"; chunked?: boolean; snapshotId?: string; totalMessages?: number; chunkState: ChunkedDeliveryState | null }
   | { type: "CHUNK_RECEIVED"; loaded: number; total: number }
   | { type: "SNAPSHOT_COMPLETE" }
   | { type: "ERROR"; error: string }
@@ -154,7 +154,25 @@ export const sessionLifecycleActions: SessionLifecycleActions = {
   disconnected: (payload) => ({ type: "DISCONNECTED", ...payload }),
   reconnecting: () => ({ type: "RECONNECTING" }),
   restartPendingCleared: () => ({ type: "RESTART_PENDING_CLEARED" }),
-  snapshotStarted: (payload = {}) => ({ type: "SNAPSHOT_STARTED", ...payload }),
+  snapshotStarted: (payload = {}) => {
+    const totalMessages = typeof payload.totalMessages === "number" ? payload.totalMessages : 0;
+    return {
+      type: "SNAPSHOT_STARTED",
+      ...payload,
+      totalMessages,
+      chunkState: payload.chunked === true
+        ? {
+            snapshotId: payload.snapshotId ?? "",
+            totalMessages,
+            totalChunks: 0,
+            receivedChunkIndexes: new Set<number>(),
+            finalChunkSeen: false,
+            loadedMessages: 0,
+            chunkBuffer: new Map<number, unknown[]>(),
+          }
+        : null,
+    };
+  },
   chunkReceived: (loaded, total) => ({ type: "CHUNK_RECEIVED", loaded, total }),
   snapshotComplete: () => ({ type: "SNAPSHOT_COMPLETE" }),
   error: (error) => ({ type: "ERROR", error }),
@@ -364,7 +382,7 @@ export function sessionLifecycleReducer(
     case "SNAPSHOT_STARTED": {
       if (!state.activeSessionId) return state;
       const isChunked = action.chunked === true;
-      const totalMessages = typeof action.totalMessages === "number" ? action.totalMessages : 0;
+      const totalMessages = action.totalMessages;
 
       if (isChunked) {
         return {
@@ -375,15 +393,7 @@ export function sessionLifecycleReducer(
             ...state.hydration,
             awaitingSnapshot: false,
             hydrated: false,
-            chunked: {
-              snapshotId: action.snapshotId ?? "",
-              totalMessages,
-              totalChunks: 0,
-              receivedChunkIndexes: new Set(),
-              finalChunkSeen: false,
-              loadedMessages: 0,
-              chunkBuffer: new Map(),
-            },
+            chunked: action.chunkState,
             lastCompletedSnapshot: null,
           },
         };

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -5,6 +5,7 @@ import {
   mergeConnectedSeq,
   registerChunkIndex,
   shouldAllowOutOfOrderSnapshotDuringHydration,
+  shouldRequestChunkRecovery,
   shouldDeferEventForHydration,
 } from "./session-seq";
 
@@ -112,6 +113,14 @@ describe("chunk index tracking", () => {
     // Arrival order [2, 0, 1] must NOT be reflected in the final transcript
     expect(assembled[0]).toBe("msg-c0-a");
     expect(assembled[assembled.length - 1]).toBe("msg-c2-b");
+  });
+});
+
+describe("shouldRequestChunkRecovery", () => {
+  test("requests recovery only when the final chunk arrives before all indexes", () => {
+    expect(shouldRequestChunkRecovery(true, false)).toBe(true);
+    expect(shouldRequestChunkRecovery(false, false)).toBe(false);
+    expect(shouldRequestChunkRecovery(true, true)).toBe(false);
   });
 });
 

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -38,6 +38,13 @@ export function shouldDeferEventForHydration(
   return false;
 }
 
+export function shouldRequestChunkRecovery(
+  finalChunkSeen: boolean,
+  readyToFinalize: boolean,
+): boolean {
+  return finalChunkSeen && !readyToFinalize;
+}
+
 export function shouldAllowOutOfOrderSnapshotDuringHydration(
   eventType: string,
   awaitingSnapshot: boolean,

--- a/packages/ui/src/lib/use-session-lifecycle.test.ts
+++ b/packages/ui/src/lib/use-session-lifecycle.test.ts
@@ -216,6 +216,30 @@ describe("useSessionLifecycle", () => {
     expect(apiRef.current!.refs.hydrated.current).toBe(true);
   });
 
+  test("snapshot callbacks update hydration refs before React flushes", () => {
+    const { apiRef } = renderHarness();
+
+    act(() => {
+      apiRef.current!.openSession("session-abc");
+    });
+
+    let immediateChunk: UseSessionLifecycleResult["refs"]["chunked"]["current"] = null;
+    act(() => {
+      apiRef.current!.onSnapshotStarted({ chunked: true, snapshotId: "snap-1", totalMessages: 10 });
+      immediateChunk = apiRef.current!.refs.chunked.current;
+    });
+
+    expect(immediateChunk?.snapshotId).toBe("snap-1");
+    expect(immediateChunk?.chunkBuffer).toBeInstanceOf(Map);
+    expect(apiRef.current!.refs.awaitingSnapshot.current).toBe(false);
+
+    act(() => {
+      apiRef.current!.onSnapshotComplete();
+      expect(apiRef.current!.refs.chunked.current).toBeNull();
+      expect(apiRef.current!.refs.hydrated.current).toBe(true);
+    });
+  });
+
   test("disconnected with isRestarting transitions to reconnecting", () => {
     const { apiRef } = renderHarness();
 

--- a/packages/ui/src/lib/use-session-lifecycle.ts
+++ b/packages/ui/src/lib/use-session-lifecycle.ts
@@ -327,13 +327,18 @@ export function useSessionLifecycle(
 
   const onSnapshotStarted = React.useCallback(
     (payload: Parameters<UseSessionLifecycleResult["onSnapshotStarted"]>[0]) => {
-      dispatch(
-        lifecycleActions.snapshotStarted({
-          chunked: payload.chunked,
-          snapshotId: payload.snapshotId,
-          totalMessages: payload.totalMessages,
-        }),
-      );
+      const action = lifecycleActions.snapshotStarted({
+        chunked: payload.chunked,
+        snapshotId: payload.snapshotId,
+        totalMessages: payload.totalMessages,
+      });
+      if (action.type === "SNAPSHOT_STARTED") {
+        awaitingSnapshotRef.current = false;
+        hydratedRef.current = false;
+        chunkedRef.current = action.chunkState;
+        lastCompletedSnapshotRef.current = action.chunked === true ? null : "non-chunked";
+      }
+      dispatch(action);
     },
     [],
   );
@@ -343,6 +348,11 @@ export function useSessionLifecycle(
   }, []);
 
   const onSnapshotComplete = React.useCallback(() => {
+    const completedSnapshot = chunkedRef.current?.snapshotId ?? lastCompletedSnapshotRef.current;
+    awaitingSnapshotRef.current = false;
+    hydratedRef.current = true;
+    chunkedRef.current = null;
+    lastCompletedSnapshotRef.current = completedSnapshot;
     dispatch(lifecycleActions.snapshotComplete());
   }, []);
 

--- a/packages/ui/src/lib/viewer-switch.test.ts
+++ b/packages/ui/src/lib/viewer-switch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isActiveViewerSessionPayload, matchesViewerGeneration } from "./viewer-switch";
+import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration } from "./viewer-switch";
 
 describe("matchesViewerGeneration", () => {
   test("accepts payloads without a generation", () => {
@@ -16,6 +16,22 @@ describe("matchesViewerGeneration", () => {
 
   test("rejects generated payloads when no current generation is set", () => {
     expect(matchesViewerGeneration(undefined, 1)).toBe(false);
+  });
+});
+
+describe("matchesHydrationGeneration", () => {
+  test("accepts an untagged state header while awaiting a cache-miss recovery", () => {
+    expect(matchesHydrationGeneration(4, undefined, "session_active", true)).toBe(true);
+    expect(matchesHydrationGeneration(4, undefined, "agent_end", true)).toBe(true);
+  });
+
+  test("rejects untagged deltas and chunks before the state header", () => {
+    expect(matchesHydrationGeneration(4, undefined, "message_update", true)).toBe(false);
+    expect(matchesHydrationGeneration(4, undefined, "session_messages_chunk", true)).toBe(false);
+  });
+
+  test("still rejects explicitly stale generations", () => {
+    expect(matchesHydrationGeneration(4, 3, "session_active", true)).toBe(false);
   });
 });
 

--- a/packages/ui/src/lib/viewer-switch.ts
+++ b/packages/ui/src/lib/viewer-switch.ts
@@ -5,6 +5,21 @@ export function matchesViewerGeneration(
   return payloadGeneration === undefined || currentGeneration === payloadGeneration;
 }
 
+export function matchesHydrationGeneration(
+  currentGeneration: number | undefined,
+  payloadGeneration: number | undefined,
+  eventType: string,
+  awaitingSnapshot: boolean,
+): boolean {
+  if (!awaitingSnapshot) {
+    return matchesViewerGeneration(currentGeneration, payloadGeneration);
+  }
+  if (payloadGeneration !== undefined) {
+    return payloadGeneration === currentGeneration;
+  }
+  return eventType === "session_active" || eventType === "agent_end";
+}
+
 export function isActiveViewerSessionPayload(
   activeSessionId: string | null,
   payloadSessionId: string,


### PR DESCRIPTION
## Summary
- keep the last complete conversation visible while chunked snapshots hydrate, then swap atomically
- replay live events after hydration and recover incomplete/superseded chunk streams safely
- prevent stale snapshot rollback and preserve durable chunk checkpoints across disconnects

## Tests
- `bun packages/server/.tmp-run-full-tests.ts` (full suite with isolated Redis)
- `bun run typecheck`
- `bun run build`
- targeted UI, CLI chunk-delivery, and server viewer/event-pipeline tests
