### PR TITLE
fix(goal): stop continuation spam after aborts and rate limits

### DIFF
--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -797,6 +797,35 @@ describe("goalExtension event wiring", () => {
         expect(messages.some((m) => m.content.includes("Goal met"))).toBe(true);
     });
 
+    test("turn_end from an aborted turn leaves the goal idle for a user follow-up", async () => {
+        resetSession("session-1");
+        const { pi, handlers, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            {},
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: { ...makeAssistantMessage(""), stopReason: "aborted" },
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("active");
+        expect(getGoal("session-1")?.turnCount).toBe(0);
+        expect(getPendingGuidance("session-1")).toBeUndefined();
+        expect(userMessages).toHaveLength(0);
+    });
+
     test("turn_end keyword not met stores guidance and auto-continues the loop", async () => {
         resetSession("session-1");
         const { pi, handlers, userMessages } = createFakePi();

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -826,6 +826,35 @@ describe("goalExtension event wiring", () => {
         expect(userMessages).toHaveLength(0);
     });
 
+    test("turn_end from a rate-limit error leaves the goal idle for a user follow-up", async () => {
+        resetSession("session-1");
+        const { pi, handlers, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            {},
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: { ...makeAssistantMessage(""), stopReason: "error", errorMessage: "rate limit exceeded" },
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("active");
+        expect(getGoal("session-1")?.turnCount).toBe(0);
+        expect(getPendingGuidance("session-1")).toBeUndefined();
+        expect(userMessages).toHaveLength(0);
+    });
+
     test("turn_end keyword not met stores guidance and auto-continues the loop", async () => {
         resetSession("session-1");
         const { pi, handlers, userMessages } = createFakePi();

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -215,7 +215,9 @@ async function runGoalStopCheck(
     const sessionId = getSessionId(ctx);
     let state = getGoal(sessionId);
     if (!state || state.status !== "active") return;
-    if (isAssistantMessage(event.message) && event.message.stopReason === "aborted") return;
+    // Aborts and provider errors (including rate limits) are not completed
+    // turns. Do not spend/evaluate them or enqueue another goal continuation.
+    if (isAssistantMessage(event.message) && (event.message.stopReason === "aborted" || event.message.stopReason === "error")) return;
 
     const usage = getAssistantUsage(event.message);
     state = recordTurnSpend(sessionId, usage.tokens, usage.cost) ?? state;

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -215,6 +215,7 @@ async function runGoalStopCheck(
     const sessionId = getSessionId(ctx);
     let state = getGoal(sessionId);
     if (!state || state.status !== "active") return;
+    if (isAssistantMessage(event.message) && event.message.stopReason === "aborted") return;
 
     const usage = getAssistantUsage(event.message);
     state = recordTurnSpend(sessionId, usage.tokens, usage.cost) ?? state;


### PR DESCRIPTION
## Summary
- keep `/goal` active after Esc aborts
- ignore provider-error turns, including rate limits, so goal continuation cannot spam retries
- add regression coverage for aborted and rate-limit turns

## Checks
- `bun run typecheck`
- `bun test packages/cli/src/extensions/goal/goal.test.ts packages/cli/src/extensions/goal/goal.integration.test.ts`
- full suite reaches unrelated pre-existing patch/environment failures
