### PR TITLE
fix: preserve emoji across byte-offset log reads

### DIFF
--- a/packages/cli/src/extensions/background-bash.test.ts
+++ b/packages/cli/src/extensions/background-bash.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds, resetBackgroundBashConfigCache } from "./background-bash.js";
+import { backgroundBashExtension, backgroundPendingJobs, pendingCommands, backgroundAfterSeconds, resetBackgroundBashConfigCache, readFrom } from "./background-bash.js";
 import { sessionJobsFilePath } from "../runner/session-procs.js";
 
 // Keep the auto-background window out of the way unless a test opts in, and
@@ -303,5 +303,31 @@ describe("process tracking and lifecycle", () => {
         await Bun.sleep(300);
         expect(pi.messages.length).toBe(0);
         expect(() => process.kill(pid, 0)).toThrow();
+    });
+});
+
+describe("readFrom UTF-8 boundaries", () => {
+    test("incremental reads never split an emoji", () => {
+        const dir = mkdtempSync(join(tmpdir(), "readfrom-"));
+        const file = join(dir, "log.txt");
+        try {
+            const full = "a🍕b🎉c";
+            const bytes = Buffer.from(full, "utf8");
+            let offset = 0;
+            let text = "";
+            // Write 3 bytes at a time — guarantees mid-emoji boundaries.
+            for (let i = 3; i <= bytes.length; i += 3) {
+                writeFileSync(file, bytes.subarray(0, i));
+                const r = readFrom(file, offset);
+                text += r.text;
+                offset = r.newOffset;
+            }
+            writeFileSync(file, bytes);
+            const last = readFrom(file, offset);
+            text += last.text;
+            expect(text).toBe(full);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/cli/src/extensions/background-bash.ts
+++ b/packages/cli/src/extensions/background-bash.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, openSync, readSync, closeSync, statSync, unlinkSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { createBashToolDefinition } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "../config.js";
@@ -124,8 +125,14 @@ function loadJobs(): void {
     saveJobs();
 }
 
-/** Read a file from `offset` to EOF. */
-function readFrom(path: string, offset: number): { text: string; newOffset: number } {
+/**
+ * Read a file from `offset` to EOF.
+ * Stops at the last complete UTF-8 sequence so an emoji straddling the read
+ * boundary isn't decoded as U+FFFD; the held-back bytes are re-read next call.
+ * ponytail: StringDecoder is stateful but a fresh one per call is enough because
+ * newOffset always lands on a character boundary (offsets start at 0).
+ */
+export function readFrom(path: string, offset: number): { text: string; newOffset: number } {
     let fd: number | undefined;
     try {
         const size = statSync(path).size;
@@ -134,7 +141,8 @@ function readFrom(path: string, offset: number): { text: string; newOffset: numb
         const buf = Buffer.allocUnsafe(len);
         fd = openSync(path, "r");
         readSync(fd, buf, 0, len, offset);
-        return { text: buf.toString("utf8"), newOffset: size };
+        const text = new StringDecoder("utf8").write(buf);
+        return { text, newOffset: offset + Buffer.byteLength(text, "utf8") };
     } catch {
         return { text: "", newOffset: offset };
     } finally {

--- a/packages/cli/src/runner/session-procs.test.ts
+++ b/packages/cli/src/runner/session-procs.test.ts
@@ -6,7 +6,11 @@ import {
     stripCapturePrefix,
     sessionProcFilePath,
     SHELL_PROC_CAPTURE_PREFIX,
+    tailFile,
 } from "./session-procs.js";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 describe("parseRecordedGroupPids", () => {
     test("dedupes and drops garbage", () => {
@@ -84,5 +88,21 @@ describe("sessionProcFilePath", () => {
         const p = sessionProcFilePath("abc/../etc");
         expect(p.endsWith("abc_.._etc.pids")).toBe(true);
         expect(p.includes("/../")).toBe(false);
+    });
+});
+
+describe("tailFile UTF-8 boundaries", () => {
+    test("truncated tail does not emit replacement characters", () => {
+        const dir = mkdtempSync(join(tmpdir(), "tailfile-"));
+        const file = join(dir, "log.txt");
+        try {
+            writeFileSync(file, "x".repeat(10) + "🍕🍕🍕");
+            // maxBytes lands mid-emoji (each 🍕 is 4 bytes)
+            const out = tailFile(file, 10);
+            expect(out).not.toContain("\uFFFD");
+            expect(out).toContain("🍕");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/cli/src/runner/session-procs.ts
+++ b/packages/cli/src/runner/session-procs.ts
@@ -147,7 +147,11 @@ export function tailFile(path: string, maxBytes = 4000): string {
         const buf = Buffer.allocUnsafe(len);
         fd = openSync(path, "r");
         readSync(fd, buf, 0, len, start);
-        return (start > 0 ? `…(truncated, full log at ${path})\n` : "") + buf.toString("utf8");
+        // A byte-offset window can start mid-UTF-8-sequence; drop the leading
+        // continuation bytes so emoji/CJK don't decode as U+FFFD.
+        let from = 0;
+        if (start > 0) while (from < buf.length && (buf[from] & 0xc0) === 0x80) from++;
+        return (start > 0 ? `…(truncated, full log at ${path})\n` : "") + buf.subarray(from).toString("utf8");
     } catch {
         return "";
     } finally {


### PR DESCRIPTION
## Problem

Emoji and other multi-byte UTF-8 (CJK, accented chars) came back as `�` when the agent read background shell output.

Two code paths slice log files at arbitrary **byte** offsets and decode each slice independently, which splits multi-byte sequences:

- `background-bash.ts` `readFrom()` — incremental `bash_output` polls read from the last offset to EOF. If the writer had flushed only part of a 4-byte emoji, that read produced `�` and the next read produced a second `�`.
- `session-procs.ts` `tailFile()` — the "last N bytes" window head can start mid-sequence, corrupting the first character after the truncation notice.

## Fix

- `readFrom()` decodes via `node:string_decoder` and advances `newOffset` only past complete characters, so a held-back partial sequence is re-read on the next poll. A fresh decoder per call is sufficient because offsets always start at 0 and every returned offset lands on a character boundary.
- `tailFile()` skips leading UTF-8 continuation bytes when the window starts mid-sequence.

## Tests

Two new tests, both verified to **fail** against the previous implementation:

- `readFrom UTF-8 boundaries > incremental reads never split an emoji` — writes a file 3 bytes at a time (guaranteeing mid-emoji boundaries) and asserts the concatenated reads reproduce the original string exactly.
- `tailFile UTF-8 boundaries > truncated tail does not emit replacement characters`

`bun test packages/cli/src/runner/session-procs.test.ts packages/cli/src/extensions/background-bash.test.ts` → 29 pass, 0 fail. `bun run typecheck` clean.

## Not included

Grapheme-cluster-aware truncation (ZWJ sequences, flags) in log tails and UI width math — worth adding only if those visibly break.
