### PR TITLE
fix(server): throttle session-state SQLite writes; flush final state on session end

### DIFF
--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -264,6 +264,19 @@ export async function recordRelaySessionState(
     userId: string | null,
     state: unknown,
 ): Promise<void> {
+    return recordRelaySessionStateSerialized(sessionId, userId, JSON.stringify(state ?? null));
+}
+
+/**
+ * Same as {@link recordRelaySessionState} but takes an already-serialized
+ * JSON string (e.g. the `lastState` value stored in Redis) to avoid a
+ * parse/stringify round-trip on multi-MB states.
+ */
+export async function recordRelaySessionStateSerialized(
+    sessionId: string,
+    userId: string | null,
+    serialized: string,
+): Promise<void> {
     // Ownership guard: verify the session's persisted userId before writing.
     // This prevents a user who re-registered an ended session ID (and was
     // subsequently redirected to a fresh ID by the caller-side guard) from
@@ -282,7 +295,6 @@ export async function recordRelaySessionState(
     }
 
     const nowIso = new Date().toISOString();
-    const serialized = JSON.stringify(state ?? null);
 
     await getKysely()
         .insertInto("relay_session_state")

--- a/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
@@ -112,6 +112,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionStart: async () => {},
     recordRelaySessionEnd: async () => {},
     recordRelaySessionState: async () => {},
+    recordRelaySessionStateSerialized: async () => {},
     touchRelaySession: async () => {},
 }));
 

--- a/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
@@ -57,6 +57,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionStart: noopAsync,
     recordRelaySessionEnd: noopAsync,
     recordRelaySessionState: noopAsync,
+    recordRelaySessionStateSerialized: noopAsync,
     touchRelaySession: noopAsync,
 }));
 

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -117,6 +117,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionStart: async () => {},
     recordRelaySessionEnd: async () => {},
     recordRelaySessionState: async () => {},
+    recordRelaySessionStateSerialized: async () => {},
     touchRelaySession: async () => {},
 }));
 

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -43,6 +43,7 @@ import {
     recordRelaySessionStart,
     recordRelaySessionEnd,
     recordRelaySessionState,
+    recordRelaySessionStateSerialized,
     touchRelaySession,
 } from "../../sessions/store.js";
 import { appendRelayEventToCache } from "../../sessions/redis.js";
@@ -560,9 +561,12 @@ export async function updateSessionState(sessionId: string, state: unknown, opts
     await updateSessionFields(session.sessionId, fields);
 
     const now = Date.now();
-    const stateMessages = stateObj && Array.isArray(stateObj.messages) ? stateObj.messages : null;
+    // Throttle applies to ALL snapshots — including ones with messages. States
+    // average hundreds of KB (up to several MB) and bun:sqlite writes are
+    // synchronous, so unthrottled per-turn writes block the event loop and
+    // stall every connected socket. endSharedSession() flushes the final
+    // state, so at most the trailing throttle window is deferred, not lost.
     const shouldPersistState =
-        stateMessages !== null && stateMessages.length > 0 ||
         now - (lastRelaySessionStateWriteTimes.get(sessionId) ?? 0) >= SQLITE_STATE_WRITE_THROTTLE_MS;
 
     // Skip SQLite write for viewer-recovery events.  The runner re-sent the
@@ -953,6 +957,17 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
         // needed for ended-session replay (viewers re-joining after agent_end).
         // The cache already has a TTL set via pExpire on every append, so it
         // will expire naturally without any explicit delete.
+    }
+
+    // Final durable flush — mid-stream SQLite state writes are throttled, so
+    // persist the freshest Redis state before it is deleted (SQLite is the
+    // cold-restore source; prod Redis runs without persistence).
+    if (session.lastState) {
+        await recordRelaySessionStateSerialized(sessionId, session.userId ?? null, session.lastState).catch(
+            (error) => {
+                log.error("Failed to flush final relay session state:", error);
+            },
+        );
     }
 
     // Delete from Redis

--- a/packages/server/src/ws/sio-registry/snapshot-state.test.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.test.ts
@@ -140,12 +140,12 @@ describe("shouldPersistSnapshotPatch", () => {
         })).toBe(true);
     });
 
-    test("persists patches that explicitly update messages immediately", () => {
+    test("throttles message-bearing patches like any other (no bypass)", () => {
         expect(shouldPersistSnapshotPatch({
             patch: { messages: [{ role: "user", content: "hi" }] },
             lastWriteAt: 39_000,
             now: 40_000,
             throttleMs: 30_000,
-        })).toBe(true);
+        })).toBe(false);
     });
 });

--- a/packages/server/src/ws/sio-registry/snapshot-state.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.ts
@@ -71,10 +71,10 @@ export function shouldPersistSnapshotPatch(input: {
     now: number;
     throttleMs: number;
 }): boolean {
-    const { patch, lastWriteAt, now, throttleMs } = input;
-    if (Object.prototype.hasOwnProperty.call(patch, "messages")) {
-        return true;
-    }
+    // Throttle applies uniformly — message-bearing patches used to bypass it,
+    // but persisting the merged multi-MB state per patch blocks the event loop
+    // (bun:sqlite is synchronous). endSharedSession() flushes the final state.
+    const { lastWriteAt, now, throttleMs } = input;
     return now - lastWriteAt >= throttleMs;
 }
 


### PR DESCRIPTION
## Problem

The relay server suffers random multi-second slowdowns that require restarts. Diagnosis from the production box:

- `relay_session_state` is **75 MB of the 96 MB** auth.db — rows average **306 KB**, max **7 MB**.
- The 30s SQLite write throttle added in #428 is defeated by operator precedence:

  ```ts
  const shouldPersistState =
      stateMessages !== null && stateMessages.length > 0 ||   // ← any real snapshot bypasses…
      now - lastWrite >= SQLITE_STATE_WRITE_THROTTLE_MS;      // ← …the throttle entirely
  ```

  Every full `session_active` (one per agent turn, per session) synchronously writes the full serialized transcript through `bun:sqlite`.
- Synchronous multi-MB writes **block the event loop**. Production compounds it: the DB sits on a macOS VirtioFS bind mount (`~/.pizzapi/web/data`) with `journal_mode=delete`, so each write is journal create + fsync + delete over Docker Desktop file sharing.
- Blocked event loop → socket.io ping timeouts on **all** namespaces → reconnect storms → full-state resends. Restarting "fixes" it until transcripts grow again.

## Fix

- Apply the 30s throttle uniformly in `updateSessionSnapshotState` and `shouldPersistSnapshotPatch` — no messages bypass.
- Flush the freshest Redis state to SQLite in `endSharedSession()` before `deleteSession()`, via new `recordRelaySessionStateSerialized()` (takes the already-serialized Redis `lastState`, avoiding a parse/stringify round-trip on multi-MB states).

Durability: SQLite remains the cold-restore source. Graceful ends lose nothing (final flush); a hard crash can lose at most the trailing 30s window — same class of loss as before, since prod Redis runs with persistence disabled.

## Follow-ups (not in this PR)

- Consider moving the prod DB off the VirtioFS bind mount onto a named volume, and/or WAL mode.
- Godmother: `nDBjdvET`

## Testing

- `bun scripts/test-isolated.ts packages/server/src` — 75 files, 0 failures
- `tsc --noEmit` clean
