### PR TITLE
feat(ui): preview videos in Files panel

### DIFF
--- a/packages/cli/src/runner/services/file-explorer-service.test.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.test.ts
@@ -42,6 +42,9 @@ function createFakeSocket() {
                 .filter((e) => e.event === "service_message" && e.data?.serviceId === "file-explorer")
                 .map((e) => e.data);
         },
+        fileResults(): any[] {
+            return emitted.filter((e) => e.event === "file_result").map((e) => e.data);
+        },
     };
 }
 
@@ -178,6 +181,71 @@ describe("FileExplorerService — browse_directory", () => {
         const names = getLastDirNames();
         const sorted = [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
         expect(names).toEqual(sorted);
+    });
+
+    test("does not read oversized binary files when truncation is rejected", async () => {
+        const videoPath = join(tmpDir, "demo.mp4");
+        writeFileSync(videoPath, "0123456789");
+
+        await socket.trigger("read_file", {
+            requestId: "video",
+            path: videoPath,
+            encoding: "base64",
+            maxBytes: 4,
+            rejectTruncated: true,
+        });
+
+        const payload = socket.fileResults().pop();
+        expect(payload).toMatchObject({ ok: true, size: 10, truncated: true });
+        expect(payload?.content).toBeUndefined();
+        expect(socket.serviceMessages()).toHaveLength(0);
+    });
+
+    test("rejects a file that grows beyond the preview limit during the read", async () => {
+        const videoPath = join(tmpDir, "growing.mp4");
+        writeFileSync(videoPath, "0123456789");
+        const originalFile = Bun.file;
+        let grew = false;
+        (Bun as any).file = (...args: Parameters<typeof Bun.file>) => {
+            if (!grew) {
+                writeFileSync(videoPath, "x", { flag: "a" });
+                grew = true;
+            }
+            return originalFile(...args);
+        };
+
+        try {
+            await socket.trigger("read_file", {
+                requestId: "growing",
+                path: videoPath,
+                encoding: "base64",
+                maxBytes: 10,
+                rejectTruncated: true,
+            });
+        } finally {
+            (Bun as any).file = originalFile;
+        }
+
+        const payload = socket.fileResults().pop();
+        expect(payload).toMatchObject({ ok: true, size: 11, truncated: true });
+        expect(payload?.content).toBeUndefined();
+    });
+
+    test("does not emit a result after a read is cancelled", async () => {
+        const videoPath = join(tmpDir, "cancelled.mp4");
+        writeFileSync(videoPath, "0123456789");
+
+        const read = socket.trigger("read_file", {
+            requestId: "cancelled",
+            path: videoPath,
+            encoding: "base64",
+            maxBytes: 10,
+        });
+        await socket.trigger("cancel_file_request", { requestId: "cancelled" });
+        await read;
+
+        expect(socket.fileResults()).toHaveLength(0);
+        expect(socket.serviceMessages()).toHaveLength(0);
     });
 
     test("dispose removes listener", () => {

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -26,21 +26,24 @@ export class FileExplorerService implements ServiceHandler {
     private _onListFiles: ((data: any) => void) | null = null;
     private _onSearchFiles: ((data: any) => void) | null = null;
     private _onReadFile: ((data: any) => void) | null = null;
+    private _onCancelFileRequest: ((data: any) => void) | null = null;
     private _onBrowseDirectory: ((data: any) => void) | null = null;
+    private _activeReadRequests = new Map<string, AbortController>();
 
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this._socket = socket;
 
-        // Helper: emit file_result on both channels (direct + service envelope).
-        // ALL file_result emissions in this service go through this helper so
-        // error paths and success paths are both covered.
-        const emitFileResult = (payload: Record<string, unknown>) => {
+        // REST reads use only the correlated direct response so file content
+        // is never broadcast to unrelated session viewers.
+        const emitFileResult = (payload: Record<string, unknown>, broadcast = true) => {
             socket.emit("file_result" as any, payload);
-            (socket as any).emit("service_message", {
-                serviceId: "file-explorer",
-                type: "file_result",
-                payload,
-            });
+            if (broadcast) {
+                (socket as any).emit("service_message", {
+                    serviceId: "file-explorer",
+                    type: "file_result",
+                    payload,
+                });
+            }
         };
 
         this._onListFiles = async (data: any) => {
@@ -229,48 +232,70 @@ export class FileExplorerService implements ServiceHandler {
                 : encoding === "base64"
                     ? 10 * 1024 * 1024
                     : 256 * 1024; // 10MB for base64, 256KB for text
+            const controller = new AbortController();
+            if (typeof requestId === "string") {
+                this._activeReadRequests.get(requestId)?.abort();
+                this._activeReadRequests.set(requestId, controller);
+            }
+            const emitReadResult = (payload: Record<string, unknown>) => {
+                if (!controller.signal.aborted) emitFileResult(payload, false);
+            };
 
-            if (!filePath) {
-                emitFileResult({ requestId, ok: false, message: "Missing path" });
-                return;
-            }
-            if (!isCwdAllowed(filePath)) {
-                emitFileResult({ requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
             try {
-                const s = await stat(filePath);
-                const truncated = s.size > maxBytes;
-                if (encoding === "base64") {
-                    const buf = await Bun.file(filePath).slice(0, maxBytes).arrayBuffer();
-                    const b64 = Buffer.from(buf).toString("base64");
-                    emitFileResult({
-                        requestId,
-                        ok: true,
-                        content: b64,
-                        encoding: "base64",
-                        size: s.size,
-                        truncated,
-                    });
-                } else {
-                    const fd = await Bun.file(filePath).slice(0, maxBytes).text();
-                    emitFileResult({
-                        requestId,
-                        ok: true,
-                        content: fd,
-                        size: s.size,
-                        truncated,
-                    });
+                if (!filePath) {
+                    emitReadResult({ requestId, ok: false, message: "Missing path" });
+                    return;
                 }
+                if (!isCwdAllowed(filePath)) {
+                    emitReadResult({ requestId, ok: false, message: "Path outside allowed roots" });
+                    return;
+                }
+
+                const s = await stat(filePath);
+                if (controller.signal.aborted) return;
+                if (s.size > maxBytes && (data as any).rejectTruncated === true) {
+                    emitReadResult({ requestId, ok: true, size: s.size, truncated: true });
+                    return;
+                }
+
+                const bytes = Buffer.from(await Bun.file(filePath).slice(0, maxBytes + 1).arrayBuffer());
+                const finalSize = (await stat(filePath)).size;
+                if (controller.signal.aborted) return;
+                const truncated = finalSize > maxBytes || bytes.byteLength > maxBytes;
+                if (truncated && (data as any).rejectTruncated === true) {
+                    emitReadResult({ requestId, ok: true, size: finalSize, truncated: true });
+                    return;
+                }
+
+                const content = bytes.subarray(0, maxBytes);
+                emitReadResult({
+                    requestId,
+                    ok: true,
+                    content: encoding === "base64" ? content.toString("base64") : content.toString("utf8"),
+                    ...(encoding === "base64" ? { encoding: "base64" } : {}),
+                    size: finalSize,
+                    truncated,
+                });
             } catch (err) {
-                emitFileResult({
+                emitReadResult({
                     requestId,
                     ok: false,
                     message: err instanceof Error ? err.message : String(err),
                 });
+            } finally {
+                if (typeof requestId === "string" && this._activeReadRequests.get(requestId) === controller) {
+                    this._activeReadRequests.delete(requestId);
+                }
             }
         };
         socket.on("read_file", this._onReadFile);
+
+        this._onCancelFileRequest = (data: any) => {
+            if (typeof data?.requestId === "string") {
+                this._activeReadRequests.get(data.requestId)?.abort();
+            }
+        };
+        socket.on("cancel_file_request" as any, this._onCancelFileRequest);
     }
 
     dispose(): void {
@@ -280,12 +305,16 @@ export class FileExplorerService implements ServiceHandler {
             if (this._onListFiles) (this._socket as any).off("list_files", this._onListFiles);
             if (this._onSearchFiles) (this._socket as any).off("search_files", this._onSearchFiles);
             if (this._onReadFile) (this._socket as any).off("read_file", this._onReadFile);
+            if (this._onCancelFileRequest) (this._socket as any).off("cancel_file_request", this._onCancelFileRequest);
             if (this._onBrowseDirectory) (this._socket as any).off("browse_directory", this._onBrowseDirectory);
             this._socket = null;
         }
         this._onListFiles = null;
         this._onSearchFiles = null;
         this._onReadFile = null;
+        this._onCancelFileRequest = null;
         this._onBrowseDirectory = null;
+        for (const controller of this._activeReadRequests.values()) controller.abort();
+        this._activeReadRequests.clear();
     }
 }

--- a/packages/docs/src/content/docs/web-ui/file-explorer.mdx
+++ b/packages/docs/src/content/docs/web-ui/file-explorer.mdx
@@ -45,8 +45,6 @@ The breadcrumb bar at the top shows the current root path (`cwd`). Use the **ref
 
 Click any file to open it in the built-in viewer. Press **Escape** to return to the directory tree.
 
-### Text Files
-
 ### Text files
 
 Text files open in a read-only monospaced preview with syntax-appropriate formatting. If the file exceeds **512 KB**, it is truncated and a warning banner appears:
@@ -67,6 +65,12 @@ Image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`, `
 - **Dimensions** — natural width × height shown in the header
 
 Images are fetched as base64-encoded data with a **10 MB** size limit.
+
+### Videos
+
+Video files (`.mp4`, `.m4v`, `.mov`, `.webm`, `.ogv`, `.ogg`) open in the browser's native video player with playback, volume, timeline, and fullscreen controls. Playback support depends on the browser and the video's codec.
+
+Videos have a **10 MB** preview limit. Larger files show their size instead of transferring a partial, unplayable video.
 
 <Aside type="tip">
   The file explorer is **read-only** — you cannot edit, rename, or delete files through it. However, the Markdown and text file viewers do offer a **Blame** toggle (when the runner has git available). Use the agent itself (or a terminal) to make changes.
@@ -141,6 +145,7 @@ POST /api/runners/:runnerId/read-file
 |-------|------|---------|-------------|
 | `path` | `string` | _(required)_ | Absolute path to the file |
 | `encoding` | `"utf8"` \| `"base64"` | `"utf8"` | Response encoding — use `base64` for images and binary files |
+| `rejectTruncated` | `boolean` | `false` | When `true`, omit `content` if the file exceeds the encoding limit instead of returning partial content |
 
 **Response:**
 
@@ -160,7 +165,7 @@ Size limits depend on encoding:
 | `utf8` | 512 KB | 15 s |
 | `base64` | 10 MB | 30 s |
 
-If the file exceeds the limit, `content` contains the first N bytes and `truncated` is `true`.
+If the file exceeds the limit, `content` contains the first N bytes and `truncated` is `true`. When `rejectTruncated` is `true`, the response still reports `size` and `truncated: true` but omits `content`; video previews use this to avoid transferring unusable partial files.
 
 ### Search files
 

--- a/packages/protocol/src/runner.test.ts
+++ b/packages/protocol/src/runner.test.ts
@@ -381,11 +381,23 @@ describe("runner — RunnerServerToClientEvents payloads", () => {
     expect(withLimit.limit).toBe(50);
   });
 
-  test("read_file carries cwd and path", () => {
+  test("read_file carries binary preview options", () => {
     type Payload = Parameters<RunnerServerToClientEvents["read_file"]>[0];
-    const p: Payload = { cwd: "/home/user", path: "src/index.ts" };
-    expect(typeof p.cwd).toBe("string");
-    expect(typeof p.path).toBe("string");
+    const p: Payload = {
+      path: "demo.mp4",
+      encoding: "base64",
+      maxBytes: 10 * 1024 * 1024,
+      rejectTruncated: true,
+    };
+    expect(p.encoding).toBe("base64");
+    expect(p.maxBytes).toBe(10 * 1024 * 1024);
+    expect(p.rejectTruncated).toBe(true);
+  });
+
+  test("cancel_file_request identifies the read to cancel", () => {
+    type Payload = Parameters<RunnerServerToClientEvents["cancel_file_request"]>[0];
+    const p: Payload = { requestId: "read-1" };
+    expect(p.requestId).toBe("read-1");
   });
 
   test("git operations use service_message channel (no dedicated events)", () => {

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -429,9 +429,15 @@ export interface RunnerServerToClientEvents {
   /** Reads a file's content */
   read_file: (data: {
     requestId?: string;
-    cwd: string;
+    cwd?: string;
     path: string;
+    encoding?: "utf8" | "base64";
+    maxBytes?: number;
+    rejectTruncated?: boolean;
   }) => void;
+
+  /** Cancels an in-flight file read */
+  cancel_file_request: (data: { requestId: string }) => void;
 
   // Git operations (status, diff, branches, checkout, stage, unstage,
   // commit, push) are handled via the service_message channel with

--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -314,7 +314,9 @@ describe("withSecurityHeaders", () => {
 
     test("injects Content-Security-Policy", () => {
         const res = withSecurityHeaders(new Response("ok"));
-        expect(res.headers.get("content-security-policy")).toContain("default-src 'self'");
+        const csp = res.headers.get("content-security-policy");
+        expect(csp).toContain("default-src 'self'");
+        expect(csp).toContain("media-src 'self' data: blob:");
     });
 
     test("preserves existing headers", () => {

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -197,7 +197,7 @@ export function withSecurityHeaders(res: Response): Response {
         //   python3 -c "import re,hashlib,base64;html=open('packages/ui/index.html').read();m=re.search(r'<script>(.*?)</script>',html,re.DOTALL);print('sha256-'+base64.b64encode(hashlib.sha256(m.group(1).encode()).digest()).decode())"
         headers.set(
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-4gSUsZcLv5hWmJpSRF6gl939rcZJHXery+eyOKMEgaQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-4gSUsZcLv5hWmJpSRF6gl939rcZJHXery+eyOKMEgaQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
         );
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -74,7 +74,8 @@ process.on("uncaughtException", (err: Error) => {
 });
 
 // Socket.IO imports
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer, type ServerResponse } from "node:http";
+import { nodeReqToFetchRequest } from "./node-request.js";
 import { Server as SocketIOServer } from "socket.io";
 import { createAdapter } from "@socket.io/redis-adapter";
 import { createClient } from "redis";
@@ -115,39 +116,6 @@ try {
 }
 
 // ── Helpers: convert node:http request/response ↔ fetch API ──────────────
-
-function nodeReqToFetchRequest(req: IncomingMessage): Request {
-    const proto = req.headers["x-forwarded-proto"] ?? "http";
-    const host = req.headers.host ?? `localhost:${PORT}`;
-    const url = new URL(req.url ?? "/", `${proto}://${host}`);
-
-    const headers = new Headers();
-    for (const [key, value] of Object.entries(req.headers)) {
-        if (value === undefined) continue;
-        if (key.toLowerCase() === "x-pizzapi-client-ip") continue; // Prevent spoofing
-        if (Array.isArray(value)) {
-            for (const v of value) headers.append(key, v);
-        } else {
-            headers.set(key, value);
-        }
-    }
-
-    // Securely attach the real client IP so downstream routes can use it for rate limiting, etc.
-    if (req.socket.remoteAddress) {
-        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
-    }
-
-    const method = (req.method ?? "GET").toUpperCase();
-    const hasBody = method !== "GET" && method !== "HEAD";
-
-    return new Request(url.toString(), {
-        method,
-        headers,
-        body: hasBody ? req as any : undefined,
-        // @ts-expect-error — Bun supports duplex on Request
-        duplex: hasBody ? "half" : undefined,
-    });
-}
 
 async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
     // Security headers are already injected by withSecurityHeaders in handleFetch.
@@ -198,7 +166,7 @@ const httpServer = createServer(async (req, res) => {
     // listener it attaches to httpServer). For all other requests, convert
     // to the fetch API and run through the existing REST + auth handlers.
     try {
-        const fetchReq = nodeReqToFetchRequest(req);
+        const fetchReq = nodeReqToFetchRequest(req, res, PORT);
         const fetchRes = await handleFetch(fetchReq, authContext);
         await sendFetchResponse(res, fetchRes);
     } catch (e) {
@@ -214,7 +182,7 @@ const httpServer = createServer(async (req, res) => {
                 "referrer-policy": "strict-origin-when-cross-origin",
                 "permissions-policy": "camera=(), microphone=(), geolocation=()",
                 "content-security-policy":
-                    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+                    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
             });
             res.end(JSON.stringify({ error: "Internal server error" }));
             return;

--- a/packages/server/src/node-request.test.ts
+++ b/packages/server/src/node-request.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { nodeReqToFetchRequest } from "./node-request.js";
+
+function requestPair() {
+    const req = Object.assign(new EventEmitter(), {
+        headers: { host: "localhost:3000", "x-pizzapi-client-ip": "spoofed" },
+        method: "GET",
+        url: "/api/test",
+        socket: { remoteAddress: "127.0.0.1" },
+    });
+    const res = Object.assign(new EventEmitter(), { writableFinished: false });
+    return { req, res };
+}
+
+describe("nodeReqToFetchRequest", () => {
+    test("aborts the fetch request when the client disconnects before the response finishes", () => {
+        const { req, res } = requestPair();
+        const request = nodeReqToFetchRequest(req as any, res as any, 3000);
+
+        res.emit("close");
+
+        expect(request.signal.aborted).toBe(true);
+    });
+
+    test("does not abort after a completed response", () => {
+        const { req, res } = requestPair();
+        const request = nodeReqToFetchRequest(req as any, res as any, 3000);
+        res.writableFinished = true;
+
+        res.emit("close");
+
+        expect(request.signal.aborted).toBe(false);
+        expect(request.headers.get("x-pizzapi-client-ip")).toBe("127.0.0.1");
+    });
+});

--- a/packages/server/src/node-request.ts
+++ b/packages/server/src/node-request.ts
@@ -1,0 +1,46 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/** Convert Node's HTTP request while propagating premature client disconnects. */
+export function nodeReqToFetchRequest(req: IncomingMessage, res: ServerResponse, port: number): Request {
+    const controller = new AbortController();
+    const cleanup = () => {
+        req.off("aborted", onAborted);
+        res.off("close", onResponseClose);
+    };
+    const onAborted = () => {
+        controller.abort();
+        cleanup();
+    };
+    const onResponseClose = () => {
+        if (!res.writableFinished) controller.abort();
+        cleanup();
+    };
+    req.once("aborted", onAborted);
+    res.once("close", onResponseClose);
+
+    const proto = req.headers["x-forwarded-proto"] ?? "http";
+    const host = req.headers.host ?? `localhost:${port}`;
+    const url = new URL(req.url ?? "/", `${proto}://${host}`);
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+    if (req.socket.remoteAddress) headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body: hasBody ? req as any : undefined,
+        signal: controller.signal,
+        // @ts-expect-error — Bun supports duplex on Request
+        duplex: hasBody ? "half" : undefined,
+    });
+}

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -49,10 +49,11 @@ mock.module("../sessions/runner-trigger-listener-store.js", () => ({
 
 const mockGetSession = mock(() => Promise.resolve(null));
 const mockEmitTriggerSubscriptionDelta = mock((_runnerId: string, _delta: any) => Promise.resolve());
+const mockSendRunnerCommand = mock(() => Promise.resolve({ ok: true }));
 mock.module("../ws/namespaces/runner.js", () => ({
     sendSkillCommand: mock(() => Promise.resolve({ ok: true })),
     sendAgentCommand: mock(() => Promise.resolve({ ok: true })),
-    sendRunnerCommand: mock(() => Promise.resolve({ ok: true })),
+    sendRunnerCommand: mockSendRunnerCommand,
     emitTriggerSubscriptionDelta: mockEmitTriggerSubscriptionDelta,
 }));
 mock.module("../ws/runner-control.js", () => ({ waitForSpawnAck: mock(() => Promise.resolve({ ok: true })) }));
@@ -108,6 +109,43 @@ describe("runner service toggle route", () => {
             serviceId: "taxonomy",
             enabled: false,
         });
+    });
+});
+
+describe("runner read-file route", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+        mockSendRunnerCommand.mockReset();
+        mockSendRunnerCommand.mockReturnValue(Promise.resolve({ ok: true, size: 3, content: "AAAA" }));
+    });
+
+    test("forwards rejectTruncated and strips partial content from older runners", async () => {
+        mockSendRunnerCommand.mockReturnValue(Promise.resolve({
+            ok: true,
+            size: 11 * 1024 * 1024,
+            content: "partial",
+            truncated: true,
+        }));
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/read-file", {
+            path: "/repo/demo.mp4",
+            encoding: "base64",
+            rejectTruncated: true,
+        });
+
+        const res = await handleRunnersRoute(req, url);
+
+        expect(res!.status).toBe(200);
+        expect(mockSendRunnerCommand).toHaveBeenCalledWith("runner-A", {
+            type: "read_file",
+            path: "/repo/demo.mp4",
+            encoding: "base64",
+            maxBytes: 10 * 1024 * 1024,
+            rejectTruncated: true,
+        }, 30_000, req.signal);
+        expect(await res!.json()).toEqual({ ok: true, size: 11 * 1024 * 1024, truncated: true });
     });
 });
 

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -1054,11 +1054,16 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
 
         const encoding = body.encoding === "base64" ? "base64" : "utf8";
         const maxBytes = encoding === "base64" ? 10 * 1024 * 1024 : 512 * 1024;
+        const rejectTruncated = body.rejectTruncated === true;
         const timeout = encoding === "base64" ? 30_000 : 15_000;
 
         try {
-            const result = await sendRunnerCommand(runnerId, { type: "read_file", path, encoding, maxBytes }, timeout);
+            const result = await sendRunnerCommand(runnerId, { type: "read_file", path, encoding, maxBytes, rejectTruncated }, timeout, req.signal);
             if (!(result as any).ok) return Response.json({ error: (result as any).message ?? "Failed to read file" }, { status: 500 });
+            if (rejectTruncated && result.truncated === true) {
+                const { content: _content, ...metadata } = result;
+                return Response.json(metadata);
+            }
             return Response.json(result);
         } catch (err) {
             return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 502 });

--- a/packages/server/src/ws/namespaces/runner.test.ts
+++ b/packages/server/src/ws/namespaces/runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import {
     MAX_PENDING_REQUESTS,
+    cancelRunnerFileRead,
     isPendingRequestCapReached,
     pendingSocketMatches,
 } from "./runner.js";
@@ -40,5 +41,15 @@ describe("runner namespace pending-request hardening", () => {
         expect(isPendingRequestCapReached(MAX_PENDING_REQUESTS - 1)).toBe(false);
         expect(isPendingRequestCapReached(MAX_PENDING_REQUESTS)).toBe(true);
         expect(isPendingRequestCapReached(MAX_PENDING_REQUESTS + 1)).toBe(true);
+    });
+
+    test("read cancellation emits the correlated runner event", () => {
+        const emitted: Array<[string, unknown]> = [];
+        const socket = { emit: (event: string, data: unknown) => emitted.push([event, data]) };
+
+        cancelRunnerFileRead(socket as any, "read_file", "read-1");
+        cancelRunnerFileRead(socket as any, "list_files", "list-1");
+
+        expect(emitted).toEqual([["cancel_file_request", { requestId: "read-1" }]]);
     });
 });

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -251,9 +251,14 @@ interface PendingRunnerCommand {
     reject: (err: Error) => void;
     timer: ReturnType<typeof setTimeout>;
     socketId: string;
+    abortCleanup?: () => void;
 }
 
 const pendingRunnerCommands = new Map<string, PendingRunnerCommand>();
+
+export function cancelRunnerFileRead(socket: Socket, eventName: string, requestId: string): void {
+    if (eventName === "read_file") socket.emit("cancel_file_request" as any, { requestId });
+}
 
 /**
  * Send a generic command to a runner via Socket.IO and wait for the response.
@@ -266,6 +271,7 @@ export async function sendRunnerCommand(
     runnerId: string,
     command: Record<string, unknown>,
     timeoutMs = 15_000,
+    signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
     const socket = getLocalRunnerSocket(runnerId);
     if (!socket) throw new Error("Runner not found");
@@ -281,17 +287,44 @@ export async function sendRunnerCommand(
         }
 
         const timer = setTimeout(() => {
+            const pending = pendingRunnerCommands.get(requestId);
+            pending?.abortCleanup?.();
             pendingRunnerCommands.delete(requestId);
+            cancelRunnerFileRead(socket as Socket, eventName, requestId);
             reject(new Error("Runner command timed out"));
         }, timeoutMs);
 
-        pendingRunnerCommands.set(requestId, { resolve, reject, timer, socketId: socket.id });
+        let abortCleanup: (() => void) | undefined;
+        let abortRequest: (() => void) | undefined;
+        if (signal) {
+            const onAbort = () => {
+                const pending = pendingRunnerCommands.get(requestId);
+                if (!pending) return;
+                clearTimeout(pending.timer);
+                pending.abortCleanup?.();
+                pendingRunnerCommands.delete(requestId);
+                cancelRunnerFileRead(socket as Socket, eventName, requestId);
+                const error = new Error("Runner command aborted");
+                error.name = "AbortError";
+                reject(error);
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            abortRequest = onAbort;
+            abortCleanup = () => signal.removeEventListener("abort", onAbort);
+        }
+
+        pendingRunnerCommands.set(requestId, { resolve, reject, timer, socketId: socket.id, abortCleanup });
 
         try {
+            if (signal?.aborted) {
+                abortRequest?.();
+                return;
+            }
             const { type: _type, ...rest } = command;
             (socket as Socket).emit(eventName, { ...rest, requestId });
         } catch (err) {
             clearTimeout(timer);
+            abortCleanup?.();
             pendingRunnerCommands.delete(requestId);
             reject(err);
         }
@@ -669,6 +702,7 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
                 const pending = pendingRunnerCommands.get(requestId);
                 if (pendingSocketMatches(pending, socket.id)) {
                     clearTimeout(pending.timer);
+                    pending.abortCleanup?.();
                     pendingRunnerCommands.delete(requestId);
                     const { requestId: _rid, ...rest } = data;
                     pending.resolve(rest);

--- a/packages/ui/src/components/file-explorer/FileExplorer.tsx
+++ b/packages/ui/src/components/file-explorer/FileExplorer.tsx
@@ -15,8 +15,9 @@ import {
   ChevronsDownUp,
 } from "lucide-react";
 import { FileEntry, FileExplorerProps } from "./types";
-import { shouldInterceptEscape, isImageFile, isMarkdownFile, getFileIcon, formatSize, repoRelativePath } from "./utils";
+import { shouldInterceptEscape, isImageFile, isVideoFile, isMarkdownFile, getFileIcon, formatSize, repoRelativePath } from "./utils";
 import { ImageViewer } from "./image-viewer";
+import { VideoViewer } from "./video-viewer";
 import { FileViewer } from "./file-viewer";
 import { MarkdownViewer } from "./markdown-viewer";
 import { useGitService } from "@/hooks/useGitService";
@@ -310,12 +311,19 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
   if (viewingFile) {
     const viewingFileName = viewingFile.split(/[\\/]/).pop() ?? viewingFile;
     const isImage = isImageFile(viewingFileName);
+    const isVideo = isVideoFile(viewingFileName);
     const isMarkdown = isMarkdownFile(viewingFileName);
 
     return (
       <div ref={previewContainerRef} tabIndex={-1} data-escape-abort-guard className={cn("flex flex-col bg-background text-foreground outline-none", className)}>
         {isImage ? (
           <ImageViewer
+            runnerId={runnerId}
+            filePath={viewingFile}
+            onClose={() => setViewingFile(null)}
+          />
+        ) : isVideo ? (
+          <VideoViewer
             runnerId={runnerId}
             filePath={viewingFile}
             onClose={() => setViewingFile(null)}
@@ -461,6 +469,7 @@ export { GitChangesView } from "./git-changes-view";
 export { PositionPicker } from "./position-picker";
 export { FileTreeNode } from "./file-tree-node";
 export { ImageViewer } from "./image-viewer";
+export { VideoViewer } from "./video-viewer";
 export { FileViewer } from "./file-viewer";
 export { MarkdownViewer } from "./markdown-viewer";
 export {
@@ -468,10 +477,13 @@ export {
   formatSize,
   getFileIcon,
   isImageFile,
+  isVideoFile,
   isMarkdownFile,
   getMimeType,
+  getVideoMimeType,
   gitStatusLabel,
   IMAGE_EXTENSIONS,
+  VIDEO_EXTENSIONS,
   MARKDOWN_EXTENSIONS,
   POSITION_OPTIONS,
   repoRelativePath,

--- a/packages/ui/src/components/file-explorer/utils.test.ts
+++ b/packages/ui/src/components/file-explorer/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { resolveFilePath, repoRelativePath } from "./utils";
+import { resolveFilePath, repoRelativePath, isVideoFile, getVideoMimeType } from "./utils";
 
 describe("resolveFilePath", () => {
   test("POSIX absolute passes through", () => {
@@ -21,6 +21,21 @@ describe("resolveFilePath", () => {
 
   test("relative joins with Windows cwd using backslash", () => {
     expect(resolveFilePath("C:\\Users\\j\\proj\\", "src/app.ts")).toBe("C:\\Users\\j\\proj\\src/app.ts");
+  });
+});
+
+describe("video files", () => {
+  test("recognizes browser-playable video containers case-insensitively", () => {
+    expect(isVideoFile("demo.MP4")).toBe(true);
+    expect(isVideoFile("demo.webm")).toBe(true);
+    expect(isVideoFile("demo.mov")).toBe(true);
+    expect(isVideoFile("demo.txt")).toBe(false);
+  });
+
+  test("returns the matching video MIME type", () => {
+    expect(getVideoMimeType("demo.mp4")).toBe("video/mp4");
+    expect(getVideoMimeType("demo.webm")).toBe("video/webm");
+    expect(getVideoMimeType("demo.ogv")).toBe("video/ogg");
   });
 });
 

--- a/packages/ui/src/components/file-explorer/utils.ts
+++ b/packages/ui/src/components/file-explorer/utils.ts
@@ -14,6 +14,7 @@ import {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 export const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif"]);
+export const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "mov", "webm", "ogv", "ogg"]);
 export const MARKDOWN_EXTENSIONS = new Set(["md", "mdx"]);
 
 export const POSITION_OPTIONS = [
@@ -66,7 +67,7 @@ export function getFileIcon(name: string): string {
     css: "🎨", html: "🌐", py: "🐍", rs: "🦀", go: "🐹",
     sh: "🐚", bash: "🐚", zsh: "🐚", yml: "⚙️", yaml: "⚙️",
     toml: "⚙️", lock: "🔒", svg: "🖼️", png: "🖼️", jpg: "🖼️",
-    gif: "🖼️", webp: "🖼️", mp4: "🎬", mp3: "🎵", pdf: "📄",
+    gif: "🖼️", webp: "🖼️", mp4: "🎬", m4v: "🎬", mov: "🎬", webm: "🎬", ogv: "🎬", ogg: "🎬", mp3: "🎵", pdf: "📄",
     zip: "📦", tar: "📦", gz: "📦", env: "🔐", gitignore: "🚫",
   };
   return icons[ext] ?? "";
@@ -77,9 +78,27 @@ export function isImageFile(name: string): boolean {
   return IMAGE_EXTENSIONS.has(ext);
 }
 
+export function isVideoFile(name: string): boolean {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return VIDEO_EXTENSIONS.has(ext);
+}
+
 export function isMarkdownFile(name: string): boolean {
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   return MARKDOWN_EXTENSIONS.has(ext);
+}
+
+export function getVideoMimeType(name: string): string {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  const mimeMap: Record<string, string> = {
+    mp4: "video/mp4",
+    m4v: "video/mp4",
+    mov: "video/quicktime",
+    webm: "video/webm",
+    ogv: "video/ogg",
+    ogg: "video/ogg",
+  };
+  return mimeMap[ext] ?? "video/mp4";
 }
 
 export function getMimeType(name: string): string {

--- a/packages/ui/src/components/file-explorer/video-viewer.test.tsx
+++ b/packages/ui/src/components/file-explorer/video-viewer.test.tsx
@@ -1,0 +1,55 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import React from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+
+const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+
+const fetchSpy = mock(async () => ({
+  ok: true,
+  json: async () => ({ content: "AAAA", size: 3, truncated: false }),
+}) as Response);
+(globalThis as any).fetch = fetchSpy;
+
+mock.module("@/components/ui/spinner", () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+const actualUtils = await import("../../lib/utils");
+mock.module("@/lib/utils", () => actualUtils);
+
+const { VideoViewer } = await import("./video-viewer");
+
+afterAll(() => mock.restore());
+
+afterEach(() => {
+  cleanup();
+  fetchSpy.mockClear();
+});
+
+describe("VideoViewer", () => {
+  test("renders the browser video player with the file MIME type", async () => {
+    const { container } = render(
+      <VideoViewer runnerId="r1" filePath="/repo/demo.webm" onClose={mock(() => {})} />,
+    );
+
+    await waitFor(() => expect(container.querySelector("video")).toBeTruthy());
+    const video = container.querySelector("video")!;
+    expect(video.controls).toBe(true);
+    expect(video.getAttribute("src")).toBe("data:video/webm;base64,AAAA");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/runners/r1/read-file",
+      expect.objectContaining({ body: JSON.stringify({ path: "/repo/demo.webm", encoding: "base64" }) }),
+    );
+  });
+});

--- a/packages/ui/src/components/file-explorer/video-viewer.test.tsx
+++ b/packages/ui/src/components/file-explorer/video-viewer.test.tsx
@@ -49,7 +49,50 @@ describe("VideoViewer", () => {
     expect(video.getAttribute("src")).toBe("data:video/webm;base64,AAAA");
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/runners/r1/read-file",
-      expect.objectContaining({ body: JSON.stringify({ path: "/repo/demo.webm", encoding: "base64" }) }),
+      expect.objectContaining({
+        body: JSON.stringify({ path: "/repo/demo.webm", encoding: "base64", rejectTruncated: true }),
+        signal: expect.any(AbortSignal),
+      }),
     );
+  });
+
+  test("announces the loading state", () => {
+    fetchSpy.mockImplementationOnce(async () => new Promise<Response>(() => {}));
+
+    const { getByRole, unmount } = render(
+      <VideoViewer runnerId="r1" filePath="/repo/demo.mp4" onClose={mock(() => {})} />,
+    );
+
+    expect(getByRole("status").textContent).toContain("Loading video preview");
+    unmount();
+  });
+
+  test("announces asynchronous preview errors", async () => {
+    fetchSpy.mockImplementationOnce(async () => ({
+      ok: true,
+      json: async () => ({ size: 11 * 1024 * 1024, truncated: true }),
+    }) as Response);
+
+    const { getByRole } = render(
+      <VideoViewer runnerId="r1" filePath="/repo/large.mp4" onClose={mock(() => {})} />,
+    );
+
+    await waitFor(() => expect(getByRole("alert").textContent).toContain("too large"));
+  });
+
+  test("aborts the file request when the preview closes", async () => {
+    let signal: AbortSignal | undefined;
+    fetchSpy.mockImplementationOnce(async (_url, init) => {
+      signal = init?.signal as AbortSignal;
+      return new Promise<Response>(() => {});
+    });
+
+    const { unmount } = render(
+      <VideoViewer runnerId="r1" filePath="/repo/demo.mp4" onClose={mock(() => {})} />,
+    );
+    await waitFor(() => expect(signal).toBeDefined());
+
+    unmount();
+    expect(signal?.aborted).toBe(true);
   });
 });

--- a/packages/ui/src/components/file-explorer/video-viewer.tsx
+++ b/packages/ui/src/components/file-explorer/video-viewer.tsx
@@ -20,6 +20,7 @@ export function VideoViewer({
 
   React.useEffect(() => {
     let cancelled = false;
+    const controller = new AbortController();
     setDataUrl(null);
     setFileSize(undefined);
     setLoading(true);
@@ -29,7 +30,8 @@ export function VideoViewer({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
-      body: JSON.stringify({ path: filePath, encoding: "base64" }),
+      signal: controller.signal,
+      body: JSON.stringify({ path: filePath, encoding: "base64", rejectTruncated: true }),
     })
       .then((res) => res.ok
         ? res.json()
@@ -52,6 +54,7 @@ export function VideoViewer({
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [runnerId, filePath, fileName]);
 
@@ -77,8 +80,13 @@ export function VideoViewer({
       </div>
 
       <div className="flex flex-1 items-center justify-center overflow-auto bg-black p-4">
-        {loading && <Spinner className="size-5" />}
-        {error && <div className="text-sm text-red-400">{error}</div>}
+        {loading && (
+          <div role="status" className="text-muted-foreground">
+            <Spinner aria-hidden="true" className="size-5" />
+            <span className="sr-only">Loading video preview</span>
+          </div>
+        )}
+        {error && <div role="alert" className="text-sm text-red-400">{error}</div>}
         {dataUrl && !error && (
           <video
             src={dataUrl}

--- a/packages/ui/src/components/file-explorer/video-viewer.tsx
+++ b/packages/ui/src/components/file-explorer/video-viewer.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { ChevronLeft } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { formatSize, getFileIcon, getVideoMimeType } from "./utils";
+
+export function VideoViewer({
+  runnerId,
+  filePath,
+  onClose,
+}: {
+  runnerId: string;
+  filePath: string;
+  onClose: () => void;
+}) {
+  const [dataUrl, setDataUrl] = React.useState<string | null>(null);
+  const [fileSize, setFileSize] = React.useState<number>();
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setDataUrl(null);
+    setFileSize(undefined);
+    setLoading(true);
+    setError(null);
+
+    void fetch(`/api/runners/${encodeURIComponent(runnerId)}/read-file`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ path: filePath, encoding: "base64" }),
+    })
+      .then((res) => res.ok
+        ? res.json()
+        : res.json().then((data) => Promise.reject(new Error(data.error || `HTTP ${res.status}`))))
+      .then((data: { content?: string; size?: number; truncated?: boolean }) => {
+        if (cancelled) return;
+        setFileSize(data.size);
+        if (data.truncated) {
+          setError(`Video is too large to preview (${formatSize(data.size)}; 10 MB max).`);
+          return;
+        }
+        setDataUrl(`data:${getVideoMimeType(fileName)};base64,${data.content ?? ""}`);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runnerId, filePath, fileName]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex min-h-[40px] items-center gap-2 border-b border-border bg-muted/50 px-3 py-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          title="Back to file list"
+          aria-label="Back to file list"
+        >
+          <ChevronLeft className="size-4" />
+        </button>
+        <span className="mr-1 text-xs text-muted-foreground">{getFileIcon(fileName)}</span>
+        <span className="flex-1 truncate font-mono text-sm" title={filePath}>{fileName}</span>
+        {fileSize !== undefined && (
+          <span className="flex-shrink-0 text-[0.6rem] tabular-nums text-muted-foreground">
+            {formatSize(fileSize)}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-1 items-center justify-center overflow-auto bg-black p-4">
+        {loading && <Spinner className="size-5" />}
+        {error && <div className="text-sm text-red-400">{error}</div>}
+        {dataUrl && !error && (
+          <video
+            src={dataUrl}
+            controls
+            playsInline
+            preload="metadata"
+            aria-label={`Preview of ${fileName}`}
+            className="max-h-full max-w-full"
+            onError={() => setError("This browser cannot play the video.")}
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- preview MP4, M4V, MOV, WebM, OGV, and OGG files with native browser video controls
- enforce the 10 MB binary preview limit without transferring unusable partial videos
- propagate request cancellation through the relay to runner file reads and avoid broadcasting file contents to unrelated sessions
- update CSP, protocol types, accessibility states, compatibility handling, tests, and File Explorer documentation

## Verification
- `bun run typecheck`
- `bun run build`
- full `bun run test` with isolated Redis
- GPT-5.6 review loop
