### PR TITLE
fix(android): only notify for attention events

### DIFF
--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -362,6 +362,35 @@ describe("native push registration", () => {
         expect(fetchCalled).toBe(false);
     });
 
+    authIt("sends native notifications only for input requests and completed agents", async () => {
+        await registerNativePush({ userId: "user-native-events", platform: "android" });
+        const originalNtfyUrl = process.env.PIZZAPI_NTFY_URL;
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => {
+            fetchCalled = true;
+            return Promise.resolve(new Response("ok", { status: 200 }));
+        };
+        try {
+            for (const type of ["agent_error", "session_started", "session_ended"] as const) {
+                await sendPushToUser("user-native-events", {
+                    type,
+                    title: "Unexpected alert",
+                    body: "something happened",
+                    sessionId: "sess-native-events",
+                });
+            }
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            if (originalNtfyUrl === undefined) delete process.env.PIZZAPI_NTFY_URL;
+            else process.env.PIZZAPI_NTFY_URL = originalNtfyUrl;
+        }
+
+        expect(fetchCalled).toBe(false);
+    });
+
     authIt("sendPushToUser publishes to ntfy with mapped headers when configured", async () => {
         await registerNativePush({ userId: "user-E", platform: "android" });
         const reg = (await getNativeRegistrationsForUser("user-E"))[0];

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -378,6 +378,7 @@ function buildNtfyPublish(payload: PushPayload): Record<string, unknown> {
  * Publish a push payload to all native (ntfy) registrations for a user.
  * Never throws — failures are logged and stale registrations pruned. Caller
  * (sendPushToUser) treats this as best-effort alongside the Web Push fan-out.
+ * Native devices alert only when the agent needs input or finishes.
  *
  * Linked child sessions never send native push by default (docs: "only
  * top-level sessions send push notifications") — native registrations have
@@ -386,7 +387,7 @@ function buildNtfyPublish(payload: PushPayload): Record<string, unknown> {
  * per-registration escape hatch yet — add one here if that's ever needed.)
  */
 async function sendNtfyToUser(userId: string, payload: PushPayload, isChildSession: boolean): Promise<void> {
-    if (isChildSession) return;
+    if (isChildSession || (payload.type !== "agent_needs_input" && payload.type !== "agent_finished")) return;
     const cfg = ntfyConfig();
     if (!cfg.url) return;
     const registrations = await getNativeRegistrationsForUser(userId);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -270,7 +270,7 @@ function createInitialSessionState(): SessionState {
 
 export function App() {
   const { data: session, isPending } = usePizzaPiSession();
-  // Drive native badge + Android activity pill from the attention store.
+  // Drive the native badge from the attention store.
   // No-op outside the bundled Capacitor app.
   useMobileNativeActivity();
   const { runners: feedRunners, status: runnersStatus } = useRunnersFeed({

--- a/packages/ui/src/lib/mobile-native.test.ts
+++ b/packages/ui/src/lib/mobile-native.test.ts
@@ -22,38 +22,16 @@ const origIsNativePlatform = Capacitor.isNativePlatform;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const pluginCalls = {
     requestPermissions: 0,
-    createChannel: 0,
-    schedule: 0,
-    cancel: 0,
     badgeRequestPermissions: 0,
     badgeSet: 0,
     badgeClear: 0,
 };
-
-const lastChannel: { value?: any } = {};
-const lastSchedule: { value?: any } = {};
 
 mock.module("@capacitor/local-notifications", () => ({
     LocalNotifications: {
         requestPermissions: () => {
             pluginCalls.requestPermissions++;
             return Promise.resolve({ display: "granted" });
-        },
-        createChannel: (channel: any) => {
-            pluginCalls.createChannel++;
-            lastChannel.value = channel;
-            return Promise.resolve();
-        },
-        schedule: (options: any) => {
-            pluginCalls.schedule++;
-            lastSchedule.value = options;
-            return Promise.resolve({
-                notifications: options.notifications.map((n: any) => ({ id: n.id })),
-            });
-        },
-        cancel: () => {
-            pluginCalls.cancel++;
-            return Promise.resolve();
         },
     },
 }));
@@ -106,14 +84,9 @@ function makeLocalStorage(serverUrl: string | null): Storage {
 
 function resetPluginCalls() {
     pluginCalls.requestPermissions = 0;
-    pluginCalls.createChannel = 0;
-    pluginCalls.schedule = 0;
-    pluginCalls.cancel = 0;
     pluginCalls.badgeRequestPermissions = 0;
     pluginCalls.badgeSet = 0;
     pluginCalls.badgeClear = 0;
-    lastChannel.value = undefined;
-    lastSchedule.value = undefined;
 }
 
 function restorePlatform() {
@@ -162,15 +135,6 @@ describe("mobile-native (web no-op path)", () => {
         expect(pluginCalls.badgeSet).toBe(0);
         expect(pluginCalls.badgeClear).toBe(0);
     });
-
-    test("setAndroidActivityPill is a no-op on web for both transitions", async () => {
-        await expect(mod.setAndroidActivityPill(1)).resolves.toBeUndefined();
-        await expect(mod.setAndroidActivityPill(3, "custom summary")).resolves.toBeUndefined();
-        await expect(mod.setAndroidActivityPill(0)).resolves.toBeUndefined();
-        expect(pluginCalls.createChannel).toBe(0);
-        expect(pluginCalls.schedule).toBe(0);
-        expect(pluginCalls.cancel).toBe(0);
-    });
 });
 
 describe("mobile-native (android path)", () => {
@@ -201,51 +165,5 @@ describe("mobile-native (android path)", () => {
         await mod.setActivityBadge(0);
         expect(pluginCalls.badgeSet).toBe(1);
         expect(pluginCalls.badgeClear).toBe(1);
-    });
-
-    test("setAndroidActivityPill creates a low-importance channel and schedules the pill", async () => {
-        await mod.setAndroidActivityPill(1);
-
-        expect(pluginCalls.createChannel).toBe(1);
-        expect(lastChannel.value).toMatchObject({
-            id: "pizzapi-agent-activity",
-            importance: 1,
-            vibration: false,
-            lights: false,
-        });
-
-        expect(pluginCalls.schedule).toBe(1);
-        const notification = lastSchedule.value.notifications[0];
-        // Must stay out of NtfyForegroundService.java's id range
-        // (SUMMARY=0x8_FFFF, SERVICE=0x9_0000, FIRST_MESSAGE=0x9_0001+).
-        expect(notification.id).toBe(0xa_0000);
-        expect(notification).toMatchObject({
-            id: 0xa_0000,
-            title: "PizzaPi",
-            body: "Agent session running",
-            channelId: "pizzapi-agent-activity",
-            ongoing: true,
-            silent: true,
-        });
-    });
-
-    test("setAndroidActivityPill uses the provided summary", async () => {
-        await mod.setAndroidActivityPill(1, "Baking the pizza");
-        expect(lastSchedule.value.notifications[0].body).toBe("Baking the pizza");
-    });
-
-    test("setAndroidActivityPill is idempotent while running", async () => {
-        await mod.setAndroidActivityPill(1);
-        await mod.setAndroidActivityPill(1);
-        await mod.setAndroidActivityPill(2);
-        expect(pluginCalls.createChannel).toBe(1);
-        expect(pluginCalls.schedule).toBe(1);
-        expect(pluginCalls.cancel).toBe(0);
-    });
-
-    test("setAndroidActivityPill cancels the pill when runningCount drops to zero", async () => {
-        await mod.setAndroidActivityPill(1);
-        await mod.setAndroidActivityPill(0);
-        expect(pluginCalls.cancel).toBe(1);
     });
 });

--- a/packages/ui/src/lib/mobile-native.ts
+++ b/packages/ui/src/lib/mobile-native.ts
@@ -4,11 +4,6 @@
  * Wires two native surfaces to the attention store:
  *  - **App icon badge** (iOS + Android): set to the count of items needing a
  *    user response (questions, plan reviews, escalations). Cleared at 0.
- *  - **Android "live update" pill**: an ongoing local notification shown while
- *    one or more agent sessions are running, dismissed when they go idle. This
- *    is Android's equivalent of an iOS Live Activity — a persistent, non-
- *    dismissable notification in the shade / on the lock screen. iOS gets no
- *    equivalent here (it uses the badge only, per the agreed scope).
  *
  * Everything is a no-op outside the native Capacitor app: web builds never
  * import the native plugin code paths because the guard short-circuits before
@@ -22,47 +17,7 @@ import { LocalNotifications } from "@capacitor/local-notifications";
 import { Badge } from "@capawesome/capacitor-badge";
 import { getMobileRuntimeConfig } from "./mobile-runtime.js";
 import { startNtfyPush } from "./ntfy-push.js";
-import { useNeedsResponseCount, useRunningCount } from "../attention/index.js";
-
-/**
- * Stable notification id for the Android activity pill.
- *
- * Must NOT collide with the native ntfy service's ids in
- * android/.../NtfyForegroundService.java: SUMMARY=0x8_FFFF, SERVICE=0x9_0000,
- * FIRST_MESSAGE=0x9_0001 and counting up for each message. We sit well above
- * that range so message notifications never overwrite the pill (and vice versa).
- * Keep these two files in sync if either range grows.
- */
-const ACTIVITY_NOTIF_ID = 0xa_0000;
-
-/** Dedicated low-importance channel id for the Android activity pill. */
-const ACTIVITY_CHANNEL_ID = "pizzapi-agent-activity";
-
-let activityChannelEnsured = false;
-
-/**
- * Create the low-importance notification channel used by the Android
- * activity pill. Idempotent — safe to call on every state transition.
- */
-async function ensureActivityChannel(): Promise<void> {
-    if (activityChannelEnsured) return;
-    activityChannelEnsured = true;
-    if (!nativeEnabled() || Capacitor.getPlatform() !== "android") return;
-    try {
-        await LocalNotifications.createChannel({
-            id: ACTIVITY_CHANNEL_ID,
-            name: "Agent activity",
-            description: "Persistent status while an agent session is running",
-            // IMPORTANCE_MIN: shown in the notification shade, no status bar icon,
-            // no sound, no vibration.
-            importance: 1,
-            vibration: false,
-            lights: false,
-        });
-    } catch (err) {
-        console.error("mobile-native: failed to create activity channel:", err);
-    }
-}
+import { useNeedsResponseCount } from "../attention/index.js";
 
 /** True only when running inside the bundled Capacitor native shell. */
 function nativeEnabled(): boolean {
@@ -109,77 +64,17 @@ export async function setActivityBadge(count: number): Promise<void> {
     }
 }
 
-// Tracks whether the Android ongoing notification is currently posted, so we
-// only schedule/cancel on state transitions (avoids re-posting every tick).
-let androidPillShown = false;
-
-/**
- * Show or hide the Android ongoing "agent working" notification. No-op on iOS
- * and web. Only acts on 0→N and N→0 transitions.
- *
- * @param runningCount number of currently-running agent sessions
- * @param summary optional human-readable body; defaults to a count-based string
- */
-export async function setAndroidActivityPill(
-    runningCount: number,
-    summary?: string,
-): Promise<void> {
-    if (!nativeEnabled() || Capacitor.getPlatform() !== "android") return;
-    try {
-        if (runningCount > 0 && !androidPillShown) {
-            await ensureActivityChannel();
-            const body =
-                summary ??
-                (runningCount === 1
-                    ? "Agent session running"
-                    : `${runningCount} agent sessions running`);
-            await LocalNotifications.schedule({
-                notifications: [
-                    {
-                        id: ACTIVITY_NOTIF_ID,
-                        title: "PizzaPi",
-                        body,
-                        channelId: ACTIVITY_CHANNEL_ID,
-                        // Ongoing => can't be swiped away; renders as a live
-                        // update pill on Android 16+ and a persistent shade
-                        // entry on older versions.
-                        ongoing: true,
-                        // Don't ring/vibrate on every state change — this is a
-                        // status indicator, not an alert.
-                        silent: true,
-                    },
-                ],
-            });
-            androidPillShown = true;
-        } else if (runningCount === 0 && androidPillShown) {
-            await LocalNotifications.cancel({
-                notifications: [{ id: ACTIVITY_NOTIF_ID }],
-            });
-            androidPillShown = false;
-        }
-    } catch (err) {
-        console.error("mobile-native: failed to update activity pill:", err);
-    }
-}
-
 /** Reset internal flags — exposed for tests. */
 export function _resetMobileNativeState(): void {
     permissionsRequested = false;
-    androidPillShown = false;
-    activityChannelEnsured = false;
 }
 
 /**
- * React hook that drives the native badge + Android activity pill from the
- * attention store. Mount once, inside <AttentionProvider>.
- *
- * - Requests notification/badge permission on first mount (native only).
- * - Mirrors `needsResponseCount` to the app icon badge.
- * - Mirrors `runningCount > 0` to the Android ongoing notification pill.
+ * React hook that drives the native badge from the attention store. Mount once,
+ * inside <AttentionProvider>.
  */
 export function useMobileNativeActivity(): void {
     const needsResponse = useNeedsResponseCount();
-    const running = useRunningCount();
 
     // Request permissions once on mount.
     React.useEffect(() => {
@@ -195,8 +90,4 @@ export function useMobileNativeActivity(): void {
         void setActivityBadge(needsResponse);
     }, [needsResponse]);
 
-    // Android pill reflects "agent is actively working".
-    React.useEffect(() => {
-        void setAndroidActivityPill(running);
-    }, [running]);
 }


### PR DESCRIPTION
## Summary
- remove the persistent Android “Agent session running” notification
- send native Android alerts only when an agent needs input or finishes
- cover suppressed native event types

## Checks
- `env -u PIZZAPI_API_KEY bun run test`
- `bun run typecheck && bun run build`
