### PR TITLE
perf(viewer): treat already-current resume as no-op instead of cache-miss rebuild

### DIFF
--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -185,18 +185,36 @@ export async function getCachedRelayEvents(sessionId: string): Promise<CachedRel
 
 /**
  * Read only the newest portion(s) of the relay cache and return the latest
- * full snapshot event (session_active/agent_end), if present.
+ * sequenced event.
  *
  * This avoids parsing the entire event list on each viewer switch when the
  * newest snapshot is near the tail (common case).
  */
 export async function getLatestCachedRelayEventSeq(sessionId: string): Promise<number | null> {
-    const events = await getCachedRelayEvents(sessionId);
-    for (let index = events.length - 1; index >= 0; index--) {
-        const event = events[index];
-        if (event && isSequencedCachedRelayEvent(event)) return event.seq;
+    if (isRedisDisabled()) return null;
+
+    const redis = await getClient();
+    if (!redis) return null;
+
+    try {
+        const key = eventsKey(sessionId);
+        const length = await redis.lLen(key);
+        if (!Number.isFinite(length) || length <= 0) return null;
+
+        const chunkSize = snapshotScanChunkSize();
+        for (let end = length - 1; end >= 0; end -= chunkSize) {
+            const start = Math.max(0, end - chunkSize + 1);
+            const rows = await redis.lRange(key, start, end);
+            for (let i = rows.length - 1; i >= 0; i--) {
+                const parsed = parseCachedRelayEventRow(rows[i]);
+                if (parsed && isSequencedCachedRelayEvent(parsed)) return parsed.seq;
+            }
+        }
+        return null;
+    } catch (error) {
+        logUnavailableOnce("Failed to read latest relay event sequence from Redis", error);
+        return null;
     }
-    return null;
 }
 
 export async function getCachedRelayEventsAfterSeq(

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -190,6 +190,15 @@ export async function getCachedRelayEvents(sessionId: string): Promise<CachedRel
  * This avoids parsing the entire event list on each viewer switch when the
  * newest snapshot is near the tail (common case).
  */
+export async function getLatestCachedRelayEventSeq(sessionId: string): Promise<number | null> {
+    const events = await getCachedRelayEvents(sessionId);
+    for (let index = events.length - 1; index >= 0; index--) {
+        const event = events[index];
+        if (event && isSequencedCachedRelayEvent(event)) return event.seq;
+    }
+    return null;
+}
+
 export async function getCachedRelayEventsAfterSeq(
     sessionId: string,
     afterSeq: number,

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -438,26 +438,37 @@ describe("getBestSnapshot — priority ordering", () => {
         expect(result!.snapshot.type).toBe("cache-delta");
     });
 
-    test("priority 1 fail: returns null (not snapshot) when lastSeq provided but delta empty", async () => {
-        // This is the critical invariant: when lastSeq is provided but delta
-        // fails, do NOT fall back to snapshot — it has no seq and would roll
-        // back the client's transcript. Return null for runner recovery.
+    test("returns an already-current no-op when the empty delta matches latestSeq", async () => {
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
-            getLatestCachedSnapshotEvent: mock(async () => ({
-                event: { type: "session_active", state: { messages: [] } },
-                eventsAfter: [],
-                })),
-            getPersistedRelaySessionSnapshot: mock(async () => ({
-                state: { messages: [] },
-            })),
         });
 
-        const result = await getBestSnapshot("sess-31", {
-            lastSeq: 10,
-            userId: "u1",
-            lastState: '{"messages":[]}',
-        }, deps);
+        const result = await getBestSnapshot("sess-31", { lastSeq: 10, latestSeq: 10 }, deps);
+
+        expect(result?.snapshot.type).toBe("already-current");
+        const socket = createMockSocket();
+        result?.send(socket);
+        expect(socket.calls).toHaveLength(0);
+    });
+
+    test("returns null when latestSeq is newer than the client's cursor", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+        });
+
+        const result = await getBestSnapshot("sess-32", { lastSeq: 10, latestSeq: 11 }, deps);
+
+        expect(result).toBeNull();
+    });
+
+    test("returns null when delta replay is unavailable", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => {
+                throw new Error("Redis unavailable");
+            }),
+        });
+
+        const result = await getBestSnapshot("sess-33", { lastSeq: 10, latestSeq: 10 }, deps);
 
         expect(result).toBeNull();
     });

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -255,7 +255,9 @@ export async function getBestSnapshot(
             const delta = await tryDeltaReplay(sessionId, lastSeq, deps);
             if (delta) return delta;
         } catch {
-            // Fall through — delta source failed
+            // An unavailable delta source is not proof that the client is
+            // current, even when latestSeq happens to match.
+            return null;
         }
         // Empty replay is a valid no-op only when the authoritative server
         // seq equals the client's cursor. A higher seq means the cache has a

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -21,7 +21,7 @@ import { sendCachedDeltaReplayEvents } from "./viewer-cache.js";
  * Discriminated union describing where a snapshot came from.
  */
 export interface Snapshot {
-    type: "cache-delta" | "cache-snapshot" | "memory" | "persisted";
+    type: "cache-delta" | "cache-snapshot" | "memory" | "persisted" | "already-current";
     /** Human-readable description of the source */
     source: string;
 }
