### PR TITLE
fix(cli): default wait_for_message timeout to indefinite

### DIFF
--- a/packages/cli/src/extensions/session-messaging.test.ts
+++ b/packages/cli/src/extensions/session-messaging.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { messageBus } from "./session-message-bus.js";
+import { sessionMessagingExtension } from "./session-messaging.js";
+
+function getWaitTool() {
+    let waitTool: any;
+    sessionMessagingExtension({
+        registerTool(tool: any) {
+            if (tool.name === "wait_for_message") waitTool = tool;
+        },
+    } as any);
+    return waitTool;
+}
+
+describe("wait_for_message", () => {
+    beforeEach(() => messageBus.resetForTests());
+
+    test("waits indefinitely by default", async () => {
+        const tool = getWaitTool();
+        const pending = tool.execute("call", {}, new AbortController().signal);
+
+        await Bun.sleep(25);
+        expect(await Promise.race([pending.then(() => true), Bun.sleep(0).then(() => false)])).toBe(false);
+
+        messageBus.receive({ fromSessionId: "sender", message: "hello", ts: new Date().toISOString() });
+        expect((await pending).content[0].text).toContain("hello");
+    });
+});

--- a/packages/cli/src/extensions/session-messaging.test.ts
+++ b/packages/cli/src/extensions/session-messaging.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { messageBus } from "./session-message-bus.js";
 import { sessionMessagingExtension } from "./session-messaging.js";
 
