### PR TITLE
fix(subagent): reuse parent ModelRuntime so OAuth/subscription providers work

### DIFF
--- a/packages/cli/scripts/e2e-claude-sub-subagent.ts
+++ b/packages/cli/scripts/e2e-claude-sub-subagent.ts
@@ -1,14 +1,14 @@
 /**
  * E2E check: subagent engine works with the claude-subscription provider.
  *
- * Registers the provider directly on a real ModelRegistry (same call the
+ * Registers the provider directly on a real ModelRuntime (same call the
  * minimalcc-pi extension makes), then runs a subagent with an anthropic/*
  * model override — exercising the same-id provider fallback AND shared
- * registry auth. Burns one tiny haiku request.
+ * runtime auth. Burns one tiny haiku request.
  *
  * Run: bun scripts/e2e-claude-sub-subagent.ts
  */
-import { ModelRegistry, AuthStorage } from "@earendil-works/pi-coding-agent";
+import { ModelRuntime, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { runSingleAgent } from "../src/extensions/subagent/engine.js";
@@ -19,8 +19,11 @@ const { MODELS, CLAUDE_SUBSCRIPTION_NATIVE_API_ID } = await import(join(mcc, "sr
 const { streamNativeClaudeSubscription } = await import(join(mcc, "src/native-stream-simple.ts"));
 
 const agentDir = join(homedir(), ".pizzapi");
-const auth = AuthStorage.create(join(agentDir, "auth.json"));
-const registry = ModelRegistry.create(auth, join(agentDir, "models.json"));
+const runtime = await ModelRuntime.create({
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+});
+const registry = new ModelRegistry(runtime);
 
 registry.unregisterProvider("anthropic");
 registry.registerProvider("claude-subscription", {

--- a/packages/cli/src/extensions/subagent/engine.test.ts
+++ b/packages/cli/src/extensions/subagent/engine.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for subagent engine credential sharing.
+ *
+ * Isolated in its own file because it must mock.module the upstream
+ * pi-coding-agent SDK; the project test runner invokes CLI tests per-file.
+ */
+
+import { describe, test, expect, mock } from "bun:test";
+
+// Hermetic: the dev/CI machine may itself run under a PizzaPi worker with
+// PIZZAPI_HIDDEN_MODELS set — that must not leak into these tests.
+delete process.env.PIZZAPI_HIDDEN_MODELS;
+
+const createAgentSessionCalls: unknown[] = [];
+const fakeRuntime = Object.freeze({ id: "parent-runtime" });
+
+mock.module("@earendil-works/pi-coding-agent", () => ({
+    createAgentSession: mock(async (options: unknown) => {
+        createAgentSessionCalls.push(options);
+        return {
+            session: {
+                prompt: mock(async () => {}),
+                subscribe: mock(() => mock(() => {})),
+                abort: mock(async () => {}),
+                dispose: mock(() => {}),
+            },
+        };
+    }),
+    DefaultResourceLoader: class {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        constructor(_options: unknown) {}
+        async reload() {}
+    },
+    createCodingTools: mock(() => [{ name: "read" }] as unknown[]),
+    createReadOnlyTools: mock(() => [{ name: "read" }] as unknown[]),
+}));
+
+import { runSingleAgent } from "./engine.js";
+
+const noopAgent = {
+    name: "noop",
+    description: "noop agent",
+    tools: ["read"],
+    systemPrompt: "",
+    source: "user" as const,
+    filePath: "noop.md",
+};
+
+describe("runSingleAgent model runtime reuse", () => {
+    test("passes the parent's live ModelRuntime so OAuth/subscription providers work", async () => {
+        const registry: any = {
+            find: () => undefined,
+            getAvailable: () => [],
+            getApiKeyForProvider: mock(async () => "key"),
+            runtime: fakeRuntime,
+        };
+
+        const result = await runSingleAgent(
+            process.cwd(),
+            [noopAgent],
+            "noop",
+            "task",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (r) => ({ mode: "single", results: r }) as any,
+            undefined,
+            registry,
+        );
+
+        expect(result.exitCode).toBe(0);
+        const options = createAgentSessionCalls[createAgentSessionCalls.length - 1] as any;
+        expect(options.modelRuntime).toBe(fakeRuntime);
+    });
+
+    test("falls back to a fresh runtime when the registry has no runtime", async () => {
+        const registry: any = {
+            find: () => undefined,
+            getAvailable: () => [],
+            getApiKeyForProvider: mock(async () => "key"),
+        };
+
+        const result = await runSingleAgent(
+            process.cwd(),
+            [noopAgent],
+            "noop",
+            "task",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (r) => ({ mode: "single", results: r }) as any,
+            undefined,
+            registry,
+        );
+
+        expect(result.exitCode).toBe(0);
+        const options = createAgentSessionCalls[createAgentSessionCalls.length - 1] as any;
+        expect(options.modelRuntime).toBeUndefined();
+    });
+
+    test("does not pass modelRuntime for a narrow test-only registry", async () => {
+        const registry: any = {
+            find: () => undefined,
+            getAvailable: () => [],
+        };
+
+        const result = await runSingleAgent(
+            process.cwd(),
+            [noopAgent],
+            "noop",
+            "task",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (r) => ({ mode: "single", results: r }) as any,
+            undefined,
+            registry,
+        );
+
+        expect(result.exitCode).toBe(0);
+        const options = createAgentSessionCalls[createAgentSessionCalls.length - 1] as any;
+        expect(options.modelRuntime).toBeUndefined();
+    });
+});

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -5,15 +5,15 @@
  * and the core single-agent runner (createAgentSession + session.prompt).
  */
 
-import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import type { AgentConfig } from "../subagent-agents.js";
+import type { Model, AssistantMessage, Message } from "@earendil-works/pi-ai";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import {
     createAgentSession,
     DefaultResourceLoader,
     createCodingTools,
     createReadOnlyTools,
 } from "@earendil-works/pi-coding-agent";
-import type { AgentConfig } from "../subagent-agents.js";
-import type { Model } from "@earendil-works/pi-ai";
 import { defaultAgentDir } from "../../config.js";
 import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
 import { isModelHidden } from "../../hidden-models.js";
@@ -126,10 +126,18 @@ export interface ModelRegistryLike {
 
 /**
  * True when the registry is a real ModelRegistry (safe to hand to
- * createAgentSession for API-key resolution), not a narrow test mock.
+ * createAgentSession for auth resolution), not a narrow test mock.
  */
 function isFullModelRegistry(registry: ModelRegistryLike): registry is ModelRegistryLike & import("@earendil-works/pi-coding-agent").ModelRegistry {
     return typeof (registry as { getApiKeyForProvider?: unknown }).getApiKeyForProvider === "function";
+}
+
+/** Extract the live ModelRuntime from a real ModelRegistry facade. */
+function getModelRuntime(registry: ModelRegistryLike): ModelRuntime | undefined {
+    if (!isFullModelRegistry(registry)) return undefined;
+    // The upstream ModelRegistry class wraps a private `runtime` field;
+    // at runtime it is an ordinary public property on the compiled class.
+    return (registry as unknown as { runtime?: ModelRuntime }).runtime;
 }
 
 /**
@@ -322,11 +330,11 @@ export async function runSingleAgent(
             tools,
             resourceLoader: loader,
             ...(resolvedModel && { model: resolvedModel }),
-            // Share the parent's model registry so extension-registered
-            // providers (e.g. claude-subscription, ollama-cloud) resolve with
-            // their API keys — the subagent session skips extensions, so a
-            // fresh registry would fail with "No API key found".
-            ...(modelRegistry && isFullModelRegistry(modelRegistry) && { modelRegistry }),
+            // Reuse the parent's live ModelRuntime so OAuth/subscription
+            // providers (which keep tokens in memory, not in auth.json) work.
+            // createAgentSession reads credentials from modelRuntime; the
+            // modelRegistry facade alone is ignored by the SDK.
+            ...(modelRegistry && { modelRuntime: getModelRuntime(modelRegistry) }),
         });
         if (signal?.aborted) {
             session.dispose();


### PR DESCRIPTION
## Problem

The `subagent` tool failed for OAuth/subscription-backed providers with:

```
No API key found for claude-subscription.
```

## Root cause

The subagent engine passed `ctx.modelRegistry` to `createAgentSession`, but the SDK only accepts `modelRuntime`. This caused subagents to silently create a fresh runtime from `auth.json`, which works for API-key providers but lacks the in-memory OAuth token that subscription providers keep in the parent session's runtime.

## Fix

Extract the live `ModelRuntime` from the parent's `ModelRegistry` facade and pass it to `createAgentSession`. Any provider the parent session can authenticate is now available to in-process subagents.

## Changes

- `packages/cli/src/extensions/subagent/engine.ts`: reuse parent `ModelRuntime` via new `getModelRuntime()` helper
- `packages/cli/src/extensions/subagent/engine.test.ts`: regression tests for runtime reuse, fallback, and narrow registries
- `packages/cli/scripts/e2e-claude-sub-subagent.ts`: update to build a real `ModelRuntime`/`ModelRegistry`

## Verification

- `bun run typecheck` clean
- Subagent test suite passes: `engine.test.ts`, `index.test.ts`, `subagent.test.ts`, `subagent-background.test.ts`
