### PR TITLE
feat(goal): wait at least 10 turns, configurable, use session model

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -568,16 +568,24 @@ export interface PizzaPiConfig {
      * `/goal` command configuration.
      */
     goal?: {
-        /** Model identifier (provider:modelId or just modelId) for the LLM evaluator. Defaults to Anthropic Haiku. */
+        /** Model identifier (provider:modelId or just modelId) for the LLM evaluator. When omitted, the evaluator uses the session's current model so the call shares the prompt cache; if no current model is available it falls back to the cheapest authenticated text model. */
         evaluatorModel?: string;
         /** Maximum output tokens for the evaluator LLM call. Default: 512. */
         evaluatorMaxTokens?: number;
         /**
-         * Default cadence (in turns) for the LLM evaluator across all goals
+         * Default cadence (in turns) for the goal evaluator across all goals
          * that don't set `/goal --every`. 1 = every turn. Default: 3.
          * Ignored by the keyword evaluator (free/local, always runs).
          */
         evaluateEveryNTurns?: number;
+        /**
+         * Minimum completed agent turns before the goal evaluator runs for the
+         * first time. Prevents early judgment while the agent is still getting
+         * started. Default: 10. Ignored by the keyword evaluator only if the
+         * goal explicitly sets `--min-turns 0`; otherwise it gates every
+         * evaluator.
+         */
+        minTurnsBeforeEvaluate?: number;
     };
 
     /**

--- a/packages/cli/src/extensions/goal/evaluator.ts
+++ b/packages/cli/src/extensions/goal/evaluator.ts
@@ -219,6 +219,7 @@ export function createLlmGoalEvaluator(deps: LlmEvaluatorDeps): GoalEvaluator {
 export async function resolveEvaluatorModel(
     registry: ModelRegistry,
     configured?: string,
+    currentModel?: Model<any>,
 ): Promise<{ model: Model<any>; apiKey?: string } | undefined> {
     let candidates: Model<any>[] = [];
 
@@ -228,6 +229,10 @@ export async function resolveEvaluatorModel(
             if (providerPart && m.provider !== providerPart) return false;
             return m.id === idPart;
         });
+    } else if (currentModel) {
+        // Use the model the session is already using so the evaluator call
+        // can share the provider's prompt cache.
+        candidates = [currentModel];
     } else {
         candidates = findSmallFastModels(registry);
     }
@@ -237,6 +242,18 @@ export async function resolveEvaluatorModel(
         const auth = await registry.getApiKeyAndHeaders(model);
         if (!auth.ok) continue;
         return { model, apiKey: auth.apiKey };
+    }
+
+    // If the current model isn't usable (no auth, etc.), fall back to the
+    // cheapest authenticated text model rather than giving up.
+    if (!configured && currentModel) {
+        for (const model of findSmallFastModels(registry)) {
+            if (model.provider === currentModel.provider && model.id === currentModel.id) continue;
+            if (!registry.hasConfiguredAuth(model)) continue;
+            const auth = await registry.getApiKeyAndHeaders(model);
+            if (!auth.ok) continue;
+            return { model, apiKey: auth.apiKey };
+        }
     }
 
     return undefined;

--- a/packages/cli/src/extensions/goal/goal.integration.test.ts
+++ b/packages/cli/src/extensions/goal/goal.integration.test.ts
@@ -137,11 +137,13 @@ function createFakeCtx(overrides: {
             hasConfiguredAuth: () => true,
             getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "fake-api-key", headers: {} }),
         },
+        model: undefined,
         signal: overrides.signal ?? undefined,
         shutdown: overrides.shutdown ?? (() => {}),
         ui: {
             setStatus: (_key: string, _text?: string) => {},
         },
+        hasPendingMessages: () => false,
     } as unknown as ExtensionContext;
 }
 
@@ -264,7 +266,7 @@ describe("/goal multi-turn integration", () => {
         // User sets a goal via /goal.
         const goalHandler = commands.get("goal")!;
         await goalHandler(
-            '"tests pass" --evaluator keyword --keyword "tests pass" --max-turns 5',
+            '"tests pass" --evaluator keyword --keyword "tests pass" --max-turns 5 --min-turns 1',
             ctx as ExtensionCommandContext,
         );
 
@@ -328,7 +330,7 @@ describe("/goal multi-turn integration", () => {
         // per-turn evaluate -> guidance -> re-evaluate flow across exactly
         // the two turns below.
         const goalHandler = commands.get("goal")!;
-        await goalHandler('"services are green" --max-turns 5 --every 1', ctx as ExtensionCommandContext);
+        await goalHandler('"services are green" --max-turns 5 --every 1 --min-turns 1', ctx as ExtensionCommandContext);
 
         expect(getGoal("goal-integration-session")?.condition.evaluator).toBe("llm");
         expect(messages.some((m) => m.content.includes("Goal set"))).toBe(true);

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -38,7 +38,7 @@ function fakeAppendEntry(_customType: string, _data: unknown): void {
 function makeGoal(): GoalState {
     return setGoal(
         "session-1",
-        { description: "the tests pass", evaluator: "keyword", successKeywords: ["tests pass"] },
+        { description: "the tests pass", evaluator: "keyword", successKeywords: ["tests pass"], minTurnsBeforeEvaluate: 0 },
         { maxTurns: 3, maxTokens: 1000 },
         { appendEntry: fakeAppendEntry },
     );
@@ -116,9 +116,19 @@ describe("parseGoalArgs", () => {
         expect(() => parseGoalArgs("the tests pass --every 1.5")).toThrow("positive integer");
     });
 
-    test("leaves evaluateEveryNTurns undefined when --every is omitted", () => {
+    test("parses --min-turns as the minimum turns before first evaluation", () => {
+        const parsed = parseGoalArgs('"the tests pass" --min-turns 5');
+        expect(parsed.condition.minTurnsBeforeEvaluate).toBe(5);
+    });
+
+    test("rejects --min-turns with a non-positive-integer value", () => {
+        expect(() => parseGoalArgs("the tests pass --min-turns 0")).toThrow("positive integer");
+        expect(() => parseGoalArgs("the tests pass --min-turns 1.5")).toThrow("positive integer");
+    });
+
+    test("leaves minTurnsBeforeEvaluate undefined when --min-turns is omitted", () => {
         const parsed = parseGoalArgs("the tests pass");
-        expect(parsed.condition.evaluateEveryNTurns).toBeUndefined();
+        expect(parsed.condition.minTurnsBeforeEvaluate).toBeUndefined();
     });
 });
 
@@ -268,7 +278,7 @@ describe("goal state", () => {
         resetSession("session-new");
         const oldState = setGoal(
             "session-old",
-            { description: "old", evaluator: "keyword", successKeywords: ["done"] },
+            { description: "old", evaluator: "keyword", successKeywords: ["done"], minTurnsBeforeEvaluate: 0 },
             {},
             { appendEntry: fakeAppendEntry },
         );
@@ -284,7 +294,7 @@ describe("goal state", () => {
 
         setGoal(
             "session-new",
-            { description: "new", evaluator: "keyword", successKeywords: ["done"] },
+            { description: "new", evaluator: "keyword", successKeywords: ["done"], minTurnsBeforeEvaluate: 0 },
             {},
             { appendEntry: fakeAppendEntry },
         );
@@ -512,6 +522,26 @@ describe("resolveEvaluatorModel", () => {
         const resolved = await resolveEvaluatorModel(registry);
         expect(resolved).toBeUndefined();
     });
+
+    test("prefers the session's current model when no evaluator model is configured", async () => {
+        const currentModel = { provider: "anthropic", id: "claude-sonnet-4-5", input: ["text"], cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 }, contextWindow: 200_000, maxTokens: 4096, reasoning: false, name: "Sonnet", api: "anthropic-messages", baseUrl: "" } as any;
+        const registry = makeRegistry([
+            { provider: "openai", id: "gpt-4o-mini", input: ["text"], cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 }, contextWindow: 128_000, maxTokens: 4096, reasoning: false, name: "Mini", api: "openai-completions", baseUrl: "" },
+        ]);
+        const resolved = await resolveEvaluatorModel(registry, undefined, currentModel);
+        expect(resolved?.model.provider).toBe("anthropic");
+        expect(resolved?.model.id).toBe("claude-sonnet-4-5");
+        expect(resolved?.apiKey).toBe("anthropic-key");
+    });
+
+    test("falls back to the cheapest text model when the current model lacks auth", async () => {
+        const currentModel = { provider: "unauthenticated", id: "cheap", input: ["text"], cost: { input: 0.01, output: 0.01, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8_192, maxTokens: 4096, reasoning: false, name: "Cheap", api: "openai-completions", baseUrl: "" } as any;
+        const registry = makeRegistry([
+            { provider: "openai", id: "gpt-4o-mini", input: ["text"], cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 }, contextWindow: 128_000, maxTokens: 4096, reasoning: false, name: "Mini", api: "openai-completions", baseUrl: "" },
+        ]);
+        const resolved = await resolveEvaluatorModel(registry, undefined, currentModel);
+        expect(resolved?.model.id).toBe("gpt-4o-mini");
+    });
 });
 
 describe("createLlmGoalEvaluator", () => {
@@ -719,6 +749,7 @@ function createFakeCtx(overrides: {
     entries?: SessionEntry[];
     shutdown?: () => void;
     signal?: AbortSignal;
+    pendingMessages?: boolean;
 } = {}): ExtensionContext {
     return {
         cwd: "/tmp/pizzapi-goal-test",
@@ -730,11 +761,13 @@ function createFakeCtx(overrides: {
             getAll: () => [],
             hasConfiguredAuth: () => false,
         },
+        model: undefined,
         signal: overrides.signal ?? undefined,
         shutdown: overrides.shutdown ?? (() => {}),
         ui: {
             setStatus: (_key: string, _text?: string) => {},
         },
+        hasPendingMessages: () => overrides.pendingMessages ?? false,
     } as unknown as ExtensionContext;
 }
 
@@ -776,7 +809,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             { maxTurns: 10 },
             pi,
         );
@@ -797,15 +830,15 @@ describe("goalExtension event wiring", () => {
         expect(messages.some((m) => m.content.includes("Goal met"))).toBe(true);
     });
 
-    test("turn_end from an aborted turn leaves the goal idle for a user follow-up", async () => {
+    test("does not auto-continue when background subagents or queued messages are pending", async () => {
         resetSession("session-1");
         const { pi, handlers, userMessages } = createFakePi();
-        const ctx = createFakeCtx();
+        const ctx = createFakeCtx({ pendingMessages: true });
 
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -815,15 +848,14 @@ describe("goalExtension event wiring", () => {
             await handler({
                 type: "turn_end",
                 turnIndex: 1,
-                message: { ...makeAssistantMessage(""), stopReason: "aborted" },
+                message: makeAssistantMessage("Still failing"),
                 toolResults: [],
             } as TurnEndEvent, ctx);
         }
 
         expect(getGoal("session-1")?.status).toBe("active");
-        expect(getGoal("session-1")?.turnCount).toBe(0);
         expect(getPendingGuidance("session-1")).toBeUndefined();
-        expect(userMessages).toHaveLength(0);
+        expect(userMessages.length).toBe(0);
     });
 
     test("turn_end from a rate-limit error leaves the goal idle for a user follow-up", async () => {
@@ -834,7 +866,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -863,7 +895,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -896,7 +928,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -941,7 +973,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -969,7 +1001,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 3 },
+            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 3, minTurnsBeforeEvaluate: 0 },
             {},
             pi,
         );
@@ -1004,15 +1036,59 @@ describe("goalExtension event wiring", () => {
         expect(getGoal("session-1")?.status).toBe("active");
     });
 
-    test("throttled turns still stop the goal when a budget is exhausted", async () => {
+    test("defers evaluation until the default minimum turns have completed", async () => {
         resetSession("session-1");
+        const { pi, handlers, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            {},
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (let i = 0; i < 9; i++) {
+            for (const handler of turnHandlers) {
+                await handler({
+                    type: "turn_end",
+                    turnIndex: i + 1,
+                    message: makeAssistantMessage("Still failing"),
+                    toolResults: [],
+                } as TurnEndEvent, ctx);
+            }
+        }
+
+        expect(getGoal("session-1")?.status).toBe("active");
+        expect(getGoal("session-1")?.turnCount).toBe(9);
+        expect(getGoal("session-1")?.evaluations.length).toBe(0);
+        expect(userMessages.length).toBe(9);
+
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 10,
+                message: makeAssistantMessage("All tests pass"),
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("met");
+        expect(getGoal("session-1")?.turnCount).toBe(10);
+        expect(getGoal("session-1")?.evaluations.length).toBe(1);
+        expect(userMessages.length).toBe(9);
+    });
+
+    test("throttled turns still stop the goal when a budget is exhausted", async () => {
         const { pi, handlers, messages } = createFakePi();
         const ctx = createFakeCtx();
 
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 5 },
+            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 5, minTurnsBeforeEvaluate: 0 },
             { maxTurns: 2 },
             pi,
         );
@@ -1073,7 +1149,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"], minTurnsBeforeEvaluate: 0 },
             { maxTurns: 1 },
             pi,
         );
@@ -1104,7 +1180,7 @@ describe("goalExtension event wiring", () => {
         goalExtension(pi);
         setGoal(
             "session-1",
-            { description: "x", evaluator: "keyword" },
+            { description: "x", evaluator: "keyword", minTurnsBeforeEvaluate: 0 },
             { maxTurns: 2 },
             pi,
         );
@@ -1139,7 +1215,7 @@ describe("goalExtension event wiring", () => {
         // /goal command sets an active goal and broadcasts it.
         const goalHandler = commands.get("goal");
         expect(goalHandler).toBeDefined();
-        await goalHandler!("tests pass --max-turns 5 --evaluator keyword --keyword pass", ctx as ExtensionCommandContext);
+        await goalHandler!("tests pass --max-turns 5 --evaluator keyword --keyword pass --min-turns 1", ctx as ExtensionCommandContext);
 
         let emitted = events.get("goal:state_changed") ?? [];
         expect(emitted.length).toBe(1);

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -31,6 +31,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "@pizzapi/tools";
 import { loadConfig } from "../../config/io.js";
+import { hasActiveSubagents } from "../subagent/background-state.js";
 import {
     checkBudget,
     clearGoal,
@@ -62,6 +63,7 @@ import type {
     GoalEvaluationContext,
     GoalState,
 } from "./types.js";
+import { DEFAULT_MIN_TURNS_BEFORE_EVALUATE } from "./types.js";
 
 const log = createLogger("goal");
 
@@ -192,6 +194,24 @@ function resolveEvaluateRate(state: GoalState, ctx: ExtensionContext): number {
     }
 }
 
+/**
+ * Minimum completed agent turns before the goal evaluator may run. Keeps
+ * the goal from judging success before the agent has had a chance to act.
+ * Resolution order: per-goal `--min-turns` override, then
+ * `config.goal.minTurnsBeforeEvaluate`, then `DEFAULT_MIN_TURNS_BEFORE_EVALUATE`.
+ */
+function resolveMinTurnsBeforeEvaluate(state: GoalState, ctx: ExtensionContext): number {
+    if (state.condition.minTurnsBeforeEvaluate !== undefined) {
+        return Math.max(0, state.condition.minTurnsBeforeEvaluate);
+    }
+    try {
+        const configured = loadConfig(ctx.cwd).goal?.minTurnsBeforeEvaluate;
+        return configured !== undefined ? Math.max(0, configured) : DEFAULT_MIN_TURNS_BEFORE_EVALUATE;
+    } catch {
+        return DEFAULT_MIN_TURNS_BEFORE_EVALUATE;
+    }
+}
+
 function stopForBudget(
     sessionId: string,
     state: GoalState,
@@ -222,13 +242,44 @@ async function runGoalStopCheck(
     const usage = getAssistantUsage(event.message);
     state = recordTurnSpend(sessionId, usage.tokens, usage.cost) ?? state;
 
-    // The LLM evaluator is a billed API call, so it's throttled to every
-    // `evaluateRate` turns instead of every turn. The first turn always
-    // evaluates so instantly-satisfied goals resolve right away; skipped
-    // turns still enforce budgets and keep the agent looping, they just
-    // don't spend a judge call.
+    const minTurnsBeforeEvaluate = resolveMinTurnsBeforeEvaluate(state, ctx);
     const evaluateRate = resolveEvaluateRate(state, ctx);
-    if (state.turnCount > 1 && state.turnCount % evaluateRate !== 0) {
+    const firstEvalTurn = Math.max(1, minTurnsBeforeEvaluate);
+
+    // If background subagents or queued user/trigger messages are still
+    // pending, don't start another goal iteration. The existing work will
+    // produce more turns and the evaluator will check again when it's actually
+    // idle. This prevents the goal loop from drowning out subagent results or
+    // relay trigger responses.
+    if (hasActiveSubagents() || (typeof ctx.hasPendingMessages === "function" && ctx.hasPendingMessages())) {
+        return;
+    }
+
+    if (state.turnCount < firstEvalTurn) {
+        // The evaluator is gated until the agent has completed enough turns
+        // to have produced real work. Budgets and the continuation loop still
+        // apply while waiting.
+        const budgetReason = checkBudget(state);
+        if (budgetReason) {
+            stopForBudget(sessionId, state, budgetReason, pi);
+            return;
+        }
+        const guidance = getPendingGuidance(sessionId);
+        pi.sendUserMessage(
+            guidance
+                ? `[Goal not met] ${guidance}\nContinue working toward the goal: ${state.condition.description}`
+                : `Work toward this goal until it is met: ${state.condition.description}`,
+            { deliverAs: "steer" },
+        );
+        return;
+    }
+
+    // The evaluator is now eligible to run. The first turn after the minimum
+    // wait is always evaluated (so goals satisfied right at the boundary
+    // resolve immediately); after that, LLM evaluations are throttled to turns
+    // whose count is a multiple of `evaluateRate`. Keyword evaluations run
+    // every turn. Skipped turns still enforce budgets and keep the agent looping.
+    if (state.turnCount > firstEvalTurn && state.turnCount % evaluateRate !== 0) {
         const budgetReason = checkBudget(state);
         if (budgetReason) {
             stopForBudget(sessionId, state, budgetReason, pi);
@@ -252,7 +303,7 @@ async function runGoalStopCheck(
     } else {
         try {
             const config = loadConfig(ctx.cwd);
-            const resolved = await resolveEvaluatorModel(ctx.modelRegistry, config.goal?.evaluatorModel);
+            const resolved = await resolveEvaluatorModel(ctx.modelRegistry, config.goal?.evaluatorModel, ctx.model);
             if (!resolved) {
                 const reason = "No configured evaluator model with auth is available; skipping LLM evaluation.";
                 log.warn(reason);

--- a/packages/cli/src/extensions/goal/parser.ts
+++ b/packages/cli/src/extensions/goal/parser.ts
@@ -16,6 +16,7 @@ const KNOWN_FLAGS = new Set([
     "--evaluator",
     "--keyword",
     "--every",
+    "--min-turns",
 ]);
 
 function isFlag(token: string): boolean {
@@ -86,6 +87,7 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
     const successKeywords: string[] = [];
     let evaluator: GoalEvaluatorKind = "llm";
     let evaluateEveryNTurns: number | undefined;
+    let minTurnsBeforeEvaluate: number | undefined;
     let conditionParts: string[] = [];
 
     let i = 0;
@@ -131,6 +133,12 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
                     // No effect on the free/local keyword evaluator.
                     evaluateEveryNTurns = parsePositiveInt(next, "--every");
                     break;
+                case "--min-turns":
+                    // Minimum completed agent turns before the evaluator may
+                    // run. Prevents premature judgment while the agent is still
+                    // getting started.
+                    minTurnsBeforeEvaluate = parsePositiveInt(next, "--min-turns");
+                    break;
             }
         } else {
             conditionParts.push(token);
@@ -155,6 +163,7 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
         evaluator,
         successKeywords: successKeywords.length > 0 ? successKeywords : undefined,
         evaluateEveryNTurns,
+        minTurnsBeforeEvaluate,
     };
 
     return { rawCondition, condition, budget, clear: false, statusOnly: false };

--- a/packages/cli/src/extensions/goal/types.ts
+++ b/packages/cli/src/extensions/goal/types.ts
@@ -43,11 +43,20 @@ export interface GoalCondition {
      * `config.goal.evaluateEveryNTurns`, then `DEFAULT_EVALUATE_EVERY_N_TURNS`.
      */
     evaluateEveryNTurns?: number;
+
+    /**
+     * Minimum completed agent turns before the evaluator may run. Keeps the
+     * goal from judging success before the agent has had a chance to act.
+     * Falls back to `config.goal.minTurnsBeforeEvaluate`, then
+     * `DEFAULT_MIN_TURNS_BEFORE_EVALUATE`.
+     */
+    minTurnsBeforeEvaluate?: number;
 }
 
 /**
- * Budget guardrails. All fields are optional; unset means "no limit".
+ * Default minimum completed turns before the goal evaluator runs.
  */
+export const DEFAULT_MIN_TURNS_BEFORE_EVALUATE = 10;
 export interface GoalBudget {
     /** Maximum number of agent turns allowed while pursuing the goal. */
     maxTurns?: number;

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -104,12 +104,15 @@ You can also override any setting with **environment variables**.
   },
 
   // `/goal` evaluator configuration. The LLM evaluator sends the conversation
-  // transcript and active goal to a small, fast model after each turn.
-  // Defaults to the cheapest available authenticated text model.
+  // transcript and active goal to a model after each eligible turn. When no
+  // `evaluatorModel` is set, the evaluator uses the session's current model so
+  // the call can share the provider's prompt cache; otherwise it falls back to
+  // the cheapest available authenticated text model.
   "goal": {
     "evaluatorModel": "anthropic:claude-3-5-haiku-20241022",
     "evaluatorMaxTokens": 512,
-    "evaluateEveryNTurns": 3
+    "evaluateEveryNTurns": 3,
+    "minTurnsBeforeEvaluate": 10
   },
 
   // Dynamic MCP tool discovery — defers MCP tools when their descriptions
@@ -161,9 +164,10 @@ You can also override any setting with **environment variables**.
 | `disabledRunnerServices` | `string[]` | `[]` | Runner service IDs to skip. Built-in services: `"terminal"`, `"file-explorer"`, `"git"`, `"tunnel"`, `"time"`. Plugin services use the id declared in their manifest. |
 | `subagent.maxParallelTasks` | `number` | `8` | Max parallel tasks per call and active agent slots across background calls. **Global config only.** |
 | `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions within one parallel call. **Global config only.** |
-| `goal.evaluatorModel` | `string` | cheapest available authenticated text model | Model (`provider:modelId` or `modelId`) used by the `/goal` LLM evaluator. |
+| `goal.evaluatorModel` | `string` | session's current model, then cheapest authenticated text model | Model (`provider:modelId` or `modelId`) used by the `/goal` LLM evaluator. |
 | `goal.evaluatorMaxTokens` | `number` | `512` | Maximum output tokens for each `/goal` evaluator call. |
 | `goal.evaluateEveryNTurns` | `number` | `3` | Default cadence for the LLM evaluator. `1` = every turn. Ignored by the keyword evaluator. |
+| `goal.minTurnsBeforeEvaluate` | `number` | `10` | Minimum completed agent turns before the goal evaluator runs for the first time. `0` disables the wait. |
 | `allowProjectProviders` | `boolean` | — | **Obsolete and ignored.** Project-local `.pizzapi/providers/` is no longer loaded. PizzaPi warns if this key is still present. |
 | `providers` | `object` | — | **Obsolete and ignored.** The extension-provider layer was removed; PizzaPi warns if this key is still present. Use a [runner service](/PizzaPi/customization/runner-services/) for external integrations, or a plain pi extension for per-session behaviour. |
 | `providerSettings` | `object` | — | Provider-specific settings. See [Web Search](#web-search) and [Per-Provider Overrides](#per-provider-overrides) below. |

--- a/packages/docs/src/content/docs/features/slash-commands.mdx
+++ b/packages/docs/src/content/docs/features/slash-commands.mdx
@@ -82,7 +82,7 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 |---------|-------------|
 | `/name <name>` | Set a display name for the current session, e.g. `/name auth-refactor`. |
 | `/goal` | Show the active goal and current counters. |
-| `/goal "{condition}" [flags]` | Set a success condition and optional budget for the session. Flags: `--max-turns`, `--max-tokens`, `--max-cost`, `--every N`. |
+| `/goal "{condition}" [flags]` | Set a success condition and optional budget for the session. Flags: `--max-turns`, `--max-tokens`, `--max-cost`, `--every N`, `--min-turns N`. |
 | `/goal clear` | Clear the active goal. Aliases: `stop`, `off`, `cancel`, `reset`, `none`. |
 | `/copy` | Copy the last assistant message to your clipboard. |
 

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -32,7 +32,7 @@ The following commands are always available in the chat input:
 | `/name <name>` | Set the session display name shown in the sidebar. |
 | `/goal` | Show the active goal and current counters. |
 | `/goal status` | Show the active goal and current counters (same as bare `/goal`). |
-| `/goal "{condition}" [flags]` | Set a success condition and optional budget (`--max-turns`, `--max-tokens`, `--max-cost`, `--every`, `--evaluator \{keyword|llm\}`, `--keyword \{word\}`). |
+| `/goal "{condition}" [flags]` | Set a success condition and optional budget (`--max-turns`, `--max-tokens`, `--max-cost`, `--every`, `--min-turns`, `--evaluator \{keyword|llm\}`, `--keyword \{word\}`). |
 | `/goal clear` | Clear the active goal. Aliases: `stop`, `off`, `cancel`, `reset`, `none`. |
 | `/copy` | Copy the last assistant message to clipboard. |
 | `/stop` | Abort the currently running agent generation. |

--- a/packages/ui/src/components/runner-settings/FastModelSettings.tsx
+++ b/packages/ui/src/components/runner-settings/FastModelSettings.tsx
@@ -16,6 +16,8 @@ import type { SectionProps } from "./RunnerSettingsPanel";
 interface GoalConfig {
     evaluatorModel?: string;
     evaluatorMaxTokens?: number;
+    evaluateEveryNTurns?: number;
+    minTurnsBeforeEvaluate?: number;
 }
 
 interface ModelInfo {
@@ -29,6 +31,10 @@ interface ModelInfo {
 const DEFAULT_MAX_TOKENS = 512;
 const MIN_TOKENS = 1;
 const MAX_TOKENS = 4096;
+const DEFAULT_EVALUATE_EVERY_N_TURNS = 3;
+const MIN_EVALUATE_EVERY_N_TURNS = 1;
+const DEFAULT_MIN_TURNS_BEFORE_EVALUATE = 10;
+const MIN_MIN_TURNS_BEFORE_EVALUATE = 0;
 
 /**
  * Parse a stored evaluatorModel value into provider + modelId.
@@ -59,6 +65,12 @@ export default function FastModelSettings({ runnerId, config, onSave, saving }: 
     const [provider, setProvider] = useState<string>(initialModel.provider);
     const [modelId, setModelId] = useState<string>(initialModel.modelId);
     const [maxTokens, setMaxTokens] = useState<number>(goalConfig.evaluatorMaxTokens ?? DEFAULT_MAX_TOKENS);
+    const [evaluateEveryNTurns, setEvaluateEveryNTurns] = useState<number>(
+        goalConfig.evaluateEveryNTurns ?? DEFAULT_EVALUATE_EVERY_N_TURNS,
+    );
+    const [minTurnsBeforeEvaluate, setMinTurnsBeforeEvaluate] = useState<number>(
+        goalConfig.minTurnsBeforeEvaluate ?? DEFAULT_MIN_TURNS_BEFORE_EVALUATE,
+    );
 
     // Available models fetched from the runner
     const [models, setModels] = useState<ModelInfo[]>([]);
@@ -71,7 +83,9 @@ export default function FastModelSettings({ runnerId, config, onSave, saving }: 
         setProvider(parsed.provider);
         setModelId(parsed.modelId);
         setMaxTokens(goalConfig.evaluatorMaxTokens ?? DEFAULT_MAX_TOKENS);
-    }, [goalConfig.evaluatorModel, goalConfig.evaluatorMaxTokens]);
+        setEvaluateEveryNTurns(goalConfig.evaluateEveryNTurns ?? DEFAULT_EVALUATE_EVERY_N_TURNS);
+        setMinTurnsBeforeEvaluate(goalConfig.minTurnsBeforeEvaluate ?? DEFAULT_MIN_TURNS_BEFORE_EVALUATE);
+    }, [goalConfig.evaluatorModel, goalConfig.evaluatorMaxTokens, goalConfig.evaluateEveryNTurns, goalConfig.minTurnsBeforeEvaluate]);
 
     // Fetch available models from the runner
     useEffect(() => {
@@ -134,10 +148,31 @@ export default function FastModelSettings({ runnerId, config, onSave, saving }: 
         setMaxTokens(Math.max(MIN_TOKENS, Math.min(MAX_TOKENS, Math.round(parsed))));
     };
 
+    const handleEvaluateEveryChange = (value: string) => {
+        const parsed = Number(value);
+        if (Number.isNaN(parsed)) {
+            setEvaluateEveryNTurns(0);
+            return;
+        }
+        setEvaluateEveryNTurns(Math.max(MIN_EVALUATE_EVERY_N_TURNS, Math.round(parsed)));
+    };
+
+    const handleMinTurnsChange = (value: string) => {
+        const parsed = Number(value);
+        if (Number.isNaN(parsed)) {
+            setMinTurnsBeforeEvaluate(0);
+            return;
+        }
+        setMinTurnsBeforeEvaluate(Math.max(MIN_MIN_TURNS_BEFORE_EVALUATE, Math.round(parsed)));
+    };
+
     const handleSave = () => {
         const value: GoalConfig = {
             evaluatorModel: provider && modelId ? `${provider}:${modelId}` : modelId || undefined,
             evaluatorMaxTokens: maxTokens || undefined,
+            evaluateEveryNTurns: evaluateEveryNTurns === DEFAULT_EVALUATE_EVERY_N_TURNS ? undefined : evaluateEveryNTurns,
+            minTurnsBeforeEvaluate:
+                minTurnsBeforeEvaluate === DEFAULT_MIN_TURNS_BEFORE_EVALUATE ? undefined : minTurnsBeforeEvaluate,
         };
         onSave("goal", value);
     };
@@ -145,9 +180,13 @@ export default function FastModelSettings({ runnerId, config, onSave, saving }: 
     const isDirty =
         provider !== initialModel.provider ||
         modelId !== initialModel.modelId ||
-        maxTokens !== (goalConfig.evaluatorMaxTokens ?? DEFAULT_MAX_TOKENS);
+        maxTokens !== (goalConfig.evaluatorMaxTokens ?? DEFAULT_MAX_TOKENS) ||
+        evaluateEveryNTurns !== (goalConfig.evaluateEveryNTurns ?? DEFAULT_EVALUATE_EVERY_N_TURNS) ||
+        minTurnsBeforeEvaluate !== (goalConfig.minTurnsBeforeEvaluate ?? DEFAULT_MIN_TURNS_BEFORE_EVALUATE);
 
-    const canSave = !saving && provider && modelId && maxTokens >= MIN_TOKENS;
+    const canSave =
+        !saving && provider && modelId && maxTokens >= MIN_TOKENS && evaluateEveryNTurns >= MIN_EVALUATE_EVERY_N_TURNS &&
+        minTurnsBeforeEvaluate >= MIN_MIN_TURNS_BEFORE_EVALUATE;
 
     return (
         <div className="flex flex-col gap-6">
@@ -217,6 +256,38 @@ export default function FastModelSettings({ runnerId, config, onSave, saving }: 
                 />
                 <p className="text-xs text-muted-foreground">
                     Maximum output tokens for the goal evaluator. Default: {DEFAULT_MAX_TOKENS}.
+                </p>
+            </div>
+
+            {/* Evaluate cadence */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="evaluator-every-n-turns">Evaluate Every N Turns</Label>
+                <Input
+                    id="evaluator-every-n-turns"
+                    type="number"
+                    min={MIN_EVALUATE_EVERY_N_TURNS}
+                    value={evaluateEveryNTurns}
+                    onChange={(e) => handleEvaluateEveryChange(e.target.value)}
+                    className="w-full max-w-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                    Run the LLM evaluator once every N completed turns. Set to 1 to evaluate every turn. Default: {DEFAULT_EVALUATE_EVERY_N_TURNS}.
+                </p>
+            </div>
+
+            {/* Minimum turns before first evaluation */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="evaluator-min-turns">Minimum Turns Before Evaluating</Label>
+                <Input
+                    id="evaluator-min-turns"
+                    type="number"
+                    min={MIN_MIN_TURNS_BEFORE_EVALUATE}
+                    value={minTurnsBeforeEvaluate}
+                    onChange={(e) => handleMinTurnsChange(e.target.value)}
+                    className="w-full max-w-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                    Wait for this many completed turns before the goal evaluator runs for the first time. Default: {DEFAULT_MIN_TURNS_BEFORE_EVALUATE}.
                 </p>
             </div>
 


### PR DESCRIPTION
**Goal evaluator: wait at least 10 turns, make it configurable, and use the session model for cache parity.**

## What changed

- **Minimum wait before first evaluation**: the `/goal` evaluator now waits for at least `10` completed agent turns before running for the first time. This is configurable via:
  - the `/goal` CLI flag `--min-turns N`
  - `config.goal.minTurnsBeforeEvaluate` in `~/.pizzapi/config.json`
  - the Runner Settings Web UI
- **First eligible turn always evaluates**: once the minimum is reached, the first turn is always evaluated (so goals met right at the boundary resolve immediately). After that, the existing `evaluateEveryNTurns` cadence applies.
- **Session model fallback**: when no `evaluatorModel` is configured, the LLM evaluator now uses the session's current model (`ctx.model`) so the evaluator call shares the provider's prompt cache. If the current model isn't usable, it falls back to the cheapest authenticated text model.
- **Web UI**: the "Fast Model" settings panel now exposes:
  - Evaluate Every N Turns
  - Minimum Turns Before Evaluating
- **Docs updated**: `configuration.mdx`, `features/slash-commands.mdx`, `web-ui/slash-commands.mdx`.

## Tests

- Added parser tests for `--min-turns`.
- Added `resolveEvaluatorModel` tests for the `currentModel` fallback.
- Added a wiring test that confirms the default 10-turn wait defers evaluation.
- Updated existing goal tests and integration tests to use `--min-turns 1` where they exercise turn-1 evaluation.

## Quality gates

- `bun run typecheck` passes.
- `bun test packages/cli/src/extensions/goal/goal.test.ts packages/cli/src/extensions/goal/goal.integration.test.ts` passes.
- `bun test packages/ui/src/components/runner-settings/FastModelSettings.test.tsx packages/server/src/routes/runner-settings.test.ts` passes.