@@ -15,14 +15,26 @@ function getWaitTool() {
 describe("wait_for_message", () => {
     beforeEach(() => messageBus.resetForTests());
 
-    test("waits indefinitely by default", async () => {
+    test("waits indefinitely by default without scheduling a timeout", async () => {
+        const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+        try {
+            const tool = getWaitTool();
+            const pending = tool.execute("call", {}, new AbortController().signal);
+
+            expect(setTimeoutSpy.mock.calls.some(([delay]) => typeof delay === "number" && delay > 0)).toBe(false);
+
+            messageBus.receive({ fromSessionId: "sender", message: "hello", ts: new Date().toISOString() });
+            expect((await pending).content[0].text).toContain("hello");
+        } finally {
+            setTimeoutSpy.mockRestore();
+        }
+    });
+
+    test("returns timedOut for an explicit timeout", async () => {
         const tool = getWaitTool();
-        const pending = tool.execute("call", {}, new AbortController().signal);
 
-        await Bun.sleep(25);
-        expect(await Promise.race([pending.then(() => true), Bun.sleep(0).then(() => false)])).toBe(false);
+        const result = await tool.execute("call", { timeout: 0.02 }, new AbortController().signal);
 
-        messageBus.receive({ fromSessionId: "sender", message: "hello", ts: new Date().toISOString() });
-        expect((await pending).content[0].text).toContain("hello");
+        expect(result.details).toMatchObject({ received: false, timedOut: true });
     });
 });

--- a/packages/cli/src/extensions/session-messaging.test.ts
+++ b/packages/cli/src/extensions/session-messaging.test.ts
@@ -21,7 +21,7 @@ describe("wait_for_message", () => {
             const tool = getWaitTool();
             const pending = tool.execute("call", {}, new AbortController().signal);
 
-            expect(setTimeoutSpy.mock.calls.some(([delay]) => typeof delay === "number" && delay > 0)).toBe(false);
+            expect(setTimeoutSpy.mock.calls.some(([, delay]) => typeof delay === "number" && delay > 0)).toBe(false);
 
             messageBus.receive({ fromSessionId: "sender", message: "hello", ts: new Date().toISOString() });
             expect((await pending).content[0].text).toContain("hello");

--- a/packages/cli/src/extensions/session-messaging.ts
+++ b/packages/cli/src/extensions/session-messaging.ts
@@ -69,9 +69,9 @@ export const sessionMessagingExtension: ExtensionFactory = (pi) => {
         label: "Wait for Message",
         description:
             "Wait for a message from another agent session. Blocks until a message " +
-            "arrives or the timeout expires. Use this to receive messages in a " +
+            "arrives or the optional timeout expires. Use this to receive messages in a " +
             "conversation with another agent. If fromSessionId is omitted, waits " +
-            "for a message from any session.",
+            "for a message from any session. Without a timeout, waits indefinitely.",
         parameters: {
             type: "object",
             properties: {
@@ -84,8 +84,8 @@ export const sessionMessagingExtension: ExtensionFactory = (pi) => {
                 timeout: {
                     type: "number",
                     description:
-                        "Maximum time to wait in seconds. Defaults to 120. " +
-                        "Returns null if no message arrives within this time.",
+                        "Optional maximum time to wait in seconds. Without a timeout, " +
+                        "waits indefinitely. Returns null if no message arrives within this time.",
                 },
             },
             required: [],
@@ -99,29 +99,26 @@ export const sessionMessagingExtension: ExtensionFactory = (pi) => {
             });
 
             const fromSessionId = params.fromSessionId?.trim() || null;
-            const timeoutSec = typeof params.timeout === "number" && params.timeout > 0 ? params.timeout : 120;
+            const timeoutSec = typeof params.timeout === "number" && params.timeout > 0 ? params.timeout : undefined;
 
-            // Create a timeout abort signal, merged with the tool's signal.
-            const timeoutController = new AbortController();
-            const timer = setTimeout(() => timeoutController.abort(), timeoutSec * 1000);
-
-            // Merge the tool abort signal with our timeout.
+            // Merge the tool abort signal with an optional timeout.
+            const timeoutController = timeoutSec === undefined ? undefined : new AbortController();
             const mergedController = new AbortController();
             const onToolAbort = () => mergedController.abort();
             const onTimeoutAbort = () => mergedController.abort();
             signal?.addEventListener("abort", onToolAbort, { once: true });
-            timeoutController.signal.addEventListener("abort", onTimeoutAbort, { once: true });
+            timeoutController?.signal.addEventListener("abort", onTimeoutAbort, { once: true });
+            const timer = timeoutSec === undefined ? undefined : setTimeout(() => timeoutController!.abort(), timeoutSec * 1000);
 
             try {
                 const msg = await messageBus.waitForMessage(fromSessionId, mergedController.signal);
-                clearTimeout(timer);
 
                 if (!msg) {
                     return ok(
-                        timeoutController.signal.aborted
+                        timeoutController?.signal.aborted
                             ? `No message received within ${timeoutSec} seconds.`
                             : "Wait was cancelled.",
-                        { received: false, timedOut: timeoutController.signal.aborted },
+                        { received: false, timedOut: timeoutController?.signal.aborted ?? false },
                     );
                 }
 
@@ -135,9 +132,9 @@ export const sessionMessagingExtension: ExtensionFactory = (pi) => {
                     },
                 );
             } finally {
-                clearTimeout(timer);
+                if (timer !== undefined) clearTimeout(timer);
                 signal?.removeEventListener("abort", onToolAbort);
-                timeoutController.signal.removeEventListener("abort", onTimeoutAbort);
+                timeoutController?.signal.removeEventListener("abort", onTimeoutAbort);
             }
         },
 


### PR DESCRIPTION
## Night Shift — default `wait_for_message` timeout to indefinite

`wait_for_message` had a hard-coded 120-second default timeout, so plan_mode proposals, AskUserQuestion prompts, and subagent waits could silently time out even while a user was actively interacting.

- Default timeout is now indefinite (no timeout scheduled when the argument is omitted).
- Explicit positive timeouts remain supported and still work.
- Regression test proves no positive timeout is scheduled by default, and a short explicit timeout still returns `timedOut: true`.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src/extensions/session-messaging.test.ts` exit 0 (2 pass, 0 fail).

Reviewed by GPT-5.6 Sol critic: LGTM (round 3).

Godmother: gLzigHzN. 🌙 Autonomous night shift — queued for human review, not auto-merged.
