### PR TITLE
fix(config): allowProjectMcp now gates project-level MCP server loading

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -515,7 +515,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcpServers.godmother.command).toBe("godmother");
   });
 
-  test("project-only mcpServers loads with warning (warn-and-load default)", () => {
+  test("project-only mcpServers is excluded by default", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
 
     const projectDir = join(tempDir, "project");
@@ -530,9 +530,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     );
 
     const config = loadConfig(projectDir) as any;
-    // Project MCP servers load by default (warning is emitted but loading is not blocked)
-    expect(config.mcpServers).toBeDefined();
-    expect(config.mcpServers.playwright.command).toBe("npx");
+    expect(config.mcpServers).toBeUndefined();
   });
 
   test("project-only mcpServers passes through when allowProjectMcp: true", () => {
@@ -656,7 +654,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcp.servers[0].name).toBe("playwright");
   });
 
-  test("mcp.servers from project loads with warning (warn-and-load default)", () => {
+  test("mcp.servers from project is excluded by default", () => {
     writeFileSync(
       join(globalDir, "config.json"),
       JSON.stringify({
@@ -682,10 +680,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     const config = loadConfig(projectDir) as any;
     // mcpServers from global still loads
     expect(config.mcpServers.godmother.command).toBe("godmother");
-    // mcp.servers from project also loads (warning is emitted but loading is not blocked)
-    expect(config.mcp).toBeDefined();
-    const names = config.mcp.servers.map((s: any) => s.name);
-    expect(names).toContain("playwright");
+    expect(config.mcp).toBeUndefined();
   });
 
   test("project mcpServers allowed via PIZZAPI_ALLOW_PROJECT_MCP env var", () => {
@@ -1013,7 +1008,7 @@ describe("loadConfig transport field blocking", () => {
     expect(warn).toHaveBeenCalledTimes(2);
     const messages = warn.mock.calls.map((call) => String(call[2]));
     expect(messages).toContain("Project config .pizzapi/config.json contains 'apiKey' — global config value will be used instead. Set it in ~/.pizzapi/config.json only.");
-    expect(messages).toContain('Project MCP servers found in .pizzapi/config.json. Set "allowProjectMcp": true in ~/.pizzapi/config.json or PIZZAPI_ALLOW_PROJECT_MCP=1 to suppress this warning.');
+    expect(messages).toContain('Project MCP servers found in .pizzapi/config.json. Set "allowProjectMcp": true in ~/.pizzapi/config.json or PIZZAPI_ALLOW_PROJECT_MCP=1 to enable loading.');
   });
 
   test("global relayUrl is preserved when project also sets relayUrl", () => {

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -292,21 +292,19 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const hasProjectMcp =
         (rawProjectMcpServers !== undefined && Object.keys(rawProjectMcpServers).length > 0) ||
         (Array.isArray(rawProjectMcp?.servers) && rawProjectMcp.servers.length > 0);
-    // P0 fix: warn-and-load by default. allowProjectMcp/PIZZAPI_ALLOW_PROJECT_MCP silences
-    // the warning rather than being required to enable loading.
     if (hasProjectMcp && !projectMcpTrusted) {
         warnLoadConfigOnce(
             projectPath,
             "project-mcp-untrusted",
             "Project MCP servers found in .pizzapi/config.json. " +
                 'Set "allowProjectMcp": true in ~/.pizzapi/config.json or ' +
-                "PIZZAPI_ALLOW_PROJECT_MCP=1 to suppress this warning.",
+                "PIZZAPI_ALLOW_PROJECT_MCP=1 to enable loading.",
         );
     }
 
-    // Always include project MCP servers (trust flag only silences the warning above).
-    const projectMcpServers = rawProjectMcpServers;
-    const projectMcp = rawProjectMcp;
+    // Project MCP servers are loaded only when explicitly trusted.
+    const projectMcpServers = projectMcpTrusted ? rawProjectMcpServers : undefined;
+    const projectMcp = projectMcpTrusted ? rawProjectMcp : undefined;
 
     // Always overwrite or delete mcpServers — the initial { ...global, ...project } spread
     // may have placed project.mcpServers into config before the trust gate could block it.

--- a/packages/cli/src/config/trust-gates.test.ts
+++ b/packages/cli/src/config/trust-gates.test.ts
@@ -117,9 +117,9 @@ describe("allowProjectHooks (enforced gate)", () => {
     });
 });
 
-// ── 2. allowProjectMcp — WARN-ONLY (not enforced) ───────────────────────────
+// ── 2. allowProjectMcp — ENFORCED ────────────────────────────────────────────
 
-describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)", () => {
+describe("allowProjectMcp (enforced gate)", () => {
     test("isProjectMcpTrusted defaults to false with no config", () => {
         expect(isProjectMcpTrusted({})).toBe(false);
     });
@@ -133,12 +133,7 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
         expect(isProjectMcpTrusted({ allowProjectMcp: false })).toBe(true);
     });
 
-    // CRITICAL: this is the "warn-and-load" behavior (see io.ts loadConfig,
-    // ~"P0 fix: warn-and-load by default"). The flag only silences the
-    // warning — it does NOT gate whether the servers are merged into config.
-    // A future unification must preserve this unless a deliberate behavior
-    // change is made and documented.
-    test("mcpServers format: project servers ARE MERGED even when untrusted (flag absent)", () => {
+    test("mcpServers format: project servers are dropped when untrusted, global servers remain", () => {
         writeGlobalConfig({
             mcpServers: { globalServer: { command: "global-cmd" } },
         });
@@ -149,11 +144,10 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
         const config = loadConfig(projectDir);
         expect((config as any).mcpServers).toEqual({
             globalServer: { command: "global-cmd" },
-            projectServer: { command: "project-cmd" },
         });
     });
 
-    test("mcpServers format: project servers ARE MERGED even when allowProjectMcp: false explicitly", () => {
+    test("mcpServers format: project servers are dropped when allowProjectMcp: false", () => {
         writeGlobalConfig({
             allowProjectMcp: false,
             mcpServers: { globalServer: { command: "global-cmd" } },
@@ -163,10 +157,10 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
         });
 
         const config = loadConfig(projectDir);
-        expect((config as any).mcpServers).toHaveProperty("projectServer");
+        expect((config as any).mcpServers).not.toHaveProperty("projectServer");
     });
 
-    test("mcp.servers (array) format: project servers ARE MERGED even when untrusted", () => {
+    test("mcp.servers (array) format: project servers are dropped when untrusted", () => {
         writeGlobalConfig({
             mcp: { servers: [{ name: "global-srv", command: "g" }] },
         });
@@ -176,11 +170,12 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
 
         const config = loadConfig(projectDir);
         const names = ((config as any).mcp.servers as Array<{ name: string }>).map((s) => s.name);
-        expect(names.sort()).toEqual(["global-srv", "project-srv"]);
+        expect(names).toEqual(["global-srv"]);
     });
 
-    test("mcp.servers (array) format: project entry with same name overwrites global entry, still merged when untrusted", () => {
+    test("mcp.servers (array) format: trusted project entry overwrites global entry", () => {
         writeGlobalConfig({
+            allowProjectMcp: true,
             mcp: { servers: [{ name: "shared", command: "global-version" }] },
         });
         writeProjectConfig({
@@ -193,7 +188,7 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
         expect(servers[0].command).toBe("project-version");
     });
 
-    test("warns once (console.warn) when project mcpServers present and flag not set, but STILL loads them on every call — the warning itself is deduped, not the loading", () => {
+    test("warns once when project mcpServers present and flag not set, and drops them", () => {
         const warnCalls: unknown[][] = [];
         const orig = console.warn;
         console.warn = (...args: unknown[]) => { warnCalls.push(args); };
@@ -204,24 +199,23 @@ describe("allowProjectMcp (warn-only gate — CRITICAL: servers load regardless)
             });
 
             const config = loadConfig(projectDir);
-            expect((config as any).mcpServers).toHaveProperty("projectServer");
+            expect((config as any).mcpServers).not.toHaveProperty("projectServer");
             const joined = warnCalls.map((a) => a.join(" ")).join("\n");
             expect(joined).toContain("Project MCP servers found");
             expect(warnCalls.length).toBe(1);
 
-            // Second load of the SAME project: servers are still merged (the
-            // gate never blocks loading — see describe title), but the warning
-            // does not fire again. warnLoadConfigOnce dedupes per (projectPath,
-            // code, message) for the lifetime of the process.
+            // Second load of the SAME project: the warning does not fire again.
+            // warnLoadConfigOnce dedupes per (projectPath, code, message) for
+            // the lifetime of the process.
             const config2 = loadConfig(projectDir);
-            expect((config2 as any).mcpServers).toHaveProperty("projectServer");
+            expect((config2 as any).mcpServers).not.toHaveProperty("projectServer");
             expect(warnCalls.length).toBe(1);
         } finally {
             console.warn = orig;
         }
     });
 
-    test("no warning when allowProjectMcp: true (still loads, silences the warning)", () => {
+    test("allowProjectMcp: true loads project servers without warning", () => {
         const warnCalls: unknown[][] = [];
         const orig = console.warn;
         console.warn = (...args: unknown[]) => { warnCalls.push(args); };

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -399,8 +399,8 @@ export interface PizzaPiConfig {
      * PIZZAPI_ALLOW_PROJECT_MCP=1 env var). Project configs cannot
      * self-authorize.
      *
-     * When false/unset, project MCP servers are still loaded but a security
-     * warning is printed. Set to true to suppress the warning.
+     * When false/unset, project MCP servers are excluded and a security
+     * warning is printed. Set to true to allow loading them.
      */
     allowProjectMcp?: boolean;
 

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -24,7 +24,8 @@ describe("toolSearchExtension lifecycle sync", () => {
 
     mkdirSync(globalConfigDir, { recursive: true });
     mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
-    writeFileSync(join(globalConfigDir, "config.json"), JSON.stringify({}), "utf-8");
+    // allowProjectMcp: these tests exercise project-level mcpServers, which loadConfig gates on trust.
+    writeFileSync(join(globalConfigDir, "config.json"), JSON.stringify({ allowProjectMcp: true }), "utf-8");
     writeFileSync(
       join(projectDir, ".pizzapi", "config.json"),
       JSON.stringify({

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -62,8 +62,8 @@ You can also override any setting with **environment variables**.
   // Must be in the GLOBAL config (project configs cannot self-authorize).
   "allowProjectHooks": false,
 
-  // Trust gate: suppress the security warning for project-local MCP servers.
-  // Project MCP servers are loaded by default (with a warning); set this to true to silence.
+  // Trust gate: allow project-local MCP servers to load.
+  // Project MCP servers are excluded by default; set this to true to enable loading.
   // Must be in the GLOBAL config.
   "allowProjectMcp": false,
 
@@ -144,7 +144,7 @@ You can also override any setting with **environment variables**.
 | `hooks` | `object` | — | Lifecycle hook scripts. See [Hooks](/PizzaPi/customization/hooks/). |
 | `envOverrides` | `Record<string, string>` | — | Environment variables to inject into runner worker sessions. |
 | `allowProjectHooks` | `boolean` | `false` | Trust gate: allow project-local hooks to run. **Global config only.** |
-| `allowProjectMcp` | `boolean` | `false` | Silences the warning for project-local MCP server definitions. **Global config only.** |
+| `allowProjectMcp` | `boolean` | `false` | Allows project-local MCP server definitions to load; otherwise they are excluded. **Global config only.** |
 | `trustedPlugins` | `string[]` | `[]` | Trusted Claude Code plugin paths. **Global config only.** Managed via `pizza plugins trust`. |
 | `disabledMcpServers` | `string[]` | `[]` | MCP server names to skip during initialization. Both global and project lists are merged (union). |
 | `oauthClientName` | `string` | `"PizzaPi"` | Global default `client_name` for MCP OAuth registration. Can also be set per-server in `mcpServers` entries. Per-server values take precedence. See [Client Name Override](/PizzaPi/customization/mcp-servers/#client-name-override). |
@@ -341,7 +341,7 @@ Every config option can also be set as an environment variable. Environment vari
 | `PIZZAPI_API_KEY` | `apiKey` | |
 | `PIZZAPI_RELAY_URL` | `relayUrl` | Set to `off` to disable relay for this invocation |
 | `PIZZAPI_ALLOW_PROJECT_HOOKS` | — | Set to `1` to enable project-local hooks |
-| `PIZZAPI_ALLOW_PROJECT_MCP` | — | Set to `1` to silence the project-local MCP warning |
+| `PIZZAPI_ALLOW_PROJECT_MCP` | — | Set to `1` to enable loading project-local MCP servers |
 | `PIZZAPI_NO_MCP` | — | Set to `1` to skip MCP servers ([Safe Mode](/PizzaPi/security/sandbox/)) |
 | `PIZZAPI_NO_PLUGINS` | — | Set to `1` to skip plugin loading ([Safe Mode](/PizzaPi/security/sandbox/)) |
 | `PIZZAPI_NO_HOOKS` | — | Set to `1` to skip hook execution ([Safe Mode](/PizzaPi/security/sandbox/)) |


### PR DESCRIPTION
## Night Shift — make `allowProjectMcp` actually gate project-level MCP server loading

`allowProjectMcp` previously only suppressed a console warning; project-level `mcpServers`/`mcp.servers` from `.pizzapi/config.json` were always deep-merged into the loaded config, allowing hostile repos to inject MCP servers.

- `allowProjectMcp: false` or unset now excludes project-level MCP servers from the loaded config.
- `allowProjectMcp: true` preserves them.
- Global/user MCP servers are unaffected.
- Updated tests in `config.test.ts` and `trust-gates.test.ts` to assert enforced gating instead of warn-and-load.
- Updated `types.ts` and configuration docs to describe the flag as a trust gate.

**Verification:** `bun run typecheck` exit 0; `bun test ./packages/cli/src/config.test.ts` exit 0 (88 pass); `bun test packages/cli/src/config/trust-gates.test.ts` exit 0 (32 pass).

Reviewed by GPT-5.6 Sol critic: LGTM (round 2).

Godmother: D24Spyfx. 🌙 Autonomous night shift — queued for human review, not auto-merged.
