### PR TITLE
feat(cli): load modular system-prompt rules from .pizzapi/rules directories

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -573,6 +573,9 @@ async function main() {
         // via pi's own flow mid-process).
         const rtProjectTrusted = resolveExplicitProjectTrust(opts.cwd, opts.agentDir);
         const rtSettingsManager = SettingsManager.create(opts.cwd, opts.agentDir, { projectTrusted: rtProjectTrusted });
+        const rtAgentsFilesOverride = createAgentsFilesOverride(opts.cwd, {
+            sendAgentsMd: config.sendAgentsMd !== false,
+        });
         const services = await createAgentSessionServices({
             cwd: opts.cwd,
             agentDir: opts.agentDir,
@@ -591,7 +594,7 @@ async function main() {
                     systemPromptOverride: () => config.systemPrompt,
                 }),
                 appendSystemPrompt: [maybeBuildSystemPrompt(config, { cwd: opts.cwd }), config.appendSystemPrompt].filter(Boolean) as string[],
-                ...(agentsFilesOverride && { agentsFilesOverride }),
+                ...(rtAgentsFilesOverride && { agentsFilesOverride: rtAgentsFilesOverride }),
             },
         });
         const result = await createAgentSessionFromServices({

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -3,7 +3,7 @@ import { SHELL_PROC_CAPTURE_PREFIX } from "./session-procs.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv, resolveExplicitProjectTrust } from "../config.js";
-import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
+import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride, loadRules } from "../skills.js";
 import { getPluginSkillPaths, getPluginPromptTemplatePaths } from "../extensions/claude-plugins.js";
 import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
@@ -229,6 +229,10 @@ function injectContextTrackingEntries(
     };
 
     if (config.sendAgentsMd !== false) {
+        const rules = loadRules(cwd);
+        for (const file of rules.global) appendContextTelemetry("context:global-rules", file.content);
+        for (const file of rules.project) appendContextTelemetry("context:project-rules", file.content);
+
         // ── Global rules (from ~/.pizzapi/AGENTS.md) ──────────────────────────
         const globalAgentsPath = join(agentDir, "AGENTS.md");
         if (existsSync(globalAgentsPath)) {

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -15,6 +15,7 @@ import {
     buildInteractiveSkillPaths,
     buildWorkerSkillPaths,
     loadProjectAgentFiles,
+    loadRulesDir,
     createAgentsFilesOverride,
 } from "./skills.js";
 
@@ -543,6 +544,28 @@ describe("loadProjectAgentFiles", () => {
     test("returns empty array when nothing exists", () => {
         const files = loadProjectAgentFiles(dir);
         expect(files).toEqual([]);
+    });
+});
+
+describe("loadRulesDir", () => {
+    test("discovers markdown rules in lexicographic order", () => {
+        const dir = makeTmpDir();
+        try {
+            writeFileSync(join(dir, "z-last.md"), "last", "utf-8");
+            writeFileSync(join(dir, "a-first.md"), "first", "utf-8");
+            writeFileSync(join(dir, "ignore.txt"), "ignore", "utf-8");
+            mkdirSync(join(dir, "nested.md"));
+            expect(loadRulesDir(dir).map(file => [file.path, file.content])).toEqual([
+                [join(dir, "a-first.md"), "first"],
+                [join(dir, "z-last.md"), "last"],
+            ]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("returns empty array for a missing directory", () => {
+        expect(loadRulesDir(join(makeTmpDir(), "missing"))).toEqual([]);
     });
 });
 

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 import {
     parseSkillFrontmatterFromString,
@@ -631,6 +631,43 @@ describe("createAgentsFilesOverride", () => {
         const result = override(base);
         expect(result.agentsFiles).toHaveLength(2);
         expect(result.agentsFiles[1].path).toBe(join(dir, ".agents", "extra.md"));
+    });
+
+    test("orders global context before project context and project rules", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Project context", "utf-8");
+        mkdirSync(join(dir, ".pizzapi", "rules"), { recursive: true });
+        writeFileSync(join(dir, ".pizzapi", "rules", "01-rule.md"), "# Project rule", "utf-8");
+        const override = createAgentsFilesOverride(dir)!;
+        const globalContext = join(homedir(), ".pizzapi", "AGENTS.md");
+        const result = override({
+            agentsFiles: [
+                { path: globalContext, content: "# Global context" },
+                { path: join(dir, "AGENTS.md"), content: "# Project context (base)" },
+            ],
+        });
+        expect(result.agentsFiles.map(file => file.content)).toEqual([
+            "# Global context",
+            "# Project context (base)",
+            "# Project rule",
+        ]);
+    });
+
+    test("deduplicates rules already present in the base files", () => {
+        mkdirSync(join(dir, ".pizzapi", "rules"), { recursive: true });
+        const rulePath = join(dir, ".pizzapi", "rules", "rule.md");
+        writeFileSync(rulePath, "# Rule", "utf-8");
+        const override = createAgentsFilesOverride(dir)!;
+        const result = override({ agentsFiles: [{ path: rulePath, content: "# Rule (base)" }] });
+        expect(result.agentsFiles).toEqual([{ path: rulePath, content: "# Rule (base)" }]);
+    });
+
+    test("excludes rules along with AGENTS.md when sending is disabled", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Agents", "utf-8");
+        mkdirSync(join(dir, ".pizzapi", "rules"), { recursive: true });
+        writeFileSync(join(dir, ".pizzapi", "rules", "rule.md"), "# Rule", "utf-8");
+        const override = createAgentsFilesOverride(dir, { sendAgentsMd: false })!;
+        const result = override({ agentsFiles: [{ path: "/repo/CLAUDE.md", content: "# Claude" }] });
+        expect(result.agentsFiles.map(file => file.content)).toEqual(["# Claude"]);
     });
 });
 

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -188,6 +188,37 @@ export interface AgentFile {
     content: string;
 }
 
+/** Load direct markdown rule files from a directory in lexicographic order. */
+export function loadRulesDir(dir: string): AgentFile[] {
+    if (!existsSync(dir)) return [];
+    let entries: string[];
+    try {
+        entries = readdirSync(dir).sort();
+    } catch {
+        return [];
+    }
+
+    const files: AgentFile[] = [];
+    for (const entry of entries) {
+        if (!entry.endsWith(".md")) continue;
+        const path = join(dir, entry);
+        try {
+            if (statSync(path).isFile()) files.push({ path, content: readFileSync(path, "utf-8") });
+        } catch {
+            // Skip unreadable or concurrently removed files.
+        }
+    }
+    return files;
+}
+
+/** Load global and project modular rules, in override-friendly order. */
+export function loadRules(cwd: string): { global: AgentFile[]; project: AgentFile[] } {
+    return {
+        global: loadRulesDir(join(homedir(), ".pizzapi", "rules")),
+        project: loadRulesDir(join(cwd, ".pizzapi", "rules")),
+    };
+}
+
 /**
  * Load project-level agent files that the upstream `DefaultResourceLoader`
  * does NOT discover on its own.
@@ -267,8 +298,11 @@ export function createAgentsFilesOverride(
     options: AgentsFilesOverrideOptions = {},
 ): ((base: { agentsFiles: AgentFile[] }) => { agentsFiles: AgentFile[] }) | null {
     const sendAgentsMd = options.sendAgentsMd !== false;
-    const additionalFiles = loadProjectAgentFiles(cwd)
-        .filter((file) => sendAgentsMd || !isAgentsMdPath(file.path));
+    const rules = loadRules(cwd);
+    const additionalFiles = [
+        ...loadProjectAgentFiles(cwd),
+        ...(sendAgentsMd ? [...rules.global, ...rules.project] : []),
+    ].filter((file) => sendAgentsMd || !isAgentsMdPath(file.path));
     if (additionalFiles.length === 0 && sendAgentsMd) return null;
 
     return (base) => {

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -213,6 +213,7 @@ export function loadRulesDir(dir: string): AgentFile[] {
 
 /** Load global and project modular rules, in override-friendly order. */
 export function loadRules(cwd: string): { global: AgentFile[]; project: AgentFile[] } {
+    // TODO: also discover Claude Code's ~/.claude/rules/ for compatibility.
     return {
         global: loadRulesDir(join(homedir(), ".pizzapi", "rules")),
         project: loadRulesDir(join(cwd, ".pizzapi", "rules")),
@@ -299,20 +300,37 @@ export function createAgentsFilesOverride(
 ): ((base: { agentsFiles: AgentFile[] }) => { agentsFiles: AgentFile[] }) | null {
     const sendAgentsMd = options.sendAgentsMd !== false;
     const rules = loadRules(cwd);
+    const projectFiles = loadProjectAgentFiles(cwd);
     const additionalFiles = [
-        ...loadProjectAgentFiles(cwd),
-        ...(sendAgentsMd ? [...rules.global, ...rules.project] : []),
-    ].filter((file) => sendAgentsMd || !isAgentsMdPath(file.path));
+        ...(sendAgentsMd ? rules.global : []),
+        ...(sendAgentsMd ? projectFiles : projectFiles.filter((file) => !isAgentsMdPath(file.path))),
+        ...(sendAgentsMd ? rules.project : []),
+    ];
     if (additionalFiles.length === 0 && sendAgentsMd) return null;
 
     return (base) => {
         const baseFiles = sendAgentsMd
             ? base.agentsFiles
             : base.agentsFiles.filter((file) => !isAgentsMdPath(file.path));
-        const seenPaths = new Set(baseFiles.map(f => f.path));
-        const deduped = additionalFiles.filter(f => !seenPaths.has(f.path));
+        const seenPaths = new Set<string>();
+        const unique = (files: AgentFile[]) => files.filter((file) => {
+            if (seenPaths.has(file.path)) return false;
+            seenPaths.add(file.path);
+            return true;
+        });
+        if (!sendAgentsMd) return { agentsFiles: unique([...baseFiles, ...additionalFiles]) };
+
+        // Keep upstream global context first, then global rules, then project context.
+        const globalRoot = join(homedir(), ".pizzapi") + "/";
+        const globalFiles = baseFiles.filter((file) => file.path.startsWith(globalRoot));
+        const projectFiles = baseFiles.filter((file) => !file.path.startsWith(globalRoot));
         return {
-            agentsFiles: [...baseFiles, ...deduped],
+            agentsFiles: unique([
+                ...globalFiles,
+                ...additionalFiles.filter((file) => rules.global.some((rule) => rule.path === file.path)),
+                ...projectFiles,
+                ...additionalFiles.filter((file) => !rules.global.some((rule) => rule.path === file.path)),
+            ]),
         };
     };
 }

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -43,8 +43,8 @@ You can also override any setting with **environment variables**.
   // Append to the default system prompt without replacing it
   "appendSystemPrompt": "Always write tests for new code.",
 
-  // Send AGENTS.md files automatically as context. Set false to omit them
-  // unless the agent explicitly reads them with tools. Default: true.
+  // Send AGENTS.md and rules/*.md files automatically as context. Set false
+  // to omit them unless the agent explicitly reads them with tools. Default: true.
   "sendAgentsMd": true,
 
   // Override the agent config directory (skills, extensions, etc.)
@@ -138,7 +138,7 @@ You can also override any setting with **environment variables**.
 | `systemPrompt` | `string` | *(pi default)* | Fully replace the default system prompt |
 | `appendSystemPrompt` | `string` | — | Append to the default system prompt |
 | `builtinSystemPrompt` | `boolean` | `true` | Set to `false` to skip PizzaPi's built-in system prompt additions (subagents, plan mode, sigils, tunnels, PizzaPi config guidance) for a vanilla pi prompt |
-| `sendAgentsMd` | `boolean` | `true` | Set to `false` to omit AGENTS.md files from automatic prompt context. The agent can still read them explicitly with tools. |
+| `sendAgentsMd` | `boolean` | `true` | Set to `false` to omit AGENTS.md and rules/*.md files from automatic prompt context. The agent can still read them explicitly with tools. |
 | `agentDir` | `string` | `~/.pizzapi` | Agent config directory (skills, extensions, etc.) |
 | `skills` | `string[]` | `[]` | Additional skill directories. Supports `~` expansion. |
 | `hooks` | `object` | — | Lifecycle hook scripts. See [Hooks](/PizzaPi/customization/hooks/). |

--- a/packages/docs/src/content/docs/features/sessions.mdx
+++ b/packages/docs/src/content/docs/features/sessions.mdx
@@ -212,6 +212,7 @@ pi automatically loads **context files** at startup to give the agent project-sp
 | File | Location | Purpose |
 |------|----------|---------|
 | `AGENTS.md` or `CLAUDE.md` | `~/.pizzapi/`, parent directories, current directory | Project instructions, conventions, common commands |
+| `rules/*.md` | `~/.pizzapi/rules/` (global), `.pizzapi/rules/` (project) | Modular instructions, sorted lexicographically within each directory |
 | `SYSTEM.md` | `.pizzapi/SYSTEM.md` (project) or `~/.pizzapi/SYSTEM.md` (global) | Replace the default system prompt entirely |
 | `APPEND_SYSTEM.md` | Same locations | Append to the system prompt without replacing it |
 
@@ -222,6 +223,8 @@ pi automatically loads **context files** at startup to give the agent project-sp
 ### How Context Files Load
 
 1. Global `AGENTS.md` from `~/.pizzapi/`
-2. Walk up from the current working directory, loading each `AGENTS.md` or `CLAUDE.md` found (the current directory is included)
+2. Global `~/.pizzapi/rules/*.md`, sorted lexicographically
+3. Walk up from the current working directory, loading each `AGENTS.md` or `CLAUDE.md` found (the current directory is included)
+4. Project `.pizzapi/rules/*.md`, sorted lexicographically
 
 All files are concatenated and included in the system prompt. This means you can have repository-wide instructions in the repo root and more specific instructions in subdirectories.


### PR DESCRIPTION
## Night Shift — modular system-prompt rules from .pizzapi/rules/

Adds Claude-Code-compatible modular rule loading: markdown files in `~/.pizzapi/rules/` (global) and `<cwd>/.pizzapi/rules/` (project) are discovered, lexicographically sorted, and appended to the system prompt (global before project). Missing/empty dirs are safe no-ops.

- `packages/cli/src/skills.ts`: `loadRulesDir()` (existsSync guard + try/catch; skips non-`.md` and directory-named-`.md`), `loadRules()`, wired into `createAgentsFilesOverride` for both CLI and worker paths.
- `packages/cli/src/runner/worker.ts`: `context:global-rules` / `context:project-rules` telemetry, gated on `sendAgentsMd !== false`, skips empty content.
- Docs updated: `sessions.mdx`, `configuration.mdx`.
- Tests: discovery, sort order, non-`.md` skip, `.md`-named-directory skip, missing dir (59 pass).

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src` — only the 3 pre-existing baseline failures.

Reviewed by Fable 5 critic: LGTM. P3 follow-ups tracked separately (`~/.claude/rules/` compat, docs load-order interleaving accuracy, `agentDir` override for rules path).

Godmother: 02fz3pIE. 🌙 Autonomous night shift — queued for human review, not auto-merged.
