### PR TITLE
fix(mcp): avoid oauthCallbackPort collision on parallel OAuth server init

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -510,9 +510,11 @@ export interface PizzaPiConfig {
      * Global default local callback port for MCP OAuth redirect URI.
      *
      * When set, the local OAuth callback server binds to this fixed port
-     * instead of an OS-assigned ephemeral port. Useful when you need a
-     * predictable `http://localhost:PORT/callback` redirect URI for
-     * pre-registered OAuth clients.
+     * instead of an OS-assigned ephemeral port for a single OAuth server.
+     * When multiple OAuth servers initialize, servers without an explicit
+     * per-server port use OS-assigned ephemeral ports to avoid collisions.
+     * Useful when you need a predictable `http://localhost:PORT/callback`
+     * redirect URI for a pre-registered OAuth client.
      *
      * Can also be set per-server via `oauthCallbackPort` in individual
      * `mcpServers` entries — per-server values take precedence.

--- a/packages/cli/src/extensions/mcp/registry.test.ts
+++ b/packages/cli/src/extensions/mcp/registry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { countOAuthServers, resolveOAuthCallbackPort, type McpConfig } from "./registry.js";
+
+describe("OAuth callback port allocation", () => {
+  test("single OAuth server honors the configured global port", () => {
+    expect(resolveOAuthCallbackPort(undefined, 4567, 1)).toBe(4567);
+    expect(countOAuthServers({
+      oauthClientId: "client",
+      mcp: { servers: [{ name: "one", transport: "streamable", url: "https://one.test/mcp" }] },
+    }, new Set())).toBe(1);
+  });
+
+  test("multiple OAuth servers without per-server ports use ephemeral ports", () => {
+    expect(resolveOAuthCallbackPort(undefined, 4567, 2)).toBe(0);
+    expect(countOAuthServers({
+      mcpServers: {
+        one: { url: "https://one.test/mcp", transport: "streamable", oauthClientId: "one" },
+        two: { url: "https://two.test/mcp", transport: "streamable", oauthClientId: "two" },
+      },
+    }, new Set())).toBe(2);
+  });
+
+  test("explicit per-server ports are always honored", () => {
+    expect(resolveOAuthCallbackPort(9876, 4567, 2)).toBe(9876);
+    expect(resolveOAuthCallbackPort(9876, undefined, 1)).toBe(9876);
+  });
+
+  test("non-OAuth streamable servers do not inflate the OAuth count", () => {
+    const config: McpConfig = {
+      mcpServers: {
+        oauth: { url: "https://oauth.test/mcp", transport: "streamable", oauthClientId: "client" },
+        bearer: { url: "https://bearer.test/mcp", transport: "streamable", headers: { Authorization: "Bearer token" } },
+      },
+    };
+    expect(countOAuthServers(config, new Set())).toBe(1);
+    expect(resolveOAuthCallbackPort(undefined, 4567, countOAuthServers(config, new Set()))).toBe(4567);
+  });
+});

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -163,13 +163,18 @@ export function resolveOAuthCallbackPort(
   return perServerPort ?? (oauthServerCount > 1 ? 0 : (globalPort ?? 0));
 }
 
-function countOAuthServers(config: PizzaPiConfig & McpConfig, disabled: Set<string>): number {
+export function countOAuthServers(config: PizzaPiConfig & McpConfig, disabled: Set<string>): number {
+  const globalOAuthConfigured = Boolean(config.oauthClientName || config.oauthClientId || config.oauthClientSecret);
+  const requiresOAuth = (server: { oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string }): boolean =>
+    globalOAuthConfigured || Boolean(server.oauthClientName || server.oauthClientId || server.oauthClientSecret);
+
   const preferred = (config.mcp?.servers ?? []).filter(
-    server => server && server.transport === "streamable" && !disabled.has(server.name),
+    server => server && server.transport === "streamable" && !disabled.has(server.name) && requiresOAuth(server),
   ).length;
-  const compatibility = Object.entries(config.mcpServers ?? {}).filter(([name, def]) =>
-    !disabled.has(name) && def && typeof def === "object" && resolveMcpCompatTransport(def as Record<string, unknown>) === "streamable",
-  ).length;
+  const compatibility = Object.entries(config.mcpServers ?? {}).filter(([name, def]) => {
+    if (disabled.has(name) || !def || typeof def !== "object" || resolveMcpCompatTransport(def as Record<string, unknown>) !== "streamable") return false;
+    return requiresOAuth(def as { oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string });
+  }).length;
   return preferred + compatibility;
 }
 

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -150,6 +150,29 @@ function isMcpDomainAllowed(url: string, serverName: string): boolean {
 // Client factory
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Keep a global fixed port for a single OAuth server, but let the OS allocate
+ * ports when several servers are initialized together. Per-server settings
+ * always win, including an explicit port 0.
+ */
+export function resolveOAuthCallbackPort(
+  perServerPort: number | undefined,
+  globalPort: number | undefined,
+  oauthServerCount: number,
+): number {
+  return perServerPort ?? (oauthServerCount > 1 ? 0 : (globalPort ?? 0));
+}
+
+function countOAuthServers(config: PizzaPiConfig & McpConfig, disabled: Set<string>): number {
+  const preferred = (config.mcp?.servers ?? []).filter(
+    server => server && server.transport === "streamable" && !disabled.has(server.name),
+  ).length;
+  const compatibility = Object.entries(config.mcpServers ?? {}).filter(([name, def]) =>
+    !disabled.has(name) && def && typeof def === "object" && resolveMcpCompatTransport(def as Record<string, unknown>) === "streamable",
+  ).length;
+  return preferred + compatibility;
+}
+
 export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConfig): Promise<McpClient[]> {
   // Clean up stale OAuth providers from previous loads (e.g. /mcp reload).
   // This stops any active re-emit timers and prevents unbounded growth.
@@ -163,6 +186,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
   const oauthClientId = config.oauthClientId;
   const oauthClientSecret = config.oauthClientSecret;
   const oauthCallbackPort = config.oauthCallbackPort;
+  const oauthServerCount = countOAuthServers(config, disabled);
 
   const clients: McpClient[] = [];
 
@@ -211,7 +235,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         clientName: s.oauthClientName || oauthClientName,
         clientId: sClientId,
         clientSecret: sClientSecret,
-        callbackPort: s.oauthCallbackPort ?? oauthCallbackPort,
+        callbackPort: resolveOAuthCallbackPort(s.oauthCallbackPort, oauthCallbackPort, oauthServerCount),
         deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
       });
       activeOAuthProviders.push(provider);
@@ -277,7 +301,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
           clientName: d.oauthClientName || oauthClientName,
           clientId: dClientId,
           clientSecret: dClientSecret,
-          callbackPort: d.oauthCallbackPort ?? oauthCallbackPort,
+          callbackPort: resolveOAuthCallbackPort(d.oauthCallbackPort, oauthCallbackPort, oauthServerCount),
           deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
         });
         activeOAuthProviders.push(provider);

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -150,7 +150,7 @@ You can also override any setting with **environment variables**.
 | `oauthClientName` | `string` | `"PizzaPi"` | Global default `client_name` for MCP OAuth registration. Can also be set per-server in `mcpServers` entries. Per-server values take precedence. See [Client Name Override](/PizzaPi/customization/mcp-servers/#client-name-override). |
 | `oauthClientId` | `string` | — | Global default pre-registered OAuth `client_id` for MCP servers. Per-server values take precedence. |
 | `oauthClientSecret` | `string` | — | Global default pre-registered OAuth `client_secret` for MCP servers. Per-server values take precedence. |
-| `oauthCallbackPort` | `number` | `0` | Global default local callback port for MCP OAuth redirect URI. `0` means OS-assigned ephemeral port. Per-server values take precedence. |
+| `oauthCallbackPort` | `number` | `0` | Global default local callback port for MCP OAuth redirect URI. A single OAuth server honors this port; multiple OAuth servers without per-server ports use OS-assigned ephemeral ports to avoid collisions. `0` means OS-assigned ephemeral port. Per-server values take precedence. |
 | `mcpTimeout` | `number` | `30000` | Timeout (ms) for each MCP server's `tools/list` call during startup. Set to `0` to disable. |
 | `toolSearch` | `object` | — | Dynamic MCP tool discovery config. See [Tool Search](/PizzaPi/customization/tool-search/). |
 | `bash.backgroundAfterSeconds` | `number` | `15` | Seconds a `bash` command streams output in the foreground before it auto-backgrounds. `0` = background immediately. See [Bash auto-backgrounding](#bash-auto-backgrounding). |


### PR DESCRIPTION
## Night Shift — avoid oauthCallbackPort collision on parallel OAuth server init

A non-zero global `oauthCallbackPort` was reused as the fallback callback port for every streamable MCP server, so parallel init of 2+ OAuth-backed servers all tried to bind the same fixed localhost port → EADDRINUSE.

- `resolveOAuthCallbackPort(perServer, global, count)` + `countOAuthServers(config, disabled)` in `packages/cli/src/extensions/mcp/registry.ts`.
- Single OAuth server + configured global port → keeps that exact port (predictable redirect URI preserved).
- 2+ OAuth servers, no per-server port → ephemeral (OS-assigned `0`) per server, no collision.
- Explicit per-server port always honored (nullish-coalescing, even `0`).
- `countOAuthServers` counts only servers actually requiring OAuth (per-server oauth config, or global oauth config), consistent with the client-creation transport predicate; pure-bearer streamable servers excluded.
- New `registry.test.ts` (4 tests: single/multi/explicit/bearer, both config formats). Docs updated.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src` — only the 3 pre-existing baseline failures; registry.test.ts 4/4.

Reviewed by Fable 5 critic: LGTM. Follow-up P2: dynamic-client-registration servers (401→DCR, no static oauth config) aren't counted, so a global port + one configured + one DCR server could still collide (mitigated by lazy binding); tracked separately.

Godmother: OQaMLLRZ. 🌙 Autonomous night shift — queued for human review, not auto-merged.
