### PR TITLE
test(cli): deflake memory storage index-truncation test

### DIFF
--- a/packages/cli/src/extensions/memory/storage.test.ts
+++ b/packages/cli/src/extensions/memory/storage.test.ts
@@ -45,7 +45,7 @@ test("index truncates at 200 lines", () => {
   expect(text.split("\n").length).toBeLessThanOrEqual(S.MAX_INDEX_LINES);
   expect(S.capInfo(S.readIndexRaw(big)).overLimit).toBe(true);
   rmSync(big, { recursive: true, force: true });
-});
+}, 10_000);
 
 test("edit requires unique match", () => {
   const e = mkdtempSync(join(tmpdir(), "memedit-"));


### PR DESCRIPTION
## Night Shift — deflake memory storage index-truncation test

`memory/storage.test.ts` "index truncates at 200 lines" performed 250 synchronous `fs` writes that could race the 5-second default `bun test` timeout, causing flaky failures.

- Raised the specific test timeout so the writes complete reliably.
- Preserved all existing truncation assertions, including the 200-line cap.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src/extensions/memory/storage.test.ts` exit 0 (7 pass, 0 fail).

Reviewed by GPT-5.6 Sol critic: LGTM, no findings.

Godmother: 6iG8xapC. 🌙 Autonomous night shift — queued for human review, not auto-merged.
