### PR TITLE
refactor(ui): thread prompt textarea via React ref instead of data-pp-prompt query

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -271,6 +271,7 @@ function createInitialSessionState(): SessionState {
 
 export function App() {
   const { data: session, isPending } = usePizzaPiSession();
+  const promptRef = React.useRef<HTMLTextAreaElement>(null);
   // Drive the native badge from the attention store.
   // No-op outside the bundled Capacitor app.
   useMobileNativeActivity();
@@ -4137,7 +4138,7 @@ export function App() {
       // Cmd/Ctrl + K — Focus the prompt textarea
       if (meta && !e.shiftKey && !e.altKey && e.key === "k") {
         e.preventDefault();
-        document.querySelector<HTMLElement>("[data-pp-prompt]")?.focus();
+        promptRef.current?.focus();
         return;
       }
 
@@ -5171,6 +5172,7 @@ export function App() {
                       <SigilProvider sigilDefs={runnerSigilDefs} panels={dynamicPanels} runnerId={activeSessionInfo?.runnerId ?? undefined}>
                       <PizzaPiNavProvider actions={pizzaPiNavActions}>
                       <SessionViewer
+                        promptRef={promptRef}
                         sessionId={activeSessionId}
                         sessionName={sessionName}
                         messages={messages}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -182,12 +182,16 @@ export function SessionViewer({
   onLoadMoreServerMessages,
   loadingOlderMessages,
   toolbarPositions,
+  promptRef: externalPromptRef,
 }: BaseSessionViewerProps & {
   hasMoreServerMessages?: boolean;
+  promptRef?: React.RefObject<HTMLTextAreaElement | null>;
   onLoadMoreServerMessages?: () => void;
   loadingOlderMessages?: boolean;
 }) {
   const inHeader = (id: ToolbarButtonId) => (toolbarPositions?.[id] ?? "top") === "top";
+  const localPromptRef = React.useRef<HTMLTextAreaElement>(null);
+  const promptRef = externalPromptRef ?? localPromptRef;
 
   // ── Misc local state ──────────────────────────────────────────────────────
   const [composerError, setComposerError] = React.useState<string | null>(null);
@@ -228,7 +232,7 @@ export function SessionViewer({
           setEditingQueuedId(null);
           setEditingQueuedText("");
           requestAnimationFrame(() => {
-            document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus();
+            promptRef.current?.focus();
           });
           return true;
         }
@@ -307,6 +311,7 @@ export function SessionViewer({
 
   // ── Slash commands ────────────────────────────────────────────────────────
   const slashCmd = useSlashCommands(input, setInput, {
+    promptRef,
     sessionId,
     sessionIdRef,
     compactingRef,
@@ -372,7 +377,7 @@ export function SessionViewer({
   });
 
   // ── @-mention handlers ────────────────────────────────────────────────────
-  const atMention = useAtMentionHandlers(sessionId, inputRef, setInput, runnerId, runnerInfo);
+  const atMention = useAtMentionHandlers(sessionId, inputRef, promptRef, setInput, runnerId, runnerInfo);
 
   const {
     atMentionOpen,
@@ -1212,7 +1217,7 @@ export function SessionViewer({
                                 setCommandOpen(false);
                                 setCommandHighlightedIndex(0);
                                 requestAnimationFrame(() => {
-                                  const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                                  const ta = promptRef.current;
                                   if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
                                 });
                                 return;
@@ -1255,7 +1260,7 @@ export function SessionViewer({
                                 setInput(`/${cmd.name} `);
                                 setCommandQuery("");
                                 setCommandOpen(keepPopoverOpenNames.has(cmd.name.toLowerCase()));
-                                requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus());
+                                requestAnimationFrame(() => promptRef.current?.focus());
                               }}>
                                 <div className="flex w-full items-center justify-between gap-2">
                                   <div className="flex items-center gap-1.5 min-w-0">
@@ -1278,7 +1283,7 @@ export function SessionViewer({
                                 setInput(`/${cmd.name} `);
                                 setCommandQuery("");
                                 setCommandOpen(false);
-                                requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus());
+                                requestAnimationFrame(() => promptRef.current?.focus());
                               }}>
                                 <div className="flex w-full items-center justify-between gap-2">
                                   <span className="font-mono text-sm truncate">/{cmd.name}</span>
@@ -1295,7 +1300,7 @@ export function SessionViewer({
                                 setInput(`/${skill.name} `);
                                 setCommandQuery("");
                                 setCommandOpen(false);
-                                requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus());
+                                requestAnimationFrame(() => promptRef.current?.focus());
                               }}>
                                 <div className="flex w-full items-center justify-between gap-2">
                                   <div className="flex items-center gap-1.5 min-w-0">
@@ -1394,6 +1399,7 @@ export function SessionViewer({
               <PromptInputBody>
                 <div className="flex w-full items-end">
                   <PromptInputTextarea
+                    ref={promptRef}
                     data-pp-prompt=""
                     aria-label="Message"
                     value={input}
@@ -1577,7 +1583,7 @@ export function SessionViewer({
                               setCommandOpen(false);
                               setCommandHighlightedIndex(0);
                               requestAnimationFrame(() => {
-                                const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                                const ta = promptRef.current;
                                 if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
                               });
                               return;
@@ -1632,7 +1638,7 @@ export function SessionViewer({
                               setCommandOpen(highlighted.name === "resume" || keepPopoverOpenNames.has(highlighted.name.toLowerCase()));
                               setCommandHighlightedIndex(0);
                               requestAnimationFrame(() => {
-                                const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                                const ta = promptRef.current;
                                 if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); }
                               });
                               return;
@@ -1648,7 +1654,7 @@ export function SessionViewer({
                             setCommandQuery("");
                             setCommandHighlightedIndex(0);
                             requestAnimationFrame(() => {
-                              const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                              const ta = promptRef.current;
                               if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
                             });
                           }
@@ -1664,7 +1670,7 @@ export function SessionViewer({
                             setCommandOpen(false);
                             setCommandHighlightedIndex(0);
                             requestAnimationFrame(() => {
-                              const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                              const ta = promptRef.current;
                               if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
                             });
                           }

--- a/packages/ui/src/components/session-viewer/at-mention-handlers.ts
+++ b/packages/ui/src/components/session-viewer/at-mention-handlers.ts
@@ -42,6 +42,7 @@ export interface AtMentionResult extends AtMentionState, AtMentionHandlers {}
 export function useAtMentionHandlers(
   sessionId: string | null,
   inputRef: React.MutableRefObject<string>,
+  promptRef: React.RefObject<HTMLTextAreaElement | null>,
   setInput: (value: string) => void,
   runnerId: string | undefined,
   runnerInfo: import("@pizzapi/protocol").RunnerInfo | null | undefined,
@@ -114,7 +115,7 @@ export function useAtMentionHandlers(
   /** Select a file entry: insert @{relativePath} into the textarea. */
   const handleAtMentionSelectFile = React.useCallback(
     (relativePath: string) => {
-      const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+      const textarea = promptRef.current;
       if (!textarea) return;
       const cursorPosition = textarea.selectionStart;
       const value = inputRef.current;
@@ -129,7 +130,7 @@ export function useAtMentionHandlers(
       resetAtMentionState();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [atMentionTriggerOffset, resetAtMentionState, setInput, inputRef],
+    [atMentionTriggerOffset, resetAtMentionState, setInput, inputRef, promptRef],
   );
 
   /** Drill into a directory, updating the textarea text to reflect the new path. */
@@ -138,7 +139,7 @@ export function useAtMentionHandlers(
       setAtMentionPath(newPath);
       setAtMentionQuery("");
       setAtMentionHighlightedIndex(0);
-      const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+      const textarea = promptRef.current;
       if (textarea) {
         const cursorPosition = textarea.selectionStart;
         const value = inputRef.current;
@@ -153,7 +154,7 @@ export function useAtMentionHandlers(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [atMentionTriggerOffset, setInput, inputRef],
+    [atMentionTriggerOffset, setInput, inputRef, promptRef],
   );
 
   /** Navigate up one directory level. */
@@ -179,7 +180,7 @@ export function useAtMentionHandlers(
   /** Select an agent entry: insert @agentName into the textarea. */
   const handleAtMentionSelectAgent = React.useCallback(
     (agentName: string) => {
-      const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+      const textarea = promptRef.current;
       if (!textarea) return;
       const cursorPosition = textarea.selectionStart;
       const value = inputRef.current;
@@ -194,7 +195,7 @@ export function useAtMentionHandlers(
       resetAtMentionState();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [atMentionTriggerOffset, resetAtMentionState, setInput, inputRef],
+    [atMentionTriggerOffset, resetAtMentionState, setInput, inputRef, promptRef],
   );
 
   return {

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -31,6 +31,7 @@ export interface SubCommandMode {
 }
 
 export interface SlashCommandDeps {
+  promptRef: React.RefObject<HTMLTextAreaElement | null>;
   sessionId: string | null;
   sessionIdRef: React.MutableRefObject<string | null>;
   compactingRef: React.MutableRefObject<boolean>;
@@ -110,6 +111,7 @@ export function useSlashCommands(
   deps: SlashCommandDeps,
 ): SlashCommandState {
   const {
+    promptRef,
     sessionId,
     sessionIdRef,
     compactingRef,
@@ -349,11 +351,11 @@ export function useSlashCommands(
       // and resent — mirrors the TUI fork flow.
       setInput(dispatched === false ? "" : message.text);
       requestAnimationFrame(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+        const ta = promptRef.current;
         if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
       });
     },
-    [onExec, setInput],
+    [onExec, setInput, promptRef],
   );
 
   // Sub-command mode (e.g. "/mcp " shows mcp sub-commands)


### PR DESCRIPTION
## Night Shift — replace data-pp-prompt querySelector with a React ref

Replaces all 13 `document.querySelector("[data-pp-prompt]")` prompt-textarea lookups with a stable React ref threaded through `SessionViewer`, `App.tsx`, and the at-mention / slash-command helpers. Removes fragile global DOM access for popover targeting and focus.

- `SessionViewer` resolves `externalPromptRef ?? localPromptRef` (stable identity, safe standalone); ref flows to the native `<textarea>` via prop spread (React 19).
- `at-mention-handlers.ts` / `slash-commands.ts` receive the ref; `App.tsx` Cmd+K focus uses `promptRef.current?.focus()`.
- `data-pp-prompt` retained only as the popover keyboard-nav `ignoreTargetSelector` (event filtering, not a lookup).
- Behavior preserved: focus, cursor placement, at-mention/slash insertion, popover refocus — same element, same timing.

**Verification:** `cd packages/ui && bun test src` exit 0 (1292 pass / 0 fail); root `tsc --build` typecheck exit 0. Surgical diff (+30/−19, 4 files).

Reviewed by Fable 5 critic: LGTM (verified ref threading end-to-end).

Godmother: 1eP0V7YC. 🌙 Autonomous night shift — queued for human review, not auto-merged.
