### PR TITLE
feat(cli): instruct models not to poll bash_output, raise auto-background threshold to 5min

### DIFF
--- a/packages/cli/src/extensions/background-bash.test.ts
+++ b/packages/cli/src/extensions/background-bash.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds } from "./background-bash.js";
+import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds, resetBackgroundBashConfigCache } from "./background-bash.js";
 import { sessionJobsFilePath } from "../runner/session-procs.js";
 
 // Keep the auto-background window out of the way unless a test opts in, and
@@ -51,14 +51,16 @@ describe("bash override with backgrounding", () => {
         expect(pi.tools.get("bash").parameters.required).toEqual(["command", "title"]);
     });
 
-    test("background threshold: default 15s, env override, invalid falls back", () => {
+    test("background threshold: default 5min, env override, invalid falls back", () => {
         const prev = process.env.PIZZAPI_BASH_BACKGROUND_SECONDS;
         delete process.env.PIZZAPI_BASH_BACKGROUND_SECONDS;
-        expect(backgroundAfterSeconds()).toBe(15);
+        // Reset module cache so config is re-read.
+        resetBackgroundBashConfigCache();
+        expect(backgroundAfterSeconds()).toBe(300);
         process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "0";
         expect(backgroundAfterSeconds()).toBe(0);
         process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = "nope";
-        expect(backgroundAfterSeconds()).toBe(15);
+        expect(backgroundAfterSeconds()).toBe(300);
         process.env.PIZZAPI_BASH_BACKGROUND_SECONDS = prev!;
     });
 

--- a/packages/cli/src/extensions/background-bash.ts
+++ b/packages/cli/src/extensions/background-bash.ts
@@ -28,7 +28,7 @@ export { tailFile } from "../runner/session-procs.js";
  * and this override keeps the name "bash".
  */
 
-const DEFAULT_BACKGROUND_AFTER_SECONDS = 15;
+const DEFAULT_BACKGROUND_AFTER_SECONDS = 300;
 const DELIVERY_RETRY_MS = 10_000;
 const MAX_DELIVERY_ATTEMPTS = 3;
 
@@ -41,6 +41,9 @@ export function backgroundAfterSeconds(): number {
 
 // ponytail: config read once per process (bash runs often); restart to change it.
 let configuredSeconds: number | undefined | null = null;
+export function resetBackgroundBashConfigCache() {
+    configuredSeconds = null;
+}
 function readConfiguredSeconds(): number | undefined {
     if (configuredSeconds === null) {
         try {
@@ -458,7 +461,7 @@ export const backgroundBashExtension: ExtensionFactory = (pi) => {
         name: "bash_output",
         label: "Bash Output",
         description:
-            "Get new output from a background shell since the last bash_output call (incremental — already-seen output is not repeated). Call without pid to list all background shells and their status. Use this to check progress instead of re-reading the log file.",
+            "Get new output from a background shell since the last bash_output call (incremental — already-seen output is not repeated). Call without pid to list all background shells and their status. Use this to check progress instead of re-reading the log file. Do NOT call bash_output(pid) in a tight loop; do other work between checks and let the exit notification tell you when the shell is done.",
         parameters: {
             type: "object",
             properties: {


### PR DESCRIPTION
Updates the `bash_output` tool description to explicitly tell models not to call it in a tight loop, and raises the default auto-background threshold from 15s to 5 minutes (300s).

Changes:
- `packages/cli/src/extensions/background-bash.ts`
  - Default `backgroundAfterSeconds` changed from `15` to `300`
  - `bash_output` tool description now instructs models to do other work between checks and let the exit notification arrive
  - Added `resetBackgroundBashConfigCache()` helper for testability
- `packages/cli/src/extensions/background-bash.test.ts`
  - Updated default-threshold test to expect 300s
  - Reset config cache before reading the default

Verification:
- `bun test packages/cli/src/extensions/background-bash.test.ts` passes (16/16)
- `bun run typecheck` is clean
