### PR TITLE
ci: skip Redis compile in release installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ permissions:
   pull-requests: write
   packages: write
 
+env:
+  # Release jobs never run Redis-backed tests; don't compile Redis during install.
+  REDISMS_DISABLE_POSTINSTALL: "true"
+
 jobs:
   # ─── Gate: only Pizzaface can trigger this ────────────────────
   authorize:


### PR DESCRIPTION
## Summary

- disable `redis-memory-server`'s postinstall for release jobs
- preserve every other dependency lifecycle script, including PizzaPi's workspace-linking postinstall
- prevent macOS release builds from compiling Redis with Apple's outdated GNU Make

Fixes the failure in [New Release run 30871419620](https://github.com/Pizzaface/PizzaPi/actions/runs/30871419620/job/91874104180).

## Verification

- clean macOS ARM64 worktree: `REDISMS_DISABLE_POSTINSTALL=true bun install --frozen-lockfile` (3,437 packages installed, exit 0)
- `actionlint -shellcheck= .github/workflows/release.yml`
- `git diff --check`
