### PR TITLE
perf(relay): snapshot overlay — stop rewriting multi-MB lastState on every metadata event

### DIFF
--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -16,7 +16,7 @@ import {
     getChildSessions,
     getPendingParentDelinkChildren,
     removePendingParentDelinkChild,
-    getSession,
+    getSessionSummary,
     markChildAsDelinked,
     isChildDelinked,
     isChildOfParent,
@@ -39,11 +39,13 @@ export async function countLinkedChildrenForParent(
     parentSessionId: string,
     deps: {
         getChildSessions?: typeof getChildSessions;
-        getSession?: typeof getSession;
+        // Summary-shaped read — only parentSessionId/linkedParentId are needed,
+        // so never pull the multi-MB lastState blob per child.
+        getSession?: (sessionId: string) => Promise<{ parentSessionId: string | null; linkedParentId?: string | null } | null>;
     } = {},
 ): Promise<number> {
     const _getChildSessions = deps.getChildSessions ?? getChildSessions;
-    const _getSession = deps.getSession ?? getSession;
+    const _getSession = deps.getSession ?? getSessionSummary;
 
     const childIds = await _getChildSessions(parentSessionId);
     if (childIds.length === 0) return 0;
@@ -218,7 +220,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             if (epoch && childIds.length > 0) {
                 // Fetch all session hashes concurrently, then check delink markers
                 // only for the subset that started after the epoch.
-                const sessions = await Promise.all(childIds.map((childId) => getSession(childId)));
+                const sessions = await Promise.all(childIds.map((childId) => getSessionSummary(childId)));
                 const markerCandidates = childIds.filter((_, i) => {
                     const childSession = sessions[i];
                     if (!childSession?.startedAt) return false;

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -3,7 +3,7 @@
 
 import type { Server as SocketIOServer } from "socket.io";
 import {
-    getSharedSession,
+    getSharedSessionSummary,
     emitToRelaySession,
     emitToRelaySessionAwaitingAck,
     emitToRunner,
@@ -100,7 +100,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
         }
 
         // Validate the sender is the parent of the target child session
-        const childSession = await getSharedSession(childSessionId);
+        const childSession = await getSharedSessionSummary(childSessionId);
         if (!childSession) {
             // Child already gone — nothing to clean up (idempotent)
             if (typeof ack === "function") ack({ ok: true });
@@ -118,7 +118,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
         }
 
         // Validate same user ownership
-        const parentSession = await getSharedSession(sessionId);
+        const parentSession = await getSharedSessionSummary(sessionId);
         if (!parentSession?.userId || parentSession.userId !== childSession.userId) {
             socket.emit("error", { message: "Target session belongs to a different user" });
             if (typeof ack === "function") ack({ ok: false, error: "Target session belongs to a different user" });
@@ -338,7 +338,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             return;
         }
 
-        const session = await getSharedSession(sessionId);
+        const session = await getSharedSessionSummary(sessionId);
         const parentId = session?.parentSessionId;
         if (!parentId) {
             // parentSessionId is already cleared in Redis (e.g. the child

--- a/packages/server/src/ws/namespaces/relay/service-message.test.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.test.ts
@@ -7,6 +7,7 @@ const mockEmitToRunner = mock((..._args: any[]) => {});
 
 mock.module("../../sio-registry/sessions.js", () => ({
     getSharedSession: mockGetSharedSession,
+    getSharedSessionSummary: mockGetSharedSession,
 }));
 
 mock.module("../../sio-registry/context.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/service-message.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.ts
@@ -6,7 +6,7 @@
 // instead of a browser viewer.
 
 import type { ServiceEnvelope } from "@pizzapi/protocol";
-import { getSharedSession } from "../../sio-registry/sessions.js";
+import { getSharedSessionSummary } from "../../sio-registry/sessions.js";
 import { emitToRunner } from "../../sio-registry/context.js";
 import type { RelaySocket } from "./types.js";
 import { createLogger } from "@pizzapi/tools";
@@ -85,7 +85,9 @@ export function registerServiceMessageHandler(socket: RelaySocket): void {
             return;
         }
 
-        const session = await getSharedSession(sessionId);
+        // Summary read — only collabMode/runnerId are needed; never pull the
+        // multi-MB lastState blob on this per-message hot path.
+        const session = await getSharedSessionSummary(sessionId);
         if (!session?.collabMode) return;
 
         const runnerId = session.runnerId;

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -251,20 +251,44 @@ describe("tryCacheSnapshot", () => {
         expect(result).toBeNull();
     });
 
-    test("overlays fresh queuedMessages from lastState onto a stale cached snapshot", async () => {
+    test("applies the snapshot overlay onto a stale cached snapshot", async () => {
         const snapshotEvent = { type: "session_active", state: { messages: [], queuedMessages: [] } };
         const deps = createDeps({
             getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
         });
 
-        const lastState = JSON.stringify({ messages: [], queuedMessages: ["follow up 1", "follow up 2"] });
-        const result = await tryCacheSnapshot("sess-14", deps, lastState);
+        const overlay = JSON.stringify({ queuedMessages: ["follow up 1", "follow up 2"], thinkingLevel: "high" });
+        const result = await tryCacheSnapshot("sess-14", deps, overlay);
         const socket = createMockSocket();
         result!.send(socket, 1);
 
-        expect((socket.calls[0].payload as any).event.state.queuedMessages).toEqual(["follow up 1", "follow up 2"]);
+        const sentState = (socket.calls[0].payload as any).event.state;
+        expect(sentState.queuedMessages).toEqual(["follow up 1", "follow up 2"]);
+        expect(sentState.thinkingLevel).toBe("high");
         // Original cached event is left untouched.
         expect(snapshotEvent.state.queuedMessages).toEqual([]);
+    });
+
+    test("overlay model is merged field-wise with the snapshot's model", async () => {
+        const snapshotEvent = {
+            type: "session_active",
+            state: { messages: [], model: { provider: "p", id: "m", contextWindow: 200000 } },
+        };
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
+        });
+
+        const overlay = JSON.stringify({ model: { provider: "p", id: "m", thinking: true } });
+        const result = await tryCacheSnapshot("sess-15", deps, overlay);
+        const socket = createMockSocket();
+        result!.send(socket, 1);
+
+        expect((socket.calls[0].payload as any).event.state.model).toEqual({
+            provider: "p",
+            id: "m",
+            contextWindow: 200000,
+            thinking: true,
+        });
     });
 });
 
@@ -277,6 +301,15 @@ describe("tryMemoryState", () => {
 
         expect(result).not.toBeNull();
         expect(result!.snapshot.type).toBe("memory");
+    });
+
+    test("applies the snapshot overlay onto lastState", () => {
+        const state = { messages: [{ role: "user" }], queuedMessages: [] };
+        const result = tryMemoryState(JSON.stringify(state), JSON.stringify({ queuedMessages: ["q1"] }));
+
+        const socket = createMockSocket();
+        result!.send(socket, 1);
+        expect((socket.calls[0].payload as any).event.state.queuedMessages).toEqual(["q1"]);
     });
 
     test("send() emits session_active with _metaViaHub hint", () => {

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -11,6 +11,7 @@
 
 import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent, type LatestCachedSnapshot } from "../../sessions/redis.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
+import { applySnapshotOverlayToState } from "../sio-registry/snapshot-state.js";
 import type { CachedRelayEvent } from "./viewer-cache.js";
 import { sendCachedDeltaReplayEvents } from "./viewer-cache.js";
 
@@ -64,16 +65,7 @@ function maybeTruncateSnapshotState(state: unknown): unknown {
     return truncateSnapshotMessages(state as Record<string, unknown>);
 }
 
-/** Pull the fresh pending follow-up queue out of the durable lastState blob. */
-function extractLastStateQueue(lastState: string | null | undefined): string[] | null {
-    if (!lastState) return null;
-    try {
-        const parsed = JSON.parse(lastState);
-        const queue = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>).queuedMessages : null;
-        if (Array.isArray(queue)) return queue.filter((m): m is string => typeof m === "string");
-    } catch { /* stale/corrupt lastState — leave the cached queue as-is */ }
-    return null;
-}
+
 
 // ── Dependency injection for testability ─────────────────────────────────────
 
@@ -126,26 +118,26 @@ export async function tryDeltaReplay(
 export async function tryCacheSnapshot(
     sessionId: string,
     deps: SnapshotProviderDeps = defaultDeps,
-    lastState?: string | null,
+    snapshotOverlay?: string | null,
 ): Promise<SnapshotResult | null> {
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return null;
     const snapshotEvent = cached.event;
-    // The cached session_active predates later queue changes (session_metadata_update
-    // carries them but is intentionally not cached). lastState always holds the freshest
-    // reported queue, so overlay it — otherwise a stale empty queue clobbers the viewer's
-    // restored follow-ups on switch.
-    const freshQueue = extractLastStateQueue(lastState);
 
     return {
         snapshot: { type: "cache-snapshot", source: "Redis cached snapshot event" },
         send(socket, generation) {
             let eventToSend: Record<string, unknown> = snapshotEvent;
             if (snapshotEvent.type === "session_active") {
-                let state = maybeTruncateSnapshotState(snapshotEvent.state);
-                if (freshQueue && state && typeof state === "object" && !Array.isArray(state)) {
-                    state = { ...(state as Record<string, unknown>), queuedMessages: freshQueue };
-                }
+                // The cached session_active predates later metadata changes
+                // (session_metadata_update carries them but is intentionally not
+                // cached). The snapshotOverlay accumulates those patches — queue,
+                // model, todo list — so apply it or a stale snapshot clobbers the
+                // viewer's restored follow-ups on switch.
+                const state = applySnapshotOverlayToState(
+                    maybeTruncateSnapshotState(snapshotEvent.state),
+                    snapshotOverlay,
+                );
                 eventToSend = { ...snapshotEvent, state };
             } else if (Array.isArray(snapshotEvent.messages)) {
                 eventToSend = maybeTruncateSnapshotState(snapshotEvent) as Record<string, unknown>;
@@ -167,6 +159,7 @@ export async function tryCacheSnapshot(
  */
 export function tryMemoryState(
     lastState: string | null | undefined,
+    snapshotOverlay?: string | null,
 ): SnapshotResult | null {
     if (!lastState) return null;
 
@@ -177,13 +170,15 @@ export function tryMemoryState(
         return null;
     }
 
+    const state = applySnapshotOverlayToState(maybeTruncateSnapshotState(parsed), snapshotOverlay);
+
     return {
         snapshot: { type: "memory", source: "In-memory lastState from Redis session hash" },
         send(socket, generation) {
             // Add _metaViaHub hint so the client knows metadata came from hub,
             // matching the original behavior in viewer.ts
             socket.emit("event", {
-                event: { type: "session_active", state: maybeTruncateSnapshotState(parsed), _metaViaHub: true },
+                event: { type: "session_active", state, _metaViaHub: true },
                 generation,
             });
         },
@@ -198,15 +193,18 @@ export async function tryPersistedSnapshot(
     sessionId: string,
     userId: string,
     deps: SnapshotProviderDeps = defaultDeps,
+    snapshotOverlay?: string | null,
 ): Promise<SnapshotResult | null> {
     const snapshot = await deps.getPersistedRelaySessionSnapshot(sessionId, userId);
     if (!snapshot || snapshot.state === null || snapshot.state === undefined) return null;
+
+    const state = applySnapshotOverlayToState(maybeTruncateSnapshotState(snapshot.state), snapshotOverlay);
 
     return {
         snapshot: { type: "persisted", source: "SQLite persisted relay session state" },
         send(socket, generation) {
             socket.emit("event", {
-                event: { type: "session_active", state: maybeTruncateSnapshotState(snapshot.state) },
+                event: { type: "session_active", state },
                 generation,
             });
         },
@@ -222,6 +220,8 @@ export interface GetBestSnapshotOpts {
     userId?: string;
     /** JSON-stringified lastState from Redis session hash */
     lastState?: string | null;
+    /** JSON-stringified metadata overlay (patches since the last full snapshot) */
+    snapshotOverlay?: string | null;
     /** Whether a chunked delivery is in-flight (skip memory state if true) */
     chunkedPending?: boolean;
 }
@@ -245,7 +245,7 @@ export async function getBestSnapshot(
     opts: GetBestSnapshotOpts = {},
     deps: SnapshotProviderDeps = defaultDeps,
 ): Promise<SnapshotResult | null> {
-    const { lastSeq, userId, lastState, chunkedPending } = opts;
+    const { lastSeq, userId, lastState, snapshotOverlay, chunkedPending } = opts;
 
     // ── Priority 1: Delta replay (only when lastSeq is provided) ─────────
     if (lastSeq !== undefined) {
@@ -262,7 +262,7 @@ export async function getBestSnapshot(
 
     // ── Priority 2: Cache snapshot ───────────────────────────────────────
     try {
-        const cached = await tryCacheSnapshot(sessionId, deps, lastState);
+        const cached = await tryCacheSnapshot(sessionId, deps, snapshotOverlay);
         if (cached) return cached;
     } catch {
         // Fall through
@@ -271,7 +271,7 @@ export async function getBestSnapshot(
     // ── Priority 3: Memory state (skip during chunked delivery) ──────────
     if (!chunkedPending) {
         try {
-            const memory = tryMemoryState(lastState);
+            const memory = tryMemoryState(lastState, snapshotOverlay);
             if (memory) return memory;
         } catch {
             // Fall through
@@ -281,7 +281,7 @@ export async function getBestSnapshot(
     // ── Priority 4: Persisted snapshot (SQLite) ──────────────────────────
     if (userId) {
         try {
-            const persisted = await tryPersistedSnapshot(sessionId, userId, deps);
+            const persisted = await tryPersistedSnapshot(sessionId, userId, deps, snapshotOverlay);
             if (persisted) return persisted;
         } catch {
             // Fall through

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -609,7 +609,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("input", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
 
             const tuiSocket = getLocalTuiSocket(currentSessionId);
@@ -652,7 +652,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("model_set", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
 
             // Hard-block hidden models by name (same rule as the spawn route).
@@ -680,7 +680,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("exec", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
 
             const tuiSocket = getLocalTuiSocket(currentSessionId);
@@ -700,7 +700,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 if (typeof ack === "function") ack({ ok: false, error: "No active session" });
                 return;
             }
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) {
                 if (typeof ack === "function") ack({ ok: false, error: "Session not in collab mode" });
                 return;
@@ -742,7 +742,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             if (!currentSessionId) return;
 
             // Require collab mode — same gate as input/exec/model_set
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
 
             // If targetSessionId is explicitly provided, route to that child.
@@ -846,7 +846,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 return;
             }
 
-            const currentSession = await getSharedSession(currentSessionId);
+            const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
             const runnerId = currentSession.runnerId;
             if (!runnerId) return;

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -48,6 +48,7 @@ import { isHiddenModel } from "../../routes/model-guard.js";
 import { createLogger } from "@pizzapi/tools";
 import { hydrateViewerFromCache, sendCachedDeltaReplayEvents, sendLatestSnapshotFromCache } from "./viewer-cache.js";
 import { getBestSnapshot } from "./snapshot-provider.js";
+import { applySnapshotOverlayToState } from "../sio-registry/snapshot-state.js";
 
 export { hydrateViewerFromCache, sendCachedDeltaReplayEvents } from "./viewer-cache.js";
 
@@ -460,6 +461,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 const snapshotResult = await getBestSnapshot(nextSessionId, {
                     lastSeq: requestedLastSeq,
                     lastState: freshSession.lastState,
+                    snapshotOverlay: freshSession.snapshotOverlay,
                     chunkedPending: false,
                 });
                 if (snapshotResult) {
@@ -507,8 +509,12 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
 
             if (freshSession.lastState) {
                 try {
+                    const state = applySnapshotOverlayToState(
+                        JSON.parse(freshSession.lastState),
+                        freshSession.snapshotOverlay,
+                    );
                     socket.emit("event", {
-                        event: withMetaViaHubHint({ type: "session_active", state: JSON.parse(freshSession.lastState) }),
+                        event: withMetaViaHubHint({ type: "session_active", state }),
                         seq: freshSeq,
                         generation,
                         sessionId: nextSessionId,

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -18,7 +18,7 @@ import {
     deleteRunner as deleteRunnerState,
     getAllRunners,
     refreshRunnerTTL,
-    getSession,
+    getSessionSummary,
     updateSessionFields,
     getAllSessionSummaries,
     setPendingRunnerLink,
@@ -328,7 +328,7 @@ export async function getRunnerServices(
 /** Record that a runner spawned a session. */
 export async function recordRunnerSession(runnerId: string, sessionId: string): Promise<void> {
     // Runner-session associations tracked via session.runnerId in Redis
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (session) {
         await updateSessionFields(sessionId, { runnerId });
     }
@@ -341,7 +341,7 @@ export async function linkSessionToRunner(runnerId: string, sessionId: string): 
     const runner = await getRunnerState(runnerId);
     if (!runner) return;
 
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (!session) {
         // TUI worker hasn't connected yet — store link for later
         await setPendingRunnerLink(sessionId, runnerId);
@@ -383,7 +383,7 @@ export async function linkSessionToRunner(runnerId: string, sessionId: string): 
 
 /** Remove a runner session association. */
 export async function removeRunnerSession(runnerId: string, sessionId: string): Promise<void> {
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (session && session.runnerId === runnerId) {
         await updateSessionFields(sessionId, { runnerId: null, runnerName: null });
         await deleteRunnerAssociation(sessionId);

--- a/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
@@ -16,6 +16,7 @@ mock.module("../sio-state/index.js", () => ({
     setSession: noopAsync,
     getSession: mockGetSession,
     getSessionSummary: mockGetSession,
+    getSessionField: async () => null,
     updateSessionFields: mockUpdateSessionFields,
     deleteSession: noopAsync,
     getAllSessionSummaries: noopAsync,

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -15,6 +15,7 @@ import {
     setSession,
     getSession,
     getSessionSummary,
+    getSessionField,
     updateSessionFields,
     deleteSession,
     getAllSessionSummaries,
@@ -50,7 +51,7 @@ import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
 import { extractMetaFromHeartbeat } from "./meta.js";
 import { truncateSnapshotMessages } from "../namespaces/snapshot-provider.js";
-import { mergeSnapshotStatePatch, shouldPersistSnapshotPatch } from "./snapshot-state.js";
+import { applySnapshotOverlayToState, mergeSnapshotOverlay } from "./snapshot-state.js";
 
 /**
  * Prepare an event for broadcast to viewers.
@@ -552,6 +553,9 @@ export async function updateSessionState(sessionId: string, state: unknown, opts
     const fields: Partial<RedisSessionData> = {
         lastState: JSON.stringify(strippedState ?? null),
         sessionName: nextSessionName,
+        // A full snapshot carries fresh metadata — the accumulated overlay of
+        // "patches since the last snapshot" is now stale. Reset it.
+        snapshotOverlay: null,
     };
 
     if (session.isEphemeral) {
@@ -600,14 +604,18 @@ export async function patchSessionSnapshotState(
     sessionId: string,
     patch: Record<string, unknown>,
 ): Promise<boolean> {
-    const session = await getSession(sessionId);
+    // Metadata patches are frequent (every session_metadata_update /
+    // capabilities event) while lastState blobs run into the MBs. Never
+    // read-modify-write the blob here — accumulate patches in the small
+    // snapshotOverlay field and apply them at read time instead.
+    const session = await getSessionSummary(sessionId);
     if (!session) return false;
 
-    const mergedState = mergeSnapshotStatePatch(session.lastState, patch);
-    if (!mergedState) return false;
+    const existingOverlay = await getSessionField(sessionId, "snapshotOverlay");
+    const mergedOverlay = mergeSnapshotOverlay(existingOverlay, patch);
 
     const fields: Partial<RedisSessionData> = {
-        lastState: JSON.stringify(mergedState),
+        snapshotOverlay: JSON.stringify(mergedOverlay),
     };
 
     if (session.isEphemeral) {
@@ -615,30 +623,15 @@ export async function patchSessionSnapshotState(
     }
 
     await updateSessionFields(sessionId, fields);
-
-    const now = Date.now();
-    const shouldPersistState = shouldPersistSnapshotPatch({
-        patch,
-        lastWriteAt: lastRelaySessionStateWriteTimes.get(sessionId) ?? 0,
-        now,
-        throttleMs: SQLITE_STATE_WRITE_THROTTLE_MS,
-    });
-
-    if (shouldPersistState) {
-        lastRelaySessionStateWriteTimes.set(sessionId, now);
-        void recordRelaySessionState(sessionId, session.userId ?? null, mergedState).catch((error) => {
-            log.error("Failed to persist patched relay session state:", error);
-        });
-    }
-
     return true;
 }
 
-/** Get session last state from Redis. */
+/** Get session last state (with any pending metadata overlay) from Redis. */
 export async function getSessionState(sessionId: string): Promise<unknown | undefined> {
     const session = await getSession(sessionId);
     if (!session?.lastState) return undefined;
-    return safeJsonParse(session.lastState);
+    const state = safeJsonParse(session.lastState);
+    return applySnapshotOverlayToState(state, session.snapshotOverlay);
 }
 
 /** Refresh ephemeral session expiry and SQLite touch. */
@@ -659,7 +652,7 @@ export async function touchSessionActivity(
     }
     lastTouchTimes.set(sessionId, now);
 
-    const session = sessionHint ?? await getSession(sessionId);
+    const session = sessionHint ?? await getSessionSummary(sessionId);
     if (!session) return;
 
     if (session.isEphemeral) {
@@ -854,7 +847,7 @@ export async function getSessionSeq(sessionId: string): Promise<number> {
 
 /** Get the last heartbeat payload for a session. */
 export async function getSessionLastHeartbeat(sessionId: string): Promise<unknown | null> {
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (!session?.lastHeartbeat) return null;
     return safeJsonParse(session.lastHeartbeat);
 }
@@ -872,7 +865,7 @@ export async function sendSnapshotToViewer(sessionId: string, socket: Socket): P
         socket.emit("event", { event: heartbeat, seq, sessionId });
     }
     if (session.lastState) {
-        const state = safeJsonParse(session.lastState);
+        const state = applySnapshotOverlayToState(safeJsonParse(session.lastState), session.snapshotOverlay);
         // Truncate session_active state for reconnect/hydration delivery so
         // initial page load / reconnect only sends the tail.  Full state
         // is available via load_messages pagination.
@@ -961,9 +954,15 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
 
     // Final durable flush — mid-stream SQLite state writes are throttled, so
     // persist the freshest Redis state before it is deleted (SQLite is the
-    // cold-restore source; prod Redis runs without persistence).
+    // cold-restore source; prod Redis runs without persistence).  Metadata
+    // patches accumulate in snapshotOverlay rather than rewriting lastState,
+    // so fold them in here — this is the one-time cost at session end.
     if (session.lastState) {
-        await recordRelaySessionStateSerialized(sessionId, session.userId ?? null, session.lastState).catch(
+        const finalState = session.snapshotOverlay
+            ? applySnapshotOverlayToState(safeJsonParse(session.lastState), session.snapshotOverlay)
+            : null;
+        const serialized = finalState ? JSON.stringify(finalState) : session.lastState;
+        await recordRelaySessionStateSerialized(sessionId, session.userId ?? null, serialized).catch(
             (error) => {
                 log.error("Failed to flush final relay session state:", error);
             },

--- a/packages/server/src/ws/sio-registry/snapshot-state.test.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.test.ts
@@ -3,8 +3,75 @@ import {
     buildSnapshotPatchFromCapabilities,
     buildSnapshotPatchFromMetadata,
     mergeSnapshotStatePatch,
+    mergeSnapshotOverlay,
+    applySnapshotOverlayToState,
     shouldPersistSnapshotPatch,
 } from "./snapshot-state.js";
+
+describe("mergeSnapshotOverlay", () => {
+    test("starts a fresh overlay when none exists", () => {
+        expect(mergeSnapshotOverlay(null, { thinkingLevel: "high" })).toEqual({ thinkingLevel: "high" });
+    });
+
+    test("accumulates patches, later values winning", () => {
+        const first = mergeSnapshotOverlay(null, { todoList: [1], thinkingLevel: "low" });
+        const second = mergeSnapshotOverlay(JSON.stringify(first), { thinkingLevel: "high" });
+        expect(second).toEqual({ todoList: [1], thinkingLevel: "high" });
+    });
+
+    test("merges same-model patches field-wise", () => {
+        const first = mergeSnapshotOverlay(null, { model: { provider: "p", id: "m", contextWindow: 1000 } });
+        const second = mergeSnapshotOverlay(JSON.stringify(first), { model: { provider: "p", id: "m", thinking: true } });
+        expect(second.model).toEqual({ provider: "p", id: "m", contextWindow: 1000, thinking: true });
+    });
+
+    test("replaces the model when provider/id change", () => {
+        const first = mergeSnapshotOverlay(null, { model: { provider: "p", id: "m", contextWindow: 1000 } });
+        const second = mergeSnapshotOverlay(JSON.stringify(first), { model: { provider: "p2", id: "m2" } });
+        expect(second.model).toEqual({ provider: "p2", id: "m2" });
+    });
+
+    test("recovers from a corrupt existing overlay", () => {
+        expect(mergeSnapshotOverlay("{not json", { goal: null })).toEqual({ goal: null });
+    });
+});
+
+describe("applySnapshotOverlayToState", () => {
+    test("returns state unchanged for empty/missing/corrupt overlay", () => {
+        const state = { messages: [1] };
+        expect(applySnapshotOverlayToState(state, null)).toBe(state);
+        expect(applySnapshotOverlayToState(state, "")).toBe(state);
+        expect(applySnapshotOverlayToState(state, "{}")).toBe(state);
+        expect(applySnapshotOverlayToState(state, "{broken")).toBe(state);
+    });
+
+    test("overlays metadata without touching messages", () => {
+        const state = { messages: [1, 2], queuedMessages: [], thinkingLevel: "low" };
+        const result = applySnapshotOverlayToState(
+            state,
+            JSON.stringify({ queuedMessages: ["q"], thinkingLevel: "high" }),
+        ) as Record<string, unknown>;
+        expect(result.messages).toEqual([1, 2]);
+        expect(result.queuedMessages).toEqual(["q"]);
+        expect(result.thinkingLevel).toBe("high");
+        // Original untouched
+        expect(state.queuedMessages).toEqual([]);
+    });
+
+    test("merges same-model overlay field-wise with the state's model", () => {
+        const state = { model: { provider: "p", id: "m", contextWindow: 5 } };
+        const result = applySnapshotOverlayToState(
+            state,
+            JSON.stringify({ model: { provider: "p", id: "m", thinking: true } }),
+        ) as Record<string, unknown>;
+        expect(result.model).toEqual({ provider: "p", id: "m", contextWindow: 5, thinking: true });
+    });
+
+    test("passes non-object state through untouched", () => {
+        expect(applySnapshotOverlayToState(null, "{\"a\":1}")).toBeNull();
+        expect(applySnapshotOverlayToState([1], "{\"a\":1}")).toEqual([1]);
+    });
+});
 
 describe("buildSnapshotPatchFromMetadata", () => {
     test("captures reconnect-relevant session metadata including models and commands", () => {

--- a/packages/server/src/ws/sio-registry/snapshot-state.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.ts
@@ -78,6 +78,64 @@ export function shouldPersistSnapshotPatch(input: {
     return now - lastWriteAt >= throttleMs;
 }
 
+/**
+ * Merge a metadata patch into the accumulated snapshot overlay (a small JSON
+ * object holding "patches since the last full snapshot"). Never touches the
+ * multi-MB lastState blob.
+ */
+export function mergeSnapshotOverlay(
+    existingRaw: string | null | undefined,
+    patch: Record<string, unknown>,
+): Record<string, unknown> {
+    let existing: Record<string, unknown> = {};
+    if (existingRaw) {
+        try {
+            const parsed = JSON.parse(existingRaw);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                existing = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // Corrupt overlay — start fresh.
+        }
+    }
+
+    const merged = { ...existing, ...patch };
+    if (Object.prototype.hasOwnProperty.call(patch, "model")) {
+        merged.model = mergeModelPatch(existing.model, patch.model);
+    }
+    return merged;
+}
+
+/**
+ * Apply an accumulated snapshot overlay to a session_active-style state object
+ * at read time. Returns the original state when the overlay is empty/invalid.
+ */
+export function applySnapshotOverlayToState(
+    state: unknown,
+    overlayRaw: string | null | undefined,
+): unknown {
+    if (!overlayRaw) return state;
+    if (!state || typeof state !== "object" || Array.isArray(state)) return state;
+
+    let overlay: unknown;
+    try {
+        overlay = JSON.parse(overlayRaw);
+    } catch {
+        return state;
+    }
+    if (!overlay || typeof overlay !== "object" || Array.isArray(overlay)) return state;
+
+    const overlayObj = overlay as Record<string, unknown>;
+    if (Object.keys(overlayObj).length === 0) return state;
+
+    const stateObj = state as Record<string, unknown>;
+    const merged = { ...stateObj, ...overlayObj };
+    if (Object.prototype.hasOwnProperty.call(overlayObj, "model")) {
+        merged.model = mergeModelPatch(stateObj.model, overlayObj.model);
+    }
+    return merged;
+}
+
 export function mergeSnapshotStatePatch(
     rawLastState: string | null | undefined,
     patch: Record<string, unknown>,

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -206,6 +206,7 @@ export interface RedisSessionData {
  */
 export interface RedisSessionSummaryData {
     sessionId: string;
+    collabMode: boolean;
     shareUrl: string;
     cwd: string;
     startedAt: string;
@@ -289,6 +290,7 @@ function toHashFields(data: Record<string, unknown>): Record<string, string> {
 
 const SESSION_SUMMARY_FIELDS = [
     "sessionId",
+    "collabMode",
     "shareUrl",
     "cwd",
     "startedAt",
@@ -310,6 +312,7 @@ function parseSessionSummaryFromHash(hash: Record<string, string>): RedisSession
     if (!hash.sessionId) return null;
     return {
         sessionId: hash.sessionId,
+        collabMode: hash.collabMode === "1",
         shareUrl: hash.shareUrl ?? "",
         cwd: hash.cwd ?? "",
         startedAt: hash.startedAt ?? "",

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -190,6 +190,13 @@ export interface RedisSessionData {
      *  Absent for sessions created before this feature; callers must use
      *  defaultMetaState() as fallback. */
     metaState?: string | null;
+    /**
+     * JSON-stringified metadata patch accumulated since the last full
+     * session_active snapshot. Written by patchSessionSnapshotState, cleared
+     * by updateSessionState. Applied on top of lastState / cached snapshots
+     * at read time so metadata events never rewrite the multi-MB state blob.
+     */
+    snapshotOverlay?: string | null;
 }
 
 /**
@@ -214,6 +221,8 @@ export interface RedisSessionSummaryData {
     runnerId: string | null;
     runnerName: string | null;
     parentSessionId: string | null;
+    /** See RedisSessionData.linkedParentId. */
+    linkedParentId?: string | null;
 }
 
 export interface RedisRunnerData {
@@ -294,6 +303,7 @@ const SESSION_SUMMARY_FIELDS = [
     "runnerId",
     "runnerName",
     "parentSessionId",
+    "linkedParentId",
 ] as const;
 
 function parseSessionSummaryFromHash(hash: Record<string, string>): RedisSessionSummaryData | null {
@@ -314,6 +324,7 @@ function parseSessionSummaryFromHash(hash: Record<string, string>): RedisSession
         runnerId: hash.runnerId || null,
         runnerName: hash.runnerName || null,
         parentSessionId: hash.parentSessionId || null,
+        linkedParentId: hash.linkedParentId || null,
     };
 }
 
@@ -361,6 +372,7 @@ function parseSessionFromHash(hash: Record<string, string>): RedisSessionData | 
         parentSessionId: hash.parentSessionId || null,
         linkedParentId: hash.linkedParentId || null,
         metaState: hash.metaState || null,
+        snapshotOverlay: hash.snapshotOverlay || null,
     };
 }
 

--- a/packages/server/src/ws/sio-state/serialization.ts
+++ b/packages/server/src/ws/sio-state/serialization.ts
@@ -42,6 +42,7 @@ export const SESSION_SUMMARY_FIELDS = [
     "runnerId",
     "runnerName",
     "parentSessionId",
+    "linkedParentId",
 ] as const;
 
 export function parseSessionSummaryFromHash(hash: Record<string, string>): RedisSessionSummaryData | null {
@@ -62,6 +63,7 @@ export function parseSessionSummaryFromHash(hash: Record<string, string>): Redis
         runnerId: hash.runnerId || null,
         runnerName: hash.runnerName || null,
         parentSessionId: hash.parentSessionId || null,
+        linkedParentId: hash.linkedParentId || null,
     };
 }
 
@@ -109,6 +111,7 @@ export function parseSessionFromHash(hash: Record<string, string>): RedisSession
         parentSessionId: hash.parentSessionId || null,
         linkedParentId: hash.linkedParentId || null,
         metaState: hash.metaState || null,
+        snapshotOverlay: hash.snapshotOverlay || null,
     };
 }
 

--- a/packages/server/src/ws/sio-state/serialization.ts
+++ b/packages/server/src/ws/sio-state/serialization.ts
@@ -28,6 +28,7 @@ export function toHashFields(data: Record<string, unknown>): Record<string, stri
 
 export const SESSION_SUMMARY_FIELDS = [
     "sessionId",
+    "collabMode",
     "shareUrl",
     "cwd",
     "startedAt",
@@ -49,6 +50,7 @@ export function parseSessionSummaryFromHash(hash: Record<string, string>): Redis
     if (!hash.sessionId) return null;
     return {
         sessionId: hash.sessionId,
+        collabMode: hash.collabMode === "1",
         shareUrl: hash.shareUrl ?? "",
         cwd: hash.cwd ?? "",
         startedAt: hash.startedAt ?? "",

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -65,6 +65,13 @@ export interface RedisSessionData {
      *  Absent for sessions created before this feature; callers must use
      *  defaultMetaState() as fallback. */
     metaState?: string | null;
+    /**
+     * JSON-stringified metadata patch accumulated since the last full
+     * session_active snapshot. Written by patchSessionSnapshotState, cleared
+     * by updateSessionState. Applied on top of lastState / cached snapshots
+     * at read time so metadata events never rewrite the multi-MB state blob.
+     */
+    snapshotOverlay?: string | null;
 }
 
 /**
@@ -89,6 +96,8 @@ export interface RedisSessionSummaryData {
     runnerId: string | null;
     runnerName: string | null;
     parentSessionId: string | null;
+    /** See RedisSessionData.linkedParentId. */
+    linkedParentId?: string | null;
 }
 
 export interface RedisRunnerData {

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -81,6 +81,7 @@ export interface RedisSessionData {
  */
 export interface RedisSessionSummaryData {
     sessionId: string;
+    collabMode: boolean;
     shareUrl: string;
     cwd: string;
     startedAt: string;


### PR DESCRIPTION
## Problem

A flapping client (MacBook Air sleeping/waking on a ~16-min Power Nap cycle over a DERP relay) exposed how expensive the relay's per-event Redis paths are: prod moved **~42GB Redis↔server in 3 hours** with only 7 live sessions (~4MB/s sustained, 680 ops/s).

Two root causes, both "full session hash read on a hot path":

1. Every `session_metadata_update` / `capabilities` event ran `patchSessionSnapshotState()` → full `HGETALL` of the session hash (whose `lastState` blob runs 0.1–0.9MB), synchronous `JSON.parse`, merge, `JSON.stringify`, `HSET` back.
2. Per-message handlers pulled the full blob for 1–2 small fields: `service_message` (discord mirror/ego fire these ~1/sec/session, needed only `collabMode`+`runnerId`), viewer collab gates (`input`/`exec`/`model_set`/`trigger_response`), child-lifecycle ownership checks (which run on **every parent reconnect** — i.e. every flap), runner link/unlink, `touchSessionActivity`.

Reconnect storms multiply both: each wake re-subscribes and re-hydrates every session while the metadata firehose keeps churning.

Godmother: `5GrYHe8k`

## Fix

**Commit 1 — snapshot overlay: merge at read time, not write time**

- **`snapshotOverlay`** — new small session-hash field accumulating metadata patches (model/todo/queue/goal/thinking/commands) since the last full snapshot. Metadata events now read+write only this KB-scale field; the multi-MB blob is untouched.
- **Cleared on every full snapshot** — `updateSessionState` resets the overlay, so overlay = "patches since last `session_active`", making read-time merge equivalent to the old write-time merge.
- **Applied at read time** — snapshot-provider (cache-snapshot / memory / persisted paths), viewer cold-start fallback, and `sendSnapshotToViewer` resync all overlay before emitting. Cache-snapshot hydration previously only overlaid `queuedMessages`; it now gets fresh model/todo/thinking too.
- **Folded into the final SQLite flush** — `endSharedSession` merges the overlay into the persisted state, so dead-session snapshots lose nothing.

**Commit 2 — summary reads for per-message hot paths**

- `collabMode` and `linkedParentId` added to `SESSION_SUMMARY_FIELDS`.
- `service_message`, viewer collab gates, child-lifecycle checks, runner link/unlink, `getSessionLastHeartbeat`, and `touchSessionActivity` now use `hmGet` summary reads instead of full `HGETALL`.

## Verification

- `tsc --noEmit -p packages/server` clean; full isolated server suite **76 files pass, 0 fail** (new unit tests for `mergeSnapshotOverlay` / `applySnapshotOverlayToState`, updated snapshot-provider overlay tests).
- **Deployed to the hosted relay and measured**: session-hash `HGETALL`s dropped from ~7/sec to **zero** in MONITOR samples; Redis egress 4.1MB/s → 2.4MB/s (remainder is live streaming payload from active sessions).

## Notes

- The `sio-state/` split directory is dead code (barrel re-exports the `sio-state.ts` monolith); its copies were kept in sync to avoid drift.
- Mid-session SQLite writes for metadata-only patches are dropped (previously throttled to 30s anyway); durable state relies on throttled full-snapshot writes + the end-of-session flush, same as messages already did.
- Diagnosis gotcha for future readers: `redis-cli MONITOR` shows command sizes, not response sizes — read amplification (HGETALL/LRANGE) is invisible there; use `total_net_output_bytes` deltas + `HSTRLEN` instead.
