### PR TITLE
fix(viewer): drop cross-session event bleed on tab switch

### DIFF
--- a/packages/protocol/src/payload-guards.test.ts
+++ b/packages/protocol/src/payload-guards.test.ts
@@ -33,6 +33,7 @@ describe("parseViewerEventEnvelope", () => {
       replay: true,
       deltaReplay: true,
       generation: 7,
+      sessionId: "sess-a",
     };
     const result = parseViewerEventEnvelope(input);
     expect(result.ok).toBe(true);
@@ -46,6 +47,7 @@ describe("parseViewerEventEnvelope", () => {
     { label: "missing event", value: { seq: 1 }, expectOk: false },
     { label: "seq is string", value: { event: {}, seq: "42" }, expectOk: true, expectUndefined: "seq" },
     { label: "generation is string", value: { event: {}, generation: "1" }, expectOk: true, expectUndefined: "generation" },
+    { label: "sessionId is number", value: { event: {}, sessionId: 42 }, expectOk: true, expectUndefined: "sessionId" },
   ];
 
   for (const { label, value, expectOk, expectUndefined } of malformed) {

--- a/packages/protocol/src/payload-guards.ts
+++ b/packages/protocol/src/payload-guards.ts
@@ -195,6 +195,8 @@ export interface ViewerEventEnvelope {
   replay?: boolean;
   deltaReplay?: boolean;
   generation?: number;
+  /** Session the event belongs to. Absent on envelopes from older servers. */
+  sessionId?: string;
 }
 
 export function parseViewerEventEnvelope(raw: unknown): ParseResult<ViewerEventEnvelope> {
@@ -212,6 +214,7 @@ export function parseViewerEventEnvelope(raw: unknown): ParseResult<ViewerEventE
       replay: optionalBoolean(raw.replay),
       deltaReplay: optionalBoolean(raw.deltaReplay),
       generation: optionalNumber(raw.generation),
+      sessionId: typeof raw.sessionId === "string" ? raw.sessionId : undefined,
     },
   };
 }

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -33,6 +33,8 @@ export interface ViewerServerToClientEvents {
     deltaReplay?: true;
     /** Optional switch generation echoed back during logical session switches. */
     generation?: number;
+    /** Session the event belongs to — lets the client drop cross-session bleed. */
+    sessionId?: string;
   }) => void;
 
   /** Notifies the viewer that the TUI disconnected */

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -493,6 +493,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                         event: withLivenessOnlyHint(JSON.parse(freshSession.lastHeartbeat)),
                         seq: freshSeq,
                         generation,
+                        sessionId: nextSessionId,
                     });
                 } catch {}
             }
@@ -510,6 +511,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                         event: withMetaViaHubHint({ type: "session_active", state: JSON.parse(freshSession.lastState) }),
                         seq: freshSeq,
                         generation,
