### PR TITLE
test(cli): isolate cross-test env pollution in models-command and identity tests

### DIFF
--- a/packages/cli/src/__tests__/models-command.test.ts
+++ b/packages/cli/src/__tests__/models-command.test.ts
@@ -2,12 +2,19 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { _setGlobalConfigDir } from "../config.js";
+import { _setGlobalConfigDir } from "../config/io.js";
 import { runModelsCommand } from "../models-command.js";
 
 const originalFetch = globalThis.fetch;
 const originalHome = process.env.HOME;
 const originalKey = process.env.OLLAMA_API_KEY;
+const ENV_KEYS = [
+    "PIZZAPI_HIDDEN_MODELS",
+    "PIZZAPI_SESSION_PROVIDER",
+    "PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER",
+    "PI_CODING_AGENT_DIR",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
 
 /**
  * Isolation notes (see daemon-list-configured-models.test.ts for the fuller
@@ -26,16 +33,11 @@ describe("models command", () => {
     let agentDir: string;
 
     async function runAndCaptureJson(cwd: string): Promise<{ code: number; models: any[] }> {
-        const originalLog = console.log;
-        let captured = "";
-        console.log = ((...args: unknown[]) => { captured += args.join(" "); }) as typeof console.log;
-        try {
-            const code = await runModelsCommand(["--json"], cwd);
-            const parsed = JSON.parse(captured.slice(captured.indexOf("{")));
-            return { code, models: parsed.models };
-        } finally {
-            console.log = originalLog;
-        }
+        const output: string[] = [];
+        const logger = { info: (message: string) => output.push(message), warn: (message: string) => output.push(message), error: (message: string) => output.push(message) };
+        const code = await runModelsCommand(["--json"], cwd, logger);
+        const captured = output.find((line) => line.startsWith("{")) ?? "{}";
+        return { code, models: JSON.parse(captured).models ?? [] };
     }
 
     function mockFetch(overrides?: { modelsFails?: boolean }) {
@@ -65,6 +67,7 @@ describe("models command", () => {
         _setGlobalConfigDir(join(tmpDir, "global-unused"));
         process.env.HOME = home;
         delete process.env.OLLAMA_API_KEY;
+        for (const key of ENV_KEYS) delete process.env[key];
         mockFetch();
     });
 
@@ -74,6 +77,11 @@ describe("models command", () => {
         process.env.HOME = originalHome;
         if (originalKey === undefined) delete process.env.OLLAMA_API_KEY;
         else process.env.OLLAMA_API_KEY = originalKey;
+        for (const key of ENV_KEYS) {
+            const value = originalEnv.get(key);
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+        }
         rmSync(tmpDir, { recursive: true, force: true });
     });
 

--- a/packages/cli/src/models-command.ts
+++ b/packages/cli/src/models-command.ts
@@ -9,7 +9,7 @@
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { join } from "path";
 import { c } from "./cli-colors.js";
-import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
+import { defaultAgentDir, expandHome, loadConfig } from "./config/io.js";
 import { createLogger } from "@pizzapi/tools";
 import { fetchOllamaCloudModels, registerOllamaCloudProvider, type OllamaCloudModel } from "./ollama-cloud-models.js";
 import { mergeModelLists, readSessionModelsCache } from "./session-models-cache.js";
@@ -24,8 +24,9 @@ interface ModelListEntry {
     reasoning: boolean;
 }
 
-export async function runModelsCommand(args: string[], cwd: string): Promise<number> {
+export async function runModelsCommand(args: string[], cwd: string, logger = log): Promise<number> {
     const showJson = args.includes("--json");
+    const env = { ...process.env };
 
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
@@ -51,12 +52,12 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
         }));
 
     let ollamaEntries: ModelListEntry[] = [];
-    if (runtime.hasConfiguredAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
+    if (runtime.hasConfiguredAuth("ollama-cloud") || env.OLLAMA_API_KEY) {
         try {
-            const live = await fetchOllamaCloudModels();
+            const live = await fetchOllamaCloudModels({ home: env.HOME });
             ollamaEntries = live.map(toModelListEntry);
         } catch (err) {
-            log.warn(
+            logger.warn(
                 `Could not refresh Ollama Cloud models: ${err instanceof Error ? err.message : String(err)}`,
             );
         }
@@ -66,17 +67,17 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
     // session's snapshot (extension-registered providers like claude-subscription).
     const allEntries = mergeModelLists(
         mergeModelLists(staticEntries, ollamaEntries),
-        readSessionModelsCache() ?? [],
+        readSessionModelsCache(env.HOME) ?? [],
     );
 
     if (showJson) {
-        log.info(JSON.stringify({ models: allEntries }, null, 2));
+        logger.info(JSON.stringify({ models: allEntries }, null, 2));
         return 0;
     }
 
     if (allEntries.length === 0) {
-        log.info("No configured models found.");
-        log.info(`Checked credentials in ${join(agentDir, "auth.json")}`);
+        logger.info("No configured models found.");
+        logger.info(`Checked credentials in ${join(agentDir, "auth.json")}`);
         return 0;
     }
 
@@ -89,18 +90,18 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
 
     const modelWidth = Math.max(...allEntries.map((m) => m.id.length), "model".length);
 
-    log.info("");
+    logger.info("");
     for (const [provider, models] of byProvider) {
-        log.info(c.label(provider));
+        logger.info(c.label(provider));
         for (const model of models) {
             const noteParts: string[] = [];
             if (model.reasoning) noteParts.push(c.accent("reasoning"));
             if (model.contextWindow) noteParts.push(c.dim(`${model.contextWindow.toLocaleString()} ctx`));
             if (model.name && model.name !== model.id) noteParts.push(c.dim(model.name));
             const notes = noteParts.join(c.dim(" • "));
-            log.info(`  ${c.cmd(model.id.padEnd(modelWidth))}  ${notes}`);
+            logger.info(`  ${c.cmd(model.id.padEnd(modelWidth))}  ${notes}`);
         }
-        log.info("");
+        logger.info("");
     }
     return 0;
 }

--- a/packages/cli/src/ollama-cloud-models.ts
+++ b/packages/cli/src/ollama-cloud-models.ts
@@ -50,12 +50,12 @@ function homeDir(): string {
     return process.env.HOME || homedir();
 }
 
-function cachePath(): string {
-    return join(homeDir(), ".pizzapi", "ollama-cloud-models-cache.json");
+function cachePath(home = homeDir()): string {
+    return join(home, ".pizzapi", "ollama-cloud-models-cache.json");
 }
 
-function readCache(): OllamaCloudCacheEntry | null {
-    const path = cachePath();
+function readCache(home?: string): OllamaCloudCacheEntry | null {
+    const path = cachePath(home);
     if (!existsSync(path)) return null;
     try {
         const raw = JSON.parse(readFileSync(path, "utf-8"));
@@ -75,10 +75,10 @@ function readCache(): OllamaCloudCacheEntry | null {
     return null;
 }
 
-function writeCache(entry: OllamaCloudCacheEntry): void {
-    const dir = join(homeDir(), ".pizzapi");
+function writeCache(entry: OllamaCloudCacheEntry, home?: string): void {
+    const dir = join(home ?? homeDir(), ".pizzapi");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-    writeFileSync(cachePath(), JSON.stringify(entry, null, 2), { mode: 0o600 });
+    writeFileSync(cachePath(home), JSON.stringify(entry, null, 2), { mode: 0o600 });
 }
 
 function isOllamaCloudModel(value: unknown): value is OllamaCloudModel {
@@ -194,12 +194,12 @@ export function registerOllamaCloudProvider(runtime: { registerProvider(provider
 }
 
 export async function fetchOllamaCloudModels(
-    { signal, force }: { signal?: AbortSignal; force?: boolean } = {},
+    { signal, force, home }: { signal?: AbortSignal; force?: boolean; home?: string } = {},
 ): Promise<OllamaCloudModel[]> {
     // force skips the freshness short-circuit so the runner's 12h refresh loop
     // always re-fetches and rewrites the cache.
     if (!force) {
-        const cached = readCache();
+        const cached = readCache(home);
         if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
             return cached.models;
         }
@@ -220,7 +220,7 @@ export async function fetchOllamaCloudModels(
         }),
     );
 
-    writeCache({ models, fetchedAt: Date.now() });
+    writeCache({ models, fetchedAt: Date.now() }, home);
     return models;
 }
 

--- a/packages/cli/src/overlay/identity.test.ts
+++ b/packages/cli/src/overlay/identity.test.ts
@@ -1,10 +1,27 @@
-import { describe, test, expect } from "bun:test";
+import { afterEach, beforeEach, describe, test, expect } from "bun:test";
 import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { DefaultPackageManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { computePackageIdentity, packageScopeBaseDir } from "./identity.js";
+
+const originalHome = process.env.HOME;
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+beforeEach(() => {
+    // The upstream comparator reads HOME at call time while our resolver uses
+    // os.homedir()'s startup value. Keep both sides on the same home directory.
+    process.env.HOME = homedir();
+    delete process.env.PI_CODING_AGENT_DIR;
+});
+
+afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+});
 
 describe("computePackageIdentity", () => {
     test("npm: strips version, keeps scope", () => {

--- a/packages/cli/src/session-models-cache.ts
+++ b/packages/cli/src/session-models-cache.ts
@@ -28,9 +28,8 @@ export interface SessionModelEntry {
     thinkingLevels?: string[];
 }
 
-function cachePath(): string {
-    // Same convention as ollama-cloud-models cache: HOME env first so tests can redirect.
-    return join(process.env.HOME || homedir(), ".pizzapi", "session-models-cache.json");
+function cachePath(home = process.env.HOME || homedir()): string {
+    return join(home, ".pizzapi", "session-models-cache.json");
 }
 
 function isEntry(value: unknown): value is SessionModelEntry {
@@ -46,8 +45,8 @@ function isEntry(value: unknown): value is SessionModelEntry {
 }
 
 /** Read the cached session model snapshot. Returns null if missing, corrupt, or stale. */
-export function readSessionModelsCache(): SessionModelEntry[] | null {
-    const path = cachePath();
+export function readSessionModelsCache(home?: string): SessionModelEntry[] | null {
+    const path = cachePath(home);
     if (!existsSync(path)) return null;
     try {
         const raw = JSON.parse(readFileSync(path, "utf-8"));


### PR DESCRIPTION
## Night Shift — isolate CLI tests from cross-test env pollution

`models-command.test.ts` and `overlay/identity.test.ts` passed in isolation but failed when the full `bun test packages/cli/src` suite ran, because earlier tests mutated global state.

Root causes fixed:
- Concurrent `console.log` capture race: replaced with an injected logger so `models-command.test.ts` no longer hijacks the global console.
- HOME/cache read races: snapshot the environment and thread the test HOME path through cache reads/writes.
- Credential-related env vars are isolated and restored per test.
- Identity tests normalize HOME and agent-dir state.

**Verification:** `bun run typecheck` exit 0; `bun test packages/cli/src` exit 0 (2,883 pass, 0 fail, 2 skip).

Reviewed by GPT-5.6 Sol critic: LGTM (round 2).

Godmother: f5ohlCyG. 🌙 Autonomous night shift — queued for human review, not auto-merged.
