### PR TITLE
fix(subagent): check abort signal before creating mirror/session

### DIFF
--- a/packages/cli/src/extensions/subagent/engine.test.ts
+++ b/packages/cli/src/extensions/subagent/engine.test.ts
@@ -12,7 +12,20 @@ import { describe, test, expect, mock } from "bun:test";
 delete process.env.PIZZAPI_HIDDEN_MODELS;
 
 const createAgentSessionCalls: unknown[] = [];
+const socketIoCalls: unknown[] = [];
 const fakeRuntime = Object.freeze({ id: "parent-runtime" });
+
+mock.module("socket.io-client", () => ({
+    io: mock(() => {
+        socketIoCalls.push(true);
+        return {
+            on: mock(() => {}),
+            emit: mock(() => {}),
+            disconnect: mock(() => {}),
+            removeAllListeners: mock(() => {}),
+        };
+    }),
+}));
 
 mock.module("@earendil-works/pi-coding-agent", () => ({
     createAgentSession: mock(async (options: unknown) => {
@@ -47,6 +60,46 @@ const noopAgent = {
 };
 
 describe("runSingleAgent model runtime reuse", () => {
+    test("does not create a mirror or session when already aborted", async () => {
+        const envKeys = {
+            apiKey: "PIZZAPI_API_KEY",
+            relayUrl: "PIZZAPI_RELAY_URL",
+            sessionId: "PIZZAPI_SESSION_ID",
+        } as const;
+        const previous = Object.fromEntries(Object.entries(envKeys).map(([key, env]) => [key, process.env[env]]));
+        process.env.PIZZAPI_API_KEY = "key";
+        process.env.PIZZAPI_RELAY_URL = "wss://relay.example";
+        process.env.PIZZAPI_SESSION_ID = "parent-session";
+        const controller = new AbortController();
+        controller.abort();
+        const sessionsBefore = createAgentSessionCalls.length;
+        const socketsBefore = socketIoCalls.length;
+
+        try {
+            await expect(
+                runSingleAgent(
+                    process.cwd(),
+                    [noopAgent],
+                    "noop",
+                    "cancelled task",
+                    undefined,
+                    undefined,
+                    controller.signal,
+                    undefined,
+                    (r) => ({ mode: "single", results: r }) as any,
+                ),
+            ).rejects.toThrow("Subagent was aborted");
+            expect(createAgentSessionCalls).toHaveLength(sessionsBefore);
+            expect(socketIoCalls).toHaveLength(socketsBefore);
+        } finally {
+            for (const [key, env] of Object.entries(envKeys)) {
+                const value = previous[key];
+                if (value === undefined) delete process.env[env];
+                else process.env[env] = value;
+            }
+        }
+    });
+
     test("passes the parent's live ModelRuntime so OAuth/subscription providers work", async () => {
         const registry: any = {
             find: () => undefined,

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -220,6 +220,9 @@ export async function runSingleAgent(
         };
     }
 
+    // Do not create relay listeners or an AgentSession for work already cancelled.
+    if (signal?.aborted) throw new Error("Subagent was aborted");
+
     // Resolve effective tools — apply disallowedTools filtering to both explicit and default toolsets
     let effectiveToolNames: string[] | undefined;
     if (agent.tools && agent.tools.length > 0) {


### PR DESCRIPTION
## Night Shift — check abort signal before creating subagent mirror/session

The subagent engine checked `signal.aborted` only after creating `SubagentMirror` and `AgentSession`, so an already-aborted call would still instantiate a relay socket listener and a session before disposing them.

- `runSingleAgent` now checks `signal.aborted` before creating the mirror or session.
- If already aborted, it returns early without leaking listeners or sessions.
- Regression test verifies zero relay sockets and sessions for an already-aborted signal.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src/extensions/subagent` exit 0 (106 pass, 0 fail).

Reviewed by GPT-5.6 Sol critic: LGTM, no findings.

Godmother: AlJEzoRK. 🌙 Autonomous night shift — queued for human review, not auto-merged.
