### PR TITLE
feat: visible subagent sessions, /skills reload, /plugin marketplace

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -8,6 +8,8 @@ import { buildPizzaPiExtensionFactories } from "./factories.js";
 import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
 import { restartExtension } from "./restart.js";
+import { reloadResourcesExtension } from "./reload-resources.js";
+import { pluginCommandExtension } from "./plugin-command.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
 import { currentTimeExtension } from "./current-time.js";
@@ -59,6 +61,8 @@ const CORE_EXTENSIONS_HEAD: ExtensionFactory[] = [
 const CORE_EXTENSIONS_TAIL: ExtensionFactory[] = [
     goalExtension,
     restartExtension,
+    reloadResourcesExtension,
+    pluginCommandExtension,
     sessionProcessesExtension,
     setSessionNameExtension,
     currentTimeExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -5,6 +5,8 @@ import { initialPromptExtension } from "./initial-prompt.js";
 import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
 import { restartExtension } from "./restart.js";
+import { reloadResourcesExtension } from "./reload-resources.js";
+import { pluginCommandExtension } from "./plugin-command.js";
 import { sessionProcessesExtension } from "./session-processes.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
@@ -123,6 +125,8 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     factories.push(
         named(goalExtension, "goal"),
         named(restartExtension, "restart"),
+        named(reloadResourcesExtension, "reload-resources"),
+        named(pluginCommandExtension, "plugin-command"),
         named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
         named(currentTimeExtension, "current-time"),

--- a/packages/cli/src/extensions/plugin-command.test.ts
+++ b/packages/cli/src/extensions/plugin-command.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPluginCommand, pluginCommandExtension } from "./plugin-command.js";
+
+let home: string;
+let originalHome: string | undefined;
+let sourceRepo: string;
+
+beforeEach(() => {
+    originalHome = process.env.HOME;
+    home = mkdtempSync(join(tmpdir(), "pizzapi-plugin-cmd-"));
+    process.env.HOME = home;
+
+    sourceRepo = mkdtempSync(join(tmpdir(), "pizzapi-plugin-src-"));
+    mkdirSync(join(sourceRepo, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+        join(sourceRepo, ".claude-plugin", "marketplace.json"),
+        JSON.stringify({ name: "demo", plugins: [{ name: "demo-plugin", description: "A demo" }] }),
+    );
+    const pluginDir = join(sourceRepo, "plugins", "demo-plugin");
+    mkdirSync(join(pluginDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(pluginDir, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "demo-plugin" }));
+});
+
+afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(sourceRepo, { recursive: true, force: true });
+});
+
+describe("runPluginCommand", () => {
+    test("bare /plugin lists an empty state", () => {
+        const { output, changed } = runPluginCommand([]);
+        expect(changed).toBe(false);
+        expect(output).toContain("No marketplaces");
+        expect(output).toContain("No plugins installed");
+    });
+
+    test("marketplace add registers and reports the catalog", () => {
+        const { output, changed } = runPluginCommand(["marketplace", "add", sourceRepo]);
+        expect(changed).toBe(true);
+        expect(output).toContain("Added marketplace");
+        expect(output).toContain("demo-plugin");
+    });
+
+    test("install → enable/disable → uninstall round trip", () => {
+        runPluginCommand(["marketplace", "add", sourceRepo]);
+
+        const install = runPluginCommand(["install", "demo-plugin"]);
+        expect(install.changed).toBe(true);
+        expect(install.output).toContain("Installed demo-plugin@");
+
+        expect(runPluginCommand([]).output).toContain("demo-plugin@");
+
+        const disabled = runPluginCommand(["disable", "demo-plugin"]);
+        expect(disabled.output).toContain("Disabled demo-plugin@");
+        expect(runPluginCommand([]).output).toContain("(disabled)");
+
+        expect(runPluginCommand(["enable", "demo-plugin"]).output).toContain("Enabled demo-plugin@");
+
+        const removed = runPluginCommand(["uninstall", "demo-plugin"]);
+        expect(removed.changed).toBe(true);
+        expect(removed.output).toContain("Uninstalled");
+    });
+
+    test("marketplace remove reports unknown names without changing state", () => {
+        const { output, changed } = runPluginCommand(["marketplace", "remove", "ghost"]);
+        expect(changed).toBe(false);
+        expect(output).toContain("Unknown marketplace");
+    });
+
+    test("missing arguments print usage instead of throwing", () => {
+        expect(runPluginCommand(["marketplace", "add"]).output).toContain("Usage:");
+        expect(runPluginCommand(["install"]).output).toContain("Usage:");
+        expect(runPluginCommand(["enable"]).output).toContain("Usage:");
+        expect(runPluginCommand(["bogus"]).output).toContain("Usage:");
+    });
+
+    test("marketplace show lists plugins with install marks", () => {
+        runPluginCommand(["marketplace", "add", sourceRepo]);
+        runPluginCommand(["install", "demo-plugin@demo"]);
+        const { output } = runPluginCommand(["marketplace", "show", "demo"]);
+        expect(output).toContain("✓ demo-plugin");
+    });
+});
+
+describe("pluginCommandExtension", () => {
+    function install() {
+        const commands = new Map<string, any>();
+        pluginCommandExtension({ registerCommand: (n: string, d: any) => commands.set(n, d) } as any);
+        return commands;
+    }
+
+    test("registers /plugin", () => {
+        expect(install().has("plugin")).toBe(true);
+    });
+
+    test("reloads resources only after a mutating subcommand", async () => {
+        const cmd = install().get("plugin");
+        let reloads = 0;
+        const ctx = { reload: async () => { reloads++; }, ui: { notify: () => {} } };
+
+        await cmd.handler("", ctx);
+        expect(reloads).toBe(0);
+
+        await cmd.handler(`marketplace add ${sourceRepo}`, ctx);
+        expect(reloads).toBe(1);
+    });
+
+    test("surfaces failures as a notice instead of throwing", async () => {
+        const cmd = install().get("plugin");
+        const notices: string[] = [];
+        await cmd.handler("marketplace add not-a-real-source", {
+            reload: async () => {},
+            ui: { notify: (m: string) => notices.push(m) },
+        });
+        expect(notices.join()).toContain("failed");
+    });
+
+    test("completions offer subcommands and marketplace actions", () => {
+        const cmd = install().get("plugin");
+        expect(cmd.getArgumentCompletions("")?.some((o: any) => o.value === "marketplace")).toBe(true);
+        expect(cmd.getArgumentCompletions("inst")?.[0].value).toBe("install");
+        expect(cmd.getArgumentCompletions("marketplace ")?.some((o: any) => o.label === "add")).toBe(true);
+        expect(cmd.getArgumentCompletions("zzz")).toBeNull();
+    });
+
+    test("plugin-name completions include catalog entries", () => {
+        runPluginCommand(["marketplace", "add", sourceRepo]);
+        const cmd = install().get("plugin");
+        const options = cmd.getArgumentCompletions("install demo");
+        expect(options?.[0].label).toBe("demo-plugin@demo");
+    });
+});

--- a/packages/cli/src/extensions/plugin-command.ts
+++ b/packages/cli/src/extensions/plugin-command.ts
@@ -1,0 +1,193 @@
+/**
+ * `/plugin` — Claude Code marketplace management from inside a session.
+ *
+ *   /plugin                              List marketplaces and installed plugins
+ *   /plugin marketplace add <source>     Add a marketplace (owner/repo, git URL, local path)
+ *   /plugin marketplace list
+ *   /plugin marketplace remove <name>
+ *   /plugin install <name[@marketplace]>
+ *   /plugin uninstall <name[@marketplace]>
+ *   /plugin enable|disable <name[@marketplace]>
+ *
+ * Mutations reload session resources so newly installed commands/skills are
+ * usable immediately. State lives in Claude Code's own files (see marketplace.ts).
+ */
+
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import {
+    addMarketplace,
+    installPlugin,
+    listInstalledPlugins,
+    listMarketplaces,
+    readMarketplaceCatalog,
+    removeMarketplace,
+    resolvePluginKey,
+    setPluginEnabled,
+    uninstallPlugin,
+} from "../plugins/marketplace.js";
+
+const USAGE = [
+    "Usage:",
+    "  /plugin marketplace add <owner/repo | git-url | path>",
+    "  /plugin marketplace list",
+    "  /plugin marketplace remove <name>",
+    "  /plugin install <name[@marketplace]>",
+    "  /plugin uninstall <name[@marketplace]>",
+    "  /plugin enable|disable <name[@marketplace]>",
+].join("\n");
+
+function formatOverview(): string {
+    const markets = listMarketplaces();
+    const installed = listInstalledPlugins();
+    const lines: string[] = [];
+
+    const names = Object.keys(markets);
+    lines.push(names.length ? `Marketplaces (${names.length}):` : "No marketplaces. Add one with /plugin marketplace add <source>");
+    for (const name of names) {
+        const count = readMarketplaceCatalog(name)?.plugins.length ?? 0;
+        lines.push(`  ${name} — ${count} plugin${count === 1 ? "" : "s"}`);
+    }
+
+    lines.push("");
+    lines.push(installed.length ? `Installed plugins (${installed.length}):` : "No plugins installed.");
+    for (const p of installed) {
+        lines.push(`  ${p.key}${p.enabled ? "" : "  (disabled)"}`);
+    }
+    return lines.join("\n");
+}
+
+function formatCatalog(name: string): string {
+    const catalog = readMarketplaceCatalog(name);
+    if (!catalog) return `Unknown marketplace: ${name}`;
+    const installed = new Set(listInstalledPlugins().map((p) => p.key));
+    const lines = [`${catalog.name} — ${catalog.plugins.length} plugin${catalog.plugins.length === 1 ? "" : "s"}`];
+    for (const p of catalog.plugins) {
+        const mark = installed.has(`${p.name}@${name}`) ? "✓ " : "  ";
+        lines.push(`${mark}${p.name}${p.description ? ` — ${p.description.split("\n")[0].slice(0, 80)}` : ""}`);
+    }
+    return lines.join("\n");
+}
+
+/** Run one `/plugin` invocation. Returns the text to show the user. */
+export function runPluginCommand(args: string[]): { output: string; changed: boolean } {
+    const [sub, ...rest] = args;
+
+    if (!sub) return { output: formatOverview(), changed: false };
+
+    if (sub === "marketplace" || sub === "marketplaces") {
+        const action = rest[0];
+        const target = rest.slice(1).join(" ").trim();
+
+        if (!action || action === "list") return { output: formatOverview(), changed: false };
+
+        if (action === "add") {
+            if (!target) return { output: "Usage: /plugin marketplace add <owner/repo | git-url | path>", changed: false };
+            const result = addMarketplace(target);
+            return {
+                output: `Added marketplace "${result.name}" (${result.pluginCount} plugins)\n\n${formatCatalog(result.name)}`,
+                changed: true,
+            };
+        }
+
+        if (action === "remove" || action === "rm") {
+            if (!target) return { output: "Usage: /plugin marketplace remove <name>", changed: false };
+            const removed = removeMarketplace(target);
+            return { output: removed ? `Removed marketplace "${target}"` : `Unknown marketplace: ${target}`, changed: removed };
+        }
+
+        if (action === "show" || action === "plugins") {
+            if (!target) return { output: "Usage: /plugin marketplace show <name>", changed: false };
+            return { output: formatCatalog(target), changed: false };
+        }
+
+        return { output: USAGE, changed: false };
+    }
+
+    const target = rest.join(" ").trim();
+
+    if (sub === "install" || sub === "add") {
+        if (!target) return { output: "Usage: /plugin install <name[@marketplace]>", changed: false };
+        const result = installPlugin(target);
+        return { output: `Installed ${result.plugin}@${result.marketplace} → ${result.installPath}`, changed: true };
+    }
+
+    if (sub === "uninstall" || sub === "remove" || sub === "rm") {
+        if (!target) return { output: "Usage: /plugin uninstall <name[@marketplace]>", changed: false };
+        const removed = uninstallPlugin(target);
+        return { output: removed ? `Uninstalled ${target}` : `Not installed: ${target}`, changed: removed };
+    }
+
+    if (sub === "enable" || sub === "disable") {
+        if (!target) return { output: `Usage: /plugin ${sub} <name[@marketplace]>`, changed: false };
+        const key = resolvePluginKey(target);
+        setPluginEnabled(key, sub === "enable");
+        return { output: `${sub === "enable" ? "Enabled" : "Disabled"} ${key}`, changed: true };
+    }
+
+    if (sub === "list") return { output: formatOverview(), changed: false };
+
+    return { output: USAGE, changed: false };
+}
+
+const SUBCOMMANDS = [
+    { value: "marketplace", label: "marketplace", description: "Add, list, or remove marketplaces" },
+    { value: "install", label: "install", description: "Install a plugin from a marketplace" },
+    { value: "uninstall", label: "uninstall", description: "Remove an installed plugin" },
+    { value: "enable", label: "enable", description: "Enable an installed plugin" },
+    { value: "disable", label: "disable", description: "Disable an installed plugin" },
+    { value: "list", label: "list", description: "List marketplaces and installed plugins" },
+];
+
+export const pluginCommandExtension: ExtensionFactory = (pi) => {
+    pi.registerCommand("plugin", {
+        description: "Manage Claude Code plugin marketplaces: marketplace add/list/remove, install, uninstall, enable, disable",
+        getArgumentCompletions: (prefix: string) => {
+            const parts = prefix.trimStart().split(/\s+/);
+            if (parts.length <= 1) {
+                const p = (parts[0] ?? "").toLowerCase();
+                const filtered = p ? SUBCOMMANDS.filter((o) => o.value.startsWith(p)) : SUBCOMMANDS;
+                return filtered.length ? filtered : null;
+            }
+            if (parts[0] === "marketplace" && parts.length === 2) {
+                const actions = [
+                    { value: "marketplace add", label: "add", description: "Add a marketplace" },
+                    { value: "marketplace list", label: "list", description: "List marketplaces" },
+                    { value: "marketplace remove", label: "remove", description: "Remove a marketplace" },
+                    { value: "marketplace show", label: "show", description: "Show a marketplace's plugins" },
+                ];
+                const p = parts[1].toLowerCase();
+                const filtered = p ? actions.filter((o) => o.label.startsWith(p)) : actions;
+                return filtered.length ? filtered : null;
+            }
+            // Plugin-name position — offer installed plugins and catalog entries.
+            if (["install", "uninstall", "enable", "disable"].includes(parts[0]) && parts.length === 2) {
+                const p = parts[1].toLowerCase();
+                const keys = new Set(listInstalledPlugins().map((x) => x.key));
+                for (const market of Object.keys(listMarketplaces())) {
+                    for (const entry of readMarketplaceCatalog(market)?.plugins ?? []) {
+                        keys.add(`${entry.name}@${market}`);
+                    }
+                }
+                const options = [...keys]
+                    .filter((k) => !p || k.toLowerCase().startsWith(p))
+                    .slice(0, 50)
+                    .map((k) => ({ value: `${parts[0]} ${k}`, label: k }));
+                return options.length ? options : null;
+            }
+            return null;
+        },
+        handler: async (rawArgs: string, ctx: any) => {
+            const args = (rawArgs ?? "").trim().split(/\s+/).filter(Boolean);
+            let result: { output: string; changed: boolean };
+            try {
+                result = runPluginCommand(args);
+            } catch (err) {
+                ctx?.ui?.notify?.(`/plugin failed: ${err instanceof Error ? err.message : String(err)}`);
+                return;
+            }
+            ctx?.ui?.notify?.(result.output);
+            // Pick up newly installed commands, skills, and hooks right away.
+            if (result.changed) await ctx.reload();
+        },
+    });
+};

--- a/packages/cli/src/extensions/reload-resources.test.ts
+++ b/packages/cli/src/extensions/reload-resources.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "bun:test";
+import { reloadResourcesExtension } from "./reload-resources.js";
+
+function install() {
+    const commands = new Map<string, any>();
+    const pi: any = {
+        registerCommand: (name: string, def: any) => commands.set(name, def),
+        on: () => {},
+    };
+    reloadResourcesExtension(pi);
+    return commands;
+}
+
+describe("reloadResourcesExtension", () => {
+    test("registers /skills", () => {
+        expect(install().has("skills")).toBe(true);
+    });
+
+    test("reload subcommand (and bare /skills) calls ctx.reload()", async () => {
+        const cmd = install().get("skills");
+        let reloads = 0;
+        const ctx = { reload: async () => { reloads++; }, ui: { notify: () => {} } };
+
+        await cmd.handler("", ctx);
+        await cmd.handler("reload", ctx);
+        expect(reloads).toBe(2);
+    });
+
+    test("unknown subcommand does not reload", async () => {
+        const cmd = install().get("skills");
+        let reloads = 0;
+        const notices: string[] = [];
+        await cmd.handler("wat", { reload: async () => { reloads++; }, ui: { notify: (m: string) => notices.push(m) } });
+        expect(reloads).toBe(0);
+        expect(notices.join()).toContain("Usage");
+    });
+
+    test("reload failures are reported, not thrown", async () => {
+        const cmd = install().get("skills");
+        const notices: string[] = [];
+        await cmd.handler("reload", {
+            reload: async () => { throw new Error("boom"); },
+            ui: { notify: (m: string) => notices.push(m) },
+        });
+        expect(notices.some((n) => n.includes("boom"))).toBe(true);
+    });
+
+    test("argument completions offer reload", () => {
+        const cmd = install().get("skills");
+        expect(cmd.getArgumentCompletions("re")?.[0].value).toBe("reload");
+        expect(cmd.getArgumentCompletions("zzz")).toBeNull();
+    });
+});

--- a/packages/cli/src/extensions/reload-resources.ts
+++ b/packages/cli/src/extensions/reload-resources.ts
@@ -1,0 +1,44 @@
+/**
+ * `/skills reload` — re-read skills from disk without restarting the session.
+ *
+ * pi's `ctx.reload()` re-reads extensions, skills, prompt templates, themes and
+ * context files, so a newly written skill becomes usable immediately. The web
+ * UI's Reload button reaches this by delivering the slash command as session
+ * input (see POST /api/runners/:id/skills/reload) — `reload` only exists on a
+ * command context, and pi invalidates that context once reload completes, so
+ * there is nothing safe to cache for out-of-band callers.
+ */
+
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("reload");
+
+export const reloadResourcesExtension: ExtensionFactory = (pi) => {
+    pi.registerCommand("skills", {
+        description: "Reload skills (and other resources) from disk without restarting the session",
+        getArgumentCompletions: (prefix: string) => {
+            const options = [{ value: "reload", label: "reload", description: "Re-scan skill directories" }];
+            const p = prefix.trim().toLowerCase();
+            const filtered = p ? options.filter((o) => o.value.startsWith(p)) : options;
+            return filtered.length ? filtered : null;
+        },
+        handler: async (args: string, ctx: any) => {
+            const sub = (args ?? "").trim().split(/\s+/)[0] || "reload";
+            if (sub !== "reload") {
+                ctx?.ui?.notify?.("Usage: /skills reload");
+                return;
+            }
+            // Notify first: reload() invalidates this ctx, so afterwards there
+            // is no ui handle left to report success through.
+            ctx?.ui?.notify?.("Reloading skills…");
+            try {
+                await ctx.reload();
+                log.info("skills reloaded");
+            } catch (err) {
+                log.error("skills reload failed:", err);
+                ctx?.ui?.notify?.(`Skills reload failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        },
+    });
+};

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -19,6 +19,7 @@ import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
 import { isModelHidden } from "../../hidden-models.js";
 import type { SingleResult, SubagentDetails, OnUpdateCallback } from "./types.js";
 import { getFinalOutput, summarizeResultForStreaming } from "./types.js";
+import { createSubagentMirror, type SubagentMirror } from "./relay-mirror.js";
 
 // ── Built-in tool registry ─────────────────────────────────────────────
 
@@ -249,7 +250,12 @@ export async function runSingleAgent(
         step,
     };
 
+    // Mirror the run as an ephemeral relay child session so it shows up in the
+    // sidebar next to spawn_session children. Null when the relay is off.
+    let mirror: SubagentMirror | null = null;
+
     const emitUpdate = () => {
+        mirror?.update(currentResult);
         if (onUpdate) {
             const summary = summarizeResultForStreaming(currentResult);
             onUpdate({
@@ -268,6 +274,7 @@ export async function runSingleAgent(
 
         // Build session options — resolve tools fail-closed
         const sessionCwd = cwd ?? defaultCwd;
+        mirror = createSubagentMirror({ agentName, task, cwd: sessionCwd, step });
         let tools: string[];
         if (isPlanMode) {
             // Plan mode: restrict to read-only tools regardless of agent config
@@ -412,5 +419,9 @@ export async function runSingleAgent(
         currentResult.exitCode = 1;
         currentResult.stderr += `\nFailed to create subagent session: ${err instanceof Error ? err.message : String(err)}`;
         return currentResult;
+    } finally {
+        // Covers every exit path after the mirror exists: success, failure,
+        // and the abort re-throw.
+        mirror?.finish(currentResult);
     }
 }

--- a/packages/cli/src/extensions/subagent/relay-mirror.test.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect } from "bun:test";
+import { createSubagentMirror, resolveSocketIoUrl, readMirrorEnv, type MirrorEnv } from "./relay-mirror.js";
+import type { SingleResult } from "./types.js";
+
+// ── Fake socket ───────────────────────────────────────────────────────────────
+
+interface Emitted {
+    event: string;
+    payload: any;
+}
+
+function makeFakeSocket() {
+    const handlers = new Map<string, (arg?: any) => void>();
+    const emitted: Emitted[] = [];
+    let disconnected = false;
+    return {
+        emitted,
+        get disconnected() {
+            return disconnected;
+        },
+        fire(event: string, arg?: any) {
+            handlers.get(event)?.(arg);
+        },
+        socket: {
+            on(event: string, cb: (arg?: any) => void) {
+                handlers.set(event, cb);
+            },
+            emit(event: string, payload: any) {
+                emitted.push({ event, payload });
+            },
+            disconnect() {
+                disconnected = true;
+            },
+            removeAllListeners() {
+                handlers.clear();
+            },
+        },
+    };
+}
+
+const ENV: MirrorEnv = {
+    apiKey: "key-123",
+    relayUrl: "wss://relay.example",
+    parentSessionId: "parent-session",
+};
+
+function result(overrides: Partial<SingleResult> = {}): SingleResult {
+    return {
+        agent: "researcher",
+        agentSource: "user",
+        task: "look into the thing",
+        exitCode: -1,
+        messages: [],
+        stderr: "",
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+        ...overrides,
+    } as SingleResult;
+}
+
+// ── URL resolution ────────────────────────────────────────────────────────────
+
+describe("resolveSocketIoUrl", () => {
+    test("converts ws/wss to http/https and strips trailing slash", () => {
+        expect(resolveSocketIoUrl({ relayUrl: "wss://relay.example/" })).toBe("https://relay.example");
+        expect(resolveSocketIoUrl({ relayUrl: "ws://localhost:4000" })).toBe("http://localhost:4000");
+    });
+
+    test("explicit socket.io url wins", () => {
+        expect(resolveSocketIoUrl({ relayUrl: "wss://a", socketIoUrl: "https://b/" })).toBe("https://b");
+    });
+
+    test("returns null when unset or disabled", () => {
+        expect(resolveSocketIoUrl({})).toBeNull();
+        expect(resolveSocketIoUrl({ relayUrl: "off" })).toBeNull();
+        expect(resolveSocketIoUrl({ relayUrl: "OFF" })).toBeNull();
+    });
+});
+
+describe("readMirrorEnv", () => {
+    test("reads relay settings from the environment", () => {
+        const env = readMirrorEnv({
+            PIZZAPI_API_KEY: "k",
+            PIZZAPI_RELAY_URL: "wss://r",
+            PIZZAPI_SESSION_ID: "s",
+        } as unknown as NodeJS.ProcessEnv);
+        expect(env).toEqual({ apiKey: "k", relayUrl: "wss://r", socketIoUrl: undefined, parentSessionId: "s" });
+    });
+});
+
+// ── Mirror lifecycle ──────────────────────────────────────────────────────────
+
+describe("createSubagentMirror", () => {
+    test("returns null when the relay is not configured", () => {
+        expect(createSubagentMirror({ agentName: "a", task: "t", cwd: "/tmp", env: {} })).toBeNull();
+        expect(
+            createSubagentMirror({ agentName: "a", task: "t", cwd: "/tmp", env: { ...ENV, apiKey: undefined } }),
+        ).toBeNull();
+        expect(
+            createSubagentMirror({ agentName: "a", task: "t", cwd: "/tmp", env: { ...ENV, parentSessionId: undefined } }),
+        ).toBeNull();
+        expect(
+            createSubagentMirror({ agentName: "a", task: "t", cwd: "/tmp", env: { ...ENV, relayUrl: "off" } }),
+        ).toBeNull();
+    });
+
+    test("registers as a child session with parentSessionId on connect", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "researcher",
+            task: "look into the thing",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        expect(mirror).not.toBeNull();
+
+        fake.fire("connect");
+        const register = fake.emitted.find((e) => e.event === "register");
+        expect(register).toBeDefined();
+        expect(register!.payload.parentSessionId).toBe("parent-session");
+        expect(register!.payload.sessionId).toBe(mirror.sessionId);
+        expect(register!.payload.ephemeral).toBe(true);
+        expect(register!.payload.cwd).toBe("/repo");
+        expect(register!.payload.sessionName).toBe("researcher: look into the thing");
+    });
+
+    test("buffers updates until registered, then emits a snapshot", () => {
+        const fake = makeFakeSocket();
+        let clock = 1000;
+        const mirror = createSubagentMirror({
+            agentName: "researcher",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+            now: () => clock,
+        })!;
+
+        fake.fire("connect");
+        mirror.update(result({ messages: [{ role: "assistant" } as any] }));
+        // No token yet — nothing forwarded.
+        expect(fake.emitted.some((e) => e.event === "event")).toBe(false);
+
+        fake.fire("registered", { token: "tok" });
+        const events = fake.emitted.filter((e) => e.event === "event");
+        expect(events.length).toBe(2); // session_active + heartbeat
+        expect(events[0].payload.token).toBe("tok");
+        expect(events[0].payload.event.type).toBe("session_active");
+        expect(events[0].payload.event.state.messages.length).toBe(1);
+        expect(events[1].payload.event).toMatchObject({ type: "heartbeat", active: true });
+    });
+
+    test("throttles snapshots within the window", () => {
+        const fake = makeFakeSocket();
+        let clock = 1000;
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+            now: () => clock,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.update(result());
+        const afterFirst = fake.emitted.filter((e) => e.event === "event").length;
+        mirror.update(result());
+        expect(fake.emitted.filter((e) => e.event === "event").length).toBe(afterFirst);
+
+        clock += 2000;
+        mirror.update(result());
+        expect(fake.emitted.filter((e) => e.event === "event").length).toBeGreaterThan(afterFirst);
+    });
+
+    test("finish emits a final snapshot, ends the session, and disconnects", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.finish(result({ exitCode: 0, model: "claude-haiku-4-5" }));
+
+        const heartbeats = fake.emitted.filter((e) => e.event === "event" && e.payload.event.type === "heartbeat");
+        expect(heartbeats.at(-1)!.payload.event.active).toBe(false);
+        expect(fake.emitted.some((e) => e.event === "session_end")).toBe(true);
+        expect(fake.disconnected).toBe(true);
+
+        // Post-finish calls are inert.
+        const count = fake.emitted.length;
+        mirror.update(result());
+        mirror.finish(result());
+        expect(fake.emitted.length).toBe(count);
+    });
+
+    test("caps the mirrored transcript", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        const messages = Array.from({ length: 500 }, (_, i) => ({ role: "assistant", i })) as any[];
+        mirror.finish(result({ messages }));
+
+        const active = fake.emitted.find((e) => e.event === "event" && e.payload.event.type === "session_active")!;
+        expect(active.payload.event.state.messages.length).toBe(200);
+        expect(active.payload.event.state.messages[0].i).toBe(300);
+    });
+
+    test("truncates long tasks in the session name and labels chain steps", () => {
+        const fake = makeFakeSocket();
+        createSubagentMirror({
+            agentName: "coder",
+            task: "x".repeat(100),
+            cwd: "/repo",
+            step: 2,
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        const name = fake.emitted.find((e) => e.event === "register")!.payload.sessionName as string;
+        expect(name.startsWith("coder #3: ")).toBe(true);
+        expect(name.endsWith("…")).toBe(true);
+    });
+});

--- a/packages/cli/src/extensions/subagent/relay-mirror.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.ts
@@ -1,0 +1,259 @@
+/**
+ * Relay mirror for in-process subagents.
+ *
+ * Subagents run inside the parent worker (createAgentSession), so they never
+ * register with the relay and only ever surfaced as an inline tool card. This
+ * module registers each run as an ephemeral child session on the /relay
+ * namespace — `parentSessionId` = the parent worker's session — which is the
+ * exact same mechanism spawn_session children use. The web UI then nests them
+ * in the sidebar tree and renders their transcript with no UI changes.
+ *
+ * Fire-and-forget: if the relay isn't configured (local TUI, no API key,
+ * PIZZAPI_RELAY_URL=off) `createSubagentMirror` returns null and the subagent
+ * runs exactly as before.
+ */
+
+import { randomUUID } from "node:crypto";
+import { io, type Socket } from "socket.io-client";
+import { SOCKET_PROTOCOL_VERSION } from "@pizzapi/protocol";
+import { createLogger } from "@pizzapi/tools";
+import type { SingleResult } from "./types.js";
+
+const log = createLogger("subagent-mirror");
+
+/** Minimum gap between session_active snapshots, in ms. */
+const SNAPSHOT_THROTTLE_MS = 1_000;
+
+/** Newest-N transcript cap, so a runaway subagent can't blow up the socket.
+ *  ponytail: flat cap, switch to the chunked-delivery path if it ever bites. */
+const MAX_MIRRORED_MESSAGES = 200;
+
+export interface SubagentMirror {
+    /** Relay session id of the mirrored child (exposed for tests/telemetry). */
+    readonly sessionId: string;
+    /** Push a transcript snapshot (throttled). */
+    update(result: SingleResult): void;
+    /** Push a final snapshot, end the relay session, and disconnect. */
+    finish(result: SingleResult): void;
+}
+
+export interface MirrorEnv {
+    apiKey?: string;
+    relayUrl?: string;
+    socketIoUrl?: string;
+    parentSessionId?: string;
+}
+
+/** Read relay connection settings from the worker's environment. */
+export function readMirrorEnv(env: NodeJS.ProcessEnv = process.env): MirrorEnv {
+    return {
+        apiKey: env.PIZZAPI_API_KEY ?? env.PIZZAPI_API_TOKEN,
+        relayUrl: env.PIZZAPI_RELAY_URL,
+        socketIoUrl: env.PIZZAPI_SOCKETIO_URL,
+        parentSessionId: env.PIZZAPI_SESSION_ID,
+    };
+}
+
+/**
+ * Resolve the Socket.IO base URL (http/https) for the relay, or null when the
+ * relay is unavailable or explicitly disabled.
+ */
+export function resolveSocketIoUrl(env: MirrorEnv): string | null {
+    if (env.socketIoUrl?.trim()) return env.socketIoUrl.trim().replace(/\/$/, "");
+    const configured = env.relayUrl?.trim();
+    if (!configured || configured.toLowerCase() === "off") return null;
+    return configured
+        .replace(/^ws:/, "http:")
+        .replace(/^wss:/, "https:")
+        .replace(/\/$/, "");
+}
+
+/** The slice of a Socket.IO client this module uses. */
+export interface MirrorSocket {
+    on(event: string, cb: (arg?: any) => void): unknown;
+    emit(event: string, payload: unknown): unknown;
+    disconnect(): unknown;
+    removeAllListeners(): unknown;
+}
+
+/** Socket factory seam — overridden in tests. */
+export type SocketFactory = (url: string, apiKey: string) => MirrorSocket;
+
+const defaultSocketFactory: SocketFactory = (url, apiKey): Socket =>
+    io(`${url}/relay`, {
+        auth: { apiKey, protocolVersion: SOCKET_PROTOCOL_VERSION },
+        transports: ["websocket"],
+        reconnection: false,
+    });
+
+export interface MirrorOptions {
+    agentName: string;
+    task: string;
+    cwd: string;
+    /** Step index for chained runs — appended to the session name. */
+    step?: number;
+    env?: MirrorEnv;
+    socketFactory?: SocketFactory;
+    now?: () => number;
+}
+
+function sessionNameFor(agentName: string, task: string, step?: number): string {
+    const trimmed = task.trim().replace(/\s+/g, " ");
+    const preview = trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed;
+    const prefix = step !== undefined ? `${agentName} #${step + 1}` : agentName;
+    return preview ? `${prefix}: ${preview}` : prefix;
+}
+
+/**
+ * Register a subagent run as an ephemeral relay child session.
+ * Returns null when the relay isn't configured — callers should treat a null
+ * mirror as "no mirroring", not an error.
+ */
+export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null {
+    const env = opts.env ?? readMirrorEnv();
+    const parentSessionId = env.parentSessionId?.trim();
+    const apiKey = env.apiKey?.trim();
+    const url = resolveSocketIoUrl(env);
+    if (!parentSessionId || !apiKey || !url) return null;
+
+    const sessionId = randomUUID();
+    const sessionName = sessionNameFor(opts.agentName, opts.task, opts.step);
+    const now = opts.now ?? Date.now;
+
+    let socket: MirrorSocket;
+    try {
+        socket = (opts.socketFactory ?? defaultSocketFactory)(url, apiKey);
+    } catch (err) {
+        log.warn("failed to open relay socket for subagent mirror:", err);
+        return null;
+    }
+
+    let token: string | null = null;
+    let seq = 0;
+    let closed = false;
+    let lastSnapshotAt = 0;
+    /** Snapshot held back by the throttle, flushed by the next update/finish. */
+    let pending: SingleResult | null = null;
+    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const emit = (event: unknown) => {
+        if (closed || !token) return;
+        try {
+            socket.emit("event", { sessionId, token, event, seq: ++seq });
+        } catch (err) {
+            log.warn("subagent mirror event failed:", err);
+        }
+    };
+
+    const snapshot = (result: SingleResult, active: boolean) => {
+        // Subagent results only carry a model id, not a provider.
+        const model = result.model ? { provider: "", id: result.model, name: result.model } : null;
+        emit({
+            type: "session_active",
+            state: {
+                messages: result.messages.slice(-MAX_MIRRORED_MESSAGES),
+                model,
+                sessionName,
+                cwd: opts.cwd,
+                goal: null,
+                todoList: [],
+                availableModels: [],
+                availableCommands: [],
+            },
+        });
+        emit({
+            type: "heartbeat",
+            active,
+            isCompacting: false,
+            ts: now(),
+            model,
+            sessionName,
+            uptime: null,
+            cwd: opts.cwd,
+        });
+    };
+
+    const clearThrottle = () => {
+        if (throttleTimer !== null) {
+            clearTimeout(throttleTimer);
+            throttleTimer = null;
+        }
+    };
+
+    const flushPending = () => {
+        throttleTimer = null;
+        if (!pending) return;
+        const result = pending;
+        pending = null;
+        lastSnapshotAt = now();
+        snapshot(result, true);
+    };
+
+    socket.on("connect", () => {
+        if (closed) return;
+        socket.emit("register", {
+            sessionId,
+            cwd: opts.cwd,
+            ephemeral: true,
+            collabMode: false,
+            sessionName,
+            parentSessionId,
+        });
+    });
+
+    socket.on("registered", (data: { token?: string }) => {
+        if (closed) return;
+        token = typeof data?.token === "string" ? data.token : null;
+        // Flush whatever the subagent has produced while we were connecting.
+        if (pending) flushPending();
+    });
+
+    socket.on("connect_error", (err: unknown) => {
+        log.warn("subagent mirror connect failed:", err);
+    });
+
+    const teardown = () => {
+        if (closed) return;
+        closed = true;
+        clearThrottle();
+        pending = null;
+        try {
+            socket.removeAllListeners();
+            socket.disconnect();
+        } catch {
+            // Socket already gone — nothing to clean up.
+        }
+    };
+
+    return {
+        sessionId,
+        update(result) {
+            if (closed) return;
+            pending = result;
+            if (!token) return; // registration flush will pick it up
+            const elapsed = now() - lastSnapshotAt;
+            if (elapsed >= SNAPSHOT_THROTTLE_MS) {
+                clearThrottle();
+                flushPending();
+            } else if (throttleTimer === null) {
+                throttleTimer = setTimeout(flushPending, SNAPSHOT_THROTTLE_MS - elapsed);
+                // Don't hold the process open for a throttled snapshot.
+                (throttleTimer as { unref?: () => void }).unref?.();
+            }
+        },
+        finish(result) {
+            if (closed) return;
+            clearThrottle();
+            pending = null;
+            snapshot(result, false);
+            if (token) {
+                try {
+                    socket.emit("session_end", { sessionId, token });
+                } catch {
+                    // Best effort — teardown below still closes the socket.
+                }
+            }
+            teardown();
+        },
+    };
+}

--- a/packages/cli/src/plugins-cli.ts
+++ b/packages/cli/src/plugins-cli.ts
@@ -8,6 +8,8 @@
  *   pizza plugins trust [path]     Trust a project-local plugin (by path or interactively)
  *   pizza plugins untrust [path]   Remove a plugin from the trust list
  *   pizza plugins trusted          Show the current trust list
+ *   pizza plugins marketplace …    Add/list/remove plugin marketplaces
+ *   pizza plugins install <name>   Install a plugin from a marketplace
  *   pizza plugins --help           Show help
  */
 import { resolve } from "node:path";
@@ -19,6 +21,17 @@ import {
     toPluginInfo,
     type DiscoveredPlugin,
 } from "./plugins.js";
+import {
+    addMarketplace,
+    installPlugin,
+    listInstalledPlugins,
+    listMarketplaces,
+    readMarketplaceCatalog,
+    removeMarketplace,
+    resolvePluginKey,
+    setPluginEnabled,
+    uninstallPlugin,
+} from "./plugins/marketplace.js";
 import {
     getTrustedPlugins,
     isPluginTrusted,
@@ -187,6 +200,79 @@ function showTrusted(): void {
     }
 }
 
+// ── Marketplace subcommands ───────────────────────────────────────────────────
+
+function marketplaceCommand(args: string[]): void {
+    const action = args[0] ?? "list";
+    const target = args.slice(1).join(" ").trim();
+
+    if (action === "list" || action === "ls") {
+        const known = listMarketplaces();
+        const names = Object.keys(known);
+        if (names.length === 0) {
+            log.info("No marketplaces. Add one with `pizza plugins marketplace add <owner/repo>`.");
+            return;
+        }
+        log.info(`Marketplaces (${names.length}):`);
+        for (const name of names) {
+            const count = readMarketplaceCatalog(name)?.plugins.length ?? 0;
+            log.info(`  ${name}  ${c.dim(`(${count} plugins)`)}`);
+            log.info(`    ${c.dim(known[name].installLocation)}`);
+        }
+        return;
+    }
+
+    if (action === "add") {
+        if (!target) {
+            log.info("Usage: pizza plugins marketplace add <owner/repo | git-url | path>");
+            return;
+        }
+        const result = addMarketplace(target);
+        log.info(`✓ Added marketplace "${result.name}" (${result.pluginCount} plugins)`);
+        log.info(`  ${c.dim(result.installLocation)}`);
+        return;
+    }
+
+    if (action === "remove" || action === "rm") {
+        if (!target) {
+            log.info("Usage: pizza plugins marketplace remove <name>");
+            return;
+        }
+        log.info(removeMarketplace(target) ? `✓ Removed marketplace "${target}"` : `⋅ Unknown marketplace: ${target}`);
+        return;
+    }
+
+    if (action === "show" || action === "plugins") {
+        const catalog = target ? readMarketplaceCatalog(target) : null;
+        if (!catalog) {
+            log.info(`Unknown marketplace: ${target || "(none given)"}`);
+            return;
+        }
+        const installed = new Set(listInstalledPlugins().map((p) => p.key));
+        log.info(`${catalog.name} — ${catalog.plugins.length} plugins`);
+        for (const p of catalog.plugins) {
+            const mark = installed.has(`${p.name}@${target}`) ? "✓" : " ";
+            log.info(`  ${mark} ${p.name}${p.description ? c.dim(` — ${p.description.split("\n")[0].slice(0, 80)}`) : ""}`);
+        }
+        return;
+    }
+
+    log.info("Usage: pizza plugins marketplace <add|list|remove|show> [target]");
+}
+
+function installedCommand(): void {
+    const installed = listInstalledPlugins();
+    if (installed.length === 0) {
+        log.info("No marketplace plugins installed.");
+        return;
+    }
+    log.info(`Installed plugins (${installed.length}):`);
+    for (const p of installed) {
+        log.info(`  ${p.key}${p.enabled ? "" : c.dim("  (disabled)")}`);
+        log.info(`    ${c.dim(p.installPath)}`);
+    }
+}
+
 function showHelp(): void {
     log.info("");
     log.info(`${c.brand("pizza plugins")} ${c.dim("— Manage Claude Code plugins")}`);
@@ -202,6 +288,18 @@ function showHelp(): void {
     log.info(`                               ${c.dim("With path → remove that specific plugin")}`);
     log.info(`  ${c.cmd("pizza plugins trusted")}        Show the current trust list`);
     log.info("");
+    log.info(c.label("Marketplaces"));
+    log.info(`  ${c.cmd("pizza plugins marketplace add")} ${c.dim("<source>")}    owner/repo, git URL, or local path`);
+    log.info(`  ${c.cmd("pizza plugins marketplace list")}`);
+    log.info(`  ${c.cmd("pizza plugins marketplace show")} ${c.dim("<name>")}      List a marketplace's plugins`);
+    log.info(`  ${c.cmd("pizza plugins marketplace remove")} ${c.dim("<name>")}`);
+    log.info(`  ${c.cmd("pizza plugins install")} ${c.dim("<name[@marketplace]>")}`);
+    log.info(`  ${c.cmd("pizza plugins uninstall")} ${c.dim("<name[@marketplace]>")}`);
+    log.info(`  ${c.cmd("pizza plugins enable|disable")} ${c.dim("<name[@marketplace]>")}`);
+    log.info(`  ${c.cmd("pizza plugins installed")}       Show marketplace-installed plugins`);
+    log.info("");
+    log.info(c.dim("Marketplace state is shared with Claude Code (~/.claude/plugins)."));
+    log.info("");
     log.info(c.dim("Trusted plugins auto-load without prompting. Global plugins"));
     log.info(c.dim("(~/.pizzapi/plugins/, ~/.agents/plugins/, ~/.claude/plugins/) are"));
     log.info(c.dim("always auto-trusted. Project-local plugins require explicit trust"));
@@ -214,6 +312,16 @@ function showHelp(): void {
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 export async function runPluginsCommand(args: string[], cwd: string): Promise<void> {
+    try {
+        await dispatchPluginsCommand(args, cwd);
+    } catch (err) {
+        // Marketplace operations throw on bad input, clone failures, etc.
+        log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+    }
+}
+
+async function dispatchPluginsCommand(args: string[], cwd: string): Promise<void> {
     const subcommand = args[0] ?? "list";
 
     if (subcommand === "--help" || subcommand === "-h" || subcommand === "help") {
@@ -238,6 +346,50 @@ export async function runPluginsCommand(args: string[], cwd: string): Promise<vo
 
     if (subcommand === "trusted") {
         showTrusted();
+        return;
+    }
+
+    if (subcommand === "marketplace" || subcommand === "marketplaces") {
+        marketplaceCommand(args.slice(1));
+        return;
+    }
+
+    if (subcommand === "installed") {
+        installedCommand();
+        return;
+    }
+
+    if (subcommand === "install") {
+        const target = args.slice(1).join(" ").trim();
+        if (!target) {
+            log.info("Usage: pizza plugins install <name[@marketplace]>");
+            return;
+        }
+        const result = installPlugin(target);
+        log.info(`✓ Installed ${result.plugin}@${result.marketplace}`);
+        log.info(`  ${c.dim(result.installPath)}`);
+        return;
+    }
+
+    if (subcommand === "uninstall") {
+        const target = args.slice(1).join(" ").trim();
+        if (!target) {
+            log.info("Usage: pizza plugins uninstall <name[@marketplace]>");
+            return;
+        }
+        log.info(uninstallPlugin(target) ? `✓ Uninstalled ${target}` : `⋅ Not installed: ${target}`);
+        return;
+    }
+
+    if (subcommand === "enable" || subcommand === "disable") {
+        const target = args.slice(1).join(" ").trim();
+        if (!target) {
+            log.info(`Usage: pizza plugins ${subcommand} <name[@marketplace]>`);
+            return;
+        }
+        const key = resolvePluginKey(target);
+        setPluginEnabled(key, subcommand === "enable");
+        log.info(`✓ ${subcommand === "enable" ? "Enabled" : "Disabled"} ${key}`);
         return;
     }
 

--- a/packages/cli/src/plugins/index.ts
+++ b/packages/cli/src/plugins/index.ts
@@ -7,9 +7,11 @@
  *   discover.ts  Directory discovery and Claude Code marketplace integration
  *   hooks.ts     Hook event mapping (Claude → pi) and tool matcher logic
  *   info.ts      Lightweight PluginInfo serialization for the Web UI / API
+ *   marketplace.ts  Marketplace add/remove + plugin install/enable (write side)
  */
 export * from "./types.js";
 export * from "./parse.js";
 export * from "./discover.js";
 export * from "./hooks.js";
 export * from "./info.js";
+export * from "./marketplace.js";

--- a/packages/cli/src/plugins/marketplace.test.ts
+++ b/packages/cli/src/plugins/marketplace.test.ts
@@ -1,0 +1,274 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    addMarketplace,
+    defaultMarketplaceName,
+    installPlugin,
+    installedPluginsPath,
+    isSafeName,
+    listInstalledPlugins,
+    listMarketplaces,
+    parseMarketplaceSource,
+    parsePluginRef,
+    readMarketplaceCatalog,
+    removeMarketplace,
+    resolvePluginSource,
+    setPluginEnabled,
+    uninstallPlugin,
+} from "./marketplace.js";
+
+let home: string;
+let originalHome: string | undefined;
+let sourceRepo: string;
+
+/** Build a fake marketplace repo on disk with one plugin. */
+function makeMarketplaceRepo(root: string, name: string, plugins: any[]) {
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+        join(root, ".claude-plugin", "marketplace.json"),
+        JSON.stringify({ name, plugins }, null, 2),
+    );
+}
+
+function makePluginDir(root: string, name: string) {
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ name, version: "1.0.0" }));
+    mkdirSync(join(root, "commands"), { recursive: true });
+    writeFileSync(join(root, "commands", "hello.md"), "# hello\n");
+}
+
+beforeEach(() => {
+    originalHome = process.env.HOME;
+    home = mkdtempSync(join(tmpdir(), "pizzapi-marketplace-"));
+    process.env.HOME = home;
+
+    sourceRepo = mkdtempSync(join(tmpdir(), "pizzapi-mkt-src-"));
+    makeMarketplaceRepo(sourceRepo, "demo-market", [
+        { name: "demo-plugin", description: "A demo" },
+        { name: "sub-plugin", description: "Subdir source", source: { source: "git", url: "https://example.invalid/x.git", path: "pkgs/sub" } },
+    ]);
+    makePluginDir(join(sourceRepo, "plugins", "demo-plugin"), "demo-plugin");
+});
+
+afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(sourceRepo, { recursive: true, force: true });
+});
+
+// ── Source parsing ────────────────────────────────────────────────────────────
+
+describe("parseMarketplaceSource", () => {
+    test("recognizes owner/repo as github", () => {
+        expect(parseMarketplaceSource("anthropics/claude-plugins-official")).toEqual({
+            source: "github",
+            repo: "anthropics/claude-plugins-official",
+        });
+    });
+
+    test("recognizes git URLs", () => {
+        expect(parseMarketplaceSource("https://github.com/a/b.git")).toEqual({
+            source: "git",
+            url: "https://github.com/a/b.git",
+        });
+        expect((parseMarketplaceSource("git@github.com:a/b.git") as any).source).toBe("git");
+    });
+
+    test("recognizes local paths", () => {
+        const parsed = parseMarketplaceSource("/tmp/some/market") as any;
+        expect(parsed.source).toBe("local");
+        expect(parsed.path).toBe("/tmp/some/market");
+    });
+
+    test("rejects junk", () => {
+        expect(parseMarketplaceSource("not a source")).toHaveProperty("error");
+        expect(parseMarketplaceSource("  ")).toHaveProperty("error");
+    });
+});
+
+describe("defaultMarketplaceName", () => {
+    test("derives a name from each source kind", () => {
+        expect(defaultMarketplaceName({ source: "github", repo: "a/b" })).toBe("b");
+        expect(defaultMarketplaceName({ source: "git", url: "https://x.dev/a/cool-market.git" })).toBe("cool-market");
+        expect(defaultMarketplaceName({ source: "local", path: "/tmp/my-market" })).toBe("my-market");
+    });
+});
+
+describe("isSafeName", () => {
+    test("rejects traversal and separators", () => {
+        expect(isSafeName("good-name")).toBe(true);
+        expect(isSafeName("../evil")).toBe(false);
+        expect(isSafeName("a/b")).toBe(false);
+        expect(isSafeName("")).toBe(false);
+    });
+});
+
+// ── Marketplace lifecycle ─────────────────────────────────────────────────────
+
+describe("addMarketplace", () => {
+    test("registers a local marketplace and reads its catalog", () => {
+        const result = addMarketplace(sourceRepo);
+        expect(result.pluginCount).toBe(2);
+        // Manifest name wins over the temp directory name.
+        expect(result.name).toBe("demo-market");
+
+        const known = listMarketplaces();
+        expect(known[result.name]).toBeDefined();
+        expect(known[result.name].installLocation).toBe(result.installLocation);
+        expect(existsSync(join(result.installLocation, ".claude-plugin", "marketplace.json"))).toBe(true);
+
+        const catalog = readMarketplaceCatalog(result.name)!;
+        expect(catalog.plugins.map((p) => p.name)).toEqual(["demo-plugin", "sub-plugin"]);
+    });
+
+    test("honors an explicit name", () => {
+        const result = addMarketplace(sourceRepo, { name: "custom" });
+        expect(result.name).toBe("custom");
+        expect(Object.keys(listMarketplaces())).toEqual(["custom"]);
+    });
+
+    test("rejects unsafe names", () => {
+        expect(() => addMarketplace(sourceRepo, { name: "../escape" })).toThrow(/Invalid marketplace name/);
+    });
+
+    test("rejects a source with no marketplace manifest and cleans up", () => {
+        const empty = mkdtempSync(join(tmpdir(), "pizzapi-empty-"));
+        try {
+            expect(() => addMarketplace(empty)).toThrow(/marketplace.json/);
+            expect(listMarketplaces()).toEqual({});
+        } finally {
+            rmSync(empty, { recursive: true, force: true });
+        }
+    });
+
+    test("re-adding refreshes in place", () => {
+        const first = addMarketplace(sourceRepo, { name: "demo" });
+        const second = addMarketplace(sourceRepo, { name: "demo" });
+        expect(second.installLocation).toBe(first.installLocation);
+        expect(Object.keys(listMarketplaces())).toEqual(["demo"]);
+    });
+});
+
+describe("removeMarketplace", () => {
+    test("removes registration and files", () => {
+        const { name, installLocation } = addMarketplace(sourceRepo, { name: "demo" });
+        expect(removeMarketplace(name)).toBe(true);
+        expect(listMarketplaces()).toEqual({});
+        expect(existsSync(installLocation)).toBe(false);
+    });
+
+    test("returns false for unknown marketplaces", () => {
+        expect(removeMarketplace("nope")).toBe(false);
+    });
+});
+
+describe("readMarketplaceCatalog", () => {
+    test("returns null for unknown or unsafe names", () => {
+        expect(readMarketplaceCatalog("missing")).toBeNull();
+        expect(readMarketplaceCatalog("../etc")).toBeNull();
+    });
+});
+
+// ── Plugin source resolution ──────────────────────────────────────────────────
+
+describe("resolvePluginSource", () => {
+    test("defaults to plugins/<name> inside the marketplace repo", () => {
+        expect(resolvePluginSource({ name: "x" }, "/mkt")).toEqual({
+            source: { source: "local", path: "/mkt/plugins/x" },
+        });
+    });
+
+    test("handles github and git-subdir entries", () => {
+        expect(resolvePluginSource({ name: "x", source: { source: "github", repo: "a/b" } as any }, "/mkt"))
+            .toEqual({ source: { source: "github", repo: "a/b" }, subdir: undefined });
+
+        expect(resolvePluginSource(
+            { name: "x", source: { source: "git-subdir", url: "https://x.dev/a.git", path: "plugins/x" } as any },
+            "/mkt",
+        )).toEqual({ source: { source: "git", url: "https://x.dev/a.git" }, subdir: "plugins/x" });
+    });
+
+    test("handles a plain relative-path source", () => {
+        expect(resolvePluginSource({ name: "x", source: "./local/x" as any }, "/mkt")).toEqual({
+            source: { source: "local", path: "/mkt/local/x" },
+        });
+    });
+});
+
+// ── Install / enable ──────────────────────────────────────────────────────────
+
+describe("installPlugin", () => {
+    test("installs from the marketplace repo, records it, and enables it", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        const result = installPlugin("demo-plugin@demo");
+
+        expect(result.installPath).toContain(join("plugins", "cache", "demo", "demo-plugin"));
+        expect(existsSync(join(result.installPath, ".claude-plugin", "plugin.json"))).toBe(true);
+
+        const installed = JSON.parse(readFileSync(installedPluginsPath(), "utf-8"));
+        expect(installed.plugins["demo-plugin@demo"][0].installPath).toBe(result.installPath);
+
+        const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf-8"));
+        expect(settings.enabledPlugins["demo-plugin@demo"]).toBe(true);
+
+        expect(listInstalledPlugins()).toEqual([
+            { key: "demo-plugin@demo", installPath: result.installPath, enabled: true },
+        ]);
+    });
+
+    test("resolves a bare plugin name to its only marketplace", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        expect(parsePluginRef("demo-plugin")).toEqual({ plugin: "demo-plugin", marketplace: "demo" });
+    });
+
+    test("errors for unknown plugins and marketplaces", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        expect(() => installPlugin("ghost@demo")).toThrow(/not found in demo/);
+        expect(() => installPlugin("demo-plugin@ghost")).toThrow(/Unknown marketplace/);
+        expect(parsePluginRef("ghost")).toHaveProperty("error");
+    });
+});
+
+describe("uninstallPlugin", () => {
+    test("removes the payload, registration, and enabled flag", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        const { installPath } = installPlugin("demo-plugin@demo");
+
+        expect(uninstallPlugin("demo-plugin@demo")).toBe(true);
+        expect(existsSync(installPath)).toBe(false);
+        expect(listInstalledPlugins()).toEqual([]);
+
+        const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf-8"));
+        expect(settings.enabledPlugins["demo-plugin@demo"]).toBeUndefined();
+    });
+
+    test("returns false when the plugin isn't installed", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        expect(uninstallPlugin("demo-plugin@demo")).toBe(false);
+    });
+});
+
+describe("setPluginEnabled", () => {
+    test("toggles enabledPlugins without dropping other settings", () => {
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(join(home, ".claude", "settings.json"), JSON.stringify({ model: "sonnet" }));
+
+        setPluginEnabled("x@y", false);
+        const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf-8"));
+        expect(settings.model).toBe("sonnet");
+        expect(settings.enabledPlugins["x@y"]).toBe(false);
+
+        setPluginEnabled("x@y", true);
+        expect(JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf-8")).enabledPlugins["x@y"]).toBe(true);
+    });
+
+    test("installed-but-disabled plugins report enabled: false", () => {
+        addMarketplace(sourceRepo, { name: "demo" });
+        installPlugin("demo-plugin@demo");
+        setPluginEnabled("demo-plugin@demo", false);
+        expect(listInstalledPlugins()[0].enabled).toBe(false);
+    });
+});

--- a/packages/cli/src/plugins/marketplace.ts
+++ b/packages/cli/src/plugins/marketplace.ts
@@ -1,0 +1,433 @@
+/**
+ * Claude Code marketplace write-side.
+ *
+ * `discover.ts` already *reads* Claude Code's marketplace state; this module
+ * adds the missing writes so `/plugin marketplace add …` and `pizza plugins
+ * install …` work. All state stays in Claude Code's own files so the two tools
+ * can share an install:
+ *
+ *   ~/.claude/plugins/known_marketplaces.json   marketplace name → source + installLocation
+ *   ~/.claude/plugins/marketplaces/<name>/      cloned marketplace repo
+ *   ~/.claude/plugins/cache/<mkt>/<plugin>/     installed plugin payloads
+ *   ~/.claude/plugins/installed_plugins.json    "<plugin>@<mkt>" → installations[]
+ *   ~/.claude/settings.json  enabledPlugins     "<plugin>@<mkt>" → boolean
+ */
+
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import type { ClaudeInstalledPluginEntry } from "./types.js";
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+function claudeHome(): string {
+    return join(process.env.HOME || homedir(), ".claude");
+}
+
+export function pluginsRoot(): string {
+    return join(claudeHome(), "plugins");
+}
+
+export function knownMarketplacesPath(): string {
+    return join(pluginsRoot(), "known_marketplaces.json");
+}
+
+export function installedPluginsPath(): string {
+    return join(pluginsRoot(), "installed_plugins.json");
+}
+
+export function marketplacesDir(): string {
+    return join(pluginsRoot(), "marketplaces");
+}
+
+export function pluginCacheDir(): string {
+    return join(pluginsRoot(), "cache");
+}
+
+function claudeSettingsPath(): string {
+    return join(claudeHome(), "settings.json");
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface MarketplaceSource {
+    source: "github" | "git" | "local";
+    repo?: string;
+    url?: string;
+    path?: string;
+}
+
+export interface KnownMarketplace {
+    source: MarketplaceSource;
+    installLocation: string;
+    lastUpdated?: string;
+}
+
+export interface MarketplacePluginEntry {
+    name: string;
+    description?: string;
+    category?: string;
+    homepage?: string;
+    author?: { name?: string } | string;
+    source?: unknown;
+}
+
+export interface MarketplaceCatalog {
+    name: string;
+    description?: string;
+    plugins: MarketplacePluginEntry[];
+}
+
+// ── JSON helpers ──────────────────────────────────────────────────────────────
+
+function readJson<T>(path: string, fallback: T): T {
+    if (!existsSync(path)) return fallback;
+    try {
+        return JSON.parse(readFileSync(path, "utf-8")) as T;
+    } catch {
+        return fallback;
+    }
+}
+
+function writeJson(path: string, value: unknown): void {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+// ── Source parsing ────────────────────────────────────────────────────────────
+
+/** Marketplace/plugin names we're willing to create directories for. */
+const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+export function isSafeName(name: string): boolean {
+    return SAFE_NAME.test(name) && !name.includes("..");
+}
+
+/**
+ * Parse a marketplace spec into a source descriptor.
+ *
+ *   owner/repo                    → github
+ *   https://…/x.git, git@…:x.git  → git
+ *   ./path, /abs/path, ~/path     → local
+ */
+export function parseMarketplaceSource(spec: string): MarketplaceSource | { error: string } {
+    const raw = spec.trim();
+    if (!raw) return { error: "Marketplace source is required" };
+
+    if (raw.startsWith("~/")) {
+        return { source: "local", path: join(homedir(), raw.slice(2)) };
+    }
+    if (raw.startsWith(".") || isAbsolute(raw)) {
+        return { source: "local", path: resolve(raw) };
+    }
+    if (/^(https?:\/\/|git@|ssh:\/\/|git:\/\/)/.test(raw)) {
+        return { source: "git", url: raw };
+    }
+    if (/^[\w.-]+\/[\w.-]+$/.test(raw)) {
+        return { source: "github", repo: raw };
+    }
+    return { error: `Unrecognized marketplace source: ${spec}` };
+}
+
+/** Default marketplace directory name for a source (overridable by the caller). */
+export function defaultMarketplaceName(source: MarketplaceSource): string {
+    if (source.source === "github" && source.repo) return source.repo.split("/")[1];
+    if (source.source === "git" && source.url) {
+        const tail = source.url.replace(/\.git$/, "").split(/[/:]/).pop() ?? "";
+        return tail;
+    }
+    if (source.source === "local" && source.path) return source.path.split("/").filter(Boolean).pop() ?? "";
+    return "";
+}
+
+function gitUrlFor(source: MarketplaceSource): string | null {
+    if (source.source === "github" && source.repo) return `https://github.com/${source.repo}.git`;
+    if (source.source === "git" && source.url) return source.url;
+    return null;
+}
+
+// ── Fetching ──────────────────────────────────────────────────────────────────
+
+export type Fetcher = (source: MarketplaceSource, dest: string) => void;
+
+/** Shallow-clone (or copy, for local sources) a marketplace/plugin into `dest`. */
+export const defaultFetcher: Fetcher = (source, dest) => {
+    rmSync(dest, { recursive: true, force: true });
+    mkdirSync(dirname(dest), { recursive: true });
+
+    if (source.source === "local") {
+        const from = source.path!;
+        if (!existsSync(from)) throw new Error(`Local source not found: ${from}`);
+        cpSync(from, dest, { recursive: true });
+        return;
+    }
+
+    const url = gitUrlFor(source);
+    if (!url) throw new Error("Marketplace source has no URL");
+    execFileSync("git", ["clone", "--depth", "1", url, dest], { stdio: "pipe" });
+};
+
+// ── Marketplaces ──────────────────────────────────────────────────────────────
+
+export function listMarketplaces(): Record<string, KnownMarketplace> {
+    return readJson<Record<string, KnownMarketplace>>(knownMarketplacesPath(), {});
+}
+
+export interface AddMarketplaceResult {
+    name: string;
+    installLocation: string;
+    pluginCount: number;
+}
+
+/**
+ * Add (or re-fetch) a marketplace and register it in known_marketplaces.json.
+ * Throws on fetch failure or when the fetched repo has no marketplace manifest.
+ */
+export function addMarketplace(spec: string, opts?: { name?: string; fetcher?: Fetcher }): AddMarketplaceResult {
+    const parsed = parseMarketplaceSource(spec);
+    if ("error" in parsed) throw new Error(parsed.error);
+
+    let name = (opts?.name ?? defaultMarketplaceName(parsed)).trim();
+    if (!isSafeName(name)) throw new Error(`Invalid marketplace name: "${name}"`);
+
+    let installLocation = join(marketplacesDir(), name);
+    (opts?.fetcher ?? defaultFetcher)(parsed, installLocation);
+
+    let catalog = readCatalogAt(installLocation, name);
+    if (!catalog) {
+        rmSync(installLocation, { recursive: true, force: true });
+        throw new Error(`No .claude-plugin/marketplace.json found in ${spec}`);
+    }
+
+    // Without an explicit name, the manifest's own name wins over the directory
+    // /repo name so plugin refs read as `plugin@<manifest name>`.
+    if (!opts?.name && catalog.name !== name && isSafeName(catalog.name)) {
+        const renamed = join(marketplacesDir(), catalog.name);
+        rmSync(renamed, { recursive: true, force: true });
+        renameSync(installLocation, renamed);
+        name = catalog.name;
+        installLocation = renamed;
+        catalog = readCatalogAt(installLocation, name)!;
+    }
+
+    const known = listMarketplaces();
+    known[name] = { source: parsed, installLocation, lastUpdated: new Date().toISOString() };
+    writeJson(knownMarketplacesPath(), known);
+
+    return { name, installLocation, pluginCount: catalog.plugins.length };
+}
+
+/** Remove a marketplace registration and its cloned copy. Returns false if unknown. */
+export function removeMarketplace(name: string): boolean {
+    const known = listMarketplaces();
+    const entry = known[name];
+    if (!entry) return false;
+    delete known[name];
+    writeJson(knownMarketplacesPath(), known);
+    if (isSafeName(name)) {
+        rmSync(entry.installLocation || join(marketplacesDir(), name), { recursive: true, force: true });
+    }
+    return true;
+}
+
+/** Read a marketplace's plugin catalog. Returns null when it isn't installed. */
+export function readMarketplaceCatalog(name: string): MarketplaceCatalog | null {
+    if (!isSafeName(name)) return null;
+    const known = listMarketplaces()[name];
+    return readCatalogAt(known?.installLocation || join(marketplacesDir(), name), name);
+}
+
+/** Read a catalog from a specific directory (used before registration). */
+function readCatalogAt(root: string, fallbackName: string): MarketplaceCatalog | null {
+    const manifest = join(root, ".claude-plugin", "marketplace.json");
+    if (!existsSync(manifest)) return null;
+    const data = readJson<Partial<MarketplaceCatalog>>(manifest, {});
+    if (!Array.isArray(data.plugins)) return null;
+    return {
+        name: typeof data.name === "string" ? data.name : fallbackName,
+        description: data.description,
+        plugins: data.plugins.filter((p): p is MarketplacePluginEntry => !!p && typeof p.name === "string"),
+    };
+}
+
+// ── Plugin install / enable ───────────────────────────────────────────────────
+
+export interface PluginRef {
+    plugin: string;
+    marketplace: string;
+}
+
+/** Parse "name@marketplace" (marketplace optional when only one is known). */
+export function parsePluginRef(spec: string): PluginRef | { error: string } {
+    const raw = spec.trim();
+    const at = raw.lastIndexOf("@");
+    if (at > 0) {
+        const plugin = raw.slice(0, at);
+        const marketplace = raw.slice(at + 1);
+        if (!isSafeName(plugin) || !isSafeName(marketplace)) return { error: `Invalid plugin reference: ${spec}` };
+        return { plugin, marketplace };
+    }
+    if (!isSafeName(raw)) return { error: `Invalid plugin reference: ${spec}` };
+
+    // Prefer an already-installed plugin, then fall back to marketplace catalogs.
+    const installedOwners = listInstalledPlugins()
+        .map((p) => p.key)
+        .filter((key) => key.slice(0, key.lastIndexOf("@")) === raw)
+        .map((key) => key.slice(key.lastIndexOf("@") + 1));
+    const owners = installedOwners.length > 0
+        ? [...new Set(installedOwners)]
+        : Object.keys(listMarketplaces()).filter((m) =>
+            readMarketplaceCatalog(m)?.plugins.some((p) => p.name === raw),
+        );
+    if (owners.length === 0) return { error: `Plugin not found in any marketplace: ${raw}` };
+    if (owners.length > 1) return { error: `Plugin "${raw}" exists in ${owners.join(", ")} — use ${raw}@<marketplace>` };
+    return { plugin: raw, marketplace: owners[0] };
+}
+
+/**
+ * Resolve a catalog entry's `source` field into a fetchable source + subdir.
+ * Supports the shapes Claude Code publishes: github, git/git-subdir (url+path),
+ * and plain relative paths inside the marketplace repo.
+ */
+export function resolvePluginSource(
+    entry: MarketplacePluginEntry,
+    marketplaceRoot: string,
+): { source: MarketplaceSource; subdir?: string } {
+    const src = entry.source as Record<string, unknown> | string | undefined;
+
+    // No source, or a relative path → the plugin lives inside the marketplace repo.
+    if (!src) return { source: { source: "local", path: join(marketplaceRoot, "plugins", entry.name) } };
+    if (typeof src === "string") {
+        return src.startsWith("http") || src.includes("://")
+            ? { source: { source: "git", url: src } }
+            : { source: { source: "local", path: resolve(marketplaceRoot, src) } };
+    }
+
+    const kind = typeof src.source === "string" ? src.source : "";
+    const url = typeof src.url === "string" ? src.url : undefined;
+    const repo = typeof src.repo === "string" ? src.repo : undefined;
+    const subdir = typeof src.path === "string" ? src.path : undefined;
+
+    if (kind === "github" && repo) return { source: { source: "github", repo }, subdir };
+    if (url) return { source: { source: "git", url }, subdir };
+    if (subdir) return { source: { source: "local", path: resolve(marketplaceRoot, subdir) } };
+    return { source: { source: "local", path: join(marketplaceRoot, "plugins", entry.name) } };
+}
+
+export interface InstallResult {
+    plugin: string;
+    marketplace: string;
+    installPath: string;
+}
+
+/** Install a plugin from a known marketplace and enable it. */
+export function installPlugin(spec: string, opts?: { fetcher?: Fetcher }): InstallResult {
+    const ref = parsePluginRef(spec);
+    if ("error" in ref) throw new Error(ref.error);
+
+    const catalog = readMarketplaceCatalog(ref.marketplace);
+    if (!catalog) throw new Error(`Unknown marketplace: ${ref.marketplace}`);
+    const entry = catalog.plugins.find((p) => p.name === ref.plugin);
+    if (!entry) throw new Error(`Plugin "${ref.plugin}" not found in ${ref.marketplace}`);
+
+    const marketplaceRoot = listMarketplaces()[ref.marketplace]?.installLocation
+        ?? join(marketplacesDir(), ref.marketplace);
+    const { source, subdir } = resolvePluginSource(entry, marketplaceRoot);
+
+    const installPath = join(pluginCacheDir(), ref.marketplace, ref.plugin);
+    const fetcher = opts?.fetcher ?? defaultFetcher;
+
+    if (subdir && source.source !== "local") {
+        // Clone the whole repo to a scratch dir, then keep only the subdir.
+        // ponytail: full shallow clone, sparse-checkout if repo size ever hurts.
+        const scratch = `${installPath}.tmp`;
+        try {
+            fetcher(source, scratch);
+            const from = join(scratch, subdir);
+            if (!existsSync(from)) throw new Error(`Subdirectory "${subdir}" not found in plugin source`);
+            rmSync(installPath, { recursive: true, force: true });
+            mkdirSync(dirname(installPath), { recursive: true });
+            cpSync(from, installPath, { recursive: true });
+        } finally {
+            rmSync(scratch, { recursive: true, force: true });
+        }
+    } else {
+        fetcher(source, installPath);
+    }
+
+    const key = `${ref.plugin}@${ref.marketplace}`;
+    const installed = readJson<{ version?: number; plugins?: Record<string, ClaudeInstalledPluginEntry[]> }>(
+        installedPluginsPath(),
+        { version: 1, plugins: {} },
+    );
+    installed.version ??= 1;
+    installed.plugins ??= {};
+    installed.plugins[key] = [{
+        scope: "user",
+        installPath,
+        version: typeof (entry as { version?: string }).version === "string" ? (entry as { version?: string }).version! : "0.0.0",
+        lastUpdated: new Date().toISOString(),
+    }];
+    writeJson(installedPluginsPath(), installed);
+
+    setPluginEnabled(key, true);
+    return { plugin: ref.plugin, marketplace: ref.marketplace, installPath };
+}
+
+/** Uninstall a plugin: drop its cache copy, registration, and enabled flag. */
+export function uninstallPlugin(spec: string): boolean {
+    const ref = parsePluginRef(spec);
+    if ("error" in ref) throw new Error(ref.error);
+    const key = `${ref.plugin}@${ref.marketplace}`;
+
+    const installed = readJson<{ version?: number; plugins?: Record<string, ClaudeInstalledPluginEntry[]> }>(
+        installedPluginsPath(),
+        { version: 1, plugins: {} },
+    );
+    const entries = installed.plugins?.[key];
+    if (!entries) return false;
+
+    for (const entry of entries) {
+        // Only delete paths we manage, never an arbitrary path from the file.
+        if (entry.installPath?.startsWith(pluginCacheDir())) {
+            rmSync(entry.installPath, { recursive: true, force: true });
+        }
+    }
+    delete installed.plugins![key];
+    writeJson(installedPluginsPath(), installed);
+
+    const settings = readJson<Record<string, any>>(claudeSettingsPath(), {});
+    if (settings.enabledPlugins && key in settings.enabledPlugins) {
+        delete settings.enabledPlugins[key];
+        writeJson(claudeSettingsPath(), settings);
+    }
+    return true;
+}
+
+/** List installed plugin keys ("name@marketplace") with their enabled state. */
+export function listInstalledPlugins(): Array<{ key: string; installPath: string; enabled: boolean }> {
+    const installed = readJson<{ plugins?: Record<string, ClaudeInstalledPluginEntry[]> }>(installedPluginsPath(), {});
+    const settings = readJson<{ enabledPlugins?: Record<string, boolean> }>(claudeSettingsPath(), {});
+    const out: Array<{ key: string; installPath: string; enabled: boolean }> = [];
+    for (const [key, entries] of Object.entries(installed.plugins ?? {})) {
+        const first = Array.isArray(entries) ? entries[0] : undefined;
+        if (!first) continue;
+        out.push({ key, installPath: first.installPath, enabled: settings.enabledPlugins?.[key] !== false });
+    }
+    return out;
+}
+
+/** Flip a plugin's `enabledPlugins` entry in ~/.claude/settings.json. */
+export function setPluginEnabled(key: string, enabled: boolean): void {
+    const settings = readJson<Record<string, any>>(claudeSettingsPath(), {});
+    settings.enabledPlugins = { ...(settings.enabledPlugins ?? {}), [key]: enabled };
+    writeJson(claudeSettingsPath(), settings);
+}
+
+/** Resolve a user-supplied plugin spec to its "name@marketplace" key. */
+export function resolvePluginKey(spec: string): string {
+    const ref = parsePluginRef(spec);
+    if ("error" in ref) throw new Error(ref.error);
+    return `${ref.plugin}@${ref.marketplace}`;
+}

--- a/packages/docs/src/content/docs/customization/claude-plugins.mdx
+++ b/packages/docs/src/content/docs/customization/claude-plugins.mdx
@@ -291,6 +291,65 @@ PizzaPi searches for plugins in these directories:
 
 A plugin folder placed directly in `~/.claude/plugins/` without a matching `installed_plugins.json` entry will **not** be discovered.
 
+---
+
+## Marketplaces
+
+PizzaPi can add marketplaces and install plugins itself, writing to the same files Claude Code
+uses — so an install made from either tool is visible to both.
+
+### From a session
+
+```
+/plugin                                  List marketplaces and installed plugins
+/plugin marketplace add <source>         Add a marketplace
+/plugin marketplace list
+/plugin marketplace show <name>           List a marketplace's plugins
+/plugin marketplace remove <name>
+/plugin install <name[@marketplace]>
+/plugin uninstall <name[@marketplace]>
+/plugin enable|disable <name[@marketplace]>
+```
+
+Mutating subcommands reload session resources afterwards, so a newly installed plugin's
+commands, skills, and rules are usable immediately — no restart.
+
+### From the CLI
+
+```bash
+pizza plugins marketplace add anthropics/claude-plugins-official
+pizza plugins marketplace list
+pizza plugins marketplace show claude-plugins-official
+pizza plugins install my-plugin@claude-plugins-official
+pizza plugins installed
+pizza plugins disable my-plugin@claude-plugins-official
+pizza plugins uninstall my-plugin@claude-plugins-official
+pizza plugins marketplace remove claude-plugins-official
+```
+
+### Sources
+
+| Spec | Interpreted as |
+|------|----------------|
+| `owner/repo` | GitHub repository (shallow clone) |
+| `https://…/x.git`, `git@host:x.git` | Git URL (shallow clone) |
+| `./path`, `/abs/path`, `~/path` | Local directory (copied) |
+
+A marketplace source must contain `.claude-plugin/marketplace.json`. The marketplace is named
+after that manifest's `name` field.
+
+The `@marketplace` suffix can be omitted when the plugin name is unambiguous.
+
+### Where state lives
+
+| Path | Contents |
+|------|----------|
+| `~/.claude/plugins/known_marketplaces.json` | Registered marketplaces and their sources |
+| `~/.claude/plugins/marketplaces/<name>/` | Cloned marketplace repository |
+| `~/.claude/plugins/cache/<marketplace>/<plugin>/` | Installed plugin payload |
+| `~/.claude/plugins/installed_plugins.json` | Install registry (`plugin@marketplace` → installations) |
+| `~/.claude/settings.json` → `enabledPlugins` | Enabled/disabled state |
+
 ### Project-local (require trust)
 
 | Directory | Source |

--- a/packages/docs/src/content/docs/customization/skills.mdx
+++ b/packages/docs/src/content/docs/customization/skills.mdx
@@ -226,6 +226,7 @@ All endpoints are scoped to a specific runner and require an authenticated sessi
 | `PUT` | `/api/runners/{runnerId}/skills/{name}` | Update an existing skill (body: `{ content }`) |
 | `DELETE` | `/api/runners/{runnerId}/skills/{name}` | Delete a skill |
 | `POST` | `/api/runners/{runnerId}/skills/refresh` | Re-scan the filesystem and refresh the skill list |
+| `POST` | `/api/runners/{runnerId}/skills/reload` | Re-scan **and** reload skills inside every live session on the runner |
 
 ### Using the Web UI
 
@@ -235,7 +236,23 @@ In the PizzaPi web interface, navigate to a runner's detail page and open the **
 - **Create** a new skill with the in-browser editor
 - **Edit** an existing skill's content (including frontmatter)
 - **Delete** skills you no longer need
-- **Refresh** to re-scan the filesystem if you've added skills outside the UI
+- **Reload** to re-scan the filesystem *and* pick the skills up in the runner's live sessions
+
+## Reloading skills without restarting
+
+Skills are read when a session starts, so a skill added mid-session isn't visible until
+the session reloads its resources. Two ways to do that:
+
+- **In a session:** run `/skills reload`. This re-reads skills, prompt templates, extensions,
+  and context files in place.
+- **From the web UI:** the **Reload** button in a runner's **Skills** tab re-scans the runner's
+  skill directories and sends `/skills reload` to each of that runner's live sessions.
+
+The response reports how many sessions were reloaded:
+
+```json
+{ "ok": true, "skills": [...], "reloaded": 2, "failed": 0, "sessionIds": ["..."], "failedSessionIds": [] }
+```
 
 ### Relationship to File-Based Discovery
 

--- a/packages/docs/src/content/docs/customization/subagents.mdx
+++ b/packages/docs/src/content/docs/customization/subagents.mdx
@@ -16,7 +16,17 @@ When the agent calls the `subagent` tool, PizzaPi:
 3. Returns immediately so the parent can continue working
 4. Runs the child behind the scenes and injects its final output as a follow-up message when done
 
-Unlike [`spawn_session`](/PizzaPi/running/cli-reference/#spawn_session), subagents stay inside the parent session rather than creating a separately visible child session. Result delivery is automatic; the parent should not poll or wait.
+Unlike [`spawn_session`](/PizzaPi/running/cli-reference/#spawn_session), subagents run **inside** the parent process — no child process, no separate worker. They are still *visible*: each run is mirrored to the relay as an ephemeral child session, so it appears nested under its parent in the session sidebar with a live transcript, just like a linked session. Result delivery is automatic; the parent should not poll or wait.
+
+### Visibility in the web UI
+
+While a subagent runs, PizzaPi registers a short-lived relay session named `<agent>: <task>`
+(`<agent> #N: <task>` for chain steps) with the parent as its `parentSessionId`. It streams the
+subagent's transcript, and ends when the subagent finishes — after which the run remains in the
+parent's conversation as the usual inline subagent card.
+
+The mirror is best-effort and entirely optional: when the relay isn't configured (local TUI,
+no API key, or `PIZZAPI_RELAY_URL=off`), subagents run exactly as before with no mirroring.
 
 ## Quick start
 

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -29,7 +29,7 @@ Commands:
   pizza setup                 Run first-time setup
   pizza usage [provider]      Show API usage stats
   pizza models                List available models
-  pizza plugins [cmd]         Manage Claude Code plugins (list/trust/untrust)
+  pizza plugins [cmd]         Manage Claude Code plugins (list/trust/marketplace/install)
   pizza install <source>      Install a pi package (extensions, skills, prompts, themes)
   pizza remove <source>       Remove an installed pi package
   pizza update [source|self]  Update installed pi packages
@@ -506,6 +506,18 @@ pizzapi plugins --help
 | `trust [path]` | Trust project-local plugins. No path = trust all untrusted in cwd. |
 | `untrust [path]` | Remove from trust list. No path = clear entire list. |
 | `trusted` | Show the current trust list from `~/.pizzapi/config.json` |
+| `marketplace add <source>` | Add a marketplace (`owner/repo`, git URL, or local path) |
+| `marketplace list` | List registered marketplaces |
+| `marketplace show <name>` | List a marketplace's plugins |
+| `marketplace remove <name>` | Remove a marketplace and its clone |
+| `install <name[@marketplace]>` | Install and enable a plugin from a marketplace |
+| `uninstall <name[@marketplace]>` | Remove an installed plugin |
+| `enable` / `disable <name[@marketplace]>` | Toggle a plugin without uninstalling |
+| `installed` | List marketplace-installed plugins and their enabled state |
+
+Marketplace state is shared with Claude Code (`~/.claude/plugins/`). The same operations are
+available inside a session via the `/plugin` command, which also reloads session resources so a
+newly installed plugin is usable right away.
 
 **Trust model:**
 

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -44,13 +44,35 @@ The following commands are always available in the chat input:
 | `/sandbox violations` | List recent sandbox violations. |
 | `/sandbox config` | Show sandbox configuration. |
 | `/skills` | Display available skills loaded on the runner. |
+| `/skills reload` | Reload skills (and prompts, extensions, context files) from disk in this session — no restart needed. The **Reload** button in a runner's Skills tab sends this to every live session on that runner. |
 | `/plugins` | List all loaded plugins with their commands, hooks, skills, agents, rules, and MCP integrations. |
+| `/plugin [sub]` | Manage Claude Code plugin marketplaces. See [plugin sub-commands](#plugin-sub-commands) below. |
 | `/agents [name]` | Spawn a new session as a named agent. Select `/agents` from the picker to open the agent list; with a name, it dispatches immediately. |
 | `/mcp [status\|reload\|disable <name>\|enable <name>]` | MCP server management. See [MCP sub-commands](#mcp-sub-commands) below. |
 
 <Aside type="tip">
 You can also trigger context compaction by clicking the **context donut** in the session toolbar — it opens a confirmation dialog with the same effect as `/compact`. See [Web UI Overview](/web-ui/overview/#context-window-donut) for details.
 </Aside>
+
+### `/plugin` sub-commands
+
+Marketplace state is shared with Claude Code (`~/.claude/plugins/`), so installs are visible to
+both tools. Mutating sub-commands reload session resources afterwards, so a newly installed
+plugin's commands and skills work immediately.
+
+| Sub-command | Description |
+|-------------|-------------|
+| *(none)* / `list` | List marketplaces and installed plugins |
+| `marketplace add <source>` | Add a marketplace — `owner/repo`, a git URL, or a local path |
+| `marketplace list` | List registered marketplaces |
+| `marketplace show <name>` | List a marketplace's plugins (✓ marks installed) |
+| `marketplace remove <name>` | Remove a marketplace and its local clone |
+| `install <name[@marketplace]>` | Install and enable a plugin |
+| `uninstall <name[@marketplace]>` | Remove an installed plugin |
+| `enable` / `disable <name[@marketplace]>` | Toggle a plugin without uninstalling |
+
+The `@marketplace` suffix is optional when the plugin name is unambiguous. See the
+[Claude Code Plugins guide](/PizzaPi/customization/claude-plugins/#marketplaces) for details.
 
 ### MCP sub-commands
 

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -337,3 +337,59 @@ describe("runner MCP reload route", () => {
         expect(body.failedSessionIds).toEqual(["sess-1", "sess-2"]);
     });
 });
+
+describe("skills reload route", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+        mockGetConnectedSessionsForRunner.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+    });
+
+    test("POST re-scans and sends /skills reload to every live session", async () => {
+        const emitA = mock(() => {});
+        const emitB = mock(() => {});
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([
+            { sessionId: "sess-1", cwd: "/tmp/a" },
+            { sessionId: "sess-2", cwd: "/tmp/b" },
+        ]));
+        mockGetLocalTuiSocket.mockImplementation((sessionId: string) => (
+            sessionId === "sess-1" ? { emit: emitA } as any : { emit: emitB } as any
+        ));
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/skills/reload");
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.reloaded).toBe(2);
+        expect(body.failed).toBe(0);
+        expect(emitA).toHaveBeenCalledWith("input", {
+            text: "/skills reload",
+            attachments: [],
+            deliverAs: "followUp",
+        });
+        expect(emitB).toHaveBeenCalled();
+    });
+
+    test("POST still succeeds when no sessions are live", async () => {
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([]));
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/skills/reload");
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.ok).toBe(true);
+        expect(body.reloaded).toBe(0);
+    });
+
+    test("POST counts sessions whose socket is gone as failed", async () => {
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([{ sessionId: "sess-1", cwd: "/tmp/a" }]));
+        mockGetLocalTuiSocket.mockReturnValue(undefined as any);
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/skills/reload");
+        const res = await handleRunnersRoute(req, url);
+        const body = await res!.json();
+        expect(body.failed).toBe(1);
+        expect(body.failedSessionIds).toEqual(["sess-1"]);
+    });
+});

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -726,6 +726,51 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
         if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
 