+                        sessionId: nextSessionId,
                     });
                 } catch {}
             } else {

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -685,14 +685,14 @@ export async function broadcastSessionEventToViewers(sessionId: string, event: u
     try {
         io.of("/viewer")
             .to(viewerSessionRoom(sessionId))
-            .emit("event", { event, seq });
+            .emit("event", { event, seq, sessionId });
     } catch (err) {
         log.warn("broadcastSessionEventToViewers failed:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local
                 .to(viewerSessionRoom(sessionId))
-                .emit("event", { event, seq });
+                .emit("event", { event, seq, sessionId });
         } catch {
             // Local delivery also failed — event may be lost but won't break cache
         }
@@ -747,7 +747,7 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
     try {
         io.of("/viewer")
             .to(viewerSessionRoom(sessionId))
-            .emit("event", { event: strippedEvent, seq });
+            .emit("event", { event: strippedEvent, seq, sessionId });
     } catch (err) {
         // Redis adapter throws EPIPE when the Redis connection drops mid-broadcast.
         // Fall back to local-only delivery so viewers on this server still receive
@@ -758,7 +758,7 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
             io.of("/viewer")
                 .local
                 .to(viewerSessionRoom(sessionId))
-                .emit("event", { event: strippedEvent, seq });
+                .emit("event", { event: strippedEvent, seq, sessionId });
         } catch {
             // Local delivery also failed — event may be lost for connected viewers,
             // but it's in the cache (if Redis accepted it) for future replay.
@@ -865,7 +865,7 @@ export async function sendSnapshotToViewer(sessionId: string, socket: Socket): P
     const seq = session.seq;
     if (session.lastHeartbeat) {
         const heartbeat = safeJsonParse(session.lastHeartbeat);
-        socket.emit("event", { event: heartbeat, seq });
+        socket.emit("event", { event: heartbeat, seq, sessionId });
     }
     if (session.lastState) {
         const state = safeJsonParse(session.lastState);
@@ -873,7 +873,7 @@ export async function sendSnapshotToViewer(sessionId: string, socket: Socket): P
         // initial page load / reconnect only sends the tail.  Full state
         // is available via load_messages pagination.
         const hydratedEvent = prepareBroadcastEvent({ type: "session_active", state });
-        socket.emit("event", { event: hydratedEvent, seq });
+        socket.emit("event", { event: hydratedEvent, seq, sessionId });
     }
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -147,7 +147,7 @@ import {
   shouldRequestChunkRecovery,
 } from "@/lib/session-seq";
 import { createLogger } from "@pizzapi/tools";
-import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration } from "@/lib/viewer-switch";
+import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration, matchesViewerSession } from "@/lib/viewer-switch";
 
 // Lazy-loaded low-frequency surfaces. Auth, session sidebar/viewer, banners,
 // and loading/error UI remain eager so critical paths stay fast.
@@ -3360,7 +3360,14 @@ export function App() {
           logFrontendEvent("viewer", "warning", "Malformed viewer event envelope", envelope.error);
           return;
         }
-        const { event: rawEvent, seq: envelopeSeq, deltaReplay, generation } = envelope.value;
+        const { event: rawEvent, seq: envelopeSeq, deltaReplay, generation, sessionId: envelopeSessionId } = envelope.value;
+
+        // Session-stamped envelopes from another session are cross-session
+        // bleed (in-flight old-room broadcasts during a tab switch) — drop
+        // them before the generation/hydration checks can accept them.
+        if (!matchesViewerSession(lifecycleRefs.activeSessionId.current, envelopeSessionId)) {
+          return;
+        }
 
         const eventType =
           rawEvent && typeof rawEvent === "object" && typeof (rawEvent as Record<string, unknown>).type === "string"

--- a/packages/ui/src/lib/viewer-switch.test.ts
+++ b/packages/ui/src/lib/viewer-switch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration } from "./viewer-switch";
+import { isActiveViewerSessionPayload, matchesHydrationGeneration, matchesViewerGeneration, matchesViewerSession } from "./viewer-switch";
 
 describe("matchesViewerGeneration", () => {
   test("accepts payloads without a generation", () => {
@@ -32,6 +32,24 @@ describe("matchesHydrationGeneration", () => {
 
   test("still rejects explicitly stale generations", () => {
     expect(matchesHydrationGeneration(4, 3, "session_active", true)).toBe(false);
+  });
+});
+
+describe("matchesViewerSession", () => {
+  test("accepts unstamped envelopes (older servers)", () => {
+    expect(matchesViewerSession("sess-a", undefined)).toBe(true);
+  });
+
+  test("accepts envelopes stamped with the active session", () => {
+    expect(matchesViewerSession("sess-a", "sess-a")).toBe(true);
+  });
+
+  test("rejects envelopes stamped with another session (tab-switch bleed)", () => {
+    expect(matchesViewerSession("sess-a", "sess-b")).toBe(false);
+  });
+
+  test("rejects stamped envelopes when no session is active", () => {
+    expect(matchesViewerSession(null, "sess-b")).toBe(false);
   });
 });
 

--- a/packages/ui/src/lib/viewer-switch.ts
+++ b/packages/ui/src/lib/viewer-switch.ts
@@ -20,6 +20,20 @@ export function matchesHydrationGeneration(
   return eventType === "session_active" || eventType === "agent_end";
 }
 
+/**
+ * Drop events stamped with a different session's ID. Envelopes from older
+ * servers have no sessionId and are accepted (generation/seq guards still
+ * apply). Closes the switch race where old-room events are already in flight
+ * when the viewer switches tabs — including a stale session_active being
+ * accepted as the hydration snapshot.
+ */
+export function matchesViewerSession(
+  activeSessionId: string | null,
+  payloadSessionId?: string,
+): boolean {
+  return payloadSessionId === undefined || payloadSessionId === activeSessionId;
+}
+
 export function isActiveViewerSessionPayload(
   activeSessionId: string | null,
   payloadSessionId: string,


### PR DESCRIPTION
## Problem

Clicking a session tab in the web UI sometimes showed **another session's live updates** — occasionally even the wrong transcript entirely.

## Root cause

Viewer room-broadcast event envelopes were `{ event, seq }` — no `sessionId`, no `generation`. The client trusted Socket.IO room membership alone:

- `matchesViewerGeneration(gen, undefined)` returns `true`, so any in-flight event from the *old* session's room (emitted before the server's `removeViewer()` completed during a switch) was accepted.
- Worse: while `awaitingSnapshot` is true, an untagged `session_active` is explicitly accepted as the hydration snapshot (that path exists for cache-miss recovery). A stale heartbeat `session_active` from the old session could hydrate the new view with the **old session's transcript**.
- The `resync` path (`sendSnapshotToViewer`) also emitted `{ event, seq }` with no generation.

## Fix

- **Server**: stamp `sessionId` on every viewer `event` envelope — room broadcasts (`publishSessionEvent`, `broadcastSessionEventToViewers`), resync snapshots (`sendSnapshotToViewer`), and cold-start fallback emits in `activateSession`.
- **Client**: drop stamped envelopes whose `sessionId` doesn't match the active session, *before* the generation/hydration checks can accept them (`matchesViewerSession` in `viewer-switch.ts`).
- **Protocol**: optional `sessionId` on `ViewerEventEnvelope` + parser.

Backward compatible for partial upgrades: envelopes from older servers have no `sessionId` and are accepted as before (generation + seq guards still apply); older UIs ignore the extra field.

## Testing

- `matchesViewerSession` unit tests (accept unstamped / matching, reject mismatched / no-active-session)
- `parseViewerEventEnvelope` passthrough + malformed-type tests
- Full suites green: protocol (240), ui (1256), server isolated (75), typecheck + build clean
