### PR TITLE
fix(push): notify Android devices with connected viewers

### DIFF
--- a/packages/docs/src/content/docs/deployment/mobile-push.mdx
+++ b/packages/docs/src/content/docs/deployment/mobile-push.mdx
@@ -24,7 +24,8 @@ same approach Home Assistant and Element use for Google-free push.
    self-hosted ntfy instance with a single HTTP `POST`.
 2. The PizzaPi Android app holds a persistent **subscribe stream** to that topic
    in an Android **foreground service**, and posts a local notification when a
-   message arrives.
+   message arrives. Native registrations receive this fan-out even when a web
+   viewer is connected; the viewer only suppresses duplicate Web Push delivery.
 3. Because the connection is held by a foreground service, the app shows a
    persistent "PizzaPi — connected" notification. This is the unavoidable price
    of Google-free background push on Android.

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -472,6 +472,38 @@ describe("native push registration", () => {
         expect(body.click).toBeUndefined(); // PIZZAPI_BASE_URL unset → omitted
     });
 
+    authIt("still sends native push when web push is suppressed for connected viewers", async () => {
+        await registerNativePush({ userId: "user-connected", platform: "android" });
+        await insertSub("sub-connected", "user-connected", "https://example.com/push/connected");
+        await getKysely()
+            .updateTable("push_subscription" as any)
+            .set({ keys: "not-json" })
+            .where("id", "=", "sub-connected")
+            .execute();
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let ntfyPublishes = 0;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => {
+            ntfyPublishes++;
+            return Promise.resolve(new Response("ok", { status: 200 }));
+        };
+        try {
+            await sendPushToUser("user-connected", {
+                type: "agent_finished",
+                title: "Agent finished",
+                body: "done",
+                sessionId: "sess-connected",
+            }, false, true);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+
+        expect(ntfyPublishes).toBe(1);
+        expect(await getSubscriptionsForUser("user-connected")).toHaveLength(1);
+    });
+
     authIt("sendPushToUser prunes ntfy registrations on 403/404", async () => {
         await registerNativePush({ userId: "user-F", platform: "android" });
         process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -557,8 +557,16 @@ function isEventEnabled(enabledEvents: string, eventType: PushEventType): boolea
  *   only ever offered an opt-IN to further suppression, never a guaranteed
  *   "receive despite being a child" opt-out, so there is nothing to preserve
  *   here — it remains stored/toggleable but is now redundant.
+ * @param suppressWebPush - Skip browser subscriptions while still delivering
+ *   native Android push. Used when a live Socket.IO viewer already covers the
+ *   browser path but other registered Android devices still need notification.
  */
-export async function sendPushToUser(userId: string, payload: PushPayload, isChildSession = false): Promise<void> {
+export async function sendPushToUser(
+    userId: string,
+    payload: PushPayload,
+    isChildSession = false,
+    suppressWebPush = false,
+): Promise<void> {
     const subscriptions = await getSubscriptionsForUser(userId);
 
     // Native (ntfy) fan-out runs regardless of Web Push subscriptions — a user
@@ -576,7 +584,7 @@ export async function sendPushToUser(userId: string, payload: PushPayload, isChi
         ntfyPromise,
         ...subscriptions.map(async (sub) => {
             if (!isEventEnabled(sub.enabledEvents, payload.type)) return;
-            if (isChildSession) return;
+            if (isChildSession || suppressWebPush) return;
 
             let keys: { p256dh: string; auth: string };
             try {
@@ -622,6 +630,7 @@ export function notifyAgentFinished(
     sessionName?: string | null,
     isChildSession = false,
     replyText?: string,
+    suppressWebPush = false,
 ): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const reply = replyText?.trim();
@@ -633,7 +642,7 @@ export function notifyAgentFinished(
             : `Your agent in "${label}" has finished its task.`,
         sessionId,
         sessionName: label,
-    }, isChildSession).catch((err) => {
+    }, isChildSession, suppressWebPush).catch((err) => {
         log.error("notifyAgentFinished failed:", err);
     });
 }
@@ -651,6 +660,7 @@ export function notifyAgentNeedsInput(
     options?: string[],
     toolCallId?: string,
     isChildSession = false,
+    suppressWebPush = false,
 ): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const body = question
@@ -693,7 +703,7 @@ export function notifyAgentNeedsInput(
             ...(options && options.length > 0 ? { options } : {}),
             ...(toolCallId ? { toolCallId } : {}),
         },
-    }, isChildSession).catch((err) => {
+    }, isChildSession, suppressWebPush).catch((err) => {
         log.error("notifyAgentNeedsInput failed:", err);
     });
 }
@@ -701,7 +711,14 @@ export function notifyAgentNeedsInput(
 /**
  * Convenience: notify a user that an error occurred.
  */
-export function notifyAgentError(userId: string, sessionId: string, errorMessage?: string, sessionName?: string | null, isChildSession = false): void {
+export function notifyAgentError(
+    userId: string,
+    sessionId: string,
+    errorMessage?: string,
+    sessionName?: string | null,
+    isChildSession = false,
+    suppressWebPush = false,
+): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const body = errorMessage
         ? `Error in "${label}": ${errorMessage.slice(0, 120)}`
@@ -712,7 +729,7 @@ export function notifyAgentError(userId: string, sessionId: string, errorMessage
         body,
         sessionId,
         sessionName: label,
-    }, isChildSession).catch((err) => {
+    }, isChildSession, suppressWebPush).catch((err) => {
         log.error("notifyAgentError failed:", err);
     });
 }

--- a/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
+++ b/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
@@ -1,5 +1,48 @@
-import { describe, it, expect } from "bun:test";
-import { extractLastAssistantText } from "./push-tracker.js";
+import { beforeEach, describe, it, expect, mock } from "bun:test";
+
+const finishedCalls: unknown[][] = [];
+
+mock.module("../../../push.js", () => ({
+    notifyAgentFinished: (...args: unknown[]) => finishedCalls.push(args),
+    notifyAgentNeedsInput: () => {},
+    notifyAgentError: () => {},
+}));
+mock.module("../../sio-state/index.js", () => ({
+    setPushPendingQuestion: async () => {},
+    clearPushPendingQuestion: async () => {},
+    isLinkedChildForSuppression: async () => false,
+}));
+mock.module("../../sio-registry.js", () => ({
+    getSharedSession: async () => ({
+        userId: "user-connected",
+        sessionName: "Connected session",
+        parentSessionId: null,
+        linkedParentId: null,
+    }),
+    getViewerCount: async () => 1,
+}));
+
+const { checkPushNotifications, extractLastAssistantText } = await import("./push-tracker.js");
+
+beforeEach(() => finishedCalls.splice(0));
+
+describe("checkPushNotifications", () => {
+    it("keeps native delivery enabled when connected viewers suppress Web Push", async () => {
+        await checkPushNotifications("sess-connected", {
+            type: "agent_end",
+            messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+        });
+
+        expect(finishedCalls).toEqual([[
+            "user-connected",
+            "sess-connected",
+            "Connected session",
+            false,
+            "done",
+            true,
+        ]]);
+    });
+});
 
 describe("extractLastAssistantText", () => {
     it("returns the last assistant message's text", () => {

--- a/packages/server/src/ws/namespaces/relay/push-tracker.ts
+++ b/packages/server/src/ws/namespaces/relay/push-tracker.ts
@@ -75,8 +75,10 @@ export async function checkPushNotifications(
     const userId = session?.userId;
     if (!userId) return;
 
-    const viewerCount = await getViewerCount(sessionId);
-    if (viewerCount > 0) return;
+    // Connected viewers receive live session events over Socket.IO, so Web Push
+    // would duplicate their in-app notification. Native Android registrations
+    // still need ntfy fan-out: one connected viewer must not silence other devices.
+    const suppressWebPush = await getViewerCount(sessionId) > 0;
 
     const sName = session?.sessionName ?? null;
 
@@ -100,7 +102,7 @@ export async function checkPushNotifications(
     const isChildSession = !!effectiveParentId && await isLinkedChildForSuppression(effectiveParentId, sessionId);
 
     if (event.type === "agent_end") {
-        notifyAgentFinished(userId, sessionId, sName, isChildSession, extractLastAssistantText(event));
+        notifyAgentFinished(userId, sessionId, sName, isChildSession, extractLastAssistantText(event), suppressWebPush);
     }
 
     if (event.type === "tool_execution_start" && event.toolName === "AskUserQuestion") {
@@ -137,11 +139,11 @@ export async function checkPushNotifications(
         // reject with 400 — so don't show action buttons in any of those cases.
         const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : undefined;
         const canQuickReply = questionCount <= 1 && session?.collabMode === true && !!toolCallId;
-        notifyAgentNeedsInput(userId, sessionId, question, sName, canQuickReply ? options : undefined, toolCallId, isChildSession);
+        notifyAgentNeedsInput(userId, sessionId, question, sName, canQuickReply ? options : undefined, toolCallId, isChildSession, suppressWebPush);
     }
 
     if (event.type === "cli_error") {
         const errMsg = typeof event.message === "string" ? event.message : undefined;
-        notifyAgentError(userId, sessionId, errMsg, sName, isChildSession);
+        notifyAgentError(userId, sessionId, errMsg, sName, isChildSession, suppressWebPush);
     }
 }


### PR DESCRIPTION
## Summary

- keep native Android ntfy fan-out active when session viewers are connected
- suppress only duplicate browser Web Push for connected viewers
- add regression coverage for the viewer-to-native delivery path
- document the connected-viewer behavior

## Verification

- `bun scripts/test-isolated.ts packages/server/src/push.test.ts packages/server/src/ws/namespaces/relay/push-tracker.test.ts`
- isolated full server test suite
- `bun run typecheck`
- `bun run build`
- `cd packages/docs && bun run build`
- independent GPT-5.6 Sol review: LGTM