+        // POST /api/runners/:id/skills/reload — re-scan from disk AND tell every
+        // live session on this runner to reload its resources, so a new skill is
+        // usable without restarting sessions. Delivered as the `/skills reload`
+        // slash command because pi only exposes reload() on a command context.
+        if (req.method === "POST" && skillName === "reload") {
+            let skills: unknown[] = [];
+            try {
+                const result = await sendSkillCommand(runnerId, { type: "list_skills" });
+                if (!result.ok) return Response.json({ error: result.message ?? "Skill scan failed" }, { status: 500 });
+                skills = result.skills ?? [];
+            } catch (err) {
+                skillsLog.error("reload scan failed:", err);
+                return Response.json({ error: "Failed to refresh skills" }, { status: 502 });
+            }
+
+            const reloadedSessionIds: string[] = [];
+            const failedSessionIds: string[] = [];
+            for (const { sessionId } of await getConnectedSessionsForRunner(runnerId)) {
+                const tuiSocket = getLocalTuiSocket(sessionId);
+                if (!tuiSocket) {
+                    failedSessionIds.push(sessionId);
+                    continue;
+                }
+                try {
+                    tuiSocket.emit("input" as string, {
+                        text: "/skills reload",
+                        attachments: [],
+                        deliverAs: "followUp",
+                    });
+                    reloadedSessionIds.push(sessionId);
+                } catch {
+                    failedSessionIds.push(sessionId);
+                }
+            }
+
+            return Response.json({
+                ok: true,
+                skills,
+                reloaded: reloadedSessionIds.length,
+                failed: failedSessionIds.length,
+                sessionIds: reloadedSessionIds,
+                failedSessionIds,
+            });
+        }
+
         // POST /api/runners/:id/skills/refresh — ask runner to re-scan skills from disk
         if (req.method === "POST" && skillName === "refresh") {
             try {

--- a/packages/ui/src/components/SkillsManager.tsx
+++ b/packages/ui/src/components/SkillsManager.tsx
@@ -425,7 +425,9 @@ export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange,
     const handleRefresh = async () => {
         setRefreshing(true);
         try {
-            const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/skills/refresh`, {
+            // /reload re-scans from disk AND tells live sessions on this runner
+            // to pick the skills up without restarting.
+            const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/skills/reload`, {
                 method: "POST",
                 credentials: "include",
             });
@@ -463,7 +465,7 @@ export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange,
                 className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
                 onClick={handleRefresh}
                 disabled={refreshing}
-                title="Re-scan skills from disk"
+                title="Re-scan skills from disk and reload them in this runner's live sessions"
             >
                 <RefreshCw className={cn("h-3 w-3 mr-1", refreshing && "animate-spin")} />
                 Reload

--- a/packages/ui/src/components/session-viewer/slash-commands-skills.test.tsx
+++ b/packages/ui/src/components/session-viewer/slash-commands-skills.test.tsx
@@ -55,9 +55,19 @@ describe("/skills", () => {
         expect(systemMessages).toHaveLength(0);
     });
 
-    test("the picker advertises the reload sub-command", () => {
+    test("/skills list renders the listing in the browser", () => {
+        const { view, systemMessages } = setup("/skills list");
+        let handled = false;
+        act(() => { handled = view.result.current.executeSlashCommand("/skills list"); });
+        expect(handled).toBe(true);
+        expect(systemMessages).toHaveLength(1);
+    });
+
+    test("the picker offers list first, then reload", () => {
         const { view } = setup("/skills ");
         const skills = view.result.current.supportedWebCommands.find((c) => c.name === "skills");
-        expect(skills?.subCommands?.map((s) => s.name)).toEqual(["reload"]);
+        expect(skills?.subCommands?.map((s) => s.name)).toEqual(["list", "reload"]);
+        // Enter with nothing typed runs the highlighted (first) entry.
+        expect(view.result.current.subCommandMode.filtered[0]?.name).toBe("list");
     });
 });

--- a/packages/ui/src/components/session-viewer/slash-commands-skills.test.tsx
+++ b/packages/ui/src/components/session-viewer/slash-commands-skills.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * `/skills` is handled in the browser (it renders the runner's skill list), but
+ * `/skills reload` must fall through to the CLI extension command instead.
+ */
+import { describe, expect, test, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).requestAnimationFrame = (() => 0) as any;
+
+const { renderHook, act, cleanup } = await import("@testing-library/react");
+const { useSlashCommands } = await import("./slash-commands");
+import type { SlashCommandDeps } from "./slash-commands";
+
+afterEach(cleanup);
+
+function setup(input: string) {
+    const systemMessages: unknown[] = [];
+    const deps: SlashCommandDeps = {
+        sessionId: "sess-1",
+        sessionIdRef: { current: "sess-1" },
+        compactingRef: { current: false },
+        runnerInfo: { skills: [{ name: "demo", description: "A demo skill" }] } as any,
+        onAppendSystemMessage: (content) => systemMessages.push(content),
+        skillCommands: [],
+        extensionCommands: [],
+        promptCommands: [],
+        onIncompleteTriggers: () => {},
+    };
+    const view = renderHook(() => useSlashCommands(input, () => {}, deps));
+    return { view, systemMessages };
+}
+
+describe("/skills", () => {
+    test("bare /skills is handled in the browser", () => {
+        const { view, systemMessages } = setup("/skills");
+        let handled = false;
+        act(() => { handled = view.result.current.executeSlashCommand("/skills"); });
+        expect(handled).toBe(true);
+        expect(systemMessages).toHaveLength(1);
+    });
+
+    test("/skills reload falls through to the CLI", () => {
+        const { view, systemMessages } = setup("/skills reload");
+        let handled = true;
+        act(() => { handled = view.result.current.executeSlashCommand("/skills reload"); });
+        expect(handled).toBe(false);
+        expect(systemMessages).toHaveLength(0);
+    });
+
+    test("the picker advertises the reload sub-command", () => {
+        const { view } = setup("/skills ");
+        const skills = view.result.current.supportedWebCommands.find((c) => c.name === "skills");
+        expect(skills?.subCommands?.map((s) => s.name)).toEqual(["reload"]);
+    });
+});

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -166,7 +166,13 @@ export function useSlashCommands(
         ],
       },
       { name: "plugins", description: "Show loaded plugins" },
-      { name: "skills", description: "Show available skills" },
+      {
+        name: "skills",
+        description: "Show available skills",
+        subCommands: [
+          { name: "reload", description: "Reload skills from disk in this session" },
+        ],
+      },
       { name: "agents", description: "Start a new session as an agent" },
       { name: "model", description: "Select model" },
       { name: "cycle_model", description: "Select model (alias of /model)" },
@@ -523,6 +529,12 @@ export function useSlashCommands(
             onAppendSystemMessage?.(`**Plugins** — Failed to load: ${err.message}`);
           });
         return true;
+      }
+
+      // `/skills reload` belongs to the CLI extension (it reloads the session's
+      // resources) — only the bare listing is handled here in the browser.
+      if (rawCommand === "skills" && args.trim().toLowerCase() === "reload") {
+        return false;
       }
 
       if (rawCommand === "skills") {

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -169,7 +169,10 @@ export function useSlashCommands(
       {
         name: "skills",
         description: "Show available skills",
+        // `list` first: it is the default action, and the picker executes the
+        // highlighted sub-command on Enter (without it, /skills always reloaded).
         subCommands: [
+          { name: "list", description: "Show available skills" },
           { name: "reload", description: "Reload skills from disk in this session" },
         ],
       },


### PR DESCRIPTION
Three requested features.

## 1. Subagent sessions shown like linked sessions

Subagents run in-process (`createAgentSession`), so they never registered with the relay and only appeared as an inline tool card. Each run now *also* registers an ephemeral relay session with `parentSessionId` = the parent worker's session — the same mechanism `spawn_session` children use — so subagents nest under their parent in the sidebar with a live transcript. **No UI changes were needed**: the sidebar tree already renders anything with a `parentSessionId`.

- `extensions/subagent/relay-mirror.ts` — second socket, `register`, throttled `session_active` + `heartbeat` snapshots, `session_end` on completion
- `engine.ts` creates the mirror once the session cwd is known and finishes it in a `finally`, so success / failure / abort all close cleanly
- Degrades to a no-op when the relay is unconfigured or `PIZZAPI_RELAY_URL=off`
- Transcript capped at the newest 200 messages so a runaway subagent can't blow up the socket

## 2. Reload Skills

`ctx.reload()` (skills + prompts + extensions + context files) exists in pi but was only reachable via `/restart`, which restarts the process.

- **Session:** `/skills reload`
- **Web UI:** the Skills tab's **Reload** button now calls `POST /api/runners/:id/skills/reload`, which re-scans from disk *and* sends the command to every live session on that runner (same response shape as the existing `mcp/reload` route)
- The browser intercepts bare `/skills` for its listing; `/skills reload` falls through to the CLI extension

`reload` only exists on a *command* context and pi invalidates that context once reload completes, so there is nothing safe to cache for out-of-band callers — hence delivering it as session input rather than adding a new exec command.

## 3. `/plugin marketplace add {marketplace}`

PizzaPi already *read* Claude Code's marketplace state; this adds the write side, keeping installs compatible with Claude Code.

```
/plugin                                  List marketplaces and installed plugins
/plugin marketplace add <source>         owner/repo, git URL, or local path
/plugin marketplace list | show | remove
/plugin install|uninstall <name[@marketplace]>
/plugin enable|disable <name[@marketplace]>
```

Same subcommands on `pizza plugins`. Mutations reload session resources so new commands/skills work immediately. `git-subdir` catalog entries are shallow-cloned then narrowed to the subdirectory. State lives in `~/.claude/plugins/` + `enabledPlugins` in `~/.claude/settings.json`.

## Testing

- `bun run typecheck` clean; `bun run build` clean; docs site builds
- New: 11 mirror tests, 5 reload tests, 24 marketplace tests, 11 `/plugin` tests, 3 server route tests, 3 UI slash-command tests
- `bun test packages/cli/src`: 3 pre-existing failures (`models-command`, `overlay/identity`) — reproduced on this branch with the new test files removed, and both files pass in isolation, so they are cross-file bleed unrelated to these changes
- Server suite via `scripts/test-isolated.ts`: 75/75. UI: 1272 pass
- Marketplace tests use a temp `HOME` and local-path sources — no network

## Docs

`customization/subagents`, `customization/skills`, `customization/claude-plugins`, `running/cli-reference`, `web-ui/slash-commands`.
