### PR TITLE
test(cli): isolate pairing/API-key tests from ambient credentials

### DIFF
--- a/packages/cli/src/runner/pairing.test.ts
+++ b/packages/cli/src/runner/pairing.test.ts
@@ -47,6 +47,9 @@ describe("shouldAutoPair", () => {
 
 describe("resolveExistingApiKey", () => {
     const originalEnv = { ...process.env };
+    beforeEach(() => {
+        for (const k of ["PIZZAPI_RUNNER_API_KEY", "PIZZAPI_API_KEY", "PIZZAPI_API_TOKEN"]) delete process.env[k];
+    });
     afterEach(() => {
         for (const k of ["PIZZAPI_RUNNER_API_KEY", "PIZZAPI_API_KEY", "PIZZAPI_API_TOKEN"]) delete process.env[k];
         Object.assign(process.env, originalEnv);

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -6,16 +6,26 @@ import { runQrSetup, qrCodeUrl, renderQrCode, requestHeadlessPairing } from "./s
 import { _setGlobalConfigDir } from "./config/io.js";
 
 const originalHome = process.env.HOME;
+const originalCredentialEnv = {
+    PIZZAPI_API_KEY: process.env.PIZZAPI_API_KEY,
+    PIZZAPI_RELAY_URL: process.env.PIZZAPI_RELAY_URL,
+};
 let tmpDir: string;
 
 beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-setup-test-"));
     process.env.HOME = tmpDir;
+    delete process.env.PIZZAPI_API_KEY;
+    delete process.env.PIZZAPI_RELAY_URL;
     _setGlobalConfigDir(tmpDir + "/.pizzapi");
 });
 
 afterEach(() => {
     process.env.HOME = originalHome;
+    if (originalCredentialEnv.PIZZAPI_API_KEY === undefined) delete process.env.PIZZAPI_API_KEY;
+    else process.env.PIZZAPI_API_KEY = originalCredentialEnv.PIZZAPI_API_KEY;
+    if (originalCredentialEnv.PIZZAPI_RELAY_URL === undefined) delete process.env.PIZZAPI_RELAY_URL;
+    else process.env.PIZZAPI_RELAY_URL = originalCredentialEnv.PIZZAPI_RELAY_URL;
     _setGlobalConfigDir(null);
     try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
 });


### PR DESCRIPTION
## Night Shift — isolate pairing/API-key tests from ambient credentials

CLI pairing and setup tests previously relied on ambient `PIZZAPI_API_KEY`, so results varied across environments and CI runs.

- `pairing.test.ts` and `setup.test.ts` now clear all API-key credential variables before each relevant test and restore ambient values afterward.
- Tests pass whether `PIZZAPI_API_KEY` is set, unset, or replaced with a synthetic key.
- No production behavior changed; only test setup hardened.

**Verification:** typecheck 0; 24 targeted tests pass in all three credential states; `git diff --check` clean.

Reviewed by GPT-5.6 Sol critic: LGTM, no findings.

Godmother: 6aEbSIz6. 🌙 Autonomous night shift — queued for human review, not auto-merged.
