### PR TITLE
refactor(ui): single source of truth for agent fetching with bounded cache

### DIFF
--- a/packages/ui/src/components/session-viewer/agent-loader.test.ts
+++ b/packages/ui/src/components/session-viewer/agent-loader.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { loadAgents } from "./agent-loader";
+
+const originalFetch = globalThis.fetch;
+const originalNow = Date.now;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Date.now = originalNow;
+});
+
+describe("loadAgents", () => {
+  test("refreshes the runner cache after its TTL", async () => {
+    let now = 1_000;
+    Date.now = () => now;
+    let requests = 0;
+    globalThis.fetch = (async () => {
+      requests++;
+      return new Response(JSON.stringify({ agents: [{ name: `agent-${requests}` }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(loadAgents("ttl-regression-runner")).resolves.toEqual([{ name: "agent-1" }]);
+    now += 4_999;
+    await expect(loadAgents("ttl-regression-runner")).resolves.toEqual([{ name: "agent-1" }]);
+    expect(requests).toBe(1);
+
+    now += 1;
+    await expect(loadAgents("ttl-regression-runner")).resolves.toEqual([{ name: "agent-2" }]);
+    expect(requests).toBe(2);
+  });
+});

--- a/packages/ui/src/components/session-viewer/agent-loader.ts
+++ b/packages/ui/src/components/session-viewer/agent-loader.ts
@@ -1,0 +1,27 @@
+import type { AgentEntry } from "./agent-loading";
+
+const agentsCache = new Map<string, AgentEntry[]>();
+const agentsPending = new Map<string, Promise<AgentEntry[]>>();
+
+export function loadAgents(runnerId: string): Promise<AgentEntry[]> {
+  const cached = agentsCache.get(runnerId);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = agentsPending.get(runnerId);
+  if (pending) return pending;
+
+  const request = fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
+    .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+    .then((data: unknown) => {
+      const raw = data as { agents?: AgentEntry[] };
+      const agents = Array.isArray(raw?.agents) ? raw.agents : [];
+      agentsCache.set(runnerId, agents);
+      return agents;
+    })
+    .finally(() => {
+      agentsPending.delete(runnerId);
+    });
+
+  agentsPending.set(runnerId, request);
+  return request;
+}

--- a/packages/ui/src/components/session-viewer/agent-loader.ts
+++ b/packages/ui/src/components/session-viewer/agent-loader.ts
@@ -1,11 +1,13 @@
 import type { AgentEntry } from "./agent-loading";
 
-const agentsCache = new Map<string, AgentEntry[]>();
+const AGENTS_CACHE_TTL_MS = 5_000;
+const agentsCache = new Map<string, { agents: AgentEntry[]; expiresAt: number }>();
 const agentsPending = new Map<string, Promise<AgentEntry[]>>();
 
 export function loadAgents(runnerId: string): Promise<AgentEntry[]> {
   const cached = agentsCache.get(runnerId);
-  if (cached) return Promise.resolve(cached);
+  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.agents);
+  if (cached) agentsCache.delete(runnerId);
 
   const pending = agentsPending.get(runnerId);
   if (pending) return pending;
@@ -15,7 +17,7 @@ export function loadAgents(runnerId: string): Promise<AgentEntry[]> {
     .then((data: unknown) => {
       const raw = data as { agents?: AgentEntry[] };
       const agents = Array.isArray(raw?.agents) ? raw.agents : [];
-      agentsCache.set(runnerId, agents);
+      agentsCache.set(runnerId, { agents, expiresAt: Date.now() + AGENTS_CACHE_TTL_MS });
       return agents;
     })
     .finally(() => {

--- a/packages/ui/src/components/session-viewer/agent-loading.ts
+++ b/packages/ui/src/components/session-viewer/agent-loading.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { loadAgents } from "./agent-loader";
 
 export interface AgentEntry {
   name: string;
@@ -59,12 +60,9 @@ export function useAgentLoading({
     // Fetch full agent data in background (REST list doesn't include content,
     // but this keeps the list current and enables content-based spawning)
     setAgentsLoading(true);
-    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then((data: unknown) => {
+    loadAgents(runnerId)
+      .then((agents) => {
         if (stale) return;
-        const raw = data as { agents?: AgentEntry[] };
-        const agents = Array.isArray(raw?.agents) ? raw.agents : [];
         setAgentsList(agents);
       })
       .catch(() => {

--- a/packages/ui/src/components/session-viewer/at-mention-handlers.ts
+++ b/packages/ui/src/components/session-viewer/at-mention-handlers.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { loadAgents } from "./agent-loader";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 
 export interface AtMentionState {
@@ -82,14 +83,9 @@ export function useAtMentionHandlers(
     if (atMentionAgentsFetchedForRef.current === runnerId) return;
     atMentionAgentsFetchedForRef.current = runnerId;
     let stale = false;
-    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then((data: unknown) => {
+    loadAgents(runnerId)
+      .then((agents) => {
         if (stale) return;
-        const raw = data as { agents?: Array<{ name: string; description?: string }> };
-        const agents = Array.isArray(raw?.agents)
-          ? raw.agents.map((a) => ({ name: a.name, description: a.description }))
-          : [];
         setAtMentionAgents(agents);
       })
       .catch(() => {

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -4,6 +4,7 @@ import type { CommandResultData } from "./rendering";
 import type { SandboxViolationEntry } from "./cards/CommandResultCard";
 import type { ResumeSessionOption, ForkMessageOption } from "@/lib/types";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
+import { loadAgents } from "./agent-loader";
 import {
   type IncompleteTriggerItem,
   type TriggerHistoryEntry,
@@ -648,12 +649,24 @@ export function useSlashCommands(
           const agentName = args.trim();
           if (onSpawnAgentSession && runnerId) {
             const dispatchSessionId = sessionId;
-            const agentsList = runnerInfo?.agents ?? null;
-            if (agentsList !== null) {
-              const match = agentsList.find(
-                (a) => a.name.toLowerCase() === agentName.toLowerCase(),
-              );
-              if (match) {
+            loadAgents(runnerId)
+              .then((agents) => {
+                if (dispatchSessionId !== sessionIdRef.current) return;
+                const match = agents.find(
+                  (a) => a.name.toLowerCase() === agentName.toLowerCase(),
+                );
+                if (!match) {
+                  onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
+                  return;
+                }
+                if (match.content !== undefined) {
+                  onSpawnAgentSession?.({
+                    name: match.name,
+                    description: match.description,
+                    systemPrompt: match.content,
+                  });
+                  return;
+                }
                 fetch(
                   `/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(match.name)}`,
                   { credentials: "include" },
@@ -672,40 +685,11 @@ export function useSlashCommands(
                     if (dispatchSessionId !== sessionIdRef.current) return;
                     onSpawnAgentSession?.({ name: match.name, description: match.description });
                   });
-              } else {
-                onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
-              }
-            } else {
-              fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, {
-                credentials: "include",
               })
-                .then((res) =>
-                  res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)),
-                )
-                .then((data: unknown) => {
-                  if (dispatchSessionId !== sessionIdRef.current) return;
-                  const raw = data as {
-                    agents?: Array<{ name: string; description?: string; content?: string }>;
-                  };
-                  const agents = Array.isArray(raw?.agents) ? raw.agents : [];
-                  const match = agents.find(
-                    (a) => a.name.toLowerCase() === agentName.toLowerCase(),
-                  );
-                  if (match) {
-                    onSpawnAgentSession?.({
-                      name: match.name,
-                      description: match.description,
-                      systemPrompt: match.content,
-                    });
-                  } else {
-                    onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
-                  }
-                })
-                .catch((err: Error) => {
-                  if (dispatchSessionId !== sessionIdRef.current) return;
-                  onAppendSystemMessage?.(`**Agents** — Failed to load: ${err.message}`);
-                });
-            }
+              .catch((err: Error) => {
+                if (dispatchSessionId !== sessionIdRef.current) return;
+                onAppendSystemMessage?.(`**Agents** — Failed to load: ${err.message}`);
+              });
           }
         }
         setInput("");


### PR DESCRIPTION
## Night Shift — single source of truth for agent fetching

Agent lists were fetched independently in two places with different caching strategies, causing stale lists and duplicate network requests.

- Introduces a shared `agent-loader.ts` with a 5-second runner-keyed cache TTL; stale entries refetch.
- Routes `/agents` picker, @-mention handler, and slash-commands agent lookup through `loadAgents` so there is truly one `fetch()`.
- Regression test verifies cached reuse and refresh after TTL expiry.

**Verification:** `cd packages/ui && bun test src` exit 0 (1293 pass, 1 skip); `bun run typecheck` exit 0.

Reviewed by GPT-5.6 Sol critic: LGTM (round 2).

Godmother: zjVjANHX. 🌙 Autonomous night shift — queued for human review, not auto-merged.
