### PR TITLE
fix(mobile): make native push actually work end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,28 @@ jobs:
       - name: Build Android debug app
         run: bun run build:mobile:android
 
+      # ponytail: this is an artifact-name check on the generated bundle
+      # trees, not a real iOS build — there's no macOS/Xcode runner here.
+      # `cap sync ios` is a pure Node/Bun file-copy + Package.swift codegen
+      # step (no CocoaPods/xcodebuild), so it runs fine on ubuntu-latest and
+      # reuses the mobile/app bundle the Android build above just produced.
+      # Upgrade this to a real Xcode/simulator build on a macOS runner if iOS
+      # ever ships for real.
+      - name: Sync iOS bundle (file copy only, no Xcode)
+        run: bunx cap sync ios
+
+      - name: Guard — no service-worker artifacts in bundled app trees
+        run: |
+          set -euo pipefail
+          HITS=$(find android/app/src/main/assets/public ios/App/App/public \
+            \( -iname 'sw.js' -o -iname 'registerSW.js' -o -iname 'workbox-*' -o -iname 'manifest.webmanifest' \) 2>/dev/null || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::Service-worker/PWA artifacts found in a mobile bundle tree. VITE_MOBILE builds must disable the PWA plugin (see packages/ui/vite.config.ts enablePWA) — a stale service worker in the native shell causes a black screen after rebuilds."
+            echo "$HITS"
+            exit 1
+          fi
+          echo "✅ No sw.js/registerSW.js/workbox-*/manifest.webmanifest in the Android or iOS bundled app trees"
+
   # ───────────────────────────────────────────────────────────────
   # Build + smoke-test compiled binaries per platform
   # ───────────────────────────────────────────────────────────────

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,17 @@
             android:name=".NtfyForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Restarts NtfyForegroundService from persisted config after a reboot
+             (BOOT_COMPLETED), or when NtfyForegroundService#scheduleRestart
+             fires an alarm following an Android 15+ FGS-timeout. -->
+        <receiver
+            android:name=".NtfyRestartReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
     <!-- Permissions -->
@@ -56,11 +67,13 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Haptics. -->
     <uses-permission android:name="android.permission.VIBRATE" />
-    <!-- Local notifications: reschedule after device reboot. -->
+    <!-- Reschedule after device reboot: used by @capacitor/local-notifications
+         and by our own NtfyRestartReceiver (ntfy foreground service restart). -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <!-- Local notifications: exact alarm scheduling (Android 12+). User-grantable
-         via Settings; unlike USE_EXACT_ALARM it needs no restricted Play Console
-         use-case declaration (P1-4/#13). -->
+    <!-- Exact alarm scheduling (Android 12+): used by @capacitor/local-notifications
+         and by NtfyForegroundService#scheduleRestart (FGS-timeout reschedule).
+         User-grantable via Settings; unlike USE_EXACT_ALARM it needs no
+         restricted Play Console use-case declaration (P1-4/#13). -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <!-- Push notifications: keep the device awake to process incoming FCM
          messages. The MessagingService itself is registered by

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,12 +39,23 @@
         </provider>
 
         <!-- ntfy foreground service: holds the persistent subscribe stream for
-             Google-free Android background push. dataSync type (Android 14+
-             requires an explicit foregroundServiceType). -->
+             Google-free Android background push. Android 14+ requires an
+             explicit foregroundServiceType.
+
+             remoteMessaging, NOT dataSync. Two hard reasons:
+              1. Android 15+ forbids a BOOT_COMPLETED receiver from starting a
+                 dataSync FGS — it throws ForegroundServiceStartNotAllowedException,
+                 which fatally crashed the app on every boot. The banned list is
+                 dataSync/camera/mediaPlayback/phoneCall/mediaProjection/microphone;
+                 remoteMessaging is not on it.
+              2. dataSync is capped at 6h per 24h (Service.onTimeout); remoteMessaging
+                 is not, so the persistent subscribe stream can actually persist.
+             It is also the honest description: this service exists solely to
+             receive remote messages and surface them as notifications. -->
         <service
             android:name=".NtfyForegroundService"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="remoteMessaging" />
 
         <!-- Restarts NtfyForegroundService from persisted config after a reboot
              (BOOT_COMPLETED), or when NtfyForegroundService#scheduleRestart
@@ -81,5 +92,5 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- ntfy foreground service (Google-free background push). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 </manifest>

--- a/android/app/src/main/java/dev/pizzapi/app/MainActivity.java
+++ b/android/app/src/main/java/dev/pizzapi/app/MainActivity.java
@@ -1,8 +1,10 @@
 package dev.pizzapi.app;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.getcapacitor.BridgeActivity;
+import com.getcapacitor.PluginHandle;
 
 public class MainActivity extends BridgeActivity {
     @Override
@@ -11,5 +13,32 @@ public class MainActivity extends BridgeActivity {
         // bridge initializes. registerPlugin must be called before super.onCreate.
         registerPlugin(NtfyPushPlugin.class);
         super.onCreate(savedInstanceState);
+        // Cold start: the launch intent may already carry a tapped-notification
+        // session id (see NtfyForegroundService#buildTapIntent).
+        handleTapIntent(getIntent());
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        // The activity is singleTop, so a tap while already running arrives
+        // here instead of onCreate. setIntent() so later getIntent() calls
+        // (e.g. a future recreation) don't see this delivery again.
+        setIntent(intent);
+        handleTapIntent(intent);
+    }
+
+    /** If the intent carries a tapped session-notification id, forward it to the JS bridge. */
+    private void handleTapIntent(Intent intent) {
+        if (intent == null) return;
+        String sessionId = intent.getStringExtra(NtfyPushPlugin.EXTRA_SESSION_ID);
+        if (sessionId == null || sessionId.isEmpty()) return;
+        // Prevent re-delivery if this same Intent object is inspected again later.
+        intent.removeExtra(NtfyPushPlugin.EXTRA_SESSION_ID);
+
+        PluginHandle handle = getBridge() != null ? getBridge().getPlugin("PizzapiNtfy") : null;
+        if (handle != null && handle.getInstance() instanceof NtfyPushPlugin) {
+            ((NtfyPushPlugin) handle.getInstance()).notifySessionTap(sessionId);
+        }
     }
 }

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
@@ -1,5 +1,6 @@
 package dev.pizzapi.app;
 
+import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -54,9 +55,10 @@ import java.util.regex.Pattern;
  *       4xx stop retrying and surface an error notification.</li>
  * </ul>
  *
- * <p>Known limitations (see deployment/mobile-push.mdx): no Doze wakelock, no
- * BOOT_COMPLETED restart, and the dataSync FGS 6h/24h cap on Android 15+ stops
- * the service on {@link #onTimeout(int)} (upgrade path noted there).
+ * <p>Known limitations (see deployment/mobile-push.mdx): no Doze wakelock. A
+ * {@link NtfyRestartReceiver} restarts the service from persisted config after
+ * a reboot (BOOT_COMPLETED) and reschedules a restart via AlarmManager when
+ * the dataSync FGS 6h/24h cap fires {@link #onTimeout(int)}.
  */
 public class NtfyForegroundService extends Service {
 
@@ -79,6 +81,14 @@ public class NtfyForegroundService extends Service {
     private static final String KEY_TOKEN = "token";
     private static final String KEY_LAST_ID = "lastId";
     private static final String KEY_FIRST_START = "firstStart";
+    /** True once {@link #start} has been called and false once {@link #stop} has
+     *  been called; lets {@link NtfyRestartReceiver} tell "user turned push off"
+     *  apart from "service got killed". */
+    private static final String KEY_ENABLED = "enabled";
+    /** Delay before retrying an FGS restart (after reboot restart failure, or
+     *  after an Android 15+ FGS-timeout reschedule). Fixed interval, no backoff
+     *  -- simplest thing that eventually recovers once the OS quota resets. */
+    private static final long RESTART_DELAY_MS = 60 * 60 * 1000L; // 1h
 
     private static final int INITIAL_BACKOFF_MS = 1000;
     private static final int MAX_BACKOFF_MS = 30_000;
@@ -493,7 +503,43 @@ public class NtfyForegroundService extends Service {
                 .putString(KEY_NTFY_URL, ntfyUrl)
                 .putString(KEY_TOPIC, topic)
                 .putString(KEY_TOKEN, token) // null clears the key
+                .putBoolean(KEY_ENABLED, true)
                 .apply();
+    }
+
+    /** True if we have persisted config AND the user hasn't explicitly stopped push. */
+    static boolean canAutoRestart(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        if (!prefs.getBoolean(KEY_ENABLED, false)) return false;
+        String ntfyUrl = prefs.getString(KEY_NTFY_URL, null);
+        String topic = prefs.getString(KEY_TOPIC, null);
+        return ntfyUrl != null && topic != null && isValidNtfyUrl(ntfyUrl);
+    }
+
+    /**
+     * Schedule a one-shot restart via AlarmManager, targeting
+     * {@link NtfyRestartReceiver}. Used both for the boot-restart-failed retry
+     * and the FGS-timeout reschedule (#onTimeout). Uses an exact alarm so the
+     * receiver qualifies for the Android 8+/12+ background-FGS-start exemption
+     * granted to apps handling an alarm they scheduled (SCHEDULE_EXACT_ALARM is
+     * already declared for @capacitor/local-notifications); falls back to an
+     * inexact alarm if that permission isn't granted, best-effort.
+     */
+    static void scheduleRestart(Context context) {
+        AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (am == null) return;
+        Intent intent = new Intent(context, NtfyRestartReceiver.class)
+                .setAction(NtfyRestartReceiver.ACTION_RESTART);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT
+                | (Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, flags);
+        long triggerAt = System.currentTimeMillis() + RESTART_DELAY_MS;
+        try {
+            am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pi);
+        } catch (SecurityException e) {
+            // Exact-alarm permission not granted; fall back to inexact (#13).
+            am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pi);
+        }
     }
 
     private void stopStream() {
@@ -521,12 +567,19 @@ public class NtfyForegroundService extends Service {
      */
     @Override
     public void onTimeout(int startId) {
-        Log.w(TAG, "FGS dataSync timeout reached; stopping cleanly");
-        // ponytail: we just stop on the cap. Upgrade path: reschedule via
-        // WorkManager/AlarmManager (or a data-carrying push transport) to resume
-        // after the 24h window resets.
+        Log.w(TAG, "FGS dataSync timeout reached; stopping and scheduling a restart");
+        // ponytail: ceiling is ~6h cumulative runtime within a rolling 24h window
+        // for a dataSync FGS (Android 15+, targetSdk 35). We can't just call
+        // startForegroundService() again right here -- the quota is still
+        // exhausted and the platform throws ForegroundServiceStartNotAllowedException
+        // -- so we schedule a retry via AlarmManager instead and let it keep
+        // retrying (NtfyRestartReceiver reschedules itself on failure) until the
+        // window frees up. Upgrade path: replace the permanent dataSync stream
+        // with WorkManager periodic sync (no FGS cap) or a data-message push
+        // transport (FCM) that only wakes us when there's something to deliver.
         running.set(false);
         stopStream();
+        scheduleRestart(this);
         stopForeground(STOP_FOREGROUND_REMOVE);
         stopSelf();
     }
@@ -557,8 +610,13 @@ public class NtfyForegroundService extends Service {
         ContextCompat.startForegroundService(context, intent);
     }
 
-    /** Convenience to stop the service. */
+    /** Convenience to stop the service. Marks push disabled so BOOT_COMPLETED /
+     *  timeout-reschedule restarts don't fight a user-initiated stop. */
     public static void stop(Context context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean(KEY_ENABLED, false)
+                .apply();
         context.stopService(new Intent(context, NtfyForegroundService.class));
     }
 }

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
@@ -138,7 +138,20 @@ public class NtfyForegroundService extends Service {
 
         // Always enter foreground promptly, even on the stop path, to avoid
         // RemoteServiceException on system-initiated restarts (#6).
-        startForeground(SERVICE_NOTIF_ID, buildServiceNotification("PizzaPi — connecting…"));
+        //
+        // NEVER let this throw: startForeground() can fail with
+        // ForegroundServiceStartNotAllowedException when the platform refuses the
+        // start (e.g. Android 15+ blocking a banned FGS type from BOOT_COMPLETED,
+        // or an exhausted quota). An uncaught throw here is a FATAL crash of the
+        // whole app, which is exactly what happened when this service was still
+        // declared dataSync. Degrade to "no push until next app launch" instead.
+        try {
+            startForeground(SERVICE_NOTIF_ID, buildServiceNotification("PizzaPi — connecting…"));
+        } catch (Exception e) {
+            Log.e(TAG, "startForeground refused: " + e.getMessage() + "; giving up this attempt");
+            stopSelf();
+            return START_NOT_STICKY;
+        }
 
         if (ntfyUrl == null || topic == null || !isValidNtfyUrl(ntfyUrl)) {
             Log.e(TAG, "no valid ntfy config (url=" + ntfyUrl + "); stopping");
@@ -572,21 +585,22 @@ public class NtfyForegroundService extends Service {
     }
 
     /**
-     * Android 15+ enforces a ~6h/24h runtime cap on dataSync foreground services.
-     * The platform calls this and expects us to stop; not stopping crashes (#7).
+     * Safety net only. The ~6h/24h FGS runtime cap applies to dataSync and
+     * mediaProcessing; this service is remoteMessaging, which the platform does
+     * not currently time out. Kept because the platform calls onTimeout() for
+     * whatever types it decides to cap in future releases, and NOT stopping when
+     * asked is a guaranteed crash (#7).
      */
     @Override
     public void onTimeout(int startId) {
-        Log.w(TAG, "FGS dataSync timeout reached; stopping and scheduling a restart");
-        // ponytail: ceiling is ~6h cumulative runtime within a rolling 24h window
-        // for a dataSync FGS (Android 15+, targetSdk 35). We can't just call
-        // startForegroundService() again right here -- the quota is still
-        // exhausted and the platform throws ForegroundServiceStartNotAllowedException
-        // -- so we schedule a retry via AlarmManager instead and let it keep
-        // retrying (NtfyRestartReceiver reschedules itself on failure) until the
-        // window frees up. Upgrade path: replace the permanent dataSync stream
-        // with WorkManager periodic sync (no FGS cap) or a data-message push
-        // transport (FCM) that only wakes us when there's something to deliver.
+        Log.w(TAG, "FGS timeout reached; stopping and scheduling a restart");
+        // ponytail: we can't just call startForegroundService() again right here
+        // -- if a quota did trigger this it is still exhausted and the platform
+        // throws ForegroundServiceStartNotAllowedException -- so we schedule a
+        // retry via AlarmManager and let it keep retrying (NtfyRestartReceiver
+        // reschedules itself on failure) until the window frees up. Upgrade path:
+        // a data-message push transport that only wakes us when there is
+        // something to deliver, removing the persistent stream entirely.
         running.set(false);
         stopStream();
         scheduleRestart(this);

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
@@ -64,6 +64,8 @@ public class NtfyForegroundService extends Service {
 
     private static final String TAG = "PizzapiNtfy";
     private static final String CHANNEL_ID = "pizzapi-ntfy";
+    /** MIN-importance channel for the unavoidable foreground-service notification. */
+    private static final String SERVICE_CHANNEL_ID = "pizzapi-ntfy-service";
     private static final int SERVICE_NOTIF_ID = 0x9_0000;
     private static final int FIRST_MESSAGE_NOTIF_ID = 0x9_0001;
     private static final int SUMMARY_NOTIF_ID = 0x8_FFFF;
@@ -298,7 +300,24 @@ public class NtfyForegroundService extends Service {
         running.set(false);
         // ponytail: no auto re-auth/reconfig — user must fix the config and restart.
         reconnectHandler.post(() -> {
-            updateServiceNotification("PizzaPi — push disabled (error " + code + ")");
+            // Routine connection states are silent, but "push is dead until you fix
+            // the config" is actionable and must stay visible. Post it as a real,
+            // dismissible alert on the ALERT channel rather than reusing the
+            // MIN-importance service pill, which the user would never see.
+            NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) {
+                Intent intent = new Intent(this, MainActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                int piFlags = PendingIntent.FLAG_UPDATE_CURRENT
+                        | (Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+                nm.notify(SERVICE_NOTIF_ID, new NotificationCompat.Builder(this, CHANNEL_ID)
+                        .setSmallIcon(android.R.drawable.stat_notify_error)
+                        .setContentTitle("PizzaPi push disabled")
+                        .setContentText("Push stopped (error " + code + "). Open PizzaPi to reconnect.")
+                        .setAutoCancel(true)
+                        .setContentIntent(PendingIntent.getActivity(this, 0, intent, piFlags))
+                        .build());
+            }
             stopForeground(STOP_FOREGROUND_DETACH); // keep the notice visible after we stop
             stopSelf();
         });
@@ -480,11 +499,18 @@ public class NtfyForegroundService extends Service {
         return PendingIntent.getActivity(this, notifId, intent, flags);
     }
 
+    /**
+     * No-op: the foreground-service notification is intentionally static.
+     *
+     * Android will not let a foreground service run without an ongoing
+     * notification, but nothing requires it to narrate itself. Rewriting it with
+     * "connecting…"/"connected"/"reconnecting…" re-posted the notification on
+     * every stream transition, which kept dragging a status pill in front of the
+     * user for information they never asked for. Connection state belongs in
+     * logcat (and the JS connectionState listener), not the shade.
+     */
     private void updateServiceNotification(String text) {
-        NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        if (nm != null) {
-            nm.notify(SERVICE_NOTIF_ID, buildServiceNotification(text));
-        }
+        Log.i(TAG, "connection state: " + text);
     }
 
     private Notification buildServiceNotification(String text) {
@@ -495,12 +521,22 @@ public class NtfyForegroundService extends Service {
                 | (Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
         PendingIntent pi = PendingIntent.getActivity(this, 0, intent, flags);
 
-        return new NotificationCompat.Builder(this, CHANNEL_ID)
+        // Posted on SERVICE_CHANNEL_ID, a dedicated silent channel. Note the
+        // platform CLAMPS foreground-service channels to IMPORTANCE_LOW even when
+        // MIN is requested (verified on device: requested MIN=1, got 2), so this
+        // cannot be hidden from code alone — it is silent, badge-free and
+        // bottom-of-shade, and the user can switch the "Background connection"
+        // channel off in system settings to hide it completely.
+        // The separate channel is the point: silencing this pill can never
+        // silence a real agent alert, which shares CHANNEL_ID.
+        return new NotificationCompat.Builder(this, SERVICE_CHANNEL_ID)
                 .setSmallIcon(android.R.drawable.stat_sys_download)
                 .setContentTitle("PizzaPi")
-                .setContentText(text)
+                .setContentText("Background connection")
                 .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setShowWhen(false)
+                .setSilent(true)
+                .setPriority(NotificationCompat.PRIORITY_MIN)
                 .setContentIntent(pi)
                 .build();
     }
@@ -508,11 +544,23 @@ public class NtfyForegroundService extends Service {
     private void createChannel() {
         if (Build.VERSION.SDK_INT >= 26) {
             NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            if (nm != null && nm.getNotificationChannel(CHANNEL_ID) == null) {
+            if (nm == null) return;
+            if (nm.getNotificationChannel(CHANNEL_ID) == null) {
                 NotificationChannel ch = new NotificationChannel(
                         CHANNEL_ID, "PizzaPi notifications", NotificationManager.IMPORTANCE_DEFAULT);
                 ch.setDescription("Agent activity and alerts from your PizzaPi sessions");
                 nm.createNotificationChannel(ch);
+            }
+            // Dedicated channel for the mandatory foreground-service notification.
+            // MIN is requested but the platform clamps FGS channels to LOW; the
+            // value of the split is that the user can disable THIS channel in
+            // system settings without touching real alerts on CHANNEL_ID.
+            if (nm.getNotificationChannel(SERVICE_CHANNEL_ID) == null) {
+                NotificationChannel svc = new NotificationChannel(
+                        SERVICE_CHANNEL_ID, "Background connection", NotificationManager.IMPORTANCE_MIN);
+                svc.setDescription("Keeps push working. Android requires a notification while it runs — turn this channel off to hide it.");
+                svc.setShowBadge(false);
+                nm.createNotificationChannel(svc);
             }
         }
     }

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyForegroundService.java
@@ -430,10 +430,20 @@ public class NtfyForegroundService extends Service {
         nm.notify(id, n);
     }
 
-    /** Build the tap intent: open a valid http/https click URL, else bring the app forward. */
+    /**
+     * Build the tap intent. Our own session click links (…/#/sessions/<id>)
+     * ALWAYS open the app directly via an explicit intent to MainActivity —
+     * never ACTION_VIEW, which would resolve to a browser instead of us. Only
+     * non-session click URLs (or none) fall back to the previous behavior.
+     */
     private PendingIntent buildTapIntent(String clickUrl, int notifId) {
+        String sessionId = sessionIdFromClickUrl(clickUrl);
         Intent intent = null;
-        if (clickUrl != null && !clickUrl.isEmpty()) {
+        if (sessionId != null) {
+            intent = new Intent(this, MainActivity.class)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    .putExtra(NtfyPushPlugin.EXTRA_SESSION_ID, sessionId);
+        } else if (clickUrl != null && !clickUrl.isEmpty()) {
             Uri uri = Uri.parse(clickUrl);
             String scheme = uri.getScheme();
             if (scheme != null) {

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyPushPlugin.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyPushPlugin.java
@@ -18,17 +18,24 @@ import androidx.core.content.ContextCompat;
  * <pre>
  *   PizzapiNtfy.start({ ntfyUrl, topic, token? })
  *   PizzapiNtfy.stop()
+ *   PizzapiNtfy.addListener("notificationTapped", ({ sessionId }) =&gt; ...)
  * </pre>
  *
- * <p>Prototype (Phase 2): start/stop only. No JS event callbacks yet
- * (notificationTapped / connectionState) — the service posts notifications
- * directly. Event callbacks are a Phase 3 refinement (needs a static bridge
- * or bound service).
+ * <p>{@code notificationTapped} is emitted by {@link MainActivity} when it
+ * receives the {@link #EXTRA_SESSION_ID} extra from a session notification's
+ * explicit tap intent (see {@code NtfyForegroundService#buildTapIntent}).
+ * Uses Capacitor's {@code notifyListeners(..., retainUntilConsumed=true)} so
+ * a cold-start tap (intent delivered before the JS listener registers) is
+ * held and replayed to the first listener that attaches — no separate
+ * pending-tap plumbing needed.
  */
 @CapacitorPlugin(name = "PizzapiNtfy")
 public class NtfyPushPlugin extends Plugin {
 
     private static final String TAG = "PizzapiNtfyPlugin";
+
+    /** Intent extra (set by NtfyForegroundService, read by MainActivity) carrying the tapped session id. */
+    static final String EXTRA_SESSION_ID = "pizzapi.sessionId";
 
     @PluginMethod
     public void start(PluginCall call) {
@@ -68,5 +75,18 @@ public class NtfyPushPlugin extends Plugin {
             Log.e(TAG, "failed to stop ntfy foreground service", e);
             call.reject("Failed to stop ntfy service: " + e.getMessage());
         }
+    }
+
+    /**
+     * Called by {@link MainActivity} when a notification tap intent carrying
+     * {@link #EXTRA_SESSION_ID} is delivered (cold start via onCreate, or warm
+     * start via onNewIntent). retainUntilConsumed=true means: if the JS
+     * listener hasn't attached yet, Capacitor holds the event and replays it
+     * to the first listener that calls addListener("notificationTapped").
+     */
+    void notifySessionTap(String sessionId) {
+        JSObject data = new JSObject();
+        data.put("sessionId", sessionId);
+        notifyListeners("notificationTapped", data, true);
     }
 }

--- a/android/app/src/main/java/dev/pizzapi/app/NtfyRestartReceiver.java
+++ b/android/app/src/main/java/dev/pizzapi/app/NtfyRestartReceiver.java
@@ -1,0 +1,51 @@
+package dev.pizzapi.app;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+
+/**
+ * Restarts {@link NtfyForegroundService} without any JS round-trip, using the
+ * config persisted by the service itself. Two triggers:
+ * <ul>
+ *   <li>{@code BOOT_COMPLETED} — the process (and any prior FGS instance) is
+ *       gone after a reboot; nothing else would ever start the service again.</li>
+ *   <li>{@link #ACTION_RESTART} — fired by an AlarmManager one-shot that
+ *       {@link NtfyForegroundService#scheduleRestart} sets, used both after an
+ *       Android 15+ FGS-timeout and to retry a failed restart attempt.</li>
+ * </ul>
+ * Both are allowed exemptions to the Android 8+/12+ background-FGS-start
+ * restrictions, so calling {@code startForegroundService()} here is safe as
+ * long as the service promotes to foreground promptly (it does, first line of
+ * {@code onStartCommand}).
+ */
+public class NtfyRestartReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "PizzapiNtfyRestart";
+
+    static final String ACTION_RESTART = "dev.pizzapi.app.ACTION_RESTART_NTFY";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent != null ? intent.getAction() : null;
+        if (!Intent.ACTION_BOOT_COMPLETED.equals(action) && !ACTION_RESTART.equals(action)) {
+            return;
+        }
+        if (!NtfyForegroundService.canAutoRestart(context)) {
+            Log.i(TAG, "no persisted ntfy config or push disabled; not restarting");
+            return;
+        }
+        try {
+            ContextCompat.startForegroundService(context, new Intent(context, NtfyForegroundService.class));
+        } catch (Exception e) {
+            // Most likely ForegroundServiceStartNotAllowedException because the
+            // dataSync FGS quota (see NtfyForegroundService#onTimeout) is still
+            // exhausted. Retry later rather than leaving push dead forever.
+            Log.w(TAG, "failed to restart ntfy service: " + e.getMessage() + "; retrying later");
+            NtfyForegroundService.scheduleRestart(context);
+        }
+    }
+}

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -22,6 +22,13 @@ app launch ──► fetch manifest ──► buildTimestamp newer? ──► Ca
 
 - **Freshness key:** the bundle's `buildTimestamp` (same signal as the web
   update banner). ISO-8601 sorts lexically, so "strictly newer" is a plain `>`.
+- **Kill-switch:** an optional `minBuildTimestamp` on the manifest. The client
+  refuses to apply a bundle whose own `buildTimestamp` is older than it, even
+  if that bundle is newer than what's installed. See "Kill-switch" below.
+- **Deferred apply:** after `download`+`set`, the client does not reload right
+  away — it waits for the app to background first (Capacitor `App` plugin's
+  `appStateChange`), so a cold-boot OTA check can't yank the WebView out from
+  under a user mid-draft.
 - **Manual mode:** the app's server URL is chosen at runtime, so Capgo's
   build-time `autoUpdate.updateUrl` can't be used. `packages/ui/src/lib/mobile-ota.ts`
   fetches the manifest and drives `download → set → reload` itself.
@@ -32,7 +39,9 @@ app launch ──► fetch manifest ──► buildTimestamp newer? ──► Ca
   `registerPlugin("CapacitorUpdater")` bridge (by name, like `PizzapiNtfy`) — it
   does **not** import the `@capgo` JS wrapper, so the web build never resolves
   the package and there's no bare-specifier `import()` for the WebView to fail
-  on. On native the proxy routes to the plugin `cap sync` installs.
+  on. On native the proxy routes to the plugin `cap sync` installs. The
+  deferred-reload listener uses the same by-name `registerPlugin("App")`
+  pattern against the Capacitor `App` plugin.
 
 ## Native setup (run on a machine with the Android/iOS toolchain)
 
@@ -68,17 +77,59 @@ launch, installed apps older than that `buildTimestamp` pull and apply it.
 
 When `PIZZAPI_MOBILE_OTA_DIR` is unset the feature is off (every OTA path 404s).
 
+## Kill-switch
+
+If a published bundle turns out to be bad, `minBuildTimestamp` on the manifest
+forces the OTA channel closed until a fixed bundle ships — clients refuse any
+bundle whose own `buildTimestamp` is older than `minBuildTimestamp`, even one
+that's newer than what they have installed. It's optional and absent by
+default, so older manifests/clients are unaffected.
+
+**To strand an already-published bad bundle right now** (no rebuild needed):
+
+```bash
+PIZZAPI_MOBILE_OTA_DIR=/srv/pizzapi-ota bun scripts/publish-mobile-ota.ts --kill-switch=<future-ISO-timestamp>
+```
+
+This patches `minBuildTimestamp` on the existing `manifest.json` in place. The
+OTA channel stays closed until you publish a bundle whose `buildTimestamp` is
+`>= <future-ISO-timestamp>` (a normal `bun run publish:mobile:ota`, since a
+fresh build's timestamp is always "now").
+
+To bake a floor into a fix as you publish it, set
+`PIZZAPI_MOBILE_OTA_MIN_BUILD_TIMESTAMP` before running the normal publish
+script:
+
+```bash
+PIZZAPI_MOBILE_OTA_DIR=/srv/pizzapi-ota PIZZAPI_MOBILE_OTA_MIN_BUILD_TIMESTAMP=<bad-build-timestamp> \
+  bun run publish:mobile:ota
+```
+
+Devices already running the bad bundle aren't force-rolled-back — the
+kill-switch only stops the OTA channel from handing that bundle to anyone
+else. There's no server-side rollback/staged-rollout system; see "Notes /
+limits" for what's intentionally out of scope.
+
 ## Notes / limits
 
 - **HTTPS-only.** OTA ships executable JS, so the client only applies a bundle
   when the relay server URL is `https://` (`isSecureOtaOrigin`). The app allows
   `http://` for LAN/loopback servers and `CapacitorHttp` bypasses mixed-content
   blocking, so plain-http OTA would be MITM-exploitable — those servers update
-  via a new APK instead.
+  via a new APK instead. That failure mode used to be silent; the client now
+  surfaces it once per launch through the existing frontend log/toast bus
+  (`reportWarning("mobile-ota", …)` in `mobile-ota.ts`) instead of a swallowed
+  `return false`.
+- **Deferred reload.** The client downloads/verifies/`set()`s a new bundle as
+  soon as it's found, but doesn't call `CapacitorUpdater.reload()` immediately
+  — it registers a one-shot listener on the Capacitor `App` plugin's
+  `appStateChange` and reloads the next time the app backgrounds. This avoids
+  reloading the WebView (and discarding in-progress input, e.g. a composer
+  draft) right as a cold-launched app resumes.
 - The bundle is public (it's the same UI the server already serves) — no auth on
   the endpoints; integrity comes from the checksum + TLS, not access control.
 - `publish:mobile:ota` uses the system `zip`. If a device ever rejects the
   archive, swap that step for `@capgo/cli bundle zip` (their exact format).
-- Rollback/staged rollout/kill-switch are not implemented — add a
-  `minBuildTimestamp` gate in the manifest if you need to force-expire a bad
-  bundle.
+- **Explicitly out of scope (ponytail):** staged rollout percentages, a manual
+  rollback UI, and signed bundles. The `minBuildTimestamp` kill-switch is the
+  whole mitigation for a bad bundle today — revisit if that's ever not enough.

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,10 +12,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
+        .package(name: "AparajitaCapacitorSecureStorage", path: "../../../node_modules/.bun/@aparajita+capacitor-secure-storage@8.0.0/node_modules/@aparajita/capacitor-secure-storage"),
         .package(name: "CapacitorHaptics", path: "../../../node_modules/.bun/@capacitor+haptics@8.0.2+767ac80cbab8ae50/node_modules/@capacitor/haptics"),
         .package(name: "CapacitorLocalNotifications", path: "../../../node_modules/.bun/@capacitor+local-notifications@8.2.0+767ac80cbab8ae50/node_modules/@capacitor/local-notifications"),
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/.bun/@capacitor+push-notifications@8.1.1+767ac80cbab8ae50/node_modules/@capacitor/push-notifications"),
-        .package(name: "CapawesomeCapacitorBadge", path: "../../../node_modules/.bun/@capawesome+capacitor-badge@8.0.2+767ac80cbab8ae50/node_modules/@capawesome/capacitor-badge")
+        .package(name: "CapawesomeCapacitorBadge", path: "../../../node_modules/.bun/@capawesome+capacitor-badge@8.0.2+767ac80cbab8ae50/node_modules/@capawesome/capacitor-badge"),
+        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.bun/@capgo+capacitor-updater@8.50.2+767ac80cbab8ae50/node_modules/@capgo/capacitor-updater")
     ],
     targets: [
         .target(
@@ -23,10 +25,12 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "AparajitaCapacitorSecureStorage", package: "AparajitaCapacitorSecureStorage"),
                 .product(name: "CapacitorHaptics", package: "CapacitorHaptics"),
                 .product(name: "CapacitorLocalNotifications", package: "CapacitorLocalNotifications"),
                 .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),
-                .product(name: "CapawesomeCapacitorBadge", package: "CapawesomeCapacitorBadge")
+                .product(name: "CapawesomeCapacitorBadge", package: "CapawesomeCapacitorBadge"),
+                .product(name: "CapgoCapacitorUpdater", package: "CapgoCapacitorUpdater")
             ]
         )
     ]

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -104,6 +104,24 @@ describe("web.ts compose template", () => {
         expect(composed).toContain('UI_DIST_HASH: "abc123def456"');
     });
 
+    test("template substitution produces prod compose structure with ntfy service", () => {
+        // Mirrors generateComposeFile's non-dev appServiceBlock: ntfy is provisioned
+        // alongside ui/server, and the server gets PIZZAPI_NTFY_URL pointed at it.
+        const ntfyBlock = `  ntfy:\n    image: binwiederhier/ntfy:v2.25.0\n    command: serve\n    restart: unless-stopped\n    environment:\n      - NTFY_BASE_URL=http://localhost:2586\n      - NTFY_AUTH_FILE=/var/lib/ntfy/auth.db\n      - NTFY_AUTH_DEFAULT_ACCESS=deny-all\n      - NTFY_BEHIND_PROXY=true\n      - NTFY_CACHE_FILE=/var/lib/ntfy/cache.db\n    volumes:\n      - ntfy-data:/var/lib/ntfy\n    healthcheck:\n      test: ["CMD", "ntfy", "healthy"]\n      interval: 15s\n      timeout: 5s\n      retries: 5\n\n`;
+        const prodBlock = `${ntfyBlock}  server:\n    build:\n      context: /home/user/.pizzapi/web/repo\n      dockerfile: Dockerfile\n      target: runtime-no-ui\n      args:\n        PREBUILT_UI: "true"\n        UI_DIST_HASH: "abc123def456"\n    ports:\n      - "7492:7492"\n    environment:\n      - PORT=7492\n      - PIZZAPI_REDIS_URL=redis://redis:6379\n      - BETTER_AUTH_SECRET=Secret123\n      - VAPID_PUBLIC_KEY=BTestPublicKey123\n      - VAPID_PRIVATE_KEY=TestPrivateKey456\n      - VAPID_SUBJECT=mailto:admin@pizzapi.local\n      # - PIZZAPI_EXTRA_ORIGINS=\n      # - PIZZAPI_TRUST_PROXY=\n      # - PIZZAPI_PROXY_DEPTH=\n      - PIZZAPI_NTFY_URL=http://ntfy\n      # - PIZZAPI_NTFY_PUBLIC_URL=\n      # - PIZZAPI_NTFY_PUBLISH_TOKEN=\n    volumes:\n      - /home/user/.pizzapi/web/data:/app/data:Z\n    depends_on:\n      redis:\n        condition: service_started\n      ntfy:\n        condition: service_started\n    restart: unless-stopped\n    stop_grace_period: 30s\n\n`;
+        const composed = COMPOSE_TEMPLATE
+            .replace(/\{\{REDIS_PLATFORM_LINE}}/g, "    platform: linux/arm64\n")
+            .replace(/\{\{APP_SERVICE_BLOCK}}/g, prodBlock)
+            .replace(/\{\{VOLUMES_SECTION}}/g, "volumes:\n  ui-dist:\n  ntfy-data:\n");
+
+        expect(composed).not.toContain("{{");
+        expect(composed).not.toContain("}}");
+        expect(composed).toContain("  ntfy:\n    image: binwiederhier/ntfy:v2.25.0");
+        expect(composed).toContain("PIZZAPI_NTFY_URL=http://ntfy");
+        expect(composed).toContain("ntfy:\n        condition: service_started");
+        expect(composed).toContain("ntfy-data:");
+    });
+
     test("template with no extra origins produces commented-out line", () => {
         const devBlock = `  dev:\n    build:\n      context: /repo\n      dockerfile: Dockerfile\n      target: builder\n    command: bun run dev\n    ports:\n      - "7492:7492"\n      - "5173:5173"\n    environment:\n      - PORT=7492\n      - PIZZAPI_REDIS_URL=redis://redis:6379\n      - BETTER_AUTH_SECRET=Secret\n      - VAPID_PUBLIC_KEY=key\n      - VAPID_PRIVATE_KEY=key\n      - VAPID_SUBJECT=mailto:test@test.com\n      # - PIZZAPI_EXTRA_ORIGINS=\n      # - PIZZAPI_TRUST_PROXY=\n      # - PIZZAPI_PROXY_DEPTH=\n    volumes:\n      - /repo:/app:Z\n      - /app/node_modules\n      - /data:/app/data:Z\n    depends_on:\n      redis:\n        condition: service_healthy\n    restart: unless-stopped\n    stop_grace_period: 30s\n\n`;
         const composed = COMPOSE_TEMPLATE

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -801,12 +801,34 @@ function generateComposeFile(opts: {
     const prodUiDependsOnLine = useLocalUiBuild ? "" : "      ui:\n        condition: service_healthy\n";
     const prodServerBuildTarget = useLocalUiBuild ? "runtime" : "runtime-no-ui";
 
+    // ── ntfy (self-hosted push, mirrors docker/compose.yml) ──
+    // PIZZAPI_NTFY_URL is the internal Docker DNS name for the bundled ntfy
+    // service and can always be set. PIZZAPI_NTFY_PUBLIC_URL / _PUBLISH_TOKEN
+    // cannot be auto-derived — read them from the environment (same convention
+    // as PIZZAPI_TRUST_PROXY above) and warn loudly when they're missing so a
+    // `pizza web` deploy doesn't silently ship a dead native-push config.
+    const ntfyPublicUrl = process.env.PIZZAPI_NTFY_PUBLIC_URL?.trim() ?? "";
+    const ntfyPublishToken = process.env.PIZZAPI_NTFY_PUBLISH_TOKEN?.trim() ?? "";
+    const ntfyPublicUrlLine = ntfyPublicUrl
+        ? `      - PIZZAPI_NTFY_PUBLIC_URL=${ntfyPublicUrl}\n`
+        : `      # - PIZZAPI_NTFY_PUBLIC_URL=\n`;
+    const ntfyPublishTokenLine = ntfyPublishToken
+        ? `      - PIZZAPI_NTFY_PUBLISH_TOKEN=${ntfyPublishToken}\n`
+        : `      # - PIZZAPI_NTFY_PUBLISH_TOKEN=\n`;
+    if (!useDevUi && (!ntfyPublicUrl || !ntfyPublishToken)) {
+        log.warn(
+            "ntfy provisioned but PIZZAPI_NTFY_PUBLIC_URL/PIZZAPI_NTFY_PUBLISH_TOKEN unset — " +
+            "Android native push will not work; see deployment/mobile-push.mdx"
+        );
+    }
+    const ntfyServiceBlock = `  ntfy:\n    image: binwiederhier/ntfy:v2.25.0\n    command: serve\n    restart: unless-stopped\n    environment:\n      - NTFY_BASE_URL=${ntfyPublicUrl || "http://localhost:2586"}\n      - NTFY_AUTH_FILE=/var/lib/ntfy/auth.db\n      - NTFY_AUTH_DEFAULT_ACCESS=deny-all\n      - NTFY_BEHIND_PROXY=true\n      - NTFY_CACHE_FILE=/var/lib/ntfy/cache.db\n    volumes:\n      - ntfy-data:/var/lib/ntfy\n    healthcheck:\n      test: ["CMD", "ntfy", "healthy"]\n      interval: 15s\n      timeout: 5s\n      retries: 5\n\n`;
+
     const devServiceBlock = `  dev:\n    build:\n      context: ${repoPath}\n      dockerfile: Dockerfile\n      target: builder\n    command: bun run dev\n    ports:\n      - "${config.port}:7492"\n      - "5173:5173"\n    environment:\n      - PORT=7492\n      - PIZZAPI_REDIS_URL=redis://redis:6379\n      - BETTER_AUTH_SECRET=${config.betterAuthSecret}\n      - AUTH_DB_PATH=/app/data/auth.db\n      - VAPID_PUBLIC_KEY=${config.vapid.publicKey}\n      - VAPID_PRIVATE_KEY=${config.vapid.privateKey}\n      - VAPID_SUBJECT=${config.vapidSubject}\n${extraOriginsLine}${trustProxyLine}${proxyDepthLine}    volumes:\n      - ${repoPath}:/app:Z\n      - /app/node_modules\n      - ${dataDir}:/app/data:Z\n    depends_on:\n      redis:\n        condition: service_healthy\n    restart: unless-stopped\n    stop_grace_period: 30s\n\n`;
 
     const appServiceBlock = useDevUi
         ? devServiceBlock
-        : `${prodUiServiceBlock}  server:\n    build:\n      context: ${repoPath}\n      dockerfile: Dockerfile\n      target: ${prodServerBuildTarget}\n      args:\n        PREBUILT_UI: "${prebuiltUi ? "true" : "false"}"\n        UI_DIST_HASH: "${uiDistHash ?? "none"}"\n    ports:\n      - "${config.port}:7492"\n    environment:\n      - PORT=7492\n      - PIZZAPI_REDIS_URL=redis://redis:6379\n      - BETTER_AUTH_SECRET=${config.betterAuthSecret}\n      - VAPID_PUBLIC_KEY=${config.vapid.publicKey}\n      - VAPID_PRIVATE_KEY=${config.vapid.privateKey}\n      - VAPID_SUBJECT=${config.vapidSubject}\n${extraOriginsLine}${trustProxyLine}${proxyDepthLine}    volumes:\n      - ${dataDir}:/app/data:Z\n${prodUiVolumeLine}    depends_on:\n      redis:\n        condition: service_started\n${prodUiDependsOnLine}    restart: unless-stopped\n    stop_grace_period: 30s\n\n`;
-    const volumesSection = useDevUi ? "" : "volumes:\n  ui-dist:\n";
+        : `${prodUiServiceBlock}${ntfyServiceBlock}  server:\n    build:\n      context: ${repoPath}\n      dockerfile: Dockerfile\n      target: ${prodServerBuildTarget}\n      args:\n        PREBUILT_UI: "${prebuiltUi ? "true" : "false"}"\n        UI_DIST_HASH: "${uiDistHash ?? "none"}"\n    ports:\n      - "${config.port}:7492"\n    environment:\n      - PORT=7492\n      - PIZZAPI_REDIS_URL=redis://redis:6379\n      - BETTER_AUTH_SECRET=${config.betterAuthSecret}\n      - VAPID_PUBLIC_KEY=${config.vapid.publicKey}\n      - VAPID_PRIVATE_KEY=${config.vapid.privateKey}\n      - VAPID_SUBJECT=${config.vapidSubject}\n${extraOriginsLine}${trustProxyLine}${proxyDepthLine}      - PIZZAPI_NTFY_URL=http://ntfy\n${ntfyPublicUrlLine}${ntfyPublishTokenLine}    volumes:\n      - ${dataDir}:/app/data:Z\n${prodUiVolumeLine}    depends_on:\n      redis:\n        condition: service_started\n${prodUiDependsOnLine}      ntfy:\n        condition: service_started\n    restart: unless-stopped\n    stop_grace_period: 30s\n\n`;
+    const volumesSection = useDevUi ? "" : "volumes:\n  ui-dist:\n  ntfy-data:\n";
 
     const compose = template
         .replace(/\{\{REDIS_PLATFORM_LINE}}/g, redisPlatformLine)

--- a/packages/docs/src/content/docs/reference/mobile-builds.mdx
+++ b/packages/docs/src/content/docs/reference/mobile-builds.mdx
@@ -14,10 +14,10 @@ The mobile app keeps the user inside the bundled UI after setup. On first launch
 - `capacitor.config.ts` points Capacitor at `mobile/`, which contains both the bootstrap page (`index.html`) and the bundled PWA (`app/`).
 - `mobile/index.html` handles first-run server URL entry, QR scanning, and mobile-link redemption.
 - `scripts/copy-mobile-ui.ts` copies the built `packages/ui/dist` assets into `mobile/app/` during `bun run build:mobile`.
-- `android/` contains the committed Android project.
-- `ios/` contains the committed iOS project.
-- Generated web assets copied into native projects are ignored; run sync/build commands to refresh them.
-- CI builds the Android debug APK on pull requests and pushes.
+- `android/` contains the committed Android project. `ios/` contains the committed iOS project.
+- `bun run build:mobile*` always builds the UI with `VITE_MOBILE=1 VITE_BASE_URL=./`, which disables the Vite PWA plugin (`enablePWA` in `packages/ui/vite.config.ts`) — a service worker registered inside the Capacitor WebView precaches by absolute scope and can serve stale HTML after a rebuild (black screen). The bundled app should therefore never contain `sw.js`, `registerSW.js`, `workbox-*.js`, or `manifest.webmanifest`.
+- `android/app/src/main/assets/public/` and `ios/App/App/public/` (the assets `cap sync` copies into each native project) are **build output, not tracked in git** — both are ignored wholesale by `android/.gitignore` and `ios/.gitignore`. Nothing under either path should ever be committed; run `bun run build:mobile`, `build:mobile:android`, or `build:mobile:ios` to (re)generate them locally.
+- CI builds the Android debug APK on pull requests and pushes, and guards both bundle trees against stale service-worker artifacts (see [CI coverage](#ci-coverage) below).
 - `CapacitorHttp` is enabled so `fetch`/`XHR` run through native networking (the API key is only injected for relay-origin requests).
 
 ## Commands
@@ -40,9 +40,9 @@ bun run build:mobile:ios
   Android builds require an Android SDK. If Gradle says `SDK location not found`, set `ANDROID_HOME` or create `android/local.properties` with `sdk.dir=/path/to/android-sdk`.
 </Aside>
 
-## Android CI
+## CI coverage
 
-`.github/workflows/ci.yml` includes a `mobile-android` job. It installs Java, Android SDK tooling, Bun dependencies, then runs:
+`.github/workflows/ci.yml` includes a `mobile-android` job that runs on every pull request and push. It installs Java, Android SDK tooling, and Bun dependencies, then runs:
 
 ```bash
 bun run build:mobile:android
@@ -50,6 +50,26 @@ bun run build:mobile:android
 
 That intentionally builds a **debug** APK only — signed with Android's throwaway
 debug key, fine for smoke-testing but not distributable.
+
+The same job then runs `bunx cap sync ios` (a plain Node/Bun file-copy + Swift
+Package manifest step — no CocoaPods, no Xcode, so it runs fine on the
+`ubuntu-latest` runner) to populate `ios/App/App/public/` from the same
+`VITE_MOBILE` bundle, and finishes with a guard step that fails the build if
+`sw.js`, `registerSW.js`, `workbox-*`, or `manifest.webmanifest` shows up
+anywhere under `android/app/src/main/assets/public/` or `ios/App/App/public/`.
+That's the regression this whole page exists to prevent: a stale PWA build
+(pre-`VITE_MOBILE`, PWA plugin still enabled) sitting in the native shell and
+black-screening the app on launch.
+
+<Aside type="caution">
+  {/* ponytail: this is an artifact-name check on the generated bundle tree,
+  not a real build for either platform. It doesn't compile, sign, or run
+  anything. Upgrade to a real Xcode/simulator build on a macOS runner if iOS
+  ever ships for real — see the iOS section below. */}
+  The `mobile-android` job's iOS step is a filename check, not a build. It
+  proves the bundle doesn't contain service-worker artifacts; it does **not**
+  prove the Xcode project compiles, links, or runs.
+</Aside>
 
 ## Release signing
 
@@ -136,7 +156,15 @@ on a tag the `versionName` defaults to the tag minus its leading `v`.
 
 ## iOS
 
-iOS is committed and syncable, but not built in CI yet. Add macOS/Xcode CI only when iOS distribution is active; it needs signing/provisioning setup and is slower than the Android smoke check.
+iOS is committed and syncable, and CI now sanity-checks its generated bundle
+(see [CI coverage](#ci-coverage) above), but nothing ever compiles the Xcode
+project in CI. Add macOS/Xcode CI only when iOS distribution is active; it
+needs signing/provisioning setup and is slower than the Android smoke check.
+
+`ios/App/App/public/` (the web assets `cap sync` copies in) is generated and
+gitignored, exactly like Android's `android/app/src/main/assets/public/` — run
+`bun run build:mobile:ios` (or `bun run build:mobile`) to regenerate it
+locally; never hand-edit or commit it.
 
 ## Server URL and Auth
 

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -104,6 +104,16 @@ export interface ViewerClientToServerEvents {
   /** Viewer greeting — triggers TUI capabilities push */
   connected: (data: Record<string, never>) => void;
 
+  /**
+   * Report whether this viewer tab is currently visible (document.visibilityState).
+   * Drives native (ntfy) push suppression: a visible viewer on a session means
+   * the user can already see the prompt, so don't buzz their phone.
+   * Window focus is deliberately NOT considered — a second monitor still counts
+   * as viewing. Web Push suppression is unaffected (any connected viewer
+   * suppresses it, because client-side browser notifications cover hidden tabs).
+   */
+  viewer_visibility: (data: { visible: boolean }) => void;
+
   /** Logically switch the existing viewer socket to a different session. */
   switch_session: (data: {
     sessionId: string;
@@ -187,4 +197,11 @@ export interface ViewerSocketData extends SocketClientMetadata {
   userName?: string;
   /** Latest requested logical session-switch generation for this viewer socket. */
   generation?: number;
+  /**
+   * Whether this viewer tab is currently visible. Undefined for clients that
+   * predate the `viewer_visibility` event. Suppression is fail-open: only an
+   * explicit `true` suppresses native push, so a missing/late signal costs a
+   * redundant buzz rather than a silently dropped notification.
+   */
+  viewerVisible?: boolean;
 }

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, spyOn } from "bun:test";
 import { createTestAuthContext, getKysely, runWithAuthContext } from "./auth.js";
 import { unsubscribePush, updateSuppressChildNotifications, getSubscriptionsForUser, isValidPushEndpoint, registerNativePush, unregisterNativePush, getNativeRegistrationsForUser, ensureNativePushRegistrationTable, sendPushToUser } from "./push.js";
 import { mkdtempSync, rmSync } from "fs";
@@ -556,6 +556,66 @@ describe("native push registration", () => {
 
         // The 403 should have pruned the registration.
         const rows = await getNativeRegistrationsForUser("user-F");
+        expect(rows).toHaveLength(0);
+    });
+
+    authIt("sendPushToUser retries once on a 5xx ntfy failure then gives up and logs", async () => {
+        await registerNativePush({ userId: "user-5xx", platform: "android" });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let callCount = 0;
+        const origFetch = globalThis.fetch;
+        const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+        (globalThis as any).fetch = () => {
+            callCount++;
+            return Promise.resolve(new Response("server error", { status: 503 }));
+        };
+        try {
+            await sendPushToUser("user-5xx", {
+                type: "agent_finished",
+                title: "done",
+                body: "x",
+                sessionId: "s",
+            });
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+
+        // Single retry: one initial attempt + one retry, then give up.
+        expect(callCount).toBe(2);
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+        // 5xx is transient, not "stale" — the registration must survive.
+        const rows = await getNativeRegistrationsForUser("user-5xx");
+        expect(rows).toHaveLength(1);
+    });
+
+    authIt("sendPushToUser does not retry on 403 (single fetch call) and prunes", async () => {
+        await registerNativePush({ userId: "user-403-noretry", platform: "android" });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let callCount = 0;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => {
+            callCount++;
+            return Promise.resolve(new Response("forbidden", { status: 403 }));
+        };
+        try {
+            await sendPushToUser("user-403-noretry", {
+                type: "agent_finished",
+                title: "done",
+                body: "x",
+                sessionId: "s",
+            });
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+
+        // 403 is not transient (forbidden topic) — no retry, prune immediately.
+        expect(callCount).toBe(1);
+        const rows = await getNativeRegistrationsForUser("user-403-noretry");
         expect(rows).toHaveLength(0);
     });
 });

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -401,26 +401,61 @@ async function sendNtfyToUser(userId: string, payload: PushPayload, isChildSessi
     const base = cfg.url.replace(/\/+$/, "");
     const staleIds: string[] = [];
 
+    // ponytail: single immediate retry on transient failure (network throw or
+    // 5xx) — no backoff, no queue, no retry framework. If ntfy is down for
+    // longer than one extra round-trip, the notification is dropped and only
+    // logged. Upgrade path if that's ever not good enough: a durable outbox
+    // table drained by a background sweep, same shape as email retry queues.
+    async function publishOnce(reg: NativePushRegistrationTable): Promise<Response> {
+        // ntfy JSON publish: POST to the base URL with `topic` in the body.
+        // 10s timeout so a hung ntfy instance can't block forever.
+        return fetch(base, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ topic: reg.topic, ...fields }),
+            signal: AbortSignal.timeout(10_000),
+        });
+    }
+
     await Promise.allSettled(
         registrations.map(async (reg) => {
+            let res: Response;
             try {
-                // ntfy JSON publish: POST to the base URL with `topic` in the body.
-                // 10s timeout so a hung ntfy instance can't block forever.
-                const res = await fetch(base, {
-                    method: "POST",
-                    headers,
-                    body: JSON.stringify({ topic: reg.topic, ...fields }),
-                    signal: AbortSignal.timeout(10_000),
-                });
-                // 403/404 = topic forbidden/unknown → prune the registration.
+                res = await publishOnce(reg);
+            } catch (err) {
+                // Network-level failure (throw) — retry once.
+                try {
+                    res = await publishOnce(reg);
+                } catch (retryErr) {
+                    log.error(`ntfy publish to topic ${reg.topic.slice(0, 16)}… failed after retry:`, retryErr);
+                    return;
+                }
+            }
+
+            // 403/404 = topic forbidden/unknown → prune the registration. Not
+            // transient — a retry can't fix an invalid/forbidden topic.
+            if (res.status === 403 || res.status === 404) {
+                staleIds.push(reg.id);
+                return;
+            }
+            if (res.ok) return;
+
+            if (res.status >= 500) {
+                // Transient server error — retry once.
+                try {
+                    res = await publishOnce(reg);
+                } catch (retryErr) {
+                    log.error(`ntfy publish to topic ${reg.topic.slice(0, 16)}… failed after retry:`, retryErr);
+                    return;
+                }
                 if (res.status === 403 || res.status === 404) {
                     staleIds.push(reg.id);
-                } else if (!res.ok) {
-                    log.error(`ntfy publish to topic ${reg.topic.slice(0, 16)}… failed: ${res.status}`);
+                    return;
                 }
-            } catch (err) {
-                log.error("ntfy publish error:", err);
+                if (res.ok) return;
             }
+
+            log.error(`ntfy publish to topic ${reg.topic.slice(0, 16)}… failed: ${res.status}`);
         }),
     );
 

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -593,15 +593,22 @@ function isEventEnabled(enabledEvents: string, eventType: PushEventType): boolea
  *   only ever offered an opt-IN to further suppression, never a guaranteed
  *   "receive despite being a child" opt-out, so there is nothing to preserve
  *   here — it remains stored/toggleable but is now redundant.
- * @param suppressWebPush - Skip browser subscriptions while still delivering
- *   native Android push. Used when a live Socket.IO viewer already covers the
- *   browser path but other registered Android devices still need notification.
+ * @param suppressWebPush - Skip browser subscriptions. Set when ANY viewer
+ *   socket is connected to the session: a connected-but-hidden tab is already
+ *   covered by client-side browser notifications (useBrowserNotifications), so
+ *   sending Web Push too would double-notify.
+ * @param suppressNative - Skip native Android (ntfy) push. Set only when a
+ *   viewer of this session has its tab VISIBLE — the user can see the prompt,
+ *   so their phone shouldn't buzz. Deliberately a separate flag from
+ *   suppressWebPush: a hidden tab still suppresses Web Push (covered by browser
+ *   notifications) but must NOT suppress the phone.
  */
 export async function sendPushToUser(
     userId: string,
     payload: PushPayload,
     isChildSession = false,
     suppressWebPush = false,
+    suppressNative = false,
 ): Promise<void> {
     const subscriptions = await getSubscriptionsForUser(userId);
 
@@ -609,9 +616,11 @@ export async function sendPushToUser(
     // may have only the native app registered, with zero browser subs. Kick it
     // off WITHOUT awaiting here so a slow/hung ntfy instance can't delay browser
     // delivery; it settles alongside the Web Push sends below.
-    const ntfyPromise = sendNtfyToUser(userId, payload, isChildSession).catch((err) => {
-        log.error("ntfy fan-out failed:", err);
-    });
+    const ntfyPromise = suppressNative
+        ? Promise.resolve()
+        : sendNtfyToUser(userId, payload, isChildSession).catch((err) => {
+              log.error("ntfy fan-out failed:", err);
+          });
 
     const payloadStr = JSON.stringify(payload);
     const staleIds: string[] = [];
@@ -658,6 +667,20 @@ export async function sendPushToUser(
 }
 
 /**
+ * Which delivery channels to skip for this notification.
+ *
+ * An object rather than two adjacent booleans: these wrappers already take up
+ * to 8 positional args, and `(..., isChildSession, suppressWebPush, suppressNative)`
+ * is a transposition bug waiting to happen.
+ */
+export interface PushSuppression {
+    /** Skip Web Push — set when any viewer socket is connected to the session. */
+    web?: boolean;
+    /** Skip native ntfy — set only when a viewer's tab is actually VISIBLE. */
+    native?: boolean;
+}
+
+/**
  * Convenience: notify a user that their agent finished working.
  */
 export function notifyAgentFinished(
@@ -666,7 +689,7 @@ export function notifyAgentFinished(
     sessionName?: string | null,
     isChildSession = false,
     replyText?: string,
-    suppressWebPush = false,
+    suppress: PushSuppression = {},
 ): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const reply = replyText?.trim();
@@ -678,7 +701,7 @@ export function notifyAgentFinished(
             : `Your agent in "${label}" has finished its task.`,
         sessionId,
         sessionName: label,
-    }, isChildSession, suppressWebPush).catch((err) => {
+    }, isChildSession, suppress.web, suppress.native).catch((err) => {
         log.error("notifyAgentFinished failed:", err);
     });
 }
@@ -696,7 +719,7 @@ export function notifyAgentNeedsInput(
     options?: string[],
     toolCallId?: string,
     isChildSession = false,
-    suppressWebPush = false,
+    suppress: PushSuppression = {},
 ): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const body = question
@@ -739,7 +762,7 @@ export function notifyAgentNeedsInput(
             ...(options && options.length > 0 ? { options } : {}),
             ...(toolCallId ? { toolCallId } : {}),
         },
-    }, isChildSession, suppressWebPush).catch((err) => {
+    }, isChildSession, suppress.web, suppress.native).catch((err) => {
         log.error("notifyAgentNeedsInput failed:", err);
     });
 }
@@ -753,7 +776,7 @@ export function notifyAgentError(
     errorMessage?: string,
     sessionName?: string | null,
     isChildSession = false,
-    suppressWebPush = false,
+    suppress: PushSuppression = {},
 ): void {
     const label = sessionName ?? sessionId.slice(0, 8);
     const body = errorMessage
@@ -765,7 +788,7 @@ export function notifyAgentError(
         body,
         sessionId,
         sessionName: label,
-    }, isChildSession, suppressWebPush).catch((err) => {
+    }, isChildSession, suppress.web, suppress.native).catch((err) => {
         log.error("notifyAgentError failed:", err);
     });
 }

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -30,6 +30,9 @@ import {
 import { sendCumulativeEventAck } from "./ack-tracker.js";
 import { trackPushPendingState, checkPushNotifications } from "./push-tracker.js";
 import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
 
 export interface ChunkedSessionState {
     snapshotId: string;
@@ -464,8 +467,13 @@ export function registerEventHandler(socket: RelaySocket): void {
             (event.type === "tool_execution_start" || event.type === "tool_execution_end")) {
             await trackPushPendingState(sessionId, event);
         }
-        // Push notifications (fire-and-forget — not on hot path)
-        void checkPushNotifications(sessionId, event);
+        // Push notifications (fire-and-forget — not on hot path). Bun does NOT
+        // route unhandled promise rejections through process.on('uncaughtException'),
+        // so an uncaught error here silently vanishes with no push-specific log
+        // line. Catch and log explicitly so push failures are greppable.
+        void checkPushNotifications(sessionId, event).catch((err) => {
+            log.error(`push notification check failed for session ${sessionId} (event=${event.type}):`, err);
+        });
 
         }); // end enqueueSessionEvent
     });

--- a/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
+++ b/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, it, expect, mock } from "bun:test";
 
 const finishedCalls: unknown[][] = [];
+const needsInputCalls: unknown[][] = [];
+
+let viewerCount = 1;
+let visibleViewer = true;
 
 mock.module("../../../push.js", () => ({
     notifyAgentFinished: (...args: unknown[]) => finishedCalls.push(args),
-    notifyAgentNeedsInput: () => {},
+    notifyAgentNeedsInput: (...args: unknown[]) => needsInputCalls.push(args),
     notifyAgentError: () => {},
 }));
 mock.module("../../sio-state/index.js", () => ({
@@ -19,15 +23,24 @@ mock.module("../../sio-registry.js", () => ({
         parentSessionId: null,
         linkedParentId: null,
     }),
-    getViewerCount: async () => 1,
+    getViewerCount: async () => viewerCount,
+    hasVisibleViewer: async () => visibleViewer,
 }));
 
 const { checkPushNotifications, extractLastAssistantText } = await import("./push-tracker.js");
 
-beforeEach(() => finishedCalls.splice(0));
+beforeEach(() => {
+    finishedCalls.splice(0);
+    needsInputCalls.splice(0);
+    viewerCount = 1;
+    visibleViewer = true;
+});
 
 describe("checkPushNotifications", () => {
-    it("keeps native delivery enabled when connected viewers suppress Web Push", async () => {
+    it("viewer connected + tab visible suppresses both web and native", async () => {
+        viewerCount = 1;
+        visibleViewer = true;
+
         await checkPushNotifications("sess-connected", {
             type: "agent_end",
             messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
@@ -39,7 +52,67 @@ describe("checkPushNotifications", () => {
             "Connected session",
             false,
             "done",
-            true,
+            { web: true, native: true },
+        ]]);
+    });
+
+    it("viewer connected + tab hidden suppresses web only", async () => {
+        viewerCount = 1;
+        visibleViewer = false;
+
+        await checkPushNotifications("sess-hidden", {
+            type: "agent_end",
+            messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+        });
+
+        expect(finishedCalls).toEqual([[
+            "user-connected",
+            "sess-hidden",
+            "Connected session",
+            false,
+            "done",
+            { web: true, native: false },
+        ]]);
+    });
+
+    it("no viewer at all suppresses neither", async () => {
+        viewerCount = 0;
+        visibleViewer = false;
+
+        await checkPushNotifications("sess-empty", {
+            type: "agent_end",
+            messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+        });
+
+        expect(finishedCalls).toEqual([[
+            "user-connected",
+            "sess-empty",
+            "Connected session",
+            false,
+            "done",
+            { web: false, native: false },
+        ]]);
+    });
+
+    it("plan_mode start produces a needs-input push with no option buttons", async () => {
+        viewerCount = 0;
+        visibleViewer = false;
+
+        await checkPushNotifications("sess-plan", {
+            type: "tool_execution_start",
+            toolName: "plan_mode",
+            toolCallId: "tc-1",
+        });
+
+        expect(needsInputCalls).toEqual([[
+            "user-connected",
+            "sess-plan",
+            "Plan ready for review",
+            "Connected session",
+            undefined,
+            undefined,
+            false,
+            { web: false, native: false },
         ]]);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/push-tracker.ts
+++ b/packages/server/src/ws/namespaces/relay/push-tracker.ts
@@ -10,7 +10,7 @@ import {
     notifyAgentNeedsInput,
     notifyAgentError,
 } from "../../../push.js";
-import { getSharedSession, getViewerCount } from "../../sio-registry.js";
+import { getSharedSession, getViewerCount, hasVisibleViewer } from "../../sio-registry.js";
 
 /**
  * Manage the push-pending Redis key for AskUserQuestion lifecycle.
@@ -66,7 +66,8 @@ export async function checkPushNotifications(
     if (
         event.type !== "agent_end" &&
         event.type !== "cli_error" &&
-        !(event.type === "tool_execution_start" && event.toolName === "AskUserQuestion")
+        !(event.type === "tool_execution_start" && event.toolName === "AskUserQuestion") &&
+        !(event.type === "tool_execution_start" && event.toolName === "plan_mode")
     ) {
         return;
     }
@@ -75,10 +76,22 @@ export async function checkPushNotifications(
     const userId = session?.userId;
     if (!userId) return;
 
-    // Connected viewers receive live session events over Socket.IO, so Web Push
-    // would duplicate their in-app notification. Native Android registrations
-    // still need ntfy fan-out: one connected viewer must not silence other devices.
-    const suppressWebPush = await getViewerCount(sessionId) > 0;
+    // Two different questions, two different answers:
+    //
+    //  • Web Push — suppressed by ANY connected viewer. A connected-but-hidden
+    //    tab is already covered by client-side browser notifications
+    //    (useBrowserNotifications), so Web Push on top would double-notify.
+    //
+    //  • Native (ntfy) — suppressed only when a viewer's tab is actually
+    //    VISIBLE on this session. If the user can see the prompt, their phone
+    //    shouldn't buzz; if every tab is hidden/backgrounded, it should.
+    //    Window focus is ignored on purpose so a second monitor counts as
+    //    viewing.
+    const [viewerCount, visibleViewer] = await Promise.all([
+        getViewerCount(sessionId),
+        hasVisibleViewer(sessionId),
+    ]);
+    const suppress = { web: viewerCount > 0, native: visibleViewer };
 
     const sName = session?.sessionName ?? null;
 
@@ -102,7 +115,7 @@ export async function checkPushNotifications(
     const isChildSession = !!effectiveParentId && await isLinkedChildForSuppression(effectiveParentId, sessionId);
 
     if (event.type === "agent_end") {
-        notifyAgentFinished(userId, sessionId, sName, isChildSession, extractLastAssistantText(event), suppressWebPush);
+        notifyAgentFinished(userId, sessionId, sName, isChildSession, extractLastAssistantText(event), suppress);
     }
 
     if (event.type === "tool_execution_start" && event.toolName === "AskUserQuestion") {
@@ -139,11 +152,20 @@ export async function checkPushNotifications(
         // reject with 400 — so don't show action buttons in any of those cases.
         const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : undefined;
         const canQuickReply = questionCount <= 1 && session?.collabMode === true && !!toolCallId;
-        notifyAgentNeedsInput(userId, sessionId, question, sName, canQuickReply ? options : undefined, toolCallId, isChildSession, suppressWebPush);
+        notifyAgentNeedsInput(userId, sessionId, question, sName, canQuickReply ? options : undefined, toolCallId, isChildSession, suppress);
+    }
+
+    if (event.type === "tool_execution_start" && event.toolName === "plan_mode") {
+        // Plan review is approve/edit/cancel, which the push answer API does
+        // not model — no quick-reply option buttons here, just a heads-up.
+        // Reuse notifyAgentNeedsInput's generic "waiting for input" plumbing
+        // but with plan-specific copy; pass no options/toolCallId so no
+        // action buttons are rendered.
+        notifyAgentNeedsInput(userId, sessionId, "Plan ready for review", sName, undefined, undefined, isChildSession, suppress);
     }
 
     if (event.type === "cli_error") {
         const errMsg = typeof event.message === "string" ? event.message : undefined;
-        notifyAgentError(userId, sessionId, errMsg, sName, isChildSession, suppressWebPush);
+        notifyAgentError(userId, sessionId, errMsg, sName, isChildSession, suppress);
     }
 }

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -546,6 +546,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             }
         });
 
+        // ── viewer_visibility — tab visible/hidden, drives native push suppression ──
+        // ponytail: state lives on socket.data (already replicated to other nodes
+        // by the Redis adapter for fetchSockets()), so no new Redis key is needed.
+        socket.on("viewer_visibility", (data) => {
+            socket.data.viewerVisible = data?.visible !== false;
+        });
+
         // ── resync — send fresh snapshot ─────────────────────────────────────
         socket.on("resync", async (data) => {
             const currentSessionId = getCurrentSessionId();

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -33,6 +33,7 @@ export {
     removeViewer,
     broadcastToViewers,
     getViewerCount,
+    hasVisibleViewer,
     markPendingRecovery,
     consumePendingRecovery,
     hasPendingRecovery,

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -1155,3 +1155,38 @@ export async function getViewerCount(sessionId: string): Promise<number> {
     const sockets = await io.of("/viewer").adapter.sockets(new Set([viewerSessionRoom(sessionId)]));
     return sockets.size;
 }
+
+/**
+ * True when at least one viewer of this session has its tab currently visible.
+ *
+ * "Visible" deliberately ignores window focus — a session on a second monitor
+ * still counts as being watched. Used to suppress NATIVE (ntfy) push: if the
+ * user can already see the prompt, don't buzz their phone.
+ *
+ * FAIL-OPEN: a socket counts as visible only when it EXPLICITLY reported
+ * `viewerVisible === true`. Unknown (older client, or the window between
+ * joining the room and the first `viewer_visibility` emit) counts as NOT
+ * visible, so we notify.
+ *
+ * The asymmetry is deliberate. Guessing "visible" costs a silently dropped
+ * phone notification — precisely the failure this whole feature exists to fix.
+ * Guessing "hidden" costs at worst one redundant buzz while you're already
+ * looking at the screen. Current clients emit on connect and on every session
+ * switch, so the unknown window is negligible in practice.
+ *
+ * Unlike getViewerCount this needs per-socket data, so it pays for
+ * fetchSockets(). Only called for the low-frequency push-worthy events,
+ * never on the hot relay path.
+ */
+export async function hasVisibleViewer(sessionId: string): Promise<boolean> {
+    const io = getIo();
+    try {
+        const sockets = await io.of("/viewer").in(viewerSessionRoom(sessionId)).fetchSockets();
+        return sockets.some((s) => (s.data as { viewerVisible?: boolean } | undefined)?.viewerVisible === true);
+    } catch (err) {
+        // Adapter hiccup — fall back to "no visible viewer" so a notification is
+        // sent. Over-notifying beats silently dropping the one that mattered.
+        log.error(`hasVisibleViewer failed for ${sessionId}:`, err);
+        return false;
+    }
+}

--- a/packages/server/src/ws/sio-registry/sessions.visible-viewer.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.visible-viewer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, mock } from "bun:test";
+
+/**
+ * hasVisibleViewer decides whether a user's PHONE stays silent, so the
+ * fail-open rule is worth pinning down: only an explicit `viewerVisible === true`
+ * counts as "the user can see this". Unknown/undefined must NOT suppress.
+ *
+ * Guessing "visible" costs a silently dropped notification (the exact bug this
+ * feature exists to fix); guessing "hidden" costs one redundant buzz.
+ */
+
+let fetchSocketsImpl: () => Promise<Array<{ data: unknown }>> = async () => [];
+
+// Spread the real module and override only getIo — context.js has many other
+// exports (hubUserRoom, etc.) that sibling modules import, and stubbing it
+// wholesale breaks them at import time.
+const actualContext = await import("./context.js");
+mock.module("./context.js", () => ({
+    ...actualContext,
+    getIo: () => ({
+        of: () => ({
+            in: () => ({ fetchSockets: fetchSocketsImpl }),
+        }),
+    }),
+}));
+
+const { hasVisibleViewer } = await import("./sessions.js");
+
+function sockets(...data: unknown[]): () => Promise<Array<{ data: unknown }>> {
+    return async () => data.map((d) => ({ data: d }));
+}
+
+describe("hasVisibleViewer (fail-open)", () => {
+    it("is true when a viewer explicitly reports visible", async () => {
+        fetchSocketsImpl = sockets({ viewerVisible: true });
+        expect(await hasVisibleViewer("s1")).toBe(true);
+    });
+
+    it("is false when a viewer explicitly reports hidden", async () => {
+        fetchSocketsImpl = sockets({ viewerVisible: false });
+        expect(await hasVisibleViewer("s1")).toBe(false);
+    });
+
+    it("is false when visibility was never reported (older client / pre-emit window)", async () => {
+        fetchSocketsImpl = sockets({});
+        expect(await hasVisibleViewer("s1")).toBe(false);
+    });
+
+    it("is false with no viewers at all", async () => {
+        fetchSocketsImpl = sockets();
+        expect(await hasVisibleViewer("s1")).toBe(false);
+    });
+
+    it("is true when any one of several viewers is visible", async () => {
+        fetchSocketsImpl = sockets({ viewerVisible: false }, {}, { viewerVisible: true });
+        expect(await hasVisibleViewer("s1")).toBe(true);
+    });
+
+    it("is false when the adapter throws \u2014 over-notify rather than drop", async () => {
+        fetchSocketsImpl = async () => {
+            throw new Error("adapter down");
+        };
+        expect(await hasVisibleViewer("s1")).toBe(false);
+    });
+});

--- a/packages/server/tests/mobile-ota.test.ts
+++ b/packages/server/tests/mobile-ota.test.ts
@@ -38,6 +38,24 @@ describe("handleMobileOtaRoute", () => {
         expect(await res?.json()).toEqual({ version: "t", checksum: "abc" });
     });
 
+    it("serves an optional minBuildTimestamp field verbatim (kill-switch passthrough)", async () => {
+        // The route is a static-file passthrough — it doesn't need to know
+        // about minBuildTimestamp at all; the client enforces the gate. This
+        // just guards against someone adding manifest validation that strips
+        // unknown fields.
+        writeFileSync(
+            join(dir, "manifest.json"),
+            JSON.stringify({ version: "t", checksum: "abc", minBuildTimestamp: "2026-07-10T00:00:00.000Z" }),
+        );
+        const res = await get("/api/mobile/ota/manifest.json");
+        expect(res?.status).toBe(200);
+        expect(await res?.json()).toEqual({
+            version: "t",
+            checksum: "abc",
+            minBuildTimestamp: "2026-07-10T00:00:00.000Z",
+        });
+    });
+
     it("serves a bundle zip immutably", async () => {
         const res = await get("/api/mobile/ota/pizzapi-t.zip");
         expect(res?.status).toBe(200);

--- a/packages/ui/public/sw-push.js
+++ b/packages/ui/public/sw-push.js
@@ -143,7 +143,10 @@ function openAppToSession(sessionId) {
                     return;
                 }
             }
-            // No window open — open a new one
-            return self.clients.openWindow("/");
+            // No window open — open one already pointed at the session, so a
+            // cold start lands on the right place instead of the session list.
+            return self.clients.openWindow(
+                sessionId ? "/#/sessions/" + encodeURIComponent(sessionId) : "/",
+            );
         });
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -66,6 +66,7 @@ import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel
 import { DockedPanelGroup, TAB_BAR_HEIGHT } from "@/components/DockedPanelGroup";
 import type { PanelPosition } from "@/hooks/usePanelLayout";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
+import { getViewerVisibilityPayload } from "@/lib/viewer-visibility";
 import { HubSocketContext } from "@/lib/hub-socket-context";
 import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
 import { mapUserError } from "@/lib/user-error-message";
@@ -3310,6 +3311,7 @@ export function App() {
           generation: lifecycleRefs.generation.current,
           lastSeq: lastSeqRef.current ?? undefined,
         });
+        nextSocket.emit("viewer_visibility", getViewerVisibilityPayload());
       });
 
       nextSocket.on("connected", (data) => {
@@ -3527,6 +3529,7 @@ export function App() {
     setViewerSwitchGeneration(socket, nextGeneration);
     if (socket.connected) {
       socket.emit("switch_session", { sessionId: relaySessionId, generation: nextGeneration });
+      socket.emit("viewer_visibility", getViewerVisibilityPayload());
     } else {
       socket.connect();
     }
@@ -4392,6 +4395,18 @@ export function App() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [availableServices, dynamicPanels, closeServicePanelById]);
+
+  // Tell the server whether the tab is actually being looked at, so it can
+  // suppress native push while a viewer is visible. "Visible" ignores window
+  // focus on purpose — a session on a second monitor still counts as viewed.
+  React.useEffect(() => {
+    if (!viewerSocket) return;
+    const emitVisibility = () => {
+      viewerSocket.emit("viewer_visibility", getViewerVisibilityPayload());
+    };
+    document.addEventListener("visibilitychange", emitVisibility);
+    return () => document.removeEventListener("visibilitychange", emitVisibility);
+  }, [viewerSocket]);
 
   // Auto-open Tunnel panel when a non-pinned tunnel is registered.
   React.useEffect(() => {

--- a/packages/ui/src/components/NotificationToggle.test.tsx
+++ b/packages/ui/src/components/NotificationToggle.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for NotificationToggle's native (Android/ntfy) subscribed state.
+ *
+ * The bug this guards against: `startNtfyPush()` used to swallow every
+ * failure (503 unconfigured, fetch error, malformed response) and the toggle
+ * derived `subscribed` purely from OS permission + a localStorage flag — so a
+ * user could see "Notifications enabled" with zero server registration.
+ *
+ * We avoid `mock.module("@/lib/ntfy-push", ...)` / `mock.module("./ntfy-push", ...)`
+ * on purpose: Bun's `mock.module` keys off the resolved file, so mocking it
+ * here would leak into ntfy-push.test.ts (run in the same process per the
+ * project's test command) and stub out the real function this test exists to
+ * exercise. Instead we monkeypatch `Capacitor` platform methods directly
+ * (same technique as mobile-native.test.ts) and control `fetch` per test.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import React from "react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { Capacitor } from "@capacitor/core";
+import * as realLocalNotifications from "@capacitor/local-notifications";
+
+const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = () => ({
+    getPropertyValue: () => "",
+    paddingRight: "",
+    paddingTop: "",
+    paddingLeft: "",
+    paddingBottom: "",
+});
+(globalThis as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+(globalThis as any).IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+
+const origGetPlatform = Capacitor.getPlatform;
+const origIsNativePlatform = Capacitor.isNativePlatform;
+const origLocalStorage = (globalThis as any).localStorage;
+
+// Permission check/request always report "granted" — these tests are about
+// what happens to `subscribed` *after* permission is already granted.
+let permissionCalls = 0;
+mock.module("@capacitor/local-notifications", () => ({
+    LocalNotifications: {
+        checkPermissions: () => {
+            permissionCalls++;
+            return Promise.resolve({ display: "granted" });
+        },
+        requestPermissions: () => {
+            permissionCalls++;
+            return Promise.resolve({ display: "granted" });
+        },
+    },
+}));
+
+afterAll(() => {
+    // Restore the real plugin module so other test files see the real plugin.
+    mock.module("@capacitor/local-notifications", () => realLocalNotifications);
+    Capacitor.getPlatform = origGetPlatform;
+    Capacitor.isNativePlatform = origIsNativePlatform;
+    (globalThis as any).localStorage = origLocalStorage;
+});
+
+function makeLocalStorage(serverUrl: string | null): Storage {
+    const store: Record<string, string> = {};
+    return {
+        getItem: (key: string) => (key === "pizzapi.serverUrl" ? serverUrl : (store[key] ?? null)),
+        setItem: (key: string, value: string) => {
+            store[key] = value;
+        },
+        removeItem: (key: string) => {
+            delete store[key];
+        },
+        clear: () => {
+            for (const key of Object.keys(store)) delete store[key];
+        },
+        key: (index: number) => Object.keys(store)[index] ?? null,
+        length: 0,
+    } as unknown as Storage;
+}
+
+function goAndroidNative() {
+    Object.defineProperty(globalThis, "localStorage", {
+        value: makeLocalStorage("https://relay.example.com"),
+        configurable: true,
+        writable: true,
+    });
+    Capacitor.getPlatform = () => "android";
+    Capacitor.isNativePlatform = () => true;
+}
+
+const { NotificationToggle } = await import("./NotificationToggle");
+
+beforeEach(() => {
+    permissionCalls = 0;
+    goAndroidNative();
+});
+
+afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+});
+
+function ariaLabel(container: HTMLElement): string | null {
+    return container.querySelector("button[aria-label]")?.getAttribute("aria-label") ?? null;
+}
+
+describe("NotificationToggle (native/ntfy registration outcome)", () => {
+    test("503 (ntfy unconfigured) surfaces as unconfigured, not subscribed", async () => {
+        (globalThis as any).fetch = mock(async () => ({ ok: false, status: 503 }) as Response);
+
+        let container!: HTMLElement;
+        await act(async () => {
+            ({ container } = render(<NotificationToggle />));
+        });
+
+        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
+        expect(ariaLabel(container)).toBe("Push not configured on this server");
+        // Not-subscribed path renders a plain button, no dropdown trigger.
+        expect(container.querySelector("[aria-haspopup]")).toBeNull();
+    });
+
+    test("successful registration surfaces as subscribed", async () => {
+        (globalThis as any).fetch = mock(async () => ({
+            ok: true,
+            json: async () => ({ ntfyPublicUrl: "https://ntfy.example.com", topic: "pizzapi-abc123" }),
+        }) as Response);
+
+        let container!: HTMLElement;
+        await act(async () => {
+            ({ container } = render(<NotificationToggle />));
+        });
+
+        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
+        expect(ariaLabel(container)).toBe("Notifications enabled");
+    });
+
+    test("fetch throw surfaces as not subscribed (generic, not unconfigured)", async () => {
+        (globalThis as any).fetch = mock(async () => {
+            throw new Error("network down");
+        });
+
+        let container!: HTMLElement;
+        await act(async () => {
+            ({ container } = render(<NotificationToggle />));
+        });
+
+        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
+        expect(ariaLabel(container)).toBe("Enable notifications");
+    });
+});

--- a/packages/ui/src/components/NotificationToggle.tsx
+++ b/packages/ui/src/components/NotificationToggle.tsx
@@ -46,14 +46,29 @@ export function usePushState() {
     const [loading, setLoading] = React.useState(true);
     const [supported, setSupported] = React.useState(false);
     const [nativeDenied, setNativeDenied] = React.useState(false);
+    // True when the last registration attempt hit the server's "ntfy not
+    // configured" (503) response — a distinct, user-visible state from a
+    // generic failure or from being subscribed.
+    const [nativeUnconfigured, setNativeUnconfigured] = React.useState(false);
     const [suppressChild, setSuppressChild] = React.useState(false);
     const [suppressChildLoading, setSuppressChildLoading] = React.useState(false);
 
     // Initial load + sync when another instance changes state
     const refreshState = React.useCallback(() => {
         if (native) {
-            hasNativePushPermission().then((granted) => {
-                setSubscribed(granted && !isNativePushDisabled());
+            hasNativePushPermission().then(async (granted) => {
+                if (!granted || isNativePushDisabled()) {
+                    setSubscribed(false);
+                    setNativeUnconfigured(false);
+                    setLoading(false);
+                    return;
+                }
+                // No persistence layer for "did the last registration succeed" —
+                // registration is idempotent and cheap, so verify it live on
+                // every refresh instead of trusting a stale flag.
+                const result = await startNtfyPush();
+                setSubscribed(result.ok);
+                setNativeUnconfigured(!result.ok && result.reason === "unconfigured");
                 setLoading(false);
             });
             return;
@@ -95,13 +110,15 @@ export function usePushState() {
                     setNativePushDisabled(true);
                     await stopNtfyPush();
                     setSubscribed(false);
+                    setNativeUnconfigured(false);
                 } else {
                     const granted = await requestNativePushPermission();
                     setNativeDenied(!granted);
                     if (granted) {
                         setNativePushDisabled(false);
-                        await startNtfyPush();
-                        setSubscribed(true);
+                        const result = await startNtfyPush();
+                        setSubscribed(result.ok);
+                        setNativeUnconfigured(!result.ok && result.reason === "unconfigured");
                     }
                 }
                 window.dispatchEvent(new CustomEvent("pp-push-state-changed"));
@@ -151,11 +168,11 @@ export function usePushState() {
     // system settings, not another prompt.
     const permissionDenied = native ? nativeDenied : getNotificationPermission() === "denied";
 
-    return { subscribed, loading, supported, native, permissionDenied, toggle, suppressChild, suppressChildLoading, toggleSuppressChild };
+    return { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild };
 }
 
 export function NotificationToggle() {
-    const { subscribed, loading, supported, native, permissionDenied, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState();
+    const { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState();
 
     if (!supported) return null;
 
@@ -165,9 +182,11 @@ export function NotificationToggle() {
           ? native
               ? "Notifications blocked — enable in system settings"
               : "Notifications blocked by browser"
-          : subscribed
-            ? "Notifications enabled"
-            : "Enable notifications";
+          : nativeUnconfigured
+            ? "Push not configured on this server"
+            : subscribed
+              ? "Notifications enabled"
+              : "Enable notifications";
 
     // When the browser/OS has denied permission, the button is disabled — so
     // tell the user how to re-enable it rather than leaving a dead end.
@@ -282,7 +301,7 @@ export function NotificationToggle() {
  * Notification toggle rendered as a DropdownMenuItem (for mobile menus).
  */
 export function MobileNotificationMenuItem() {
-    const { subscribed, loading, supported, native, permissionDenied, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState();
+    const { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState();
 
     if (!supported) return null;
 
@@ -301,7 +320,11 @@ export function MobileNotificationMenuItem() {
                 ) : (
                     <BellOff className="h-4 w-4" />
                 )}
-                {subscribed ? "Disable notifications" : "Enable notifications"}
+                {subscribed
+                    ? "Disable notifications"
+                    : nativeUnconfigured
+                      ? "Push not configured on this server"
+                      : "Enable notifications"}
             </DropdownMenuItem>
             {subscribed && !native && (
                 <DropdownMenuItem

--- a/packages/ui/src/hooks/useBrowserNotifications.test.ts
+++ b/packages/ui/src/hooks/useBrowserNotifications.test.ts
@@ -29,11 +29,45 @@ function shouldNotify(
   isHidden: boolean,
   hasFocus: boolean,
   alreadyNotified: Set<string>,
+  seenWhileActive: Set<string> = new Set(),
 ): boolean {
   if (alreadyNotified.has(sessionId)) return false;
+  if (seenWhileActive.has(sessionId)) return false;
   // Only suppress when the tab is visible AND focused AND viewing this session
   if (!isHidden && hasFocus && sessionId === activeSessionId) return false;
   return true;
+}
+
+// Mirrors the hook's "mark seen while active" effect: a session gets
+// marked as already-seen the moment it's awaiting input while actively
+// viewed (visible + focused).
+function markSeenWhileActive(
+  sessionsAwaitingInput: Set<string>,
+  activeSessionId: string | null,
+  isHidden: boolean,
+  hasFocus: boolean,
+  seenWhileActive: Set<string>,
+): void {
+  if (!isHidden && hasFocus && activeSessionId && sessionsAwaitingInput.has(activeSessionId)) {
+    seenWhileActive.add(activeSessionId);
+  }
+}
+
+// Mirrors the hook's visibilitychange handler: returning to the tab closes the
+// notification, clears the notified record AND marks the session as seen.
+// Marking here is essential — the markSeenWhileActive effect only re-runs on
+// React state changes, and visibilitychange is a DOM event.
+function onVisibilityReturn(
+  activeSessionId: string | null,
+  sessionsAwaitingInput: Set<string>,
+  alreadyNotified: Set<string>,
+  seenWhileActive: Set<string>,
+): void {
+  if (!activeSessionId) return;
+  alreadyNotified.delete(activeSessionId);
+  if (sessionsAwaitingInput.has(activeSessionId)) {
+    seenWhileActive.add(activeSessionId);
+  }
 }
 
 describe("useBrowserNotifications logic", () => {
@@ -57,6 +91,32 @@ describe("useBrowserNotifications logic", () => {
   });
 
   // ── Notification decision logic ────────────────────────────────────────
+
+  test("reading a prompt after returning to the tab, then switching sessions, does not re-notify", () => {
+    const awaiting = new Set(["s1"]);
+    const notified = new Set<string>();
+    const seen = new Set<string>();
+
+    // 1. Tab hidden when the question arrives → notify.
+    expect(shouldNotify("s1", "s1", true, false, notified, seen)).toBe(true);
+    notified.add("s1");
+
+    // 2. User returns to the tab and reads it.
+    onVisibilityReturn("s1", awaiting, notified, seen);
+    expect(notified.has("s1")).toBe(false); // record cleared, notification closed
+    expect(seen.has("s1")).toBe(true); // but now marked as seen
+
+    // 3. User switches to another session while s1 is still awaiting.
+    //    Without the visibilitychange marking this would re-notify.
+    expect(shouldNotify("s1", "s2", false, true, notified, seen)).toBe(false);
+  });
+
+  test("returning to the tab does not mark a session that is not awaiting", () => {
+    const notified = new Set<string>(["s1"]);
+    const seen = new Set<string>();
+    onVisibilityReturn("s1", new Set(), notified, seen);
+    expect(seen.has("s1")).toBe(false);
+  });
 
   test("should notify when tab is hidden", () => {
     expect(shouldNotify("s1", "s1", true, false, new Set())).toBe(true);
@@ -147,6 +207,42 @@ describe("useBrowserNotifications logic", () => {
       sessionId: "session-123",
       type: "browser_input",
     });
+  });
+
+  test("session that starts awaiting while actively viewed does not notify after switching away", () => {
+    const seenWhileActive = new Set<string>();
+    const awaiting = new Set(["s1"]);
+
+    markSeenWhileActive(awaiting, "s1", false, true, seenWhileActive);
+    expect(seenWhileActive.has("s1")).toBe(true);
+
+    expect(shouldNotify("s1", "s1", false, true, new Set(), seenWhileActive)).toBe(false);
+    expect(shouldNotify("s1", "s2", false, true, new Set(), seenWhileActive)).toBe(false);
+    expect(shouldNotify("s1", "s2", true, false, new Set(), seenWhileActive)).toBe(false);
+  });
+
+  test("session that starts awaiting while NOT actively viewed still notifies", () => {
+    const seenWhileActive = new Set<string>();
+    const awaiting = new Set(["s1"]);
+
+    markSeenWhileActive(awaiting, "s2", false, true, seenWhileActive);
+    expect(seenWhileActive.has("s1")).toBe(false);
+
+    expect(shouldNotify("s1", "s2", false, true, new Set(), seenWhileActive)).toBe(true);
+  });
+
+  test("seen-while-active entries are cleared once the session stops awaiting", () => {
+    const seenWhileActive = new Set(["s1", "s2"]);
+    const stillAwaiting = new Set(["s1"]);
+
+    for (const sessionId of Array.from(seenWhileActive)) {
+      if (!stillAwaiting.has(sessionId)) {
+        seenWhileActive.delete(sessionId);
+      }
+    }
+
+    expect(seenWhileActive.has("s1")).toBe(true);
+    expect(seenWhileActive.has("s2")).toBe(false);
   });
 
   test("extracts session id from service worker open-session messages", () => {

--- a/packages/ui/src/hooks/useBrowserNotifications.ts
+++ b/packages/ui/src/hooks/useBrowserNotifications.ts
@@ -66,6 +66,9 @@ export function useBrowserNotifications({
   // Track which sessions we've already notified about to avoid spam.
   const notifiedRef = useRef<Set<string>>(new Set());
   const sessionsAwaitingInputRef = useRef<Set<string>>(sessionsAwaitingInput);
+  // Sessions that were awaiting input while actively viewed — once true,
+  // never notify for that awaiting period, even after switching away.
+  const seenWhileActiveRef = useRef<Set<string>>(new Set());
   const originalTitleRef = useRef<string>(document.title);
   const flashIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -88,7 +91,27 @@ export function useBrowserNotifications({
         void closeBrowserInputNotification(sessionId);
       }
     }
+    const seen = seenWhileActiveRef.current;
+    for (const sessionId of Array.from(seen)) {
+      if (!sessionsAwaitingInput.has(sessionId)) {
+        seen.delete(sessionId);
+      }
+    }
   }, [sessionsAwaitingInput]);
+
+  // Mark the active session as "already seen" the moment it's awaiting while
+  // the user is actively viewing it (visible + focused). This must not be
+  // undone by later tab/session switches — the awaiting period is complete.
+  useEffect(() => {
+    if (
+      !document.hidden &&
+      document.hasFocus() &&
+      activeSessionId &&
+      sessionsAwaitingInput.has(activeSessionId)
+    ) {
+      seenWhileActiveRef.current.add(activeSessionId);
+    }
+  }, [sessionsAwaitingInput, activeSessionId]);
 
   // When the service worker reports that a session was opened, clear the
   // matching notification record so a future await can notify again.
@@ -122,6 +145,10 @@ export function useBrowserNotifications({
         for (const sessionId of sessionsAwaitingInput) {
           // Already notified for this session.
           if (notified.has(sessionId)) continue;
+
+          // The user already saw this session's prompt while it was awaiting
+          // and actively viewed — don't notify even after switching away.
+          if (seenWhileActiveRef.current.has(sessionId)) continue;
 
           // If the tab is visible AND focused AND the user is viewing this session,
           // no need to notify — they can see the input prompt directly.
@@ -209,6 +236,14 @@ export function useBrowserNotifications({
         if (activeSessionId) {
           notifiedRef.current.delete(activeSessionId);
           void closeBrowserInputNotification(activeSessionId);
+          // Returning to the tab IS the act of seeing it. Mark it seen here too,
+          // not just in the marking effect: that effect only re-runs on React
+          // state changes, and visibilitychange is a DOM event. Without this,
+          // clearing notifiedRef above would let a later session switch
+          // re-notify for a prompt the user has already read.
+          if (sessionsAwaitingInputRef.current.has(activeSessionId)) {
+            seenWhileActiveRef.current.add(activeSessionId);
+          }
         }
       }
     };

--- a/packages/ui/src/lib/mobile-native.ts
+++ b/packages/ui/src/lib/mobile-native.ts
@@ -16,7 +16,7 @@ import { Capacitor } from "@capacitor/core";
 import { LocalNotifications } from "@capacitor/local-notifications";
 import { Badge } from "@capawesome/capacitor-badge";
 import { getMobileRuntimeConfig } from "./mobile-runtime.js";
-import { startNtfyPush } from "./ntfy-push.js";
+import { registerNtfyTapListener, startNtfyPush } from "./ntfy-push.js";
 import { useNeedsResponseCount } from "../attention/index.js";
 
 /** True only when running inside the bundled Capacitor native shell. */
@@ -83,6 +83,10 @@ export function useMobileNativeActivity(): void {
         // web/iOS. Best-effort — the server returns 503 if ntfy isn't configured,
         // in which case startNtfyPush degrades silently (Web Push still runs).
         void startNtfyPush();
+        // Wire up notification-tap → in-app navigation. Registered before any
+        // tap can be consumed since Capacitor retains a cold-start tap event
+        // until this listener attaches.
+        registerNtfyTapListener();
     }, []);
 
     // Badge reflects "needs your response" — the conventional unread signal.

--- a/packages/ui/src/lib/mobile-ota.test.ts
+++ b/packages/ui/src/lib/mobile-ota.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isSecureOtaOrigin, shouldApplyOta } from "./mobile-ota";
+import { deferReloadUntilBackground, isSecureOtaOrigin, shouldApplyOta } from "./mobile-ota";
 
 const installed = "2026-07-09T10:00:00.000Z";
 const valid = {
@@ -35,6 +35,22 @@ describe("shouldApplyOta", () => {
     test("applies against an empty installed timestamp (fresh install / dev)", () => {
         expect(shouldApplyOta(valid, "")).toBe(true);
     });
+
+    test("kill-switch: rejects a bundle older than minBuildTimestamp", () => {
+        // The offered bundle is newer than what's installed, but ops set a
+        // floor above its own buildTimestamp to strand it.
+        expect(shouldApplyOta({ ...valid, minBuildTimestamp: "2027-01-01T00:00:00.000Z" }, installed)).toBe(false);
+    });
+
+    test("kill-switch: applies a bundle at or above minBuildTimestamp", () => {
+        expect(shouldApplyOta({ ...valid, minBuildTimestamp: valid.buildTimestamp }, installed)).toBe(true);
+        expect(shouldApplyOta({ ...valid, minBuildTimestamp: "2020-01-01T00:00:00.000Z" }, installed)).toBe(true);
+    });
+
+    test("absent minBuildTimestamp still applies (backward compatible)", () => {
+        expect("minBuildTimestamp" in valid).toBe(false);
+        expect(shouldApplyOta(valid, installed)).toBe(true);
+    });
 });
 
 describe("isSecureOtaOrigin", () => {
@@ -53,5 +69,45 @@ describe("isSecureOtaOrigin", () => {
         // Guard against sneaky prefixes that merely contain "https".
         expect(isSecureOtaOrigin("httpshh://x")).toBe(false);
         expect(isSecureOtaOrigin("http://x?https://y")).toBe(false);
+    });
+});
+
+describe("deferReloadUntilBackground", () => {
+    test("does not reload immediately after registering", async () => {
+        let reloadCalls = 0;
+        const appPlugin = {
+            addListener: async () => ({ remove: async () => {} }),
+        };
+        const updater = { reload: async () => { reloadCalls++; } };
+
+        deferReloadUntilBackground(appPlugin, updater);
+        // Let the (fake) addListener promise settle.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(reloadCalls).toBe(0);
+    });
+
+    test("reloads only once the app backgrounds, not while foregrounded", async () => {
+        let listener: ((state: { isActive: boolean }) => void) | undefined;
+        let reloadCalls = 0;
+        const appPlugin = {
+            addListener: async (_event: "appStateChange", cb: (state: { isActive: boolean }) => void) => {
+                listener = cb;
+                return { remove: async () => {} };
+            },
+        };
+        const updater = { reload: async () => { reloadCalls++; } };
+
+        deferReloadUntilBackground(appPlugin, updater);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(listener).toBeDefined();
+
+        listener!({ isActive: true }); // still foregrounded — must not reload
+        expect(reloadCalls).toBe(0);
+
+        listener!({ isActive: false }); // backgrounded — now it's safe to reload
+        expect(reloadCalls).toBe(1);
     });
 });

--- a/packages/ui/src/lib/mobile-ota.ts
+++ b/packages/ui/src/lib/mobile-ota.ts
@@ -22,9 +22,28 @@
  *
  * ponytail: no retry/scheduler/progress UI — one check on launch. Add a
  * progress bar + periodic re-check only if bundles get large or updates frequent.
+ *
+ * Kill-switch (`minBuildTimestamp`) and deferred-reload notes:
+ *  - `minBuildTimestamp` is an optional, ops-set floor on the manifest. If the
+ *    offered bundle's own `buildTimestamp` is older than it, the client
+ *    refuses to apply it — even though it may still be newer than what's
+ *    installed. That's the kill-switch: bump `minBuildTimestamp` above a bad
+ *    bundle's `buildTimestamp` (see scripts/publish-mobile-ota.ts --kill-switch)
+ *    to strand it until a fixed bundle is published. Absent = no gate (default).
+ *  - The reload that swaps in a newly-downloaded bundle is deferred until the
+ *    app backgrounds (via the Capacitor `App` plugin's `appStateChange`)
+ *    instead of firing immediately after `set()`. A cold-boot OTA check can
+ *    otherwise reload the WebView right as a killed-and-relaunched app
+ *    resumes, discarding whatever the user was mid-typing. Explicitly *not*
+ *    building a scheduler/periodic re-check here — one listener, fires once.
+ *
+ * Explicitly skipped (ponytail — see docs/mobile-ota.md): staged rollout
+ * percentages, a rollback UI, and signed bundles. Add those only if a real
+ * incident shows the manual kill-switch isn't enough.
  */
 import { Capacitor, registerPlugin } from "@capacitor/core";
 import { getMobileRuntimeConfig } from "./mobile-runtime.js";
+import { reportWarning } from "./frontend-log.js";
 
 /** Build timestamp baked into THIS bundle (the currently-installed version). */
 declare const __PIZZAPI_BUILD_TIMESTAMP__: string;
@@ -42,6 +61,13 @@ export interface OtaManifest {
     checksum: string;
     /** Optional size in bytes (informational). */
     bytes?: number;
+    /**
+     * Optional kill-switch floor. When present, a bundle whose own
+     * `buildTimestamp` is older than this is refused, regardless of whether
+     * it's newer than what's installed. Absent = no gate (fully backward
+     * compatible with older manifests / clients that don't know the field).
+     */
+    minBuildTimestamp?: string;
 }
 
 /**
@@ -51,14 +77,19 @@ export interface OtaManifest {
 export function shouldApplyOta(manifest: unknown, installedBuildTimestamp: string): boolean {
     if (!manifest || typeof manifest !== "object") return false;
     const m = manifest as Partial<OtaManifest>;
-    return (
+    const fresh =
         typeof m.buildTimestamp === "string" &&
         typeof m.url === "string" &&
         !!m.url &&
         typeof m.checksum === "string" &&
         !!m.checksum &&
-        m.buildTimestamp > installedBuildTimestamp
-    );
+        m.buildTimestamp > installedBuildTimestamp;
+    if (!fresh) return false;
+    // Kill-switch: an absent minBuildTimestamp never blocks anything.
+    if (typeof m.minBuildTimestamp === "string" && (m.buildTimestamp as string) < m.minBuildTimestamp) {
+        return false;
+    }
+    return true;
 }
 
 /** True only inside the bundled native shell — web/PWA is always a no-op. */
@@ -108,6 +139,53 @@ const CapacitorUpdater = registerPlugin<CapgoUpdater>("CapacitorUpdater", {
     web: async () => new CapacitorUpdaterWeb(),
 });
 
+interface AppStateChangeEvent {
+    /** True when foregrounded; false when backgrounded. */
+    isActive: boolean;
+}
+
+/** Minimal shape of the bits of @capacitor/app we call. */
+interface CapacitorAppPlugin {
+    addListener(
+        eventName: "appStateChange",
+        listenerFunc: (state: AppStateChangeEvent) => void,
+    ): Promise<{ remove: () => Promise<void> }>;
+}
+
+// Same by-name registerPlugin pattern as CapacitorUpdater above — @capacitor/app
+// is already pulled in transitively (via @aparajita/capacitor-secure-storage)
+// and `cap sync` installs the native App plugin, so there's no need to add a
+// direct npm dependency or import the @capacitor/app JS wrapper.
+class CapacitorAppWeb implements CapacitorAppPlugin {
+    async addListener(): Promise<{ remove: () => Promise<void> }> {
+        return { remove: async () => {} };
+    }
+}
+
+const CapacitorApp = registerPlugin<CapacitorAppPlugin>("App", {
+    web: async () => new CapacitorAppWeb(),
+});
+
+/**
+ * Register a one-shot listener that applies a newly-downloaded/set OTA bundle
+ * the next time the app leaves the foreground, instead of reloading right
+ * away. Exported (and parameterized on the plugin handles) so tests can pass
+ * fakes without touching Capacitor at all.
+ */
+export function deferReloadUntilBackground(
+    appPlugin: Pick<CapacitorAppPlugin, "addListener">,
+    updater: Pick<CapgoUpdater, "reload">,
+): void {
+    void appPlugin
+        .addListener("appStateChange", (state) => {
+            if (state.isActive) return; // still foregrounded — keep waiting
+            void updater.reload();
+        })
+        .catch((err) => {
+            console.error("mobile-ota: failed to defer reload:", err);
+        });
+}
+
 /**
  * Tell the updater this bundle booted successfully, cancelling the automatic
  * rollback that would otherwise revert a freshly-applied OTA bundle. Call once
@@ -134,8 +212,18 @@ export async function checkAndApplyOtaUpdate(
     const { serverUrl } = getMobileRuntimeConfig();
     if (!serverUrl) return false;
     const base = serverUrl.replace(/\/+$/, "");
-    // Never apply code fetched over an unauthenticated (http) channel.
-    if (!isSecureOtaOrigin(base)) return false;
+    // Never apply code fetched over an unauthenticated (http) channel. LAN/
+    // loopback http servers never receive OTA (see isSecureOtaOrigin) and
+    // otherwise fail silently forever — surface it once via the existing
+    // frontend log/toast bus so it isn't a silent trap.
+    if (!isSecureOtaOrigin(base)) {
+        reportWarning(
+            "mobile-ota",
+            "Mobile OTA updates are disabled for this server (plain http://) — publish a new APK to update it.",
+            { detail: base, toast: false },
+        );
+        return false;
+    }
 
     let manifest: unknown;
     try {
@@ -156,7 +244,10 @@ export async function checkAndApplyOtaUpdate(
             checksum: m.checksum,
         });
         await CapacitorUpdater.set(bundle);
-        await CapacitorUpdater.reload();
+        // Don't reload mid-session: apply on the next backgrounding instead of
+        // yanking the WebView out from under a possibly-just-resumed app (e.g.
+        // discarding an in-progress composer draft).
+        deferReloadUntilBackground(CapacitorApp, CapacitorUpdater);
         return true;
     } catch (err) {
         console.error("mobile-ota: update failed:", err);

--- a/packages/ui/src/lib/ntfy-push.test.ts
+++ b/packages/ui/src/lib/ntfy-push.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, afterEach } from "bun:test";
 
 /**
  * Web no-op path for ntfy push. The plugin + helpers are gated on
@@ -15,7 +15,18 @@ import {
     setNativePushDisabled,
     hasNativePushPermission,
     requestNativePushPermission,
+    handleNotificationTapped,
 } from "./ntfy-push";
+
+// bun's runtime provides a global EventTarget/CustomEvent that work together
+// (unlike happy-dom's Window, which requires events constructed via itself).
+// A plain EventTarget is enough to stand in for `window` here.
+const fakeWindow = new EventTarget();
+const originalWindow = (globalThis as any).window;
+
+afterEach(() => {
+    (globalThis as any).window = originalWindow;
+});
 
 describe("ntfy-push (web no-op path)", () => {
     test("startNtfyPush is a no-op on web (does not throw, makes no network call)", async () => {
@@ -60,6 +71,36 @@ describe("ntfy-push (web no-op path)", () => {
         expect(isNativePushAvailable()).toBe(false);
         await expect(hasNativePushPermission()).resolves.toBe(false);
         await expect(requestNativePushPermission()).resolves.toBe(false);
+    });
+
+    test("handleNotificationTapped dispatches pp-navigate-session with the sessionId", () => {
+        (globalThis as any).window = fakeWindow;
+        let received: string | undefined;
+        const listener = (e: Event) => {
+            received = (e as CustomEvent).detail?.sessionId;
+        };
+        fakeWindow.addEventListener("pp-navigate-session", listener);
+        try {
+            handleNotificationTapped({ sessionId: "abc123" });
+        } finally {
+            fakeWindow.removeEventListener("pp-navigate-session", listener);
+        }
+        expect(received).toBe("abc123");
+    });
+
+    test("handleNotificationTapped ignores events without a sessionId", () => {
+        (globalThis as any).window = fakeWindow;
+        let called = false;
+        const listener = () => {
+            called = true;
+        };
+        fakeWindow.addEventListener("pp-navigate-session", listener);
+        try {
+            handleNotificationTapped({});
+        } finally {
+            fakeWindow.removeEventListener("pp-navigate-session", listener);
+        }
+        expect(called).toBe(false);
     });
 
     test("disabled flag round-trips through localStorage", () => {

--- a/packages/ui/src/lib/ntfy-push.test.ts
+++ b/packages/ui/src/lib/ntfy-push.test.ts
@@ -26,7 +26,7 @@ describe("ntfy-push (web no-op path)", () => {
             return Promise.resolve(new Response("{}", { status: 200 }));
         };
         try {
-            await expect(startNtfyPush()).resolves.toBeUndefined();
+            await expect(startNtfyPush()).resolves.toEqual({ ok: true });
         } finally {
             (globalThis as any).fetch = origFetch;
         }

--- a/packages/ui/src/lib/ntfy-push.ts
+++ b/packages/ui/src/lib/ntfy-push.ts
@@ -102,16 +102,27 @@ export async function requestNativePushPermission(): Promise<boolean> {
 }
 
 /**
+ * Outcome of a registration attempt. `unconfigured` is the 503 the server
+ * returns when it has no ntfy instance set up — a distinct, user-visible
+ * state, not a generic failure. `error` covers everything else (network,
+ * malformed response, plugin start failure).
+ */
+export type NtfyStartResult = { ok: true } | { ok: false; reason: "unconfigured" | "error" };
+
+/**
  * Register with the server for native push and start the foreground-service
  * subscribe stream. No-op outside the Android native app. Safe to call on
  * every launch — registration is idempotent (server reuses the topic per
  * user+platform), and starting an already-running service re-configures it.
  *
- * Requires `PIZZAPI_NTFY_URL` to be configured on the server (returns silently
- * if the server reports ntfy is not configured, so the app degrades gracefully).
+ * Requires `PIZZAPI_NTFY_URL` to be configured on the server; returns
+ * `{ ok: false, reason: "unconfigured" }` if the server reports ntfy is not
+ * configured, so callers can degrade gracefully instead of claiming success.
  */
-export async function startNtfyPush(): Promise<void> {
-    if (!androidNative() || isNativePushDisabled()) return;
+export async function startNtfyPush(): Promise<NtfyStartResult> {
+    // ponytail: "nothing to do" reports ok — callers must check platform/disabled
+    // state THEMSELVES before treating ok as "registered". Both current callers do.
+    if (!androidNative() || isNativePushDisabled()) return { ok: true };
     try {
         const res = await fetch(resolveMobileUrl("/api/push/register-native"), {
             method: "POST",
@@ -119,11 +130,12 @@ export async function startNtfyPush(): Promise<void> {
             body: JSON.stringify({ platform: "android" }),
         });
         if (!res.ok) {
-            // 503 = ntfy not configured on the server → degrade silently.
-            if (res.status !== 503) {
-                console.error("ntfy register-native failed:", res.status);
+            // 503 = ntfy not configured on the server → distinct state, not an error.
+            if (res.status === 503) {
+                return { ok: false, reason: "unconfigured" };
             }
-            return;
+            console.error("ntfy register-native failed:", res.status);
+            return { ok: false, reason: "error" };
         }
         const body = (await res.json()) as {
             ntfyPublicUrl?: string;
@@ -133,7 +145,7 @@ export async function startNtfyPush(): Promise<void> {
         };
         if (!body.ntfyPublicUrl || !body.topic) {
             console.error("ntfy register-native returned no topic/url");
-            return;
+            return { ok: false, reason: "error" };
         }
         // Phase 1: subscribe anonymously. ntfy is provisioned with anonymous
         // read-only on `pizzapi-*` (see deployment/mobile-push.mdx), and the
@@ -143,8 +155,10 @@ export async function startNtfyPush(): Promise<void> {
             topic: body.topic,
             token: undefined,
         });
+        return { ok: true };
     } catch (err) {
         console.error("startNtfyPush failed:", err);
+        return { ok: false, reason: "error" };
     }
 }
 

--- a/packages/ui/src/lib/ntfy-push.ts
+++ b/packages/ui/src/lib/ntfy-push.ts
@@ -181,3 +181,40 @@ export async function stopNtfyPush(): Promise<void> {
         console.error("stopNtfyPush (unregister) failed:", err);
     }
 }
+
+// ponytail: module-level guard so re-registering (e.g. HMR, repeated hook
+// mounts) doesn't stack duplicate listeners.
+let tapListenerRegistered = false;
+
+/**
+ * Register the `notificationTapped` listener so tapping a PizzaPi Android
+ * notification navigates to the session in-app instead of opening a browser.
+ * Dispatches the existing `pp-navigate-session` CustomEvent that App.tsx
+ * already listens for. No-op outside the Android native app.
+ *
+ * Safe to call once at app start (see mobile-native.ts). The native side
+ * (NtfyPushPlugin) retains a cold-start tap event until this listener
+ * attaches, so calling this on startup — even if the intent that launched
+ * the app already carried a tap before JS was ready — still delivers it.
+ */
+export function registerNtfyTapListener(): void {
+    if (!androidNative() || tapListenerRegistered) return;
+    tapListenerRegistered = true;
+    void PizzapiNtfy.addListener("notificationTapped", handleNotificationTapped);
+}
+
+/**
+ * Handles a raw `notificationTapped` plugin event by dispatching the
+ * `pp-navigate-session` CustomEvent App.tsx listens for. Exported
+ * (unguarded by the androidNative() check) so it's directly unit-testable.
+ */
+export function handleNotificationTapped(event: Record<string, unknown>): void {
+    const sessionId = typeof event?.sessionId === "string" ? event.sessionId : undefined;
+    if (!sessionId) return;
+    window.dispatchEvent(new CustomEvent("pp-navigate-session", { detail: { sessionId } }));
+}
+
+/** Reset internal flags — exposed for tests. */
+export function _resetNtfyPushState(): void {
+    tapListenerRegistered = false;
+}

--- a/packages/ui/src/lib/viewer-visibility.test.ts
+++ b/packages/ui/src/lib/viewer-visibility.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for the `viewer_visibility` payload helper used by the viewer socket
+ * connection (App.tsx) to tell the server whether the tab is being looked
+ * at. Deliberately ignores window focus — only `document.visibilityState`
+ * matters.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+import { getViewerVisibilityPayload } from "./viewer-visibility";
+
+const win = new Window({ url: "http://localhost/" });
+const originalDocument = (globalThis as any).document;
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(win.document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+  (globalThis as any).document = win.document;
+}
+
+afterEach(() => {
+  (globalThis as any).document = originalDocument;
+});
+
+describe("getViewerVisibilityPayload", () => {
+  test("reports visible:false when the document is hidden", () => {
+    setVisibility("hidden");
+    expect(getViewerVisibilityPayload()).toEqual({ visible: false });
+  });
+
+  test("reports visible:true when the document is visible", () => {
+    setVisibility("visible");
+    expect(getViewerVisibilityPayload()).toEqual({ visible: true });
+  });
+
+  test("only depends on visibilityState, not window focus", () => {
+    // No focus API involved at all — visibility alone determines the payload.
+    setVisibility("visible");
+    expect(getViewerVisibilityPayload().visible).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/viewer-visibility.ts
+++ b/packages/ui/src/lib/viewer-visibility.ts
@@ -1,0 +1,12 @@
+/**
+ * Payload for the `viewer_visibility` client→server event, which tells the
+ * server whether the tab is actually being looked at (so it can suppress
+ * native push while a viewer is visible).
+ *
+ * "Visible" is `document.visibilityState === "visible"` — window focus is
+ * intentionally ignored, since a session on a second monitor still counts
+ * as being viewed.
+ */
+export function getViewerVisibilityPayload(): { visible: boolean } {
+  return { visible: document.visibilityState === "visible" };
+}

--- a/scripts/publish-mobile-ota.ts
+++ b/scripts/publish-mobile-ota.ts
@@ -19,6 +19,20 @@
  * Prereq: `bun run build:mobile` (produces mobile/app/). Requires the system
  * `zip` tool.
  *
+ * Kill-switch: set PIZZAPI_MOBILE_OTA_MIN_BUILD_TIMESTAMP when publishing a
+ * fix to include a `minBuildTimestamp` floor in the new manifest, or — to
+ * strand an already-published bad bundle *without* a rebuild — run:
+ *
+ *   PIZZAPI_MOBILE_OTA_DIR=/srv/pizzapi-ota bun scripts/publish-mobile-ota.ts \
+ *     --kill-switch=2026-07-10T00:00:00.000Z
+ *
+ * which patches minBuildTimestamp on the existing manifest.json in place (the
+ * zip/checksum/buildTimestamp are untouched). Clients refuse that bundle until
+ * a bundle with buildTimestamp >= the kill-switch timestamp is published.
+ *
+ * ponytail: no staged rollout percentages, no rollback UI, no signed bundles —
+ * the kill-switch is the whole mitigation. See docs/mobile-ota.md.
+ *
  * ponytail: system `zip` + node:crypto, no new deps. If a device ever rejects
  * the archive, swap the zip step for `@capgo/cli bundle zip` (their format).
  */
@@ -33,6 +47,33 @@ const appDir = join(webDir, "app");
 // Resolve to absolute: the zip step runs after `cd ${appDir}`, so a relative
 // outDir would otherwise be written under mobile/app and then not found.
 const outDir = resolve(process.env.PIZZAPI_MOBILE_OTA_DIR || join(root, "mobile-ota"));
+
+// --kill-switch=<ISO-8601 timestamp>: patch minBuildTimestamp on the existing
+// manifest without rebuilding/rezipping. This is the fast path for stranding
+// an already-published bad bundle.
+const killSwitchArg = process.argv.slice(2).find((a) => a.startsWith("--kill-switch="));
+if (killSwitchArg) {
+    const minBuildTimestamp = killSwitchArg.slice("--kill-switch=".length);
+    if (!minBuildTimestamp) {
+        console.error("--kill-switch requires a value, e.g. --kill-switch=2026-07-10T00:00:00.000Z");
+        process.exit(1);
+    }
+    const manifestPath = join(outDir, "manifest.json");
+    if (!existsSync(manifestPath)) {
+        console.error(`No manifest at ${manifestPath} — publish a bundle first.`);
+        process.exit(1);
+    }
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+    manifest.minBuildTimestamp = minBuildTimestamp;
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(
+        `Kill-switch set on ${manifestPath}:\n` +
+            `  minBuildTimestamp = ${minBuildTimestamp}\n` +
+            `Clients will refuse bundle ${String(manifest.buildTimestamp ?? "(unknown)")} until a bundle with a ` +
+            `buildTimestamp >= ${minBuildTimestamp} is published.`,
+    );
+    process.exit(0);
+}
 
 if (!existsSync(join(appDir, "index.html"))) {
     console.error(`No built mobile UI at ${appDir}.\nRun: bun run build:mobile`);
@@ -65,12 +106,18 @@ await $`cd ${webDir} && zip -r -q -X ${zipPath} ${entries}`;
 const buf = readFileSync(zipPath);
 const checksum = createHash("sha256").update(buf).digest("hex");
 
+// Optional kill-switch floor to set on this newly-published (good) manifest —
+// e.g. after a fix, PIZZAPI_MOBILE_OTA_MIN_BUILD_TIMESTAMP=<bad build's ts>
+// makes explicit that nothing older is ever eligible again. Optional/absent
+// by default so normal publishes are unaffected.
+const minBuildTimestamp = process.env.PIZZAPI_MOBILE_OTA_MIN_BUILD_TIMESTAMP;
 const manifest = {
     buildTimestamp,
     version: buildTimestamp,
     url: `/api/mobile/ota/${zipName}`,
     checksum,
     bytes: buf.length,
+    ...(minBuildTimestamp ? { minBuildTimestamp } : {}),
 };
 writeFileSync(join(outDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 


### PR DESCRIPTION
Closes the **Mobile push & native reliability** epic (`gSAEl3yri8troieXjPTyH`) — all 6 ideas, born from the 4-agent mobile audit.

The headline: **native Android push was a silent no-op in every `pizza web` deployment.** Not broken — never wired. Fixed, deployed, and verified delivering to a real Pixel 10 Pro.

## What was wrong

`pizza web`'s compose generator never provisioned ntfy (unlike the hand-written `docker/compose.yml`). So `PIZZAPI_NTFY_URL` was unset → `isNtfyConfigured()` false → `/api/push/register-native` 503s → zero rows in `native_push_registration` → `sendNtfyToUser` returned early, forever, silently. Meanwhile the UI cheerfully reported "Notifications enabled".

## Changes

| Idea | Fix |
|---|---|
| `A17BdEtz` **P0** | Generator now emits the `ntfy` service + `PIZZAPI_NTFY_URL`, and **warns loudly** when `PIZZAPI_NTFY_PUBLIC_URL`/`PIZZAPI_NTFY_PUBLISH_TOKEN` are unset instead of producing a dead config |
| `BbjRyicu` P1 | `startNtfyPush()` returns `{ok} \| {ok:false, reason:"unconfigured"\|"error"}` instead of swallowing failures to console. Toggle reflects *real* registration state; 503 gets its own "Push not configured on this server" label |
| `FcosSTez` P2 | New `NtfyRestartReceiver` (BOOT_COMPLETED) + `AlarmManager` reschedule on Android 15+ FGS timeout. Gated on a persisted `enabled` flag so a user-disabled service stays dead |
| `0BdO9byP` P2 | `.catch()` on the fire-and-forget `checkPushNotifications` (Bun doesn't route unhandled rejections through `uncaughtException`, so these genuinely vanished) + one retry on transient ntfy publish failure, never on 403/404 |
| `4NyaXUcZ` P2 | `minBuildTimestamp` OTA kill-switch + defer `reload()` to backgrounding so it can't discard composer drafts mid-session |
| `0sn83mq7` P2 | Deleted stale pre-`VITE_MOBILE` iOS bundle w/ service-worker artifacts; CI now fails if `sw.js`/`workbox-*` ever reappear in either native tree |

## Verification

Live infra (already deployed, not part of this diff): ntfy behind `tailscale serve --https=8443`. HTTPS is mandatory — `targetSdk=36` blocks cleartext.

**On-device (Pixel 10 Pro):**
- Registration row created on app launch; test publish → notification delivered on the `pizzapi-ntfy` channel ✅
- Boot restart confirmed via reboot with the app never opened — service record shows `code:BOOT_COMPLETED` ✅

**Suites:** `typecheck` exit 0 · UI 1281 pass · server `src` 75 + `tests` 16 pass (isolated runner + Redis) · CLI 2880 pass.

CLI's 3 failures (`models-command` ×2, `overlay/identity`) are **pre-existing ambient-env pollution** — they pass under `env -u PIZZAPI_HIDDEN_MODELS -u PIZZAPI_API_KEY`. Untouched by this PR.

## Notes for review

- `startNtfyPush()` returns `{ok:true}` for the "not applicable" case (non-native / user-disabled). Both call sites check platform+disabled state first; flagged with a `ponytail:` comment so the next caller doesn't get burned.
- FGS reschedule ceiling is ~6h cumulative `dataSync` runtime per rolling 24h on Android 15+; upgrade path (WorkManager/FCM data messages) noted in-code.
- iOS CI guard is an **artifact-name check, not a real build** — deliberate, since a simulator build needs a macOS runner. Ceiling documented.
- Deliberately skipped: OTA staged rollout, manual rollback tooling, signed bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
