### PR TITLE
fix(server): persist uploaded attachment metadata to SQLite across restarts

### DIFF
--- a/packages/server/src/attachments/store.test.ts
+++ b/packages/server/src/attachments/store.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, test } from "bun:test";
-import { normalizeExtractedImageMimeType, sanitizeFilename, sanitizeStoredFilename, attachmentMaxFileSizeBytes } from "./store";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const tempDir = mkdtempSync(join(tmpdir(), "pizzapi-attachments-"));
+process.env.AUTH_DB_PATH = join(tempDir, "auth.db");
+process.env.PIZZAPI_ATTACHMENT_DIR = join(tempDir, "uploads");
+
+const store = await import("./store.js");
+const { normalizeExtractedImageMimeType, sanitizeFilename, sanitizeStoredFilename, attachmentMaxFileSizeBytes } = store;
+const { createTestAuthContext, runWithAuthContext } = await import("../auth.js");
+const authContext = createTestAuthContext({ dbPath: process.env.AUTH_DB_PATH });
+await runWithAuthContext(authContext, () => store.ensureExtractedAttachmentTable());
+
+// A separate module instance provides the fresh in-memory Map used after restart.
+const restartedStore = await (async (specifier: string) => import(specifier))("./store.js?restart");
+
+afterAll(async () => {
+    await authContext.db.destroy();
+    rmSync(tempDir, { recursive: true, force: true });
+});
 
 describe("normalizeExtractedImageMimeType", () => {
     test("passes through plain image types", () => {
@@ -112,5 +132,32 @@ describe.skip("attachmentMaxFileSizeBytes", () => {
         } else {
             delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
         }
+    });
+});
+
+describe("attachment metadata persistence", () => {
+    test("rehydrates uploaded metadata into a fresh store after a simulated restart", async () => {
+        const uploaded = await runWithAuthContext(authContext, () => store.storeSessionAttachment({
+            sessionId: "session-restart-test",
+            ownerUserId: "user-restart-test",
+            uploaderUserId: "user-restart-test",
+            file: new File(["attachment contents"], "report.txt", { type: "text/plain" }),
+        }));
+
+        const loaded = await runWithAuthContext(authContext, async () => {
+            expect(await restartedStore.rehydrateAttachments()).toBe(1);
+            return restartedStore.getStoredAttachment(uploaded.attachmentId);
+        });
+
+        expect(loaded).toMatchObject({
+            attachmentId: uploaded.attachmentId,
+            sessionId: "session-restart-test",
+            ownerUserId: "user-restart-test",
+            uploaderUserId: "user-restart-test",
+            filename: "report.txt",
+            mimeType: uploaded.mimeType,
+            size: uploaded.size,
+            filePath: uploaded.filePath,
+        });
     });
 });

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -95,7 +95,16 @@ export async function storeSessionAttachment(input: {
         filePath: targetPath,
     };
 
-    await persistUploadedAttachment(record);
+    try {
+        await persistUploadedAttachment(record);
+    } catch (err) {
+        try {
+            await rm(targetPath, { force: true });
+        } catch (cleanupErr) {
+            log.error("Failed to clean up uploaded attachment after persistence failure:", cleanupErr);
+        }
+        throw err;
+    }
     attachments.set(attachmentId, record);
     return record;
 }

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -95,6 +95,7 @@ export async function storeSessionAttachment(input: {
         filePath: targetPath,
     };
 
+    await persistUploadedAttachment(record);
     attachments.set(attachmentId, record);
     return record;
 }
@@ -136,8 +137,11 @@ export async function deleteStoredAttachment(attachmentId: string): Promise<void
     try {
         await rm(record.filePath, { force: true });
     } catch {}
-    void removePersistedAttachment(attachmentId).catch(() => {});
-    void removePersistedSessionRefs(attachmentId).catch(() => {});
+    void Promise.all([
+        removePersistedAttachment(attachmentId),
+        removePersistedUploadedAttachment(attachmentId),
+        removePersistedSessionRefs(attachmentId),
+    ]).catch(() => {});
 }
 
 // ── Extracted image storage ──────────────────────────────────────────────────
