### PR TITLE
fix(git-panel): correct optimistic XY status for mixed index/worktree cases

### DIFF
--- a/packages/ui/src/hooks/git-optimistic-status.test.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.test.ts
@@ -39,11 +39,13 @@ describe("applyOptimisticMutation", () => {
         ]);
     });
 
-    test("optimistically stageAll stages all unstaged changes", () => {
+    test("optimistically stageAll stages mixed index/worktree changes like Git", () => {
         const status = makeStatus([
-            { status: " M", path: "src/a.ts" },
-            { status: "MM", path: "src/b.ts" },
+            { status: "MD", path: "src/modified-then-deleted.ts" },
+            { status: "MM", path: "src/modified-twice.ts" },
+            { status: "AD", path: "src/added-then-deleted.ts" },
             { status: "AM", path: "src/already-added.ts" },
+            { status: " M", path: "src/a.ts" },
             { status: "??", path: "src/c.ts" },
             { status: "M ", path: "src/staged.ts" },
         ]);
@@ -54,9 +56,10 @@ describe("applyOptimisticMutation", () => {
         });
 
         expect(next?.changes).toEqual([
-            { status: "M ", path: "src/a.ts" },
-            { status: "M ", path: "src/b.ts" },
+            { status: "D ", path: "src/modified-then-deleted.ts" },
+            { status: "M ", path: "src/modified-twice.ts" },
             { status: "A ", path: "src/already-added.ts" },
+            { status: "M ", path: "src/a.ts" },
             { status: "A ", path: "src/c.ts" },
             { status: "M ", path: "src/staged.ts" },
         ]);

--- a/packages/ui/src/hooks/git-optimistic-status.test.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.test.ts
@@ -42,6 +42,7 @@ describe("applyOptimisticMutation", () => {
     test("optimistically stageAll stages mixed index/worktree changes like Git", () => {
         const status = makeStatus([
             { status: "MD", path: "src/modified-then-deleted.ts" },
+            { status: "RD", path: "src/renamed-then-deleted.ts", originalPath: "src/original.ts" },
             { status: "MM", path: "src/modified-twice.ts" },
             { status: "AD", path: "src/added-then-deleted.ts" },
             { status: "AM", path: "src/already-added.ts" },
@@ -57,6 +58,7 @@ describe("applyOptimisticMutation", () => {
 
         expect(next?.changes).toEqual([
             { status: "D ", path: "src/modified-then-deleted.ts" },
+            { status: "D ", path: "src/original.ts" },
             { status: "M ", path: "src/modified-twice.ts" },
             { status: "A ", path: "src/already-added.ts" },
             { status: "M ", path: "src/a.ts" },

--- a/packages/ui/src/hooks/git-optimistic-status.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.ts
@@ -43,7 +43,9 @@ function applyOptimisticStage(change: GitChange): GitChange | null {
 
     // Staging a deletion replaces the index state; an added-then-deleted path disappears.
     if (worktreeStatus === "D") {
-        return indexStatus === "A" ? null : { ...change, status: "D " };
+        if (indexStatus === "A") return null;
+        if (change.originalPath) return { status: "D ", path: change.originalPath };
+        return { ...change, status: "D " };
     }
 
     const hasExistingIndexStatus = indexStatus !== " " && indexStatus !== "?" && indexStatus !== "!";

--- a/packages/ui/src/hooks/git-optimistic-status.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.ts
@@ -26,7 +26,7 @@ export function cloneStatusSnapshot(status: GitStatus | null): GitStatus | null 
     };
 }
 
-function applyOptimisticStage(change: GitChange): GitChange {
+function applyOptimisticStage(change: GitChange): GitChange | null {
     if (!hasUnstagedChanges(change.status)) return change;
 
     if (change.status === "??") {
@@ -39,6 +39,11 @@ function applyOptimisticStage(change: GitChange): GitChange {
     const worktreeStatus = change.status[1];
     if (worktreeStatus === " " || worktreeStatus === "?" || worktreeStatus === "!") {
         return change;
+    }
+
+    // Staging a deletion replaces the index state; an added-then-deleted path disappears.
+    if (worktreeStatus === "D") {
+        return indexStatus === "A" ? null : { ...change, status: "D " };
     }
 
     const hasExistingIndexStatus = indexStatus !== " " && indexStatus !== "?" && indexStatus !== "!";


### PR DESCRIPTION
## Night Shift — correct optimistic XY status for mixed index/worktree cases

`applyOptimisticStage` preserved the existing index status for mixed index/worktree cases, so staging a path showed the wrong status until the next refresh (e.g. `MD` — modified-in-index, deleted-in-worktree — stayed `M ` instead of staging the deletion as `D `).

Empirically matched to real `git add` behavior:
| Before | git after | now |
|---|---|---|
| `MD` | `D ` | `D ` ✅ |
| `MM` | `M ` | `M ` ✅ |
| `AD` | gone | removed (null) ✅ |
| `AM` | `A ` | `A ` ✅ |

`applyOptimisticStage` is module-private; its sole caller already handled `null`, so the `GitChange | null` widening is safe.

**Verification:** critic restored main's impl against the new test → exit 1 (fails), new code → exit 0 (proves the fix). `bun test src/hooks/git-optimistic-status.test.ts` 7 pass / 0 fail; root typecheck exit 0.

Reviewed by Fable 5 critic: LGTM (one P3: RD/DD/UU remain approximations, out of scope, self-correct on next refresh).

Godmother: LyIocz0p. 🌙 Autonomous night shift — queued for human review, not auto-merged.
