### PR TITLE
fix(ui): hide disabled runner-service panel buttons in session toolbar

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4339,7 +4339,7 @@ export function App() {
   }, [activeSessionId, activeSessionInfo?.runnerId, liveSessions]);
 
   // Runner service panels — dynamically discovered
-  const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket, activeRunnerInfo);
+  const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket, activeRunnerInfo);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
   const attentionSessionNames = React.useMemo(() => {
     const names = new Map<string, string>();
@@ -4476,7 +4476,7 @@ export function App() {
   }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition, setServicePanelPosition]);
 
   // ── Service panel buttons in rails/strips ────────────────────────────
-  const visibleServicePanels = useVisibleServicePanels(availableServices, dynamicPanels);
+  const visibleServicePanels = useVisibleServicePanels(availableServices, dynamicPanels, disabledServiceIds);
   const railServicePanels = React.useMemo(
     () => visibleServicePanels.map((p) => ({ ...p, active: activeServicePanels.has(p.serviceId) })),
     [visibleServicePanels, activeServicePanels],
@@ -5038,6 +5038,7 @@ export function App() {
               groups={{ top: buttonPositions.slots["left-top"], middle: buttonPositions.slots["left-middle"], bottom: buttonPositions.slots["left-bottom"] }}
               onDragStart={handleButtonDragStart}
               servicePanels={railServicePanels}
+              disabledServiceIds={disabledServiceIds}
               onToggleServicePanel={handleToggleServicePanelFromDock}
               onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
               onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}
@@ -5119,6 +5120,7 @@ export function App() {
                 buttonIds={buttonPositions.slots["center-top"]}
                 onDragStart={handleButtonDragStart}
                 servicePanels={railServicePanels}
+                disabledServiceIds={disabledServiceIds}
                 onToggleServicePanel={handleToggleServicePanelFromDock}
                 onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
                 onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}
@@ -5224,6 +5226,7 @@ export function App() {
                         extraHeaderButtons={
                           <ServicePanelButtons
                             availableServices={availableServices}
+                            disabledServiceIds={disabledServiceIds}
                             dynamicPanels={dynamicPanels}
                             activePanelIds={activeServicePanels}
                             onTogglePanel={handleToggleServicePanel}
@@ -5234,6 +5237,7 @@ export function App() {
                         extraOverflowItems={
                           <ServicePanelOverflowItems
                             availableServices={availableServices}
+                            disabledServiceIds={disabledServiceIds}
                             dynamicPanels={dynamicPanels}
                             activePanelIds={activeServicePanels}
                             onTogglePanel={handleToggleServicePanel}
@@ -5384,6 +5388,7 @@ export function App() {
               groups={{ top: buttonPositions.slots["right-top"], middle: buttonPositions.slots["right-middle"], bottom: buttonPositions.slots["right-bottom"] }}
               onDragStart={handleButtonDragStart}
               servicePanels={railServicePanels}
+              disabledServiceIds={disabledServiceIds}
               onToggleServicePanel={handleToggleServicePanelFromDock}
               onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
               onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}
@@ -5426,6 +5431,7 @@ export function App() {
             buttonIds={buttonPositions.slots["center-bottom"]}
             onDragStart={handleButtonDragStart}
             servicePanels={railServicePanels}
+            disabledServiceIds={disabledServiceIds}
             onToggleServicePanel={handleToggleServicePanelFromDock}
             onToggleTerminal={() => openPanelFromDockedButton("terminal", showTerminal, setShowTerminal, handleTerminalPositionChange)}
             onToggleFileExplorer={() => openPanelFromDockedButton("files", showFileExplorer, setShowFileExplorer, handleFilesPositionChange)}

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -23,6 +23,14 @@
 
 import { describe, expect, test } from "bun:test";
 import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction } from "../../utils/servicePanelUtils";
+import { filterDisabledServicePanels } from "./ServicePanels";
+
+describe("filterDisabledServicePanels", () => {
+    test("omits disabled service panel buttons", () => {
+        const panels = [{ serviceId: "enabled" }, { serviceId: "disabled" }];
+        expect(filterDisabledServicePanels(panels, new Set(["disabled"]))).toEqual([{ serviceId: "enabled" }]);
+    });
+});
 
 // ── Adding bug: new panel should join the current active group ────────────────
 

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -25,6 +25,10 @@ export interface VisibleServicePanel {
     icon: React.ReactNode;
 }
 
+export function filterDisabledServicePanels<T extends { serviceId: string }>(panels: T[], disabledServiceIds: Set<string>): T[] {
+    return panels.filter((panel) => !disabledServiceIds.has(panel.serviceId));
+}
+
 /**
  * Merged, hidden-filtered list of service panels for the current runner.
  * Static registry panels win over dynamic panels with the same serviceId.
@@ -32,6 +36,7 @@ export interface VisibleServicePanel {
 export function useVisibleServicePanels(
     availableServices: Set<string>,
     dynamicPanels: ServicePanelInfo[] = [],
+    disabledServiceIds: Set<string> = new Set(),
 ): VisibleServicePanel[] {
     const hiddenPanels = useHiddenServicePanels();
     return React.useMemo(() => {
@@ -42,14 +47,15 @@ export function useVisibleServicePanels(
         const dynamics = dynamicPanels
             .filter(p => !staticIds.has(p.serviceId) && !hiddenPanels.has(p.serviceId))
             .map(p => ({ serviceId: p.serviceId, label: p.label, icon: <DynamicLucideIcon name={p.icon} /> }));
-        return [...statics, ...dynamics];
-    }, [availableServices, dynamicPanels, hiddenPanels]);
+        return filterDisabledServicePanels([...statics, ...dynamics], disabledServiceIds);
+    }, [availableServices, dynamicPanels, disabledServiceIds, hiddenPanels]);
 }
 
 // ── Buttons for the header bar ────────────────────────────────────────────────
 
 interface ServicePanelButtonsProps {
     availableServices: Set<string>;
+    disabledServiceIds?: Set<string>;
     /** Dynamic panels announced by runner services at runtime. */
     dynamicPanels?: ServicePanelInfo[];
     activePanelIds: Set<string>;
@@ -62,13 +68,14 @@ interface ServicePanelButtonsProps {
 
 export function ServicePanelButtons({
     availableServices,
+    disabledServiceIds,
     dynamicPanels = [],
     activePanelIds,
     onTogglePanel,
     onButtonDragStart,
     toolbarPositions,
 }: ServicePanelButtonsProps) {
-    const visiblePanels = useVisibleServicePanels(availableServices, dynamicPanels);
+    const visiblePanels = useVisibleServicePanels(availableServices, dynamicPanels, disabledServiceIds);
     const inHeader = (serviceId: string) =>
         (toolbarPositions?.[`service:${serviceId}` as ServiceButtonId] ?? "top") === "top";
 
@@ -113,11 +120,12 @@ export function ServicePanelButtons({
  */
 export function ServicePanelOverflowItems({
     availableServices,
+    disabledServiceIds,
     dynamicPanels = [],
     activePanelIds,
     onTogglePanel,
-}: Pick<ServicePanelButtonsProps, "availableServices" | "dynamicPanels" | "activePanelIds" | "onTogglePanel">) {
-    const visiblePanels = useVisibleServicePanels(availableServices, dynamicPanels);
+}: Pick<ServicePanelButtonsProps, "availableServices" | "disabledServiceIds" | "dynamicPanels" | "activePanelIds" | "onTogglePanel">) {
+    const visiblePanels = useVisibleServicePanels(availableServices, dynamicPanels, disabledServiceIds);
     if (visiblePanels.length === 0) return null;
     return (
         <>

--- a/packages/ui/src/components/session-viewer/ButtonSidebar.tsx
+++ b/packages/ui/src/components/session-viewer/ButtonSidebar.tsx
@@ -26,6 +26,7 @@ export interface CommonButtonProps {
   onDragStart?: (buttonId: ToolbarButtonId) => void;
   /** Metadata for runner service panel buttons (ids of the form "service:<id>"). */
   servicePanels?: ServicePanelButtonMeta[];
+  disabledServiceIds?: Set<string>;
   onToggleServicePanel?: (serviceId: string) => void;
   onToggleTerminal?: () => void;
   onToggleFileExplorer?: () => void;
@@ -94,13 +95,14 @@ function ToolbarButton({
   planModeEnabled,
   tokenUsage,
   servicePanels,
+  disabledServiceIds,
   onToggleServicePanel,
 }: ToolbarButtonRenderProps): React.ReactElement | null {
   if (id.startsWith("service:")) {
     const serviceId = id.slice("service:".length);
     const meta = servicePanels?.find((p) => p.serviceId === serviceId);
-    // Service not available on this runner right now — render nothing.
-    if (!meta) return null;
+    // Service not available or disabled on this runner — render nothing.
+    if (!meta || disabledServiceIds?.has(serviceId)) return null;
     return (
       <DraggableToolbarButton key={id} buttonId={id} onDragStart={onDragStart}>
         <Tooltip>
@@ -207,9 +209,12 @@ function ToolbarButton({
 }
 
 /** Drop service ids whose panel isn't available on the current runner. */
-function renderableIds(ids: ToolbarButtonId[], servicePanels?: ServicePanelButtonMeta[]): ToolbarButtonId[] {
+function renderableIds(ids: ToolbarButtonId[], servicePanels?: ServicePanelButtonMeta[], disabledServiceIds?: Set<string>): ToolbarButtonId[] {
   return ids.filter(
-    (id) => !id.startsWith("service:") || servicePanels?.some((p) => `service:${p.serviceId}` === id),
+    (id) => !id.startsWith("service:") || (
+      !disabledServiceIds?.has(id.slice("service:".length)) &&
+      servicePanels?.some((p) => `service:${p.serviceId}` === id)
+    ),
   );
 }
 
@@ -222,9 +227,9 @@ export function ButtonRail({
   groups: { top: ToolbarButtonId[]; middle: ToolbarButtonId[]; bottom: ToolbarButtonId[] };
 }): React.ReactElement | null {
   const groups = {
-    top: renderableIds(rawGroups.top, rest.servicePanels),
-    middle: renderableIds(rawGroups.middle, rest.servicePanels),
-    bottom: renderableIds(rawGroups.bottom, rest.servicePanels),
+    top: renderableIds(rawGroups.top, rest.servicePanels, rest.disabledServiceIds),
+    middle: renderableIds(rawGroups.middle, rest.servicePanels, rest.disabledServiceIds),
+    bottom: renderableIds(rawGroups.bottom, rest.servicePanels, rest.disabledServiceIds),
   };
   if (groups.top.length === 0 && groups.middle.length === 0 && groups.bottom.length === 0) {
     return null;
@@ -267,7 +272,7 @@ export function ButtonStrip({
   position: "center-top" | "center-bottom";
   buttonIds: ToolbarButtonId[];
 }): React.ReactElement | null {
-  const buttonIds = renderableIds(rawButtonIds, rest.servicePanels);
+  const buttonIds = renderableIds(rawButtonIds, rest.servicePanels, rest.disabledServiceIds);
   if (buttonIds.length === 0) return null;
 
   const tooltipSide = position === "center-top" ? "bottom" : "top";


### PR DESCRIPTION
## Night Shift — hide disabled runner-service panel buttons in session toolbar

Disabled runner services were still rendering panel buttons in the session toolbar, cluttering the UI and offering dead actions.

- Toolbar rendering now consumes `useRunnerServices.disabledServiceIds`/`disabledServices`.
- Disabled buttons are filtered from the header, overflow menu, left/right rails, and top/bottom strips.
- Regression test retains enabled services while removing disabled ones.

**Verification:** `cd packages/ui && bun test src` exit 0 (1293 pass, 1 skip); `bun run typecheck` exit 0.

Reviewed by GPT-5.6 Sol critic: LGTM, no findings.

Godmother: JWrMTxiS. 🌙 Autonomous night shift — queued for human review, not auto-merged.