@@ -224,6 +224,8 @@ export interface GetBestSnapshotOpts {
     snapshotOverlay?: string | null;
     /** Whether a chunked delivery is in-flight (skip memory state if true) */
     chunkedPending?: boolean;
+    /** Authoritative current seq, used to distinguish an empty replay from a gap. */
+    latestSeq?: number;
 }
 
 /**
@@ -254,6 +256,15 @@ export async function getBestSnapshot(
             if (delta) return delta;
         } catch {
             // Fall through — delta source failed
+        }
+        // Empty replay is a valid no-op only when the authoritative server
+        // seq equals the client's cursor. A higher seq means the cache has a
+        // genuine gap and must recover through the runner.
+        if (opts.latestSeq === lastSeq) {
+            return {
+                snapshot: { type: "already-current", source: "Viewer already at latest cached seq" },
+                send() {},
+            };
         }
         // When lastSeq is provided but delta fails, do NOT fall through to
         // snapshot — a snapshot has no seq and would roll back the client.

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -5,7 +5,12 @@
 // loading the full namespace module or relying on global mock.module state.
 // ============================================================================
 
-import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent, type LatestCachedSnapshot } from "../../sessions/redis.js";
+import {
+    getCachedRelayEventsAfterSeq,
+    getLatestCachedRelayEventSeq,
+    getLatestCachedSnapshotEvent,
+    type LatestCachedSnapshot,
+} from "../../sessions/redis.js";
 
 type ViewerEventEmitter = {
     emit: any;
@@ -18,11 +23,13 @@ export type CachedRelayEvent = {
 
 export interface ViewerCacheDeps {
     getCachedRelayEventsAfterSeq: (sessionId: string, afterSeq: number) => Promise<CachedRelayEvent[]>;
+    getLatestCachedRelayEventSeq: (sessionId: string) => Promise<number | null>;
     getLatestCachedSnapshotEvent: (sessionId: string) => Promise<LatestCachedSnapshot | null>;
 }
 
 const defaultViewerCacheDeps: ViewerCacheDeps = {
     getCachedRelayEventsAfterSeq,
+    getLatestCachedRelayEventSeq,
     getLatestCachedSnapshotEvent,
 };
 
@@ -100,11 +107,13 @@ export async function hydrateViewerFromCache(
                 deps,
             );
             if (deltaOk) return true;
-            // Delta replay was requested but unavailable (seq gap too large /
-            // events evicted).  Return false so the caller triggers runner
-            // recovery rather than treating the snapshot fallback as
-            // authoritative — a snapshot has no seq, so it can roll back the
-            // client's transcript or cause missed updates.
+            // An empty replay is safe only when the cache confirms the client
+            // already has the newest stored event. Otherwise this is a real
+            // gap (or an unavailable cache), so runner recovery is required.
+            const latestSeq = await deps.getLatestCachedRelayEventSeq(sessionId);
+            if (latestSeq === opts.lastSeq) return true;
+            // A snapshot has no seq and could roll back the client's
+            // transcript or cause missed updates.
             return false;
         }
 

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -24,6 +24,7 @@ function createMockSocket(): { emit: ReturnType<typeof mock>; calls: EmittedCall
 function createDeps(overrides: Partial<ViewerCacheDeps> = {}): ViewerCacheDeps {
     return {
         getCachedRelayEventsAfterSeq: overrides.getCachedRelayEventsAfterSeq ?? mock(async () => [] as CachedRelayEvent[]),
+        getLatestCachedRelayEventSeq: overrides.getLatestCachedRelayEventSeq ?? mock(async () => null),
         getLatestCachedSnapshotEvent: overrides.getLatestCachedSnapshotEvent ?? mock(async () => null),
     };
 }
@@ -111,18 +112,31 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         expect(getLatestCachedSnapshotEvent).not.toHaveBeenCalled();
     });
 
-    test("returns false (runner recovery) when delta returns no events after lastSeq", async () => {
-        // When lastSeq is provided but delta replay yields nothing, we must NOT fall back
-        // to a snapshot — it has no seq and could roll back the client transcript.
-        // Return false so the caller triggers runner-driven recovery instead.
-        const snapshot = { type: "session_active", state: { messages: [] } };
+    test("returns true without emitting when the client is already at the latest seq", async () => {
+        const getLatestCachedRelayEventSeq = mock(async () => 5);
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
-            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })),
+            getLatestCachedRelayEventSeq,
         });
 
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-011", { lastSeq: 5 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(0);
+        expect(getLatestCachedRelayEventSeq).toHaveBeenCalledWith("sess-011");
+    });
+
+    test("returns false for a genuine gap when the cache has newer events", async () => {
+        const snapshot = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedRelayEventSeq: mock(async () => 8),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-012", { lastSeq: 5 }, deps);
 
         expect(result).toBe(false);
         expect(calls.length).toBe(0);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -463,6 +463,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     lastState: freshSession.lastState,
                     snapshotOverlay: freshSession.snapshotOverlay,
                     chunkedPending: false,
+                    latestSeq: freshSeq,
                 });
                 if (snapshotResult) {
                     // Cache hit — viewer is fully hydrated.  Suppress the


### PR DESCRIPTION
## Night Shift — treat already-current viewer resume as no-op, not cache-miss rebuild

Server-side viewer hydration treated an empty delta replay (no events after the client's `lastSeq`) as a cache miss → full runner rebuild, even when the resume was already current. This recognizes the already-current case (`lastSeq == latest seq`, no newer events) and returns a no-op instead — while still rebuilding on a genuine gap.

- `snapshot-provider.ts` (`getBestSnapshot`): `already-current` no-op when `lastSeq == latestSeq` (authoritative Redis counter).
- `viewer-cache.ts` (`hydrateViewerFromCache`): same guard on the resync path.
- Gap-safety preserved: any contiguity break or missing chunk → `latest != lastSeq` → runner recovery. Every ambiguous/failure state resolves to recovery.
- `viewer.hydration.test.ts`: covers both already-current (no rebuild) and gap (rebuild).

**Verification:** `bun scripts/test-isolated.ts packages/server/src` exit 0 (76 pass); `bun run typecheck` exit 0.

Reviewed by Fable 5 critic: LGTM with a full concurrency guard trace (race-safe, cannot skip rebuild on a genuine gap). P3 follow-up: align `hydrateViewerFromCache` to use `getSessionSeq()` counter like the snapshot path.

Godmother: zwTRaHgS. 🌙 Autonomous night shift — queued for human review, not auto-merged.
