### PR TITLE
Fix WebUI slash commands during active turns

### DIFF
--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -197,9 +197,13 @@ export interface RelayContext {
 
     // Mutable flags
     isAgentActive: boolean;
+    /** True after an attempt ends, until the agent settles its retries. */
+    isAgentSettling: boolean;
     isCompacting: boolean;
     shuttingDown: boolean;
     wasAborted: boolean;
+    /** Number of steering slash commands aborting a turn before dispatch. */
+    pendingSteeringSlashCommands: number;
     sessionStartedAt: number | null;
     lastRetryableError: RetryState | null;
 

--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -269,6 +269,67 @@ describe("remote connection startup gate", () => {
         expect(firstCall[0]).toBe("fix the flaky test please");
     });
 
+    test("aborts steering slash commands while active or settling", async () => {
+        const abort = mock(async () => {});
+        const sendUserMessage = mock(() => {});
+        const rctx = {
+            shuttingDown: false,
+            sioSocket: null,
+            relay: null,
+            relaySessionId: null,
+            apiKey: () => "test-key",
+            relayUrl: () => "ws://relay.test",
+            relayHttpBaseUrl: () => "http://relay.test",
+            disconnectedStatusText: () => "Disconnected",
+            setRelayStatus: mock(() => {}),
+            getCurrentSessionName: () => null,
+            forwardEvent: mock(() => {}),
+            buildCapabilitiesState: () => ({ type: "capabilities" }),
+            isAgentActive: true,
+            isAgentSettling: false,
+            pendingSteeringSlashCommands: 0,
+            sessionHost: { abort },
+        } as any;
+        const handlers = {
+            clearFollowUpGrace: mock(() => {}),
+            setModelFromWeb: mock(async () => {}),
+            sendUserMessage,
+            isPendingDelinkOwnParent: () => false,
+            setServerClockOffset: mock(() => {}),
+            isStaleChild: () => false,
+            getStalePrimaryParentId: () => null,
+            onParentExplicitlyDelinked: mock(() => {}),
+            onParentTransientlyOffline: mock(() => {}),
+            onParentDelinked: mock(() => {}),
+            flushDeferredDelinks: mock(() => {}),
+            onDelinkDisconnect: mock(() => {}),
+            onSocketTeardown: mock(() => {}),
+            getParentSessionIdForRegister: () => undefined,
+        } as any;
+
+        connect(rctx, handlers);
+        // The UI can omit deliverAs when its active state is stale; resolve the
+        // runner-side default before deciding whether to abort.
+        lastSocket!.trigger("input", { text: "/goal finish the task" });
+        await sleep(50);
+
+        expect(abort).toHaveBeenCalledTimes(1);
+        expect(sendUserMessage).toHaveBeenCalledWith(
+            "/goal finish the task",
+            expect.objectContaining({ deliverAs: "steer" }),
+        );
+
+        // agent_end clears isAgentActive before agent_settled. An explicitly
+        // steering command must still abort during that settling window.
+        rctx.isAgentActive = false;
+        rctx.isAgentSettling = true;
+        lastSocket!.trigger("input", { text: "/goal finish the task", deliverAs: "steer" });
+        await sleep(50);
+
+        expect(abort).toHaveBeenCalledTimes(2);
+        expect(rctx.pendingSteeringSlashCommands).toBe(0);
+    });
+
     test("delivers immediately when gate is not armed (normal CLI session)", async () => {
         // Don't arm the gate — simulates a normal interactive CLI session
         const sendUserMessage = mock(() => {});

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -450,11 +450,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 // started streaming by the time we resume here. See
                 // resolveInputDeliverAs for the rationale.
                 const agentIsRunning = rctx.isAgentActive || rctx.isAgentSettling;
-                // Keep the generic input fallback as follow-up, but slash
-                // commands must steer when they arrive during a running turn.
-                // The UI's active state can be stale when it emitted the input.
-                const requestedDeliverAs = deliverAs ?? (isSlashCommand && agentIsRunning ? "steer" : undefined);
-                const effectiveDeliverAs = resolveInputDeliverAs(requestedDeliverAs, agentIsRunning);
+                const effectiveDeliverAs = resolveInputDeliverAs(deliverAs, agentIsRunning);
                 // Extension commands run before pi applies streaming behavior, so
                 // stop the prior turn before dispatching a steering slash command.
                 // This is also harmless while already idle. Suppress its interim

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -437,6 +437,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         const deliverAs = data.deliverAs === "followUp" ? "followUp" as const
             : data.deliverAs === "steer" ? "steer" as const
             : undefined;
+        const isSlashCommand = typeof inputText === "string" && inputText.trimStart().startsWith("/");
         void (async () => {
             try {
                 const httpBase = rctx.relayHttpBaseUrl();
@@ -448,8 +449,25 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 // initial prompt (or another buffered message) may have already
                 // started streaming by the time we resume here. See
                 // resolveInputDeliverAs for the rationale.
-                const effectiveDeliverAs = resolveInputDeliverAs(deliverAs, rctx.isAgentActive === true);
-                await handlers.sendUserMessage(message, { expandPromptTemplates: true, ...(effectiveDeliverAs ? { deliverAs: effectiveDeliverAs } : {}) });
+                const agentIsRunning = rctx.isAgentActive || rctx.isAgentSettling;
+                // Keep the generic input fallback as follow-up, but slash
+                // commands must steer when they arrive during a running turn.
+                // The UI's active state can be stale when it emitted the input.
+                const requestedDeliverAs = deliverAs ?? (isSlashCommand && agentIsRunning ? "steer" : undefined);
+                const effectiveDeliverAs = resolveInputDeliverAs(requestedDeliverAs, agentIsRunning);
+                // Extension commands run before pi applies streaming behavior, so
+                // stop the prior turn before dispatching a steering slash command.
+                // This is also harmless while already idle. Suppress its interim
+                // settlement: auto-close or a parent must not complete the session
+                // before the command gets to run.
+                const abortForSlashCommand = isSlashCommand && effectiveDeliverAs === "steer";
+                if (abortForSlashCommand) rctx.pendingSteeringSlashCommands += 1;
+                try {
+                    if (abortForSlashCommand) await rctx.sessionHost?.abort();
+                    await handlers.sendUserMessage(message, { expandPromptTemplates: true, ...(effectiveDeliverAs ? { deliverAs: effectiveDeliverAs } : {}) });
+                } finally {
+                    if (abortForSlashCommand) rctx.pendingSteeringSlashCommands -= 1;
+                }
             } catch (err) {
                 const errMessage = err instanceof Error ? err.message : String(err);
                 log.error(`pizzapi: failed to deliver remote input: ${errMessage}`);

--- a/packages/cli/src/extensions/remote/deliver-as-default.test.ts
+++ b/packages/cli/src/extensions/remote/deliver-as-default.test.ts
@@ -12,7 +12,7 @@
  * effective delivery mode. These tests pin that behavior:
  *
  *   - If the UI supplied a deliverAs, it always wins.
- *   - If it didn't and the agent is streaming, default to "followUp".
+ *   - If it didn't and the agent is streaming, default to "steer".
  *   - Otherwise, leave it undefined so idle-agent semantics apply.
  */
 import { describe, expect, test } from "bun:test";
@@ -31,8 +31,8 @@ describe("resolveInputDeliverAs", () => {
         expect(resolveInputDeliverAs("followUp", true)).toBe("followUp");
     });
 
-    test("defaults to followUp when mode is missing and agent is active", () => {
-        expect(resolveInputDeliverAs(undefined, true)).toBe("followUp");
+    test("defaults to steer when mode is missing and agent is active", () => {
+        expect(resolveInputDeliverAs(undefined, true)).toBe("steer");
     });
 
     test("leaves mode undefined when agent is idle and no mode was requested", () => {

--- a/packages/cli/src/extensions/remote/deliver-as-default.ts
+++ b/packages/cli/src/extensions/remote/deliver-as-default.ts
@@ -20,13 +20,13 @@
  * and the message would be silently dropped.
  *
  * If no explicit mode was supplied and the agent is currently streaming,
- * default to `"followUp"` so the message is safely queued.
+ * default to `"steer"` so the new input immediately takes over.
  */
 export function resolveInputDeliverAs(
     requested: "followUp" | "steer" | undefined,
     isAgentActive: boolean,
 ): "followUp" | "steer" | undefined {
     if (requested) return requested;
-    if (isAgentActive) return "followUp";
+    if (isAgentActive) return "steer";
     return undefined;
 }

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
@@ -171,6 +171,19 @@ describe("agent_end — session_error / session_complete ordering", () => {
         expect(emitted).toEqual([]);
     });
 
+    test("does not complete while a steering slash command aborts then dispatches", () => {
+        const { agentEnd, agentSettled, emitted, rctx } = setup(null);
+        (rctx as any).pendingSteeringSlashCommands = 1;
+
+        agentEnd({ messages: [] }, agentEndCtx);
+        expect((rctx as any).isAgentSettling).toBe(true);
+        agentSettled({}, agentEndCtx);
+
+        expect(emitted).toEqual([]);
+        expect((rctx as any).isAgentSettling).toBe(false);
+        expect((rctx as any).lastRetryableError).toBeNull();
+    });
+
     test("no session_error when a retry recovers before settling", () => {
         const { agentEnd, agentSettled, emitted, rctx } = setup({
             errorMessage: "You have exceeded your usage limit",

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -373,6 +373,7 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     pi.on("agent_start", (event: any) => {
         rctx.isAgentActive = true;
+        rctx.isAgentSettling = false;
         rctx.lastRetryableError = null;
         emitRetryStateChanged(rctx, null);
         rctx.forwardEvent(event);
@@ -381,6 +382,7 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     pi.on("agent_end", (event: any, ctx: any) => {
         rctx.isAgentActive = false;
+        rctx.isAgentSettling = true;
         // pi's agent_end.messages contains only THIS run's messages (prompts +
         // new assistant/tool messages), not the full transcript. The web UI and
         // the server's snapshot cache both treat agent_end.messages as a full
@@ -398,7 +400,17 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
     });
 
     function handleAgentSettled(_event: any, ctx: any) {
+        rctx.isAgentSettling = false;
         if (settledMessages === null) return; // settled without a preceding agent_end
+        // A steering slash command aborts its predecessor because pi executes
+        // extension commands before applying streaming behavior. Do not let
+        // that interim settle report completion or auto-close the session.
+        if (rctx.pendingSteeringSlashCommands > 0) {
+            settledMessages = null;
+            rctx.lastRetryableError = null;
+            emitRetryStateChanged(rctx, null);
+            return;
+        }
         if (hasActiveSubagents()) {
             deferredSettlementCtx = ctx;
             noteSubagentSettlementDeferred();

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -67,9 +67,11 @@ export function createRelayContext(
         latestCtx: null,
 
         isAgentActive: false,
+        isAgentSettling: false,
         isCompacting: false,
         shuttingDown: false,
         wasAborted: false,
+        pendingSteeringSlashCommands: 0,
         sessionStartedAt: null,
         lastRetryableError: null,
 

--- a/packages/cli/src/runner/session-host.test.ts
+++ b/packages/cli/src/runner/session-host.test.ts
@@ -65,6 +65,14 @@ function makeHost(opts: { sessionOverrides?: Record<string, unknown>; replaceFn?
     return { host, lifecycle, session: () => current, setSession: (s: Record<string, unknown>) => (current = s) };
 }
 
+describe("SessionHost.abort", () => {
+    test("waits for the active session to become idle", async () => {
+        const { host, session } = makeHost();
+        await host.abort();
+        expect(session().calls).toContainEqual({ method: "abort", args: [] });
+    });
+});
+
 describe("SessionHost.sendUserMessage", () => {
     test("string content maps to prompt with extension defaults", async () => {
         const { host, session } = makeHost();

--- a/packages/cli/src/runner/session-host.ts
+++ b/packages/cli/src/runner/session-host.ts
@@ -160,6 +160,7 @@ export class SessionHost {
         return this.lifecycle.importFromJsonl(inputPath, cwdOverride);
     }
 
+    /** Abort the active turn and wait until a slash command can safely run. */
     abort(): Promise<void> {
         return this.session.abort();
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3565,7 +3565,7 @@ export function App() {
   const inputDedupeRef = React.useRef<InputDedupeState | null>(null);
   const inputAttemptIdRef = React.useRef(0);
 
-  type SessionInputMessage = { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string;
+  type SessionInputMessage = { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean } | string;
 
   // Messages submitted while the session was still hydrating (e.g. the runner
   // was loading MCP servers). Flushed once the snapshot completes.
@@ -3710,6 +3710,7 @@ export function App() {
     }
 
     const deliverAs = typeof message === "object" ? message.deliverAs : undefined;
+    const suppressOptimistic = typeof message === "object" && message.suppressOptimistic;
 
     try {
       socket.emit("input", {
@@ -3725,7 +3726,7 @@ export function App() {
       }
 
       // Track queued messages when the agent is active
-      if (deliverAs && trimmed) {
+      if (deliverAs && trimmed && !suppressOptimistic) {
         if (deliverAs === "steer") {
           // Steer messages appear immediately in the conversation
           const now = Date.now();

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -312,6 +312,7 @@ export function SessionViewer({
     compactingRef,
     onExec,
     onSendInput,
+    isAgentActive: agentActive,
     resumeSessions,
     onRequestResumeSessions,
     forkMessages,

--- a/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
+++ b/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
@@ -33,7 +33,9 @@ function setup(options: {
     input: string;
     forkMessages?: ForkMessageOption[];
     onExec?: (payload: unknown) => boolean | void;
+    onSendInput?: SlashCommandDeps["onSendInput"];
     onRequestForkMessages?: () => boolean | void;
+    isAgentActive?: boolean;
 }) {
     const setInputCalls: string[] = [];
     const deps: SlashCommandDeps = {
@@ -41,6 +43,8 @@ function setup(options: {
         sessionIdRef: { current: "sess-1" },
         compactingRef: { current: false },
         onExec: options.onExec,
+        onSendInput: options.onSendInput,
+        isAgentActive: options.isAgentActive,
         forkMessages: options.forkMessages,
         onRequestForkMessages: options.onRequestForkMessages,
         skillCommands: [],
@@ -61,6 +65,21 @@ const messages: ForkMessageOption[] = [
     { entryId: "e2", text: "second question" },
     { entryId: "e3", text: "third about CSS" },
 ];
+
+describe("slash command delivery", () => {
+    test("steers runner slash commands while the agent is active", () => {
+        const sent: unknown[] = [];
+        const { view } = setup({
+            input: "/goal finish the task",
+            isAgentActive: true,
+            onSendInput: (message) => { sent.push(message); },
+        });
+
+        act(() => { view.result.current.executeSlashCommand("/goal finish the task"); });
+
+        expect(sent).toEqual([{ text: "/goal finish the task", files: [], deliverAs: "steer", suppressOptimistic: true }]);
+    });
+});
 
 describe("rewind mode", () => {
     test("activates for /rewind and /fork, not for other commands", () => {

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -36,8 +36,9 @@ export interface SlashCommandDeps {
   compactingRef: React.MutableRefObject<boolean>;
   onExec?: (payload: unknown) => boolean | void;
   onSendInput?: (
-    message: (PromptInputMessage & { deliverAs?: "steer" | "followUp" }) | string,
+    message: (PromptInputMessage & { deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean }) | string,
   ) => boolean | void | Promise<boolean | void>;
+  isAgentActive?: boolean;
   resumeSessions?: ResumeSessionOption[];
   onRequestResumeSessions?: () => boolean | void;
   forkMessages?: ForkMessageOption[];
@@ -114,6 +115,7 @@ export function useSlashCommands(
     compactingRef,
     onExec,
     onSendInput,
+    isAgentActive,
     resumeSessions,
     onRequestResumeSessions,
     forkMessages,
@@ -438,9 +440,9 @@ export function useSlashCommands(
         command: "new_session",
       });
     } else if (onSendInput) {
-      void onSendInput({ text: "/new", files: [] });
+      void onSendInput({ text: "/new", files: [], suppressOptimistic: true, ...(isAgentActive ? { deliverAs: "steer" as const } : {}) });
     }
-  }, [onExec, onSendInput]);
+  }, [onExec, onSendInput, isAgentActive]);
 
   const requestNewSession = React.useCallback(() => {
     void checkTriggersAndRun(fireNewSession);
@@ -579,7 +581,7 @@ export function useSlashCommands(
           // Sub-commands (violations/config) are handled by the runner's
           // sandbox extension — forward as raw input.
           if (!onSendInput) return false;
-          void onSendInput({ text: trimmed, files: [] });
+          void onSendInput({ text: trimmed, files: [], suppressOptimistic: true, ...(isAgentActive ? { deliverAs: "steer" as const } : {}) });
           setInput("");
           setCommandOpen(false);
           setCommandQuery("");
@@ -718,7 +720,7 @@ export function useSlashCommands(
       );
       if (rawCommand === "goal" || isExtensionCommand) {
         if (!onSendInput) return false;
-        void onSendInput({ text: trimmed, files: [] });
+        void onSendInput({ text: trimmed, files: [], suppressOptimistic: true, ...(isAgentActive ? { deliverAs: "steer" as const } : {}) });
         setInput("");
         setCommandOpen(false);
         setCommandQuery("");
@@ -870,6 +872,7 @@ export function useSlashCommands(
     [
       onExec,
       onSendInput,
+      isAgentActive,
       resumeSessions,
       forkMessages,
       rewindToMessage,

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -42,7 +42,7 @@ export interface SessionViewerProps {
   forkMessages?: ForkMessageOption[];
   forkMessagesLoading?: boolean;
   onRequestForkMessages?: () => boolean | void;
-  onSendInput?: (message: PromptInputMessage & { deliverAs?: "steer" | "followUp" } | string) => boolean | void | Promise<boolean | void>;
+  onSendInput?: (message: PromptInputMessage & { deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean } | string) => boolean | void | Promise<boolean | void>;
   onExec?: (payload: unknown) => boolean | void;
   onShowModelSelector?: () => void;
   /** Opens the new-session wizard (renders a CTA in the empty state). */


### PR DESCRIPTION
## Summary
- default active WebUI input to `steer`
- abort the predecessor before runner-handled slash commands and suppress interim completion
- avoid phantom optimistic transcript entries for runner-handled slash commands

## Tests
- `bun run typecheck`
- `env -u PIZZAPI_RUNNER_API_KEY -u PIZZAPI_API_KEY -u PIZZAPI_API_TOKEN bun run test`