@@ -327,6 +331,21 @@ function hasAnyDurableSessionRef(
 
 export async function ensureExtractedAttachmentTable(): Promise<void> {
     await getKysely().schema
+        .createTable("attachment")
+        .ifNotExists()
+        .addColumn("attachmentId", "text", (col) => col.primaryKey())
+        .addColumn("sessionId", "text", (col) => col.notNull())
+        .addColumn("ownerUserId", "text", (col) => col.notNull())
+        .addColumn("uploaderUserId", "text", (col) => col.notNull())
+        .addColumn("filename", "text", (col) => col.notNull())
+        .addColumn("mimeType", "text", (col) => col.notNull())
+        .addColumn("size", "integer", (col) => col.notNull())
+        .addColumn("createdAt", "text", (col) => col.notNull())
+        .addColumn("expiresAt", "text", (col) => col.notNull())
+        .addColumn("filePath", "text", (col) => col.notNull())
+        .execute();
+
+    await getKysely().schema
         .createTable("extracted_attachment")
         .ifNotExists()
         .addColumn("attachmentId", "text", (col) => col.primaryKey())
@@ -409,6 +428,32 @@ async function removePersistedSessionRefs(attachmentId: string): Promise<void> {
 }
 
 /** Persist an extracted attachment record to SQLite (upsert). */
+async function persistUploadedAttachment(record: StoredAttachment): Promise<void> {
+    await getKysely()
+        .insertInto("attachment" as any)
+        .values({
+            attachmentId: record.attachmentId,
+            sessionId: record.sessionId,
+            ownerUserId: record.ownerUserId,
+            uploaderUserId: record.uploaderUserId,
+            filename: record.filename,
+            mimeType: record.mimeType,
+            size: record.size,
+            createdAt: record.createdAt,
+            expiresAt: record.expiresAt,
+            filePath: record.filePath,
+        })
+        .onConflict((oc) => oc.column("attachmentId").doUpdateSet({ expiresAt: record.expiresAt }))
+        .execute();
+}
+
+async function removePersistedUploadedAttachment(attachmentId: string): Promise<void> {
+    await getKysely()
+        .deleteFrom("attachment" as any)
+        .where("attachmentId", "=", attachmentId)
+        .execute();
+}
+
 async function persistExtractedAttachment(record: StoredAttachment): Promise<void> {
     await getKysely()
         .insertInto("extracted_attachment")
@@ -444,6 +489,40 @@ async function removePersistedAttachment(attachmentId: string): Promise<void> {
  * Rehydrate the in-memory attachment registry from SQLite on server startup.
  * Only loads non-expired records whose files still exist on disk.
  */
+export async function rehydrateAttachments(): Promise<number> {
+    const rows = await getKysely().selectFrom("attachment" as any).selectAll().execute();
+    let loaded = 0;
+    for (const row of rows as Array<Record<string, string | number>>) {
+        const expiresAtMs = Date.parse(String(row.expiresAt));
+        if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+            try { await rm(String(row.filePath), { force: true }); } catch {}
+            await removePersistedUploadedAttachment(String(row.attachmentId));
+            continue;
+        }
+        try {
+            await access(String(row.filePath));
+        } catch {
+            await removePersistedUploadedAttachment(String(row.attachmentId));
+            continue;
+        }
+        attachments.set(String(row.attachmentId), {
+            attachmentId: String(row.attachmentId),
+            sessionId: String(row.sessionId),
+            ownerUserId: String(row.ownerUserId),
+            uploaderUserId: String(row.uploaderUserId),
+            filename: String(row.filename),
+            mimeType: String(row.mimeType),
+            size: Number(row.size),
+            createdAt: String(row.createdAt),
+            expiresAt: String(row.expiresAt),
+            expiresAtMs,
+            filePath: String(row.filePath),
+        });
+        loaded++;
+    }
+    return loaded;
+}
+
 export async function rehydrateExtractedAttachments(): Promise<number> {
     const nowMs = Date.now();
     const nowIso = new Date(nowMs).toISOString();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from "./sessions/store.js";
 import { deleteRelayEventCaches, initializeRelayRedisCache } from "./sessions/redis.js";
 import { sweepExpiredSessions, sweepOrphanedRunners } from "./ws/sio-registry.js";
-import { sweepExpiredAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
+import { sweepExpiredAttachments, rehydrateAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
 import { sweepExpiredSetupClaims } from "./setup-claims.js";
 import { sweepExpiredMobileLinks } from "./mobile-links.js";
 import { runAllMigrations } from "./migrations.js";
@@ -119,8 +119,12 @@ void initializeRelayRedisCache();
 // Rehydrate extracted image attachments from SQLite so URLs in persisted
 // session state survive server restarts.
 try {
-    const count = await runWithAuthContext(authContext, () => rehydrateExtractedAttachments());
-    if (count > 0) startupLog.info(`Rehydrated ${count} extracted image attachment(s) from database.`);
+    const [uploadCount, extractedCount] = await runWithAuthContext(authContext, async () => [
+        await rehydrateAttachments(),
+        await rehydrateExtractedAttachments(),
+    ]);
+    if (uploadCount > 0) startupLog.info(`Rehydrated ${uploadCount} uploaded attachment(s) from database.`);
+    if (extractedCount > 0) startupLog.info(`Rehydrated ${extractedCount} extracted image attachment(s) from database.`);
 } catch (err) {
     startupLog.error("Failed to rehydrate extracted attachments:", err);
 }


### PR DESCRIPTION
## Night Shift — persist uploaded attachment metadata to SQLite

User-uploaded attachment metadata was stored only in-memory, so a server restart lost all attachment records. This mirrors the existing extracted-image persistence pattern: SQLite durability with an in-memory hot-path Map.

- Upload metadata is written to SQLite before the upload response returns.
- Startup rehydrates valid metadata into fresh Maps and removes rows whose files are missing/expired.
- Regression test uses a query-qualified module import to get distinct module namespaces/functions (fresh Maps) sharing one SQLite database, then verifies the "restarted" store retrieves complete metadata.

**Verification:** `bun scripts/test-isolated.ts packages/server/src` exit 0 (76 pass); `bun run typecheck` exit 0; `git diff --check` clean.

Reviewed by GPT-5.6 Sol critic: LGTM, no findings.

Godmother: cmHfFF7I. 🌙 Autonomous night shift — queued for human review, not auto-merged.
