### PR TITLE
fix(models): use official OpenAI context limits

### DIFF
--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -8,6 +8,8 @@
  * See patches/README.md for details.
  */
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -52,6 +54,20 @@ function piTuiPath(subpath: string): string {
     const pkgMain = fileURLToPath(pkgMainUrl);
     const pkgRoot = resolve(dirname(pkgMain), "..");
     return resolve(pkgRoot, subpath);
+}
+
+async function withIsolatedModelRuntime(run: (runtime: any) => void | Promise<void>): Promise<void> {
+    const dir = mkdtempSync(resolve(tmpdir(), "pizzapi-model-runtime-"));
+    try {
+        const { ModelRuntime } = await import("@earendil-works/pi-coding-agent");
+        const runtime = await ModelRuntime.create({
+            authPath: resolve(dir, "auth.json"),
+            modelsPath: null,
+        });
+        await run(runtime);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
 }
 
 // ===========================================================================
@@ -168,6 +184,16 @@ describe("pi-coding-agent patch application", () => {
         expect(typeof handleConfigCommand).toBe("function");
     });
 
+    test("model-runtime.js: overrides Pi's OpenAI pricing-tier caps with published context windows", async () => {
+        const source = await Bun.file(
+            piCodingAgentPath("dist/core/model-runtime.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): Report OpenAI API's published context capacity");
+        expect(source).toContain('"gpt-5.6-sol": 1050000');
+        expect(source).toContain("withOfficialOpenAIContextWindows");
+    });
+
     test("config.js: getChangelogPath honors PIZZAPI_CHANGELOG_PATH", async () => {
         const { getChangelogPath } = await import(piCodingAgentPath("dist/config.js"));
         const prev = process.env.PIZZAPI_CHANGELOG_PATH;
@@ -210,6 +236,75 @@ describe("pi-coding-agent patched runtime behavior", () => {
         const dir = getSessionsDir();
         expect(dir).toContain(".pizzapi/sessions");
         expect(dir).not.toContain(".pizzapi/agent/sessions");
+    });
+
+    test("OpenAI API models expose published capacity without changing Codex backend limits", async () => {
+        await withIsolatedModelRuntime((runtime) => {
+            const expected: Record<string, number> = {
+                "gpt-5.4": 1_050_000,
+                "gpt-5.4-mini": 400_000,
+                "gpt-5.4-nano": 400_000,
+                "gpt-5.4-pro": 1_050_000,
+                "gpt-5.5": 1_050_000,
+                "gpt-5.5-pro": 1_050_000,
+                "gpt-5.6-luna": 1_050_000,
+                "gpt-5.6-sol": 1_050_000,
+                "gpt-5.6-terra": 1_050_000,
+            };
+
+            for (const [id, contextWindow] of Object.entries(expected)) {
+                expect(runtime.getModel("openai", id)?.contextWindow).toBe(contextWindow);
+            }
+            expect(runtime.getModel("openai-codex", "gpt-5.4")?.contextWindow).toBe(272_000);
+            expect(runtime.getModel("openai-codex", "gpt-5.4-mini")?.contextWindow).toBe(272_000);
+            expect(runtime.getModel("openai", "gpt-4o")?.contextWindow).toBe(128_000);
+        });
+    });
+
+    test("OpenAI defaults preserve remote catalogs, native providers, and named overlays", async () => {
+        await withIsolatedModelRuntime(async (runtime) => {
+            const provider = runtime.getProvider("openai")!;
+            const model = runtime.getModel("openai", "gpt-5.4")!;
+            const futureModel = {
+                ...model,
+                id: "gpt-future",
+                name: "GPT Future",
+                contextWindow: 777_000,
+            };
+
+            await provider.refreshModels({
+                allowNetwork: false,
+                store: {
+                    read: async () => ({
+                        checkedAt: Date.now(),
+                        lastModified: Number.MAX_SAFE_INTEGER,
+                        models: [futureModel],
+                    }),
+                    write: async () => undefined,
+                },
+            });
+            expect(runtime.getModel("openai", "gpt-future")?.contextWindow).toBe(777_000);
+
+            runtime.registerNativeProvider({
+                ...provider,
+                getModels: () => [{ ...model, contextWindow: 123_000 }],
+            });
+            expect(runtime.getModel("openai", "gpt-5.4")?.contextWindow).toBe(123_000);
+
+            runtime.registerProvider("openai", {
+                apiKey: "proxy-key",
+                baseUrl: "https://proxy.example/v1",
+                headers: { "X-Proxy": "enabled" },
+                models: [{ ...model, baseUrl: "https://proxy.example/v1", contextWindow: 222_000 }],
+            });
+            expect(runtime.getRegisteredProviderConfig("openai")).toMatchObject({
+                apiKey: "proxy-key",
+                baseUrl: "https://proxy.example/v1",
+                headers: { "X-Proxy": "enabled" },
+            });
+            expect(runtime.getModel("openai", "gpt-5.4")?.baseUrl).toBe("https://proxy.example/v1");
+            expect(runtime.getModel("openai", "gpt-5.4")?.contextWindow).toBe(222_000);
+        });
     });
 
     test("extension API does NOT expose newSession/switchSession/fork (removed in Phase 1)", async () => {

--- a/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.82.1.patch
@@ -47,6 +47,52 @@ index 4cd51566b17e362a4c9c149fa3a339458abc30f6..6f41d5c16b9e476dfe01c312cf86fe0b
      "vercel-ai-gateway": "zai/glm-5.1",
      xai: "grok-4.5",
      groq: "openai/gpt-oss-120b",
+diff --git a/dist/core/model-runtime.js b/dist/core/model-runtime.js
+index e81a5368e8072e452a16ffbbfb4db7767a3a0e38..c90c3a087a48af85bff2e0504e10df6e27f72a03 100644
+--- a/dist/core/model-runtime.js
++++ b/dist/core/model-runtime.js
+@@ -8,6 +8,32 @@ import { FileModelsStore, InMemoryCodingAgentModelsStore } from "./models-store.
+ import { composeModelProvider, configuredRequestAuthStatus, resolveCompatibilityRequestConfig, resolveConfiguredModelHeaders, validateExtensionProvider, } from "./provider-composer.js";
+ import { withRemoteCatalog } from "./remote-catalog-provider.js";
+ import { RuntimeCredentials } from "./runtime-credentials.js";
++// PATCH(pizzapi): Report OpenAI API's published context capacity instead of
++// the lower short-context pricing threshold used by Pi's model catalog.
++const OPENAI_CONTEXT_WINDOWS = {
++    "gpt-5.4": 1050000,
++    "gpt-5.4-mini": 400000,
++    "gpt-5.4-nano": 400000,
++    "gpt-5.4-pro": 1050000,
++    "gpt-5.5": 1050000,
++    "gpt-5.5-pro": 1050000,
++    "gpt-5.6-luna": 1050000,
++    "gpt-5.6-sol": 1050000,
++    "gpt-5.6-terra": 1050000,
++};
++function withOfficialOpenAIContextWindows(provider) {
++    if (!provider || provider.id !== "openai")
++        return provider;
++    return {
++        ...provider,
++        getModels: () => provider.getModels().map((model) => {
++            const contextWindow = OPENAI_CONTEXT_WINDOWS[model.id];
++            return contextWindow === undefined || contextWindow === model.contextWindow
++                ? model
++                : { ...model, contextWindow };
++        }),
++    };
++}
+ function mergeHeaders(base, override) {
+     if (!base && !override)
+         return undefined;
+@@ -109,7 +135,7 @@ export class ModelRuntime {
+         ]);
+     }
+     recomposeProvider(providerId) {
+-        const base = this.nativeExtensionProviders.get(providerId) ?? this.builtins.get(providerId);
++        const base = this.nativeExtensionProviders.get(providerId) ?? withOfficialOpenAIContextWindows(this.builtins.get(providerId));
+         const extension = this.extensionProviders.get(providerId);
+         if (!base && !this.config.getProvider(providerId) && !extension) {
+             this.models.deleteProvider(providerId);
 diff --git a/dist/index.d.ts b/dist/index.d.ts
 index e91e38f8bedfabb6e67305f9739277d1ebacde22..8ee1013bedc3895457115c714122c40b65871ed8 100644
 --- a/dist/index.d.ts

--- a/patches/README.md
+++ b/patches/README.md
@@ -90,11 +90,22 @@ removals absorbed elsewhere rather than restored:
   shape anymore. Instead, `packages/cli` callers were migrated to
   `ModelRuntime`/`ModelRegistry`/`readStoredCredential` (see below).
 
+OpenAI's direct API catalog reports a 272K short-context pricing threshold for
+some GPT-5.4, GPT-5.5, and GPT-5.6 models instead of their actual capacity.
+PizzaPi wraps the built-in `openai` provider in `ModelRuntime` after
+remote-catalog discovery but before extension and `models.json` composition,
+so direct API consumers see OpenAI's published 1.05M/400K windows while
+provider auth, streaming, model discovery, user overrides, and custom native-
+provider metadata remain intact. The separate `openai-codex` OAuth backend
+keeps its own catalog limits.
+Source: https://developers.openai.com/api/docs/models/compare
+
 **What it changes:**
 
 | File | Change |
 |------|--------|
 | `dist/config.js` | Same `.pizzapi` config-dir / flat-directory / `PIZZAPI_CHANGELOG_PATH` overrides as 0.80.6 |
+| `dist/core/model-runtime.js` | Wraps the built-in OpenAI API provider so GPT-5.4+ defaults match OpenAI's published context capacities |
 | `dist/core/model-resolver.js` | Same `ollama-cloud` default model (`glm-5.1`) as 0.80.6 |
 | `dist/modes/interactive/interactive-mode.js` | Same version-notification-UI removal as 0.80.6 (upstream shifted a few lines; hunk re-applied manually) |
 | `dist/index.js` / `dist/index.d.ts` | Same `handlePackageCommand`/`handleConfigCommand` re-export as 0.80.6 |


### PR DESCRIPTION
## Summary
- report OpenAI's published GPT-5.4+ context capacities for the direct API provider
- preserve remote catalogs, native providers, and user provider overrides
- keep Codex OAuth backend context limits unchanged
- add isolated runtime regression coverage

## Verification
- `bun test packages/cli/src/patches.test.ts packages/cli/src/__tests__/models-command.test.ts`
- `bun run typecheck`
- `bun run build`
- independent review: LGTM

## Notes
The broader CLI suite still has pre-existing Bun shared-state test pollution tracked separately; targeted affected tests pass.
