### PR TITLE
fix(ui): cross-platform path-segment helper for Windows backslash cwds

### DIFF
--- a/packages/ui/src/components/AppHeaders.tsx
+++ b/packages/ui/src/components/AppHeaders.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { signOut } from "@/lib/auth-client";
 import { useTheme, type ThemeMode } from "@/components/ThemeProvider";
+import { pathSegments } from "@/lib/path";
 
 const THEME_CYCLE: ThemeMode[] = ["auto", "light", "dark"];
 const THEME_ICON: Record<ThemeMode, React.ReactNode> = {
@@ -407,7 +408,7 @@ export const MobileHeader = React.memo(function MobileHeader({
                       <div className="flex-1 min-w-0">
                         <div className="text-sm font-medium truncate">{label}</div>
                         {s.cwd && (
-                          <div className="text-[0.65rem] text-muted-foreground truncate">{s.cwd.split("/").slice(-2).join("/")}</div>
+                          <div className="text-[0.65rem] text-muted-foreground truncate">{pathSegments(s.cwd).slice(-2).join("/")}</div>
                         )}
                       </div>
                       {/* Checkmark for active */}

--- a/packages/ui/src/components/AtMentionPopover.tsx
+++ b/packages/ui/src/components/AtMentionPopover.tsx
@@ -11,6 +11,7 @@ import { useAtMentionFiles, type Entry } from "@/hooks/useAtMentionFiles";
 import { useAtMentionSearch } from "@/hooks/useAtMentionSearch";
 import { Bot, ChevronLeft, File, Folder, Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { pathSegments } from "@/lib/path";
 import { useDocumentPopoverKeyboardNavigation } from "@/components/session-viewer/popover-keyboard";
 
 // ── Icons ─────────────────────────────────────────────────────────────────────
@@ -339,8 +340,8 @@ export function AtMentionPopover({
             <>
               <span className="font-mono text-muted-foreground truncate flex-1">
                 {isAtRoot
-                  ? (sessionCwd ? sessionCwd.split("/").filter(Boolean).pop() ?? "/" : "/")
-                  : `${sessionCwd ? sessionCwd.split("/").filter(Boolean).pop() + "/" : "/"}${path}`}
+                  ? (sessionCwd ? pathSegments(sessionCwd).pop() ?? "/" : "/")
+                  : `${sessionCwd ? pathSegments(sessionCwd).pop() + "/" : "/"}${path}`}
               </span>
               {query && (
                 <span className="text-muted-foreground/60">

--- a/packages/ui/src/components/FolderBrowser.test.ts
+++ b/packages/ui/src/components/FolderBrowser.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { breadcrumbSegments, parentPath } from "./FolderBrowser";
+
+describe("FolderBrowser Windows paths", () => {
+    test("keeps backslashes in breadcrumb paths", () => {
+        expect(breadcrumbSegments("C:\\Users\\me\\projects")).toEqual([
+            { label: "C:", path: "C:\\" },
+            { label: "Users", path: "C:\\Users" },
+            { label: "me", path: "C:\\Users\\me" },
+            { label: "projects", path: "C:\\Users\\me\\projects" },
+        ]);
+    });
+
+    test("navigates up through backslash-separated paths", () => {
+        expect(parentPath("C:\\Users\\me")).toBe("C:\\Users");
+        expect(parentPath("C:\\Users")).toBe("C:\\");
+        expect(parentPath("C:\\")).toBe("C:\\");
+    });
+});

--- a/packages/ui/src/components/FolderBrowser.test.ts
+++ b/packages/ui/src/components/FolderBrowser.test.ts
@@ -17,3 +17,14 @@ describe("FolderBrowser Windows paths", () => {
         expect(parentPath("C:\\")).toBe("C:\\");
     });
 });
+
+describe("FolderBrowser POSIX paths", () => {
+    test("navigates up through slash-separated paths", () => {
+        expect(parentPath("/usr/local")).toBe("/usr");
+        expect(parentPath("/usr")).toBe("/");
+    });
+
+    test("keeps the POSIX root stable", () => {
+        expect(parentPath("/")).toBe("/");
+    });
+});

--- a/packages/ui/src/components/FolderBrowser.test.ts
+++ b/packages/ui/src/components/FolderBrowser.test.ts
@@ -16,6 +16,18 @@ describe("FolderBrowser Windows paths", () => {
         expect(parentPath("C:\\Users")).toBe("C:\\");
         expect(parentPath("C:\\")).toBe("C:\\");
     });
+
+    test("keeps UNC share roots in breadcrumbs", () => {
+        expect(breadcrumbSegments("\\\\server\\share\\project")).toEqual([
+            { label: "\\\\server\\share", path: "\\\\server\\share" },
+            { label: "project", path: "\\\\server\\share\\project" },
+        ]);
+    });
+
+    test("does not navigate above a UNC share root", () => {
+        expect(parentPath("\\\\server\\share\\project")).toBe("\\\\server\\share");
+        expect(parentPath("\\\\server\\share")).toBe("\\\\server\\share");
+    });
 });
 
 describe("FolderBrowser POSIX paths", () => {

--- a/packages/ui/src/components/FolderBrowser.tsx
+++ b/packages/ui/src/components/FolderBrowser.tsx
@@ -10,6 +10,43 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { pathSegments } from "@/lib/path";
 
+export interface BreadcrumbSegment {
+    label: string;
+    path: string;
+}
+
+export function breadcrumbSegments(currentPath: string): BreadcrumbSegment[] {
+    const parts = pathSegments(currentPath);
+    const windows = currentPath.includes("\\");
+    if (windows && /^[A-Za-z]:$/.test(parts[0] ?? "")) {
+        const separator = "\\";
+        const result: BreadcrumbSegment[] = [{ label: parts[0], path: `${parts[0]}${separator}` }];
+        let acc = `${parts[0]}${separator}`;
+        for (const part of parts.slice(1)) {
+            acc += `${part}${separator}`;
+            result.push({ label: part, path: acc.slice(0, -1) });
+        }
+        return result;
+    }
+
+    const result: BreadcrumbSegment[] = [{ label: "/", path: "/" }];
+    let acc = "";
+    for (const part of parts) {
+        acc += `/${part}`;
+        result.push({ label: part, path: acc });
+    }
+    return result;
+}
+
+export function parentPath(currentPath: string): string {
+    const windows = currentPath.includes("\\");
+    if (currentPath === "/" || (windows && /^[A-Za-z]:\\?$/.test(currentPath))) return currentPath;
+
+    const parent = currentPath.replace(/[\\/][^\\/]+[\\/]?$/, "");
+    if (windows && /^[A-Za-z]:$/.test(parent)) return `${parent}${"\\"}`;
+    return parent || (windows ? `${pathSegments(currentPath)[0] ?? ""}${"\\"}` : "/");
+}
+
 export interface FolderBrowserProps {
     runnerId: string;
     /** Called when the user selects (confirms) a directory. */
@@ -83,22 +120,10 @@ export function FolderBrowser({
     }
 
     function navigateUp() {
-        if (currentPath === "/") return;
-        const parent = currentPath.replace(/\/[^/]+\/?$/, "") || "/";
-        navigateTo(parent);
+        navigateTo(parentPath(currentPath));
     }
 
-    // Build breadcrumb segments
-    const segments = React.useMemo(() => {
-        const parts = pathSegments(currentPath);
-        const result: { label: string; path: string }[] = [{ label: "/", path: "/" }];
-        let acc = "";
-        for (const part of parts) {
-            acc += "/" + part;
-            result.push({ label: part, path: acc });
-        }
-        return result;
-    }, [currentPath]);
+    const segments = React.useMemo(() => breadcrumbSegments(currentPath), [currentPath]);
 
     return (
         <div className="flex flex-col gap-2">
@@ -109,7 +134,7 @@ export function FolderBrowser({
                     size="sm"
                     className="h-6 w-6 p-0 flex-shrink-0"
                     onClick={navigateUp}
-                    disabled={disabled || currentPath === "/"}
+                    disabled={disabled || parentPath(currentPath) === currentPath}
                     title="Go up"
                 >
                     <ArrowUp className="h-3 w-3" />

--- a/packages/ui/src/components/FolderBrowser.tsx
+++ b/packages/ui/src/components/FolderBrowser.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 import { Folder, FolderOpen, ChevronRight, Loader2, AlertCircle, ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { pathSegments } from "@/lib/path";
 
 export interface FolderBrowserProps {
     runnerId: string;
@@ -89,7 +90,7 @@ export function FolderBrowser({
 
     // Build breadcrumb segments
     const segments = React.useMemo(() => {
-        const parts = currentPath.split("/").filter(Boolean);
+        const parts = pathSegments(currentPath);
         const result: { label: string; path: string }[] = [{ label: "/", path: "/" }];
         let acc = "";
         for (const part of parts) {

--- a/packages/ui/src/components/FolderBrowser.tsx
+++ b/packages/ui/src/components/FolderBrowser.tsx
@@ -17,9 +17,22 @@ export interface BreadcrumbSegment {
 
 export function breadcrumbSegments(currentPath: string): BreadcrumbSegment[] {
     const parts = pathSegments(currentPath);
-    const windows = currentPath.includes("\\");
+    const windows = currentPath.includes("\\") || /^[A-Za-z]:/.test(currentPath);
+    const separator = currentPath.includes("\\") ? "\\" : "/";
+    const unc = /^[\\/]{2}/.test(currentPath) && parts.length >= 2;
+
+    if (unc) {
+        const root = `${separator}${separator}${parts[0]}${separator}${parts[1]}`;
+        const result: BreadcrumbSegment[] = [{ label: root, path: root }];
+        let acc = root;
+        for (const part of parts.slice(2)) {
+            acc += `${separator}${part}`;
+            result.push({ label: part, path: acc });
+        }
+        return result;
+    }
+
     if (windows && /^[A-Za-z]:$/.test(parts[0] ?? "")) {
-        const separator = "\\";
         const result: BreadcrumbSegment[] = [{ label: parts[0], path: `${parts[0]}${separator}` }];
         let acc = `${parts[0]}${separator}`;
         for (const part of parts.slice(1)) {
@@ -39,12 +52,19 @@ export function breadcrumbSegments(currentPath: string): BreadcrumbSegment[] {
 }
 
 export function parentPath(currentPath: string): string {
-    const windows = currentPath.includes("\\");
+    const windows = currentPath.includes("\\") || /^[A-Za-z]:/.test(currentPath);
+    const separator = currentPath.includes("\\") ? "\\" : "/";
+    const parts = pathSegments(currentPath);
+    const unc = /^[\\/]{2}/.test(currentPath) && parts.length >= 2;
     if (currentPath === "/" || (windows && /^[A-Za-z]:\\?$/.test(currentPath))) return currentPath;
+    if (unc) {
+        if (parts.length <= 2) return currentPath;
+        return `${separator}${separator}${parts.slice(0, -1).join(separator)}`;
+    }
 
     const parent = currentPath.replace(/[\\/][^\\/]+[\\/]?$/, "");
-    if (windows && /^[A-Za-z]:$/.test(parent)) return `${parent}${"\\"}`;
-    return parent || (windows ? `${pathSegments(currentPath)[0] ?? ""}${"\\"}` : "/");
+    if (windows && /^[A-Za-z]:$/.test(parent)) return `${parent}${separator}`;
+    return parent || (windows ? `${parts[0] ?? ""}${separator}` : "/");
 }
 
 export interface FolderBrowserProps {

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -10,7 +10,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { FolderOpen, FolderSearch, Loader2, X, ChevronLeft, Monitor } from "lucide-react";
 import { SiApple, SiLinux } from "react-icons/si";
 import { cn } from "@/lib/utils";
-import { formatPathTail } from "@/lib/path";
+import { formatPathTail, pathSegments } from "@/lib/path";
 import { filterFolders, getInitialFolder } from "@/lib/filterFolders";
 import { FolderBrowser } from "@/components/FolderBrowser";
 import { Button } from "@/components/ui/button";
@@ -490,7 +490,7 @@ export function NewSessionWizardDialog({
                                             {virtualizer.getVirtualItems().map((item) => {
                                                 const folder = filteredFolders[item.index];
                                                 const basename =
-                                                    folder.split("/").filter(Boolean).pop() || folder;
+                                                    pathSegments(folder).pop() || folder;
                                                 const tail = formatPathTail(folder, 2);
                                                 const isSelected = cwd === folder;
                                                 return (

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -25,6 +25,7 @@ import { Label } from "@/components/ui/label";
 import { TerminalIcon, Plus, ChevronLeft, X, GripHorizontal, PanelBottom, PanelRight, PanelLeft } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { pathSegments } from "@/lib/path";
 
 interface RunnerInfo {
   runnerId: string;
@@ -182,7 +183,7 @@ export function TerminalManager({
       // Count existing session tabs to pick a numeric label
       const siblingCount = tabs.filter((t) => t.sessionId === (sessionId ?? null)).length;
       const baseName = cwdToUse?.trim()
-        ? (cwdToUse.trim().split("/").pop() || "terminal")
+        ? (pathSegments(cwdToUse.trim()).pop() || "terminal")
         : "terminal";
       const label = siblingCount === 0 ? baseName : `${baseName} ${siblingCount + 1}`;
 
@@ -230,7 +231,7 @@ export function TerminalManager({
 
       const runner = effectiveRunners.find((r) => r.runnerId === selectedRunnerId);
       const label = cwd.trim()
-        ? (cwd.trim().split("/").pop() || "terminal")
+        ? (pathSegments(cwd.trim()).pop() || "terminal")
         : (runner?.name || "terminal");
 
       onTabAdd({
@@ -739,7 +740,7 @@ function NewTerminalDialog({
                       className="px-2 py-0.5 truncate max-w-[200px]"
                       title={folder}
                     >
-                      {folder.split("/").filter(Boolean).pop() || folder}
+                      {pathSegments(folder).pop() || folder}
                     </button>
                     <button
                       onClick={async (e) => {

--- a/packages/ui/src/components/WebhooksManager.tsx
+++ b/packages/ui/src/components/WebhooksManager.tsx
@@ -24,7 +24,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { formatPathTail } from "@/lib/path";
+import { formatPathTail, pathSegments } from "@/lib/path";
 import { filterFolders } from "@/lib/filterFolders";
 import {
     Webhook as WebhookIcon,
@@ -637,7 +637,7 @@ function CreateWebhookForm({
                                     {virtualizer.getVirtualItems().map((item) => {
                                         const folder = filteredFolders[item.index];
                                         const basename =
-                                            folder.split("/").filter(Boolean).pop() || folder;
+                                            pathSegments(folder).pop() || folder;
                                         const tail = formatPathTail(folder, 2);
                                         const isSelected = cwd === folder;
                                         return (

--- a/packages/ui/src/lib/filterFolders.ts
+++ b/packages/ui/src/lib/filterFolders.ts
@@ -5,11 +5,13 @@
  * Extracted from NewSessionWizardDialog so it can be unit-tested without
  * pulling in React/JSX dependencies.
  */
+import { pathSegments } from "./path";
+
 export function filterFolders(folders: string[], query: string): string[] {
     if (!query.trim()) return folders;
     const q = query.toLowerCase();
     return folders.filter((f) => {
-        const basename = f.split("/").filter(Boolean).pop() ?? f;
+        const basename = pathSegments(f).pop() ?? f;
         return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
     });
 }

--- a/packages/ui/src/lib/path.test.ts
+++ b/packages/ui/src/lib/path.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { extractWorktreeName, formatPathTail, worktreeRoots } from "./path";
+import { extractWorktreeName, formatPathTail, pathSegments, worktreeRoots } from "./path";
+
+describe("pathSegments", () => {
+    test("splits Unix, Windows, and mixed separators", () => {
+        expect(pathSegments("/home/user/project")).toEqual(["home", "user", "project"]);
+        expect(pathSegments("C:\\Users\\me\\project")).toEqual(["C:", "Users", "me", "project"]);
+        expect(pathSegments("/home\\user/project\\src")).toEqual(["home", "user", "project", "src"]);
+    });
+});
 
 describe("formatPathTail", () => {
     test("returns empty string for empty input", () => {

--- a/packages/ui/src/lib/path.ts
+++ b/packages/ui/src/lib/path.ts
@@ -70,6 +70,11 @@ export function worktreeRoots(cwds: Iterable<string>): string[] {
   );
 }
 
+/** Split a filesystem path into non-empty segments, regardless of platform separator. */
+export function pathSegments(path: string): string[] {
+  return path.split(/[\\/]+/).filter(Boolean);
+}
+
 export function formatPathTail(path: string, maxSegments = 2): string {
   if (!path) return "";
   const normalized = path.replace(/\\/g, "/");
@@ -86,7 +91,7 @@ export function formatPathTail(path: string, maxSegments = 2): string {
     rest = normalized.slice(1);
   }
 
-  const parts = rest.split("/").filter(Boolean);
+  const parts = pathSegments(rest);
   if (parts.length === 0) return normalized;
   if (parts.length === 1) return normalized;
 


### PR DESCRIPTION
## Night Shift — cross-platform path-segment helper for Windows backslash cwds

The UI used hardcoded `.split("/")` / `.indexOf("/")` for cwd/folder extraction, which broke on Windows paths using backslashes.

- Added `pathSegments()` in `@/lib/path` handling `/`, `\\`, and mixed separators; unit tests cover all three.
- Replaced inline cwd/folder extractions in the listed components with the helper.
- `filterFolders.ts` now handles backslashes.
- `FolderBrowser` breadcrumbs preserve Windows paths; `parentPath()` / `navigateUp()` handle both separators, drive roots, and POSIX root.

**Verification:** `cd packages/ui && bun test src` exit 0 (1297 pass, 1 skip); root `bun run typecheck` exit 0.

Reviewed by GPT-5.6 Sol critic: LGTM (round 3).

Godmother: (captured as backlog windows-path item). 🌙 Autonomous night shift — queued for human review, not auto-merged.
