### PR TITLE
feat: Code|Work session modes — sessionModes contribution + sidebar toggle (PizzaWork)

### DIFF
--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -365,6 +365,19 @@ describe("readOverlayManifest", () => {
         expect(result.issues.some((i) => i.field === "services[0].triggers[0].params[1].multiselect")).toBe(true);
     });
 
+    test("valid sessionModes are accepted and malformed modes are actionable", () => {
+        const validDir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./service.ts", sessionModes: [{ id: "work", label: "Work", workspace: "~/Documents/Workspace" }] }] });
+        dirs.push(validDir);
+        const valid = readOverlayManifest(validDir, provenance);
+        expect(valid.overlay?.services?.[0].sessionModes).toHaveLength(1);
+        const invalidDir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./service.ts", sessionModes: [{ id: "work", label: "Work", workspace: "~/x" }, { id: "work", label: "", workspace: "" }] }] });
+        dirs.push(invalidDir);
+        const invalid = readOverlayManifest(invalidDir, provenance);
+        expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].id") && i.message.includes("duplicate"))).toBe(true);
+        expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].label"))).toBe(true);
+        expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].workspace"))).toBe(true);
+    });
+
     test("valid inline trigger and sigil definitions are accepted", () => {
         const dir = fixturePkg({
             schemaVersion: 1,

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -28,7 +28,7 @@ const PREFERRED_MCP_TRANSPORT_KEYS: Record<string, Set<string>> = {
     http: new Set(["url", "headers"]),
     streamable: new Set(["url", "headers", "oauthClientName", "oauthClientId", "oauthClientSecret", "oauthCallbackPort"]),
 };
-const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils"]);
+const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils", "sessionModes"]);
 const PANEL_KEYS = new Set(["dir", "requires"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
 const SERVICE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
@@ -41,6 +41,7 @@ const TRIGGER_PARAM_KEYS = new Set(["name", "label", "type", "description", "req
 const TRIGGER_KEYS = new Set(["type", "label", "description", "schema", "params"]);
 /** Allowed keys on a sigil definition, mirrored from ServiceSigilDef (excludes daemon-populated serviceId/resolvePort). */
 const SIGIL_KEYS = new Set(["type", "label", "description", "icon", "resolve", "schema", "aliases", "variants"]);
+const SESSION_MODE_KEYS = new Set(["id", "label", "icon", "workspace"]);
 
 export interface PackageProvenance {
     /** Normalized package identity, e.g. "npm:@acme/pi-github". */
@@ -531,6 +532,24 @@ function validateTriggerDef(entry: unknown, field: string, push: PushFn): void {
     }
 }
 
+function validateSessionModeDef(entry: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a { id, label, workspace } session mode definition object.`);
+        return;
+    }
+    for (const key of Object.keys(entry)) {
+        if (!SESSION_MODE_KEYS.has(key)) {
+            push(`${field}.${key}`, `unknown session mode key "${key}"`, `Remove "${key}" — allowed keys: ${[...SESSION_MODE_KEYS].join(", ")}.`);
+        }
+    }
+    if (typeof entry.id !== "string" || entry.id.length === 0) push(`${field}.id`, "must be a non-empty string", "Set id to a unique mode identifier.");
+    if (typeof entry.label !== "string" || entry.label.length === 0) push(`${field}.label`, "must be a non-empty string", "Set label to a human-readable mode name.");
+    if (entry.icon !== undefined && typeof entry.icon !== "string") push(`${field}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
+    if (typeof entry.workspace !== "string" || !/^~(?:\/|$)/.test(entry.workspace)) {
+        push(`${field}.workspace`, "must be a home-relative path beginning with ~/", "Set workspace to a path such as ~/Documents/Workspace.");
+    }
+}
+
 function validateSigilDef(entry: unknown, field: string, push: PushFn): void {
     if (!isPlainObject(entry)) {
         push(field, "must be an object", `Fix ${field} to a { type, label } sigil definition object.`);
@@ -627,6 +646,7 @@ function validateServices(
 
     const result: PizzaPiServiceDeclaration[] = [];
     const seenIds = new Set<string>();
+    const seenSessionModeIds = new Set<string>();
 
     value.forEach((raw, i) => {
         const field = `services[${i}]`;
@@ -737,6 +757,21 @@ function validateServices(
         // array (inline or sidecar-parsed) is written back onto `raw` so
         // downstream consumers (daemon package-service discovery) always see
         // a literal ServiceTriggerDef[]/ServiceSigilDef[], never a sidecar path.
+        if (raw.sessionModes !== undefined) {
+            if (!Array.isArray(raw.sessionModes)) {
+                push(`${field}.sessionModes`, "must be an array of session mode definitions", "Set sessionModes to an array of { id, label, workspace } objects.");
+            } else {
+                raw.sessionModes.forEach((mode, modeIndex) => {
+                    const modeField = `${field}.sessionModes[${modeIndex}]`;
+                    validateSessionModeDef(mode, modeField, push);
+                    if (isPlainObject(mode) && typeof mode.id === "string") {
+                        if (seenSessionModeIds.has(mode.id)) push(`${modeField}.id`, `duplicate session mode id "${mode.id}"`, "Give each session mode a unique id across the package.");
+                        seenSessionModeIds.add(mode.id);
+                    }
+                });
+            }
+        }
+
         for (const sidecarField of ["triggers", "sigils"] as const) {
             const sidecarValue = raw[sidecarField];
             if (sidecarValue === undefined) continue;

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -36,7 +36,7 @@ import type { PizzaPiConfig } from "../config.js";
 import { findSessionPathById } from "./session-list-cache.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
-import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock, patchRunnerState } from "./runner-state.js";
@@ -97,6 +97,8 @@ export type PanelEntry = {
     triggers?: ServiceTriggerDef[];
     /** Sigil types declared in this service's manifest */
     sigils?: ServiceSigilDef[];
+    /** Session modes declared by this service; workspace is resolved per runner. */
+    sessionModes?: ServiceModeDef[];
     /**
      * Whether this service has a UI panel shown to users.
      * false = service has trigger/sigil defs but no panel (e.g. the time service).
@@ -281,7 +283,8 @@ export function panelEntryFromManifest(
     if (!manifest) return null;
     const hasTriggers = !!(manifest.triggers && manifest.triggers.length > 0);
     const hasSigils = !!(manifest.sigils && manifest.sigils.length > 0);
-    if (!manifest.panel && !hasTriggers && !hasSigils) return null;
+    const hasSessionModes = !!(manifest.sessionModes && manifest.sessionModes.length > 0);
+    if (!manifest.panel && !hasTriggers && !hasSigils && !hasSessionModes) return null;
     return {
         serviceId,
         label: manifest.label,
@@ -290,6 +293,7 @@ export function panelEntryFromManifest(
         ...(existingPort !== undefined ? { port: existingPort } : {}),
         ...(hasTriggers ? { triggers: manifest.triggers } : {}),
         ...(hasSigils ? { sigils: manifest.sigils } : {}),
+        ...(hasSessionModes ? { sessionModes: manifest.sessionModes } : {}),
         ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
     };
 }
@@ -938,10 +942,15 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // Collect all trigger defs and sigil defs across all services with manifests
             const allTriggerDefs: ServiceTriggerDef[] = [];
             const allSigilDefs: ServiceSigilDef[] = [];
+            const allSessionModes: ServiceModeDef[] = [];
             for (const entry of panelEntries.values()) {
                 if (!activeServiceIds.has(entry.serviceId)) continue;
                 if (entry.triggers && entry.triggers.length > 0) {
                     allTriggerDefs.push(...entry.triggers);
+                }
+                if (entry.sessionModes && entry.sessionModes.length > 0) {
+                    // Resolve home-relative workspaces on each runner; matching is exact cwd equality.
+                    allSessionModes.push(...entry.sessionModes.map((mode) => ({ ...mode, serviceId: entry.serviceId, workspace: expandHome(mode.workspace) })));
                 }
                 if (entry.sigils && entry.sigils.length > 0) {
                     // Stamp serviceId and (if available) resolvePort onto each sigil def.
@@ -962,6 +971,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 ...(panels.length > 0 ? { panels } : {}),
                 ...(allTriggerDefs.length > 0 ? { triggerDefs: allTriggerDefs } : {}),
                 ...(allSigilDefs.length > 0 ? { sigilDefs: allSigilDefs } : {}),
+                ...(allSessionModes.length > 0 ? { sessionModes: allSessionModes } : {}),
             });
         };
 

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -248,6 +248,7 @@ export async function discoverPackageServices(
                 ...(decl.panel ? { panel: { dir: panelDir, requires: decl.panel.requires } } : {}),
                 ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
                 ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),
+                ...(Array.isArray(decl.sessionModes) && decl.sessionModes.length > 0 ? { sessionModes: decl.sessionModes } : {}),
             };
 
             services.push({

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -18,7 +18,7 @@
  * just no longer contribute runner services.
  */
 import type { ServiceHandler } from "./service-handler.js";
-import type { ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -43,6 +43,7 @@ export interface ServiceManifest {
     triggers?: ServiceTriggerDef[];
     /** Sigil types this service defines. */
     sigils?: ServiceSigilDef[];
+    sessionModes?: ServiceModeDef[];
 }
 
 export interface ServicePluginResult {

--- a/packages/extension-sdk/src/overlay.ts
+++ b/packages/extension-sdk/src/overlay.ts
@@ -1,4 +1,4 @@
-import type { ServiceSigilDef, ServiceTriggerDef } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServiceSigilDef, ServiceTriggerDef } from "@pizzapi/protocol";
 
 /**
  * `pi.pizzapi` package manifest overlay — schema version 1.
@@ -23,6 +23,7 @@ export interface PizzaPiServiceDeclaration {
   };
   triggers?: string | ServiceTriggerDef[];
   sigils?: string | ServiceSigilDef[];
+  sessionModes?: ServiceModeDef[];
 }
 
 export type PanelVariable = "PWD" | "SESSION_ID" | "HOME" | "USER" | "PROJECT_DIR";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,6 +20,7 @@ export type {
   ServiceTriggerDef,
   ServiceTriggerParamDef,
   ServiceSigilDef,
+  ServiceModeDef,
   JsonValue,
   TriggerFilter,
   TriggerFilterMode,

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -71,6 +71,8 @@ export interface RunnerInfo {
   triggerDefs?: ServiceTriggerDef[];
   /** Sigil types declared by services on this runner (from service_announce). */
   sigilDefs?: ServiceSigilDef[];
+  /** Session modes declared by services on this runner. */
+  sessionModes?: ServiceModeDef[];
   /** Active warnings from the runner daemon (e.g. tunnel connection failures). */
   warnings?: string[];
 }
@@ -232,6 +234,19 @@ export type TriggerFilterMode = "and" | "or";
  * Declared in a service's sigils.json (or manifest.json) and forwarded via
  * service_announce so the UI knows how to render [[type:id]] tokens.
  */
+export interface ServiceModeDef {
+  /** Stable mode identifier within the runner. */
+  id: string;
+  /** Human-readable mode label. */
+  label: string;
+  /** Optional Lucide icon name. */
+  icon?: string;
+  /** Home-relative workspace path, resolved by the runner. */
+  workspace: string;
+  /** Service that declared this mode. */
+  serviceId?: string;
+}
+
 export interface ServiceSigilDef {
   /** Sigil type name, e.g. "pr", "commit", "cost" */
   type: string;
@@ -294,6 +309,8 @@ export interface ServiceAnnounceData {
   triggerDefs?: ServiceTriggerDef[];
   /** Sigil types declared by services on this runner. */
   sigilDefs?: ServiceSigilDef[];
+  /** Session modes declared by services on this runner. */
+  sessionModes?: ServiceModeDef[];
   /** Runner ID associated with this announce when the data was routed via a session. */
   runnerId?: string;
   /** Hint that the payload is a reference to runner metadata, not a standalone source. */
@@ -308,6 +325,7 @@ export interface ServiceAnnounceDelta {
     panels: ServicePanelInfo[];
     triggerDefs: ServiceTriggerDef[];
     sigilDefs: ServiceSigilDef[];
+    sessionModes?: ServiceModeDef[];
   };
   removed: {
     /** Service IDs that were removed. */
@@ -318,11 +336,14 @@ export interface ServiceAnnounceDelta {
     triggerDefs: string[];
     /** Sigil types that were removed. */
     sigilDefs: string[];
+    /** Session mode IDs that were removed. */
+    sessionModes?: string[];
   };
   updated: {
     panels: ServicePanelInfo[];
     triggerDefs: ServiceTriggerDef[];
     sigilDefs: ServiceSigilDef[];
+    sessionModes?: ServiceModeDef[];
   };
   /** Runner ID associated with this delta when routed via a session. */
   runnerId?: string;

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -466,6 +466,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             panels: services?.panels ?? [],
             triggerDefs: services?.triggerDefs ?? [],
             sigilDefs: services?.sigilDefs ?? [],
+            sessionModes: services?.sessionModes ?? [],
         });
     }
 

--- a/packages/server/src/ws/namespaces/runner.service-announce.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.ts
@@ -3,7 +3,7 @@
  * Kept in its own module so tests can import just this helper
  * without pulling in the full runner namespace and its transitive deps.
  */
-import type { ServiceAnnounceData, ServiceAnnounceDelta, ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { ServiceAnnounceData, ServiceAnnounceDelta, ServiceModeDef, ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 
 export function chooseServiceAnnounceSeed(
     current: ServiceAnnounceData | null | undefined,
@@ -79,6 +79,10 @@ export function isSameServiceAnnounce(
             return false;
         }
     }
+
+    const aModes = a.sessionModes ?? [];
+    const bModes = b.sessionModes ?? [];
+    if (JSON.stringify(aModes) !== JSON.stringify(bModes)) return false;
 
     // Compare sigil defs
     const aSigils = a.sigilDefs ?? [];
@@ -211,6 +215,21 @@ export function computeServiceAnnounceDelta(
         if (!nextTriggerMap.has(trigger.type)) removedTriggerTypes.push(trigger.type);
     }
 
+    // Session modes — keyed by id
+    const prevModes = previous.sessionModes ?? [];
+    const nextModes = next.sessionModes ?? [];
+    const prevModeMap = new Map(prevModes.map((m) => [m.id, m]));
+    const nextModeMap = new Map(nextModes.map((m) => [m.id, m]));
+    const addedModes: ServiceModeDef[] = [];
+    const updatedModes: ServiceModeDef[] = [];
+    const removedModeIds: string[] = [];
+    for (const mode of nextModes) {
+        const prev = prevModeMap.get(mode.id);
+        if (!prev) addedModes.push(mode);
+        else if (JSON.stringify(prev) !== JSON.stringify(mode)) updatedModes.push(mode);
+    }
+    for (const mode of prevModes) if (!nextModeMap.has(mode.id)) removedModeIds.push(mode.id);
+
     // SigilDefs — keyed by type
     const prevSigils = previous.sigilDefs ?? [];
     const nextSigils = next.sigilDefs ?? [];
@@ -236,17 +255,20 @@ export function computeServiceAnnounceDelta(
             panels: addedPanels,
             triggerDefs: addedTriggers,
             sigilDefs: addedSigils,
+            sessionModes: addedModes,
         },
         removed: {
             serviceIds: removedServiceIds,
             panels: removedPanelIds,
             triggerDefs: removedTriggerTypes,
             sigilDefs: removedSigilTypes,
+            sessionModes: removedModeIds,
         },
         updated: {
             panels: updatedPanels,
             triggerDefs: updatedTriggers,
             sigilDefs: updatedSigils,
+            sessionModes: updatedModes,
         },
     };
 }
@@ -260,12 +282,15 @@ export function isEmptyDelta(delta: ServiceAnnounceDelta): boolean {
         delta.added.panels.length === 0 &&
         delta.added.triggerDefs.length === 0 &&
         delta.added.sigilDefs.length === 0 &&
+        (delta.added.sessionModes ?? []).length === 0 &&
         delta.removed.serviceIds.length === 0 &&
         delta.removed.panels.length === 0 &&
         delta.removed.triggerDefs.length === 0 &&
         delta.removed.sigilDefs.length === 0 &&
+        (delta.removed.sessionModes ?? []).length === 0 &&
         delta.updated.panels.length === 0 &&
         delta.updated.triggerDefs.length === 0 &&
-        delta.updated.sigilDefs.length === 0
+        delta.updated.sigilDefs.length === 0 &&
+        (delta.updated.sessionModes ?? []).length === 0
     );
 }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -370,6 +370,7 @@ export async function seedServiceAnnounceCache(runnerId: string): Promise<void> 
                 panels: persisted.panels,
                 triggerDefs: persisted.triggerDefs,
                 sigilDefs: persisted.sigilDefs,
+                sessionModes: persisted.sessionModes,
             }
             : null,
     );
@@ -1174,7 +1175,7 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
             // Persist to Redis so the data survives server restarts.
             // Identical payloads can skip the write; viewers still need fanout.
             if (!sameAsCached) {
-                void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs, data.disabledServiceIds).catch((err) => {
+                void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs, data.disabledServiceIds, data.sessionModes).catch((err) => {
                     log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
                 });
             }

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -436,6 +436,33 @@ describe("runners broadcast", () => {
         expect(data.panels[0].serviceId).toBe("dashboard");
     });
 
+    it("rehydrates sessionModes through the runner info broadcast path", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "modes-runner",
+            roots: [],
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: "1.0.0",
+            platform: "linux",
+            userId: "user9",
+            userName: "User Nine",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        const sessionModes = [{ id: "work", label: "Work", workspace: "/work", serviceId: "workspace" }];
+
+        await updateRunnerServices(runnerId, ["workspace"], undefined, undefined, undefined, undefined, sessionModes);
+
+        const updated = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.event === "runner_updated",
+        );
+        expect(updated).toBeDefined();
+        expect((updated!.data as any).sessionModes).toEqual(sessionModes);
+    });
+
     it("updateRunnerServices with no panels stores empty array", async () => {
         const socket = { join: mock(async () => {}), data: {} } as any;
         const result = await registerRunner(socket, {

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -432,6 +432,7 @@ function runnerDataToInfo(r: RedisRunnerData, sessionCount = 0): RunnerInfo {
     const panels = r.panels ? safeJsonParse(r.panels) ?? undefined : undefined;
     const triggerDefs = r.triggerDefs ? safeJsonParse(r.triggerDefs) ?? undefined : undefined;
     const sigilDefs = r.sigilDefs ? safeJsonParse(r.sigilDefs) ?? undefined : undefined;
+    const sessionModes = r.sessionModes ? safeJsonParse(r.sessionModes) ?? undefined : undefined;
     const warnings: string[] | undefined = r.warnings ? safeJsonParse(r.warnings) ?? undefined : undefined;
     return {
         runnerId: r.runnerId,
@@ -449,6 +450,7 @@ function runnerDataToInfo(r: RedisRunnerData, sessionCount = 0): RunnerInfo {
         ...(panels ? { panels } : {}),
         ...(triggerDefs && triggerDefs.length > 0 ? { triggerDefs } : {}),
         ...(sigilDefs && sigilDefs.length > 0 ? { sigilDefs } : {}),
+        ...(sessionModes && sessionModes.length > 0 ? { sessionModes } : {}),
         ...(warnings && warnings.length > 0 ? { warnings } : {}),
     };
 }

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -261,6 +261,7 @@ export async function updateRunnerServices(
     triggerDefs?: Array<{ type: string; label: string; description?: string; schema?: Record<string, unknown> }>,
     sigilDefs?: Array<{ type: string; label: string; description?: string; icon?: string; serviceId?: string; resolve?: string; schema?: Record<string, unknown>; aliases?: string[] }>,
     disabledServiceIds?: string[],
+    sessionModes?: Array<{ id: string; label: string; icon?: string; workspace: string; serviceId?: string }>,
 ): Promise<void> {
     const fields: Record<string, string> = {
         serviceIds: JSON.stringify(serviceIds),
@@ -279,6 +280,11 @@ export async function updateRunnerServices(
         fields.sigilDefs = JSON.stringify(sigilDefs);
     } else {
         fields.sigilDefs = "[]";
+    }
+    if (sessionModes && sessionModes.length > 0) {
+        fields.sessionModes = JSON.stringify(sessionModes);
+    } else {
+        fields.sessionModes = "[]";
     }
     if (disabledServiceIds && disabledServiceIds.length > 0) {
         fields.disabledServiceIds = JSON.stringify(disabledServiceIds);
@@ -301,6 +307,7 @@ export async function getRunnerServices(
     panels?: Array<{ serviceId: string; port: number; label: string; icon: string }>;
     triggerDefs?: ServiceTriggerDef[];
     sigilDefs?: ServiceSigilDef[];
+    sessionModes?: Array<{ id: string; label: string; icon?: string; workspace: string; serviceId?: string }>;
 } | null> {
     const runner = await getRunnerState(runnerId);
     if (!runner) return null;
@@ -316,12 +323,14 @@ export async function getRunnerServices(
     const panels = runner.panels ? safeJsonParse(runner.panels) ?? undefined : undefined;
     const triggerDefs = runner.triggerDefs ? safeJsonParse(runner.triggerDefs) ?? undefined : undefined;
     const sigilDefs = runner.sigilDefs ? safeJsonParse(runner.sigilDefs) ?? undefined : undefined;
+    const sessionModes = runner.sessionModes ? safeJsonParse(runner.sessionModes) ?? undefined : undefined;
     return {
         serviceIds,
         disabledServiceIds,
         ...(panels && panels.length > 0 ? { panels } : {}),
         ...(triggerDefs && triggerDefs.length > 0 ? { triggerDefs } : {}),
         ...(sigilDefs && sigilDefs.length > 0 ? { sigilDefs } : {}),
+        ...(sessionModes && sessionModes.length > 0 ? { sessionModes } : {}),
     };
 }
 

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -255,6 +255,8 @@ export interface RedisRunnerData {
     triggerDefs?: string;
     /** JSON-stringified ServiceSigilDef[] — sigil defs from last service_announce */
     sigilDefs?: string;
+    /** JSON-stringified ServiceModeDef[] — session modes from last service_announce */
+    sessionModes?: string;
     /** JSON-stringified string[] — active warnings from the runner daemon */
     warnings?: string;
 }
@@ -398,6 +400,7 @@ function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerData | nu
         panels: hash.panels || undefined,
         triggerDefs: hash.triggerDefs || undefined,
         sigilDefs: hash.sigilDefs || undefined,
+        sessionModes: hash.sessionModes || undefined,
     };
 }
 

--- a/packages/server/src/ws/sio-state/serialization.ts
+++ b/packages/server/src/ws/sio-state/serialization.ts
@@ -136,6 +136,7 @@ export function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerDa
         panels: hash.panels || undefined,
         triggerDefs: hash.triggerDefs || undefined,
         sigilDefs: hash.sigilDefs || undefined,
+        sessionModes: hash.sessionModes || undefined,
     };
 }
 

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -128,6 +128,8 @@ export interface RedisRunnerData {
     triggerDefs?: string;
     /** JSON-stringified ServiceSigilDef[] — sigil defs from last service_announce */
     sigilDefs?: string;
+    /** JSON-stringified ServiceModeDef[] — session modes from last service_announce */
+    sessionModes?: string;
     /** JSON-stringified string[] — disabled runner service IDs */
     disabledServiceIds?: string;
     /** JSON-stringified string[] — active warnings from the runner daemon */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4181,7 +4181,7 @@ export function App() {
   }, [isMac, agentActive, sendRemoteExec]);
 
   const handleNewSession = React.useCallback((initialCwd?: string) => {
-    setLifecycleSpawnParams({ runnerId: undefined, preselectedRunnerId: null, cwd: initialCwd ?? "" });
+    setLifecycleSpawnParams({ runnerId: undefined, preselectedRunnerId: null, cwd: typeof initialCwd === "string" ? initialCwd : "" });
     setNewSessionOpen(true);
   }, [setLifecycleSpawnParams]);
 
@@ -4965,6 +4965,7 @@ export function App() {
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
               sessionModes={sessionModes}
+              sessionModesRunnerId={activeRunnerInfo?.runnerId}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}
               activeSessionId={activeSessionId}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4180,8 +4180,8 @@ export function App() {
     return () => window.removeEventListener("keydown", handler);
   }, [isMac, agentActive, sendRemoteExec]);
 
-  const handleNewSession = React.useCallback(() => {
-    setLifecycleSpawnParams({ runnerId: undefined, preselectedRunnerId: null, cwd: "" });
+  const handleNewSession = React.useCallback((initialCwd?: string) => {
+    setLifecycleSpawnParams({ runnerId: undefined, preselectedRunnerId: null, cwd: initialCwd ?? "" });
     setNewSessionOpen(true);
   }, [setLifecycleSpawnParams]);
 
@@ -4339,7 +4339,7 @@ export function App() {
   }, [activeSessionId, activeSessionInfo?.runnerId, liveSessions]);
 
   // Runner service panels — dynamically discovered
-  const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket, activeRunnerInfo);
+  const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs, sessionModes } = useRunnerServices(viewerSocket, activeRunnerInfo);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
   const attentionSessionNames = React.useMemo(() => {
     const names = new Map<string, string>();
@@ -4964,6 +4964,7 @@ export function App() {
             <SessionSidebar
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
+              sessionModes={sessionModes}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}
               activeSessionId={activeSessionId}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4965,7 +4965,7 @@ export function App() {
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
               sessionModes={sessionModes}
-              sessionModesRunnerId={activeRunnerInfo?.runnerId}
+              sessionModesRunnerId={activeSessionInfo?.runnerId}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}
               activeSessionId={activeSessionId}

--- a/packages/ui/src/components/SessionSidebar.sort.test.ts
+++ b/packages/ui/src/components/SessionSidebar.sort.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect } from "bun:test";
+import { filterSessionsByMode } from "./SessionSidebar";
+import type { ServiceModeDef } from "@pizzapi/protocol";
 
 // ── Minimal type stubs ────────────────────────────────────────────────────────
 
@@ -47,6 +49,23 @@ function makeProjectComparator(pinnedSessionIds: Set<string>) {
         return latestTs(b) - latestTs(a);
     };
 }
+
+describe("session mode filtering", () => {
+    const modes: ServiceModeDef[] = [{ id: "work", label: "Work", workspace: "/work" }];
+    const sessions = [
+        { sessionId: "code", cwd: "/code" },
+        { sessionId: "work", cwd: "/work" },
+        { sessionId: "work-child", cwd: "/work-other" },
+    ];
+
+    it("matches a selected mode by exact cwd", () => {
+        expect(filterSessionsByMode(sessions, "work", modes).map((s) => s.sessionId)).toEqual(["work"]);
+    });
+
+    it("keeps all unclaimed sessions in Code mode", () => {
+        expect(filterSessionsByMode(sessions, null, modes).map((s) => s.sessionId)).toEqual(["code", "work-child"]);
+    });
+});
 
 // ── Session sort tests ────────────────────────────────────────────────────────
 

--- a/packages/ui/src/components/SessionSidebar.sort.test.ts
+++ b/packages/ui/src/components/SessionSidebar.sort.test.ts
@@ -65,6 +65,15 @@ describe("session mode filtering", () => {
     it("keeps all unclaimed sessions in Code mode", () => {
         expect(filterSessionsByMode(sessions, null, modes).map((s) => s.sessionId)).toEqual(["code", "work-child"]);
     });
+
+    it("only claims sessions from the mode's runner", () => {
+        const scopedSessions = [
+            { sessionId: "runner-a", cwd: "/work", runnerId: "runner-a" },
+            { sessionId: "runner-b", cwd: "/work", runnerId: "runner-b" },
+        ];
+        expect(filterSessionsByMode(scopedSessions, "work", modes, "runner-a").map((s) => s.sessionId)).toEqual(["runner-a"]);
+        expect(filterSessionsByMode(scopedSessions, null, modes, "runner-a").map((s) => s.sessionId)).toEqual(["runner-b"]);
+    });
 });
 
 // ── Session sort tests ────────────────────────────────────────────────────────

--- a/packages/ui/src/components/SessionSidebar.sort.test.ts
+++ b/packages/ui/src/components/SessionSidebar.sort.test.ts
@@ -53,17 +53,25 @@ function makeProjectComparator(pinnedSessionIds: Set<string>) {
 describe("session mode filtering", () => {
     const modes: ServiceModeDef[] = [{ id: "work", label: "Work", workspace: "/work" }];
     const sessions = [
-        { sessionId: "code", cwd: "/code" },
-        { sessionId: "work", cwd: "/work" },
-        { sessionId: "work-child", cwd: "/work-other" },
+        { sessionId: "code", cwd: "/code", runnerId: "runner-a" },
+        { sessionId: "work", cwd: "/work", runnerId: "runner-a" },
+        { sessionId: "work-child", cwd: "/work-other", runnerId: "runner-a" },
     ];
 
-    it("matches a selected mode by exact cwd", () => {
-        expect(filterSessionsByMode(sessions, "work", modes).map((s) => s.sessionId)).toEqual(["work"]);
+    it("fails closed when the mode runner is unknown", () => {
+        expect(filterSessionsByMode(sessions, "work", modes).map((s) => s.sessionId)).toEqual([]);
     });
 
     it("keeps all unclaimed sessions in Code mode", () => {
-        expect(filterSessionsByMode(sessions, null, modes).map((s) => s.sessionId)).toEqual(["code", "work-child"]);
+        expect(filterSessionsByMode(sessions, null, modes, "runner-a").map((s) => s.sessionId)).toEqual(["code", "work-child"]);
+    });
+
+    it("matches a selected mode by exact cwd on its runner", () => {
+        const scopedSessions = [
+            { sessionId: "runner-a", cwd: "/work", runnerId: "runner-a" },
+            { sessionId: "runner-b", cwd: "/work", runnerId: "runner-b" },
+        ];
+        expect(filterSessionsByMode(scopedSessions, "work", modes, "runner-a").map((s) => s.sessionId)).toEqual(["runner-a"]);
     });
 
     it("only claims sessions from the mode's runner", () => {

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -111,20 +111,24 @@ export interface SessionSidebarProps {
     /** Set of session IDs that are actively compacting their context window. */
     sessionsCompacting?: Set<string>;
     sessionModes?: ServiceModeDef[];
+    sessionModesRunnerId?: string | null;
 }
 
 /** Filter by the selected mode without changing the runner/project/session tree. */
-export function filterSessionsByMode<T extends { cwd: string }>(
+export function filterSessionsByMode<T extends { cwd: string; runnerId?: string | null }>(
     sessions: T[],
     selectedModeId: string | null,
     modes: ServiceModeDef[],
+    modeRunnerId?: string | null,
 ): T[] {
+    const belongsToModeRunner = (session: T) =>
+        !modeRunnerId || session.runnerId === modeRunnerId;
     if (!selectedModeId) {
         const claimed = new Set(modes.map((mode) => mode.workspace));
-        return sessions.filter((session) => !claimed.has(session.cwd));
+        return sessions.filter((session) => !belongsToModeRunner(session) || !claimed.has(session.cwd));
     }
     const mode = modes.find((candidate) => candidate.id === selectedModeId);
-    return mode ? sessions.filter((session) => session.cwd === mode.workspace) : sessions;
+    return mode ? sessions.filter((session) => belongsToModeRunner(session) && session.cwd === mode.workspace) : sessions;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -218,6 +222,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     sessionsAwaitingInput,
     sessionsCompacting,
     sessionModes = [],
+    sessionModesRunnerId,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -827,9 +832,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 
     const [selectedMode, setSelectedMode] = React.useState<string | null>(null);
     const activeMode = sessionModes.find((mode) => mode.id === selectedMode) ?? null;
+    React.useEffect(() => {
+        if (selectedMode && !sessionModes.some((mode) => mode.id === selectedMode)) setSelectedMode(null);
+    }, [selectedMode, sessionModes]);
     const visibleSessions = React.useMemo(
-        () => filterSessionsByMode(liveSessions, selectedMode, sessionModes),
-        [liveSessions, selectedMode, sessionModes],
+        () => filterSessionsByMode(liveSessions, selectedMode, sessionModes, sessionModesRunnerId),
+        [liveSessions, selectedMode, sessionModes, sessionModesRunnerId],
     );
 
     const liveGroups = React.useMemo(() => {
@@ -1148,7 +1156,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                     <div className="px-3 pt-2 flex-shrink-0 space-y-2">
                         <div className="flex rounded-md border border-sidebar-border/60 p-0.5" role="group" aria-label="Session mode">
                             <button
-                                className={cn("flex-1 rounded px-2 py-1 text-xs font-medium", !selectedMode && "bg-sidebar-accent text-sidebar-foreground")}
+                                className={cn("flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-xs font-medium", !selectedMode && "bg-sidebar-accent text-sidebar-foreground")}
                                 onClick={() => setSelectedMode(null)}
                                 aria-pressed={!selectedMode}
                             >
@@ -1158,7 +1166,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                             {sessionModes.map((mode) => (
                                 <button
                                     key={mode.id}
-                                    className={cn("flex-1 rounded px-2 py-1 text-xs font-medium", selectedMode === mode.id && "bg-sidebar-accent text-sidebar-foreground")}
+                                    className={cn("flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-xs font-medium", selectedMode === mode.id && "bg-sidebar-accent text-sidebar-foreground")}
                                     onClick={() => setSelectedMode(mode.id)}
                                     aria-pressed={selectedMode === mode.id}
                                 >

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -13,11 +13,13 @@ import { cn } from "@/lib/utils";
 import { useHubSocket } from "@/lib/hub-socket-context";
 import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, Code2, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
 import { pruneSwipeOffsets } from "@/lib/swipe-reveal";
 import { getSessionVisualState } from "@/lib/session-visual-state";
 import { parseHubSessionsPayload } from "@/lib/hub-sessions";
+import type { ServiceModeDef } from "@pizzapi/protocol";
 
 interface HubSession {
     sessionId: string;
@@ -74,7 +76,7 @@ export type { HubSession };
 
 export interface SessionSidebarProps {
     onOpenSession: (sessionId: string) => void;
-    onNewSession: () => void;
+    onNewSession: (initialCwd?: string) => void;
     onClearSelection: () => void;
     onShowRunners: () => void;
     activeSessionId: string | null;
@@ -108,6 +110,21 @@ export interface SessionSidebarProps {
     sessionsAwaitingInput?: Set<string>;
     /** Set of session IDs that are actively compacting their context window. */
     sessionsCompacting?: Set<string>;
+    sessionModes?: ServiceModeDef[];
+}
+
+/** Filter by the selected mode without changing the runner/project/session tree. */
+export function filterSessionsByMode<T extends { cwd: string }>(
+    sessions: T[],
+    selectedModeId: string | null,
+    modes: ServiceModeDef[],
+): T[] {
+    if (!selectedModeId) {
+        const claimed = new Set(modes.map((mode) => mode.workspace));
+        return sessions.filter((session) => !claimed.has(session.cwd));
+    }
+    const mode = modes.find((candidate) => candidate.id === selectedModeId);
+    return mode ? sessions.filter((session) => session.cwd === mode.workspace) : sessions;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -200,6 +217,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     onShowSessions,
     sessionsAwaitingInput,
     sessionsCompacting,
+    sessionModes = [],
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -807,10 +825,17 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         projects: ProjectGroup[];
     }
 
+    const [selectedMode, setSelectedMode] = React.useState<string | null>(null);
+    const activeMode = sessionModes.find((mode) => mode.id === selectedMode) ?? null;
+    const visibleSessions = React.useMemo(
+        () => filterSessionsByMode(liveSessions, selectedMode, sessionModes),
+        [liveSessions, selectedMode, sessionModes],
+    );
+
     const liveGroups = React.useMemo(() => {
         // Step 1: group sessions by runnerId.
         const runnerMap = new Map<string, { label: string; sessions: HubSession[] }>();
-        for (const s of liveSessions) {
+        for (const s of visibleSessions) {
             const key = s.runnerId ?? "__local__";
             if (!runnerMap.has(key)) {
                 const label = s.runnerName?.trim() || (s.runnerId ? `Runner ${s.runnerId.slice(0, 8)}…` : "Local");
@@ -822,7 +847,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         // Pre-parse timestamps once so comparators don't re-parse on every
         // comparison (O(log n) per sort) and every heartbeat memo recomputation.
         const tsBySession = new Map<string, number>();
-        for (const s of liveSessions) {
+        for (const s of visibleSessions) {
             tsBySession.set(s.sessionId, Date.parse(s.lastHeartbeatAt ?? s.startedAt));
         }
 
@@ -888,7 +913,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         });
 
         return result;
-    }, [liveSessions, pinnedSessionIds]);
+    }, [visibleSessions, pinnedSessionIds]);
 
     // Find session name for the confirm dialog
     const confirmSession = confirmEndSessionId
@@ -1108,7 +1133,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                             variant="ghost"
                             size="icon"
                             className="h-9 w-9 md:h-8 md:w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                            onClick={onNewSession}
+                            onClick={() => onNewSession()}
                             aria-label="New session"
                             title="New session"
                         >
@@ -1119,6 +1144,36 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             )}
 
             <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+                {sessionModes.length > 0 && !showRunners && !selectMode && (
+                    <div className="px-3 pt-2 flex-shrink-0 space-y-2">
+                        <div className="flex rounded-md border border-sidebar-border/60 p-0.5" role="group" aria-label="Session mode">
+                            <button
+                                className={cn("flex-1 rounded px-2 py-1 text-xs font-medium", !selectedMode && "bg-sidebar-accent text-sidebar-foreground")}
+                                onClick={() => setSelectedMode(null)}
+                                aria-pressed={!selectedMode}
+                            >
+                                <Code2 className="h-3.5 w-3.5" />
+                                Code
+                            </button>
+                            {sessionModes.map((mode) => (
+                                <button
+                                    key={mode.id}
+                                    className={cn("flex-1 rounded px-2 py-1 text-xs font-medium", selectedMode === mode.id && "bg-sidebar-accent text-sidebar-foreground")}
+                                    onClick={() => setSelectedMode(mode.id)}
+                                    aria-pressed={selectedMode === mode.id}
+                                >
+                                    {mode.icon ? <DynamicLucideIcon name={mode.icon} className="h-3.5 w-3.5" /> : <FolderOpen className="h-3.5 w-3.5" />}
+                                    {mode.label}
+                                </button>
+                            ))}
+                        </div>
+                        <Button className="w-full" variant="outline" size="sm" onClick={() => onNewSession(activeMode?.workspace)}>
+                            <Plus className="h-4 w-4" />
+                            {activeMode ? `New in ${activeMode.label}` : "New"}
+                        </Button>
+                    </div>
+                )}
+
                 {/* Sessions / Runners nav tabs */}
                 <div className="mx-3 mt-2 mb-1 flex-shrink-0 flex border-b border-sidebar-border/50">
                     <button

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -122,7 +122,7 @@ export function filterSessionsByMode<T extends { cwd: string; runnerId?: string 
     modeRunnerId?: string | null,
 ): T[] {
     const belongsToModeRunner = (session: T) =>
-        !modeRunnerId || session.runnerId === modeRunnerId;
+        Boolean(modeRunnerId) && session.runnerId === modeRunnerId;
     if (!selectedModeId) {
         const claimed = new Set(modes.map((mode) => mode.workspace));
         return sessions.filter((session) => !belongsToModeRunner(session) || !claimed.has(session.cwd));

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -852,7 +852,7 @@ export function SessionViewer({
                   </p>
                 </div>
                 {onNewSession && (
-                  <Button size="sm" onClick={onNewSession}>
+                  <Button size="sm" onClick={() => onNewSession()}>
                     <Plus className="size-4" />
                     New session
                   </Button>

--- a/packages/ui/src/hooks/useRunnerServices.test.ts
+++ b/packages/ui/src/hooks/useRunnerServices.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test, mock } from "bun:test";
 const actualViewerSwitchModule = await import("../lib/viewer-switch");
 mock.module("@/lib/viewer-switch", () => actualViewerSwitchModule);
 
-const { attachServiceAnnounceListener, seedServiceCache } = await import("./useRunnerServices");
+const { attachServiceAnnounceListener, seedServiceCache, runnerInfoToServices } = await import("./useRunnerServices");
 
 // The internal cache keys used by the module
 const SERVICE_IDS_KEY = "__serviceIds";
@@ -40,6 +40,24 @@ function createMockSocket(): any {
     };
     return socket;
 }
+
+describe("runnerInfoToServices", () => {
+    test("preserves session modes from runner-info rehydration", () => {
+        const services = runnerInfoToServices({
+            runnerId: "runner-1",
+            name: "Runner",
+            roots: [],
+            sessionCount: 0,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            serviceIds: ["workspace"],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/work" }],
+        });
+        expect(services.sessionModes).toEqual([{ id: "work", label: "Work", workspace: "/work" }]);
+    });
+});
 
 describe("attachServiceAnnounceListener", () => {
     test("populates socket cache on service_announce", () => {

--- a/packages/ui/src/hooks/useRunnerServices.test.ts
+++ b/packages/ui/src/hooks/useRunnerServices.test.ts
@@ -20,6 +20,7 @@ const DISABLED_SERVICE_IDS_KEY = "__disabledServiceIds";
 const PANELS_KEY = "__panels";
 const TRIGGER_DEFS_KEY = "__triggerDefs";
 const SIGIL_DEFS_KEY = "__sigilDefs";
+const SESSION_MODES_KEY = "__sessionModes";
 
 // Minimal mock socket with on/off/emit — uses a plain object with
 // index-writable properties so `(socket as any)[KEY] = value` works.
@@ -51,6 +52,7 @@ describe("attachServiceAnnounceListener", () => {
             panels: [{ serviceId: "github", port: 3001, label: "GitHub", icon: "git-branch" }],
             triggerDefs: [{ type: "github:pr_comment", label: "PR Comment" }],
             sigilDefs: [{ type: "pr", label: "Pull Request", serviceId: "github" }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/Users/test/work" }],
         });
 
         expect(socket[SERVICE_IDS_KEY]).toEqual(["github", "godmother"]);
@@ -58,6 +60,13 @@ describe("attachServiceAnnounceListener", () => {
         expect(socket[PANELS_KEY]).toHaveLength(1);
         expect(socket[TRIGGER_DEFS_KEY]).toHaveLength(1);
         expect(socket[SIGIL_DEFS_KEY]).toHaveLength(1);
+        expect(socket[SESSION_MODES_KEY]).toEqual([{ id: "work", label: "Work", workspace: "/Users/test/work" }]);
+        socket.emit("service_announce_delta", {
+            added: { serviceIds: [], panels: [], triggerDefs: [], sigilDefs: [], sessionModes: [{ id: "other", label: "Other", workspace: "/Users/test/other" }] },
+            updated: { panels: [], triggerDefs: [], sigilDefs: [], sessionModes: [] },
+            removed: { serviceIds: [], panels: [], triggerDefs: [], sigilDefs: [], sessionModes: ["work"] },
+        });
+        expect(socket[SESSION_MODES_KEY]).toEqual([{ id: "other", label: "Other", workspace: "/Users/test/other" }]);
     });
 
     test("clears socket cache on disconnect", () => {
@@ -93,6 +102,7 @@ describe("seedServiceCache", () => {
             panels: [{ serviceId: "github", port: 3001, label: "GitHub", icon: "git-branch" }],
             triggerDefs: [{ type: "github:pr_comment", label: "PR Comment" }],
             sigilDefs: [{ type: "pr", label: "Pull Request", serviceId: "github" }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/Users/test/work" }],
         });
 
         const next = createMockSocket();
@@ -103,6 +113,7 @@ describe("seedServiceCache", () => {
         expect(next[PANELS_KEY]).toHaveLength(1);
         expect(next[TRIGGER_DEFS_KEY]).toHaveLength(1);
         expect(next[SIGIL_DEFS_KEY]).toHaveLength(1);
+        expect(next[SESSION_MODES_KEY]).toHaveLength(1);
     });
 
     test("does not copy when prevSocket is null", () => {

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -16,7 +16,7 @@
  */
 import { useState, useEffect, useRef } from "react";
 import type { Socket } from "socket.io-client";
-import type { RunnerInfo, ServiceAnnounceData, ServiceAnnounceDelta, ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { RunnerInfo, ServiceAnnounceData, ServiceAnnounceDelta, ServiceModeDef, ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 import { matchesViewerGeneration } from "@/lib/viewer-switch";
 
 const SERVICE_IDS_KEY = "__serviceIds" as const;
@@ -24,6 +24,7 @@ const DISABLED_SERVICE_IDS_KEY = "__disabledServiceIds" as const;
 const PANELS_KEY = "__panels" as const;
 const TRIGGER_DEFS_KEY = "__triggerDefs" as const;
 const SIGIL_DEFS_KEY = "__sigilDefs" as const;
+const SESSION_MODES_KEY = "__sessionModes" as const;
 const VIEWER_SWITCH_GENERATION_KEY = "__viewerSwitchGeneration" as const;
 
 /** Apply a delta to the socket's cached service state in-place. */
@@ -60,6 +61,11 @@ function applyDeltaToSocket(socket: Socket, delta: ServiceAnnounceDelta): void {
         .filter((s) => !removedSigils.has(s.type))
         .map((s) => updatedSigilMap.get(s.type) ?? s);
     (socket as any)[SIGIL_DEFS_KEY] = [...newSigils, ...delta.added.sigilDefs];
+
+    const modes: ServiceModeDef[] = ((socket as any)[SESSION_MODES_KEY] as ServiceModeDef[] | undefined) ?? [];
+    const removedModes = new Set(delta.removed.sessionModes ?? []);
+    const updatedModeMap = new Map((delta.updated.sessionModes ?? []).map((m) => [m.id, m]));
+    (socket as any)[SESSION_MODES_KEY] = [...modes.filter((m) => !removedModes.has(m.id)).map((m) => updatedModeMap.get(m.id) ?? m), ...(delta.added.sessionModes ?? [])];
 }
 
 /**
@@ -78,6 +84,7 @@ export function attachServiceAnnounceListener(socket: Socket): void {
         (socket as any)[PANELS_KEY] = data.panels;
         (socket as any)[TRIGGER_DEFS_KEY] = data.triggerDefs;
         (socket as any)[SIGIL_DEFS_KEY] = data.sigilDefs;
+        (socket as any)[SESSION_MODES_KEY] = data.sessionModes ?? [];
     });
     socket.on("service_announce_delta", (data: ServiceAnnounceDelta & { generation?: number }) => {
         const currentGeneration = (socket as any)[VIEWER_SWITCH_GENERATION_KEY] as number | undefined;
@@ -92,6 +99,7 @@ export function attachServiceAnnounceListener(socket: Socket): void {
         (socket as any)[PANELS_KEY] = undefined;
         (socket as any)[TRIGGER_DEFS_KEY] = undefined;
         (socket as any)[SIGIL_DEFS_KEY] = undefined;
+        (socket as any)[SESSION_MODES_KEY] = undefined;
     });
 }
 
@@ -107,11 +115,13 @@ export function seedServiceCache(newSocket: Socket, prevSocket: Socket | null): 
     const panels = (prevSocket as any)[PANELS_KEY] as ServicePanelInfo[] | undefined;
     const triggerDefs = (prevSocket as any)[TRIGGER_DEFS_KEY] as ServiceTriggerDef[] | undefined;
     const sigilDefs = (prevSocket as any)[SIGIL_DEFS_KEY] as ServiceSigilDef[] | undefined;
+    const sessionModes = (prevSocket as any)[SESSION_MODES_KEY] as ServiceModeDef[] | undefined;
     if (ids) (newSocket as any)[SERVICE_IDS_KEY] = ids;
     if (disabledIds) (newSocket as any)[DISABLED_SERVICE_IDS_KEY] = disabledIds;
     if (panels) (newSocket as any)[PANELS_KEY] = panels;
     if (triggerDefs) (newSocket as any)[TRIGGER_DEFS_KEY] = triggerDefs;
     if (sigilDefs) (newSocket as any)[SIGIL_DEFS_KEY] = sigilDefs;
+    if (sessionModes) (newSocket as any)[SESSION_MODES_KEY] = sessionModes;
 }
 
 export function setViewerSwitchGeneration(socket: Socket, generation: number): void {
@@ -144,6 +154,9 @@ function getEagerTriggerDefs(socket: Socket | null): ServiceTriggerDef[] {
 function getEagerSigilDefs(socket: Socket | null): ServiceSigilDef[] {
     return (socket ? (socket as any)[SIGIL_DEFS_KEY] as ServiceSigilDef[] | undefined : undefined) ?? [];
 }
+function getEagerSessionModes(socket: Socket | null): ServiceModeDef[] {
+    return (socket ? (socket as any)[SESSION_MODES_KEY] as ServiceModeDef[] | undefined : undefined) ?? [];
+}
 
 export interface RunnerServicesState {
     services: Set<string>;
@@ -151,6 +164,7 @@ export interface RunnerServicesState {
     panels: ServicePanelInfo[];
     triggerDefs: ServiceTriggerDef[];
     sigilDefs: ServiceSigilDef[];
+    sessionModes: ServiceModeDef[];
 }
 
 function hasRunnerServiceMetadata(runnerInfo: RunnerInfo | null | undefined): boolean {
@@ -159,7 +173,8 @@ function hasRunnerServiceMetadata(runnerInfo: RunnerInfo | null | undefined): bo
         (runnerInfo.disabledServiceIds?.length ?? 0) > 0 ||
         (runnerInfo.panels?.length ?? 0) > 0 ||
         (runnerInfo.triggerDefs?.length ?? 0) > 0 ||
-        (runnerInfo.sigilDefs?.length ?? 0) > 0
+        (runnerInfo.sigilDefs?.length ?? 0) > 0 ||
+        (runnerInfo.sessionModes?.length ?? 0) > 0
     );
 }
 
@@ -170,6 +185,7 @@ function runnerInfoToServices(runnerInfo: RunnerInfo | null | undefined): Runner
         panels: runnerInfo?.panels ?? [],
         triggerDefs: runnerInfo?.triggerDefs ?? [],
         sigilDefs: runnerInfo?.sigilDefs ?? [],
+        sessionModes: runnerInfo?.sessionModes ?? [],
     };
 }
 
@@ -180,6 +196,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
     const [panels, setPanels] = useState<ServicePanelInfo[]>(() => initialFromRunner?.panels ?? getEagerPanels(socket));
     const [triggerDefs, setTriggerDefs] = useState<ServiceTriggerDef[]>(() => initialFromRunner?.triggerDefs ?? getEagerTriggerDefs(socket));
     const [sigilDefs, setSigilDefs] = useState<ServiceSigilDef[]>(() => initialFromRunner?.sigilDefs ?? getEagerSigilDefs(socket));
+    const [sessionModes, setSessionModes] = useState<ServiceModeDef[]>(() => initialFromRunner?.sessionModes ?? getEagerSessionModes(socket));
     const prevSocketRef = useRef(socket);
 
     if (socket !== prevSocketRef.current) {
@@ -193,6 +210,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setPanels([]);
             setTriggerDefs([]);
             setSigilDefs([]);
+            setSessionModes([]);
             return;
         }
 
@@ -206,6 +224,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setPanels(next.panels);
             setTriggerDefs(next.triggerDefs);
             setSigilDefs(next.sigilDefs);
+            setSessionModes(next.sessionModes);
         } else if (runnerInfo === null) {
             // True non-runner/local session: clear stale runner service state.
             setServices(new Set());
@@ -213,6 +232,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setPanels([]);
             setTriggerDefs([]);
             setSigilDefs([]);
+            setSessionModes([]);
         } else {
             // Runner is known but feed metadata is not hydrated yet.
             // Read any eagerly captured announce data (including values seeded
@@ -225,6 +245,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setPanels(getEagerPanels(socket));
             setTriggerDefs(getEagerTriggerDefs(socket));
             setSigilDefs(getEagerSigilDefs(socket));
+            setSessionModes(getEagerSessionModes(socket));
         }
 
         const handleAnnounce = (data: ServiceAnnounceData & { generation?: number }) => {
@@ -239,12 +260,14 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
                 panels: data.panels ?? [],
                 triggerDefs: data.triggerDefs ?? [],
                 sigilDefs: data.sigilDefs ?? [],
+                sessionModes: data.sessionModes ?? [],
             };
             setServices(next.services);
             setDisabledServices(next.disabledServices);
             setPanels(next.panels);
             setTriggerDefs(next.triggerDefs);
             setSigilDefs(next.sigilDefs);
+            setSessionModes(next.sessionModes);
         };
 
         const handleDelta = (data: ServiceAnnounceDelta & { generation?: number }) => {
@@ -259,6 +282,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             const newPanels = (socket as any)[PANELS_KEY] as ServicePanelInfo[] | undefined;
             const newTriggerDefs = (socket as any)[TRIGGER_DEFS_KEY] as ServiceTriggerDef[] | undefined;
             const newSigilDefs = (socket as any)[SIGIL_DEFS_KEY] as ServiceSigilDef[] | undefined;
+            const newSessionModes = (socket as any)[SESSION_MODES_KEY] as ServiceModeDef[] | undefined;
             const useRunnerFeed = data._runnerRef === true && runnerInfo?.runnerId === data.runnerId && hasRunnerServiceMetadata(runnerInfo);
             if (useRunnerFeed) {
                 const next = runnerInfoToServices(runnerInfo);
@@ -267,6 +291,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
                 setPanels(next.panels);
                 setTriggerDefs(next.triggerDefs);
                 setSigilDefs(next.sigilDefs);
+                setSessionModes(next.sessionModes);
                 return;
             }
             setServices(new Set(newIds ?? []));
@@ -274,6 +299,7 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setPanels(newPanels ?? []);
             setTriggerDefs(newTriggerDefs ?? []);
             setSigilDefs(newSigilDefs ?? []);
+            setSessionModes(newSessionModes ?? []);
         };
 
         // NOTE: No handleDisconnect listener — we intentionally preserve
@@ -294,5 +320,5 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
         };
     }, [socket, runnerInfo]);
 
-    return { services, disabledServices, panels, triggerDefs, sigilDefs };
+    return { services, disabledServices, panels, triggerDefs, sigilDefs, sessionModes };
 }

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -178,7 +178,7 @@ function hasRunnerServiceMetadata(runnerInfo: RunnerInfo | null | undefined): bo
     );
 }
 
-function runnerInfoToServices(runnerInfo: RunnerInfo | null | undefined): RunnerServicesState {
+export function runnerInfoToServices(runnerInfo: RunnerInfo | null | undefined): RunnerServicesState {
     return {
         services: new Set(runnerInfo?.serviceIds ?? []),
         disabledServices: new Set(runnerInfo?.disabledServiceIds ?? []),


### PR DESCRIPTION
## Night Shift — Code | Work session modes (PizzaWork foundation)

Implements the **sessionModes** package contribution + sidebar Code|Work toggle — the core-side foundation the PizzaWork package builds on. Realizes epic "Work mode — non-coding assistant sessions" (spike TU8m8x5X + feature LTLcJwZr).

**Two dishes, one pairing:**

### pw-001 — sessionModes manifest contribution + transport (spike: GO)
- Adds `sessionModes` as a 4th declarative package contribution (alongside panel/triggers/sigils) in `packages/cli/src/overlay/manifest.ts` with schema validation + unknown-key rejection.
- Flows runner→relay→UI over the existing service-contribution delta channel (`packages/server/src/ws/...`, `packages/protocol`, `useRunnerServices.ts`), survives reconnect/restart/session-switch.
- Equality-on-cwd matching (a mode claims only sessions whose cwd resolves exactly to its workspace); core owns the implicit "Code" mode. Spike verified end-to-end: typecheck 0, UI tests 0.

### pw-002 — sidebar Code|Work toggle + filter + initialCwd
- Segmented mode pill (renders only when ≥1 mode declared; Code leftmost + default), exact-cwd session filter, full-width New button that labels its destination and opens the wizard with `initialCwd` for the selected mode.
- Containment: Code always renders everything unclaimed (a bogus/hostile mode workspace hides nothing). Surgical — no restructuring of the sidebar tree.

**Verification:** root `tsc --build` typecheck exit 0; `cd packages/ui && bun test src` exit 0 (1294 pass). CLI package shows only the 3 pre-existing baseline failures.

Reviewed by Fable 5 critic (combined pairing review). 🌙 Autonomous night shift — queued for human review, not auto-merged.
