### PR TITLE
fix(ui): blank slate instead of "Waiting for session events" for empty sessions

### DIFF
--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -886,6 +886,7 @@ export function SessionViewer({
               </Conversation>
             ) : (() => {
               const emptyUi = getSessionEmptyStateUi(viewerStatus);
+              if (!emptyUi) return null; // connected + empty session — blank slate
               return (
                 <ConversationEmptyState
                   icon={

--- a/packages/ui/src/lib/session-empty-state.test.ts
+++ b/packages/ui/src/lib/session-empty-state.test.ts
@@ -87,11 +87,18 @@ describe("getSessionEmptyStateUi", () => {
     });
   });
 
-  test("returns non-spinning waiting state for idle empty sessions", () => {
+  test("returns non-spinning waiting state while not yet connected", () => {
     expect(getSessionEmptyStateUi("Waiting for session events")).toEqual({
       title: "Waiting for session events",
       description: "Messages will appear here in real time.",
       shouldSpinLogo: false,
     });
+    expect(getSessionEmptyStateUi("Disconnected")).not.toBeNull();
+    expect(getSessionEmptyStateUi(null)).not.toBeNull();
+  });
+
+  test("returns null for connected sessions that are simply empty", () => {
+    expect(getSessionEmptyStateUi("Connected")).toBeNull();
+    expect(getSessionEmptyStateUi("Snapshot replay")).toBeNull();
   });
 });

--- a/packages/ui/src/lib/session-empty-state.ts
+++ b/packages/ui/src/lib/session-empty-state.ts
@@ -62,14 +62,23 @@ export function classifySessionInput(
 
 /**
  * Copy + animation state for session-specific empty states.
+ *
+ * Returns null when the session is fully hydrated and simply has no messages
+ * yet (a genuinely empty session) — the transcript area should stay blank
+ * instead of implying we're still waiting on data.
  */
-export function getSessionEmptyStateUi(viewerStatus: string | null | undefined): SessionEmptyStateUi {
+export function getSessionEmptyStateUi(viewerStatus: string | null | undefined): SessionEmptyStateUi | null {
   if (isSessionHydrating(viewerStatus)) {
     return {
       title: "Loading session",
       description: "Fetching conversation data…",
       shouldSpinLogo: true,
     };
+  }
+
+  const status = typeof viewerStatus === "string" ? viewerStatus.trim().toLowerCase() : "";
+  if (status === "connected" || status === "snapshot replay") {
+    return null;
   }
 
   return {


### PR DESCRIPTION
A connected (or snapshot-replay) session with zero messages showed the "Waiting for session events / Messages will appear here in real time." placeholder — implying the UI was still waiting on data when the session is simply empty.

`getSessionEmptyStateUi` now returns `null` once the viewer status is `Connected` or `Snapshot replay`, and `SessionViewer` renders an empty transcript area in that case. Hydrating (`Loading session…`) and pre-connection (`Connecting…`/`Disconnected`) states keep their existing placeholders.

Tests updated + new cases; `tsc -p packages/ui` clean.