### PR TITLE
fix(cli): show Gemini usage as 'used' to match other providers

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ import { join } from "path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv, resolveExplicitProjectTrust } from "./config.js";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
 import { getOAuthAccessToken, getAnthropicKeychainToken } from "./runner/usage-auth.js";
-import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
+import { c, usageBar, colorPct } from "./cli-colors.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "./skills.js";
 import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "./extensions/claude-plugins.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
@@ -310,12 +310,12 @@ async function main() {
                                 ? (1 - bucket.remainingFraction) * 100
                                 : null;
                             const bar = usedPct !== null ? usageBar(usedPct) : "";
-                            const remainingStr = bucket.remainingFraction != null
-                                ? ` ${colorRemaining(bucket.remainingFraction * 100)} remaining`
+                            const usedStr = usedPct !== null
+                                ? ` ${colorPct(usedPct)} used`
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";
-                            log.info(`  ${label.padEnd(28)} ${bar}${remainingStr}${amt}${reset}`);
+                            log.info(`  ${label.padEnd(28)} ${bar}${usedStr}${amt}${reset}`);
                         }
                     }
                     printedAny = true;


### PR DESCRIPTION
## Night Shift — Gemini usage label fix

Fixes the `pizza usage` Gemini row to show **used** semantics (`(1 - remainingFraction) * 100`) consistent with the anthropic/openai rows, instead of mislabeling the remaining fraction. Health-inspector violation from PR #305.

- `packages/cli/src/index.ts`: Gemini bucket now renders `usedPct` via `colorPct` (green <50, red ≥80), matching other providers; removed now-unused `colorRemaining` import.
- Null guard preserved; `(N left)` amount + reset time untouched; no other provider rows changed.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src` — only the 3 pre-existing baseline failures (models command ×2, computePackageIdentity), no new failures.

Reviewed by Fable 5 critic: LGTM (one P3 non-blocking: used% printed in both the bar and the label).

Godmother: bT9HJH06. 🌙 Autonomous night shift — queued for human review, not auto-merged.
