### PR TITLE
fix(server): deduplicate emitToRunner for local runner sockets

### DIFF
--- a/packages/server/src/ws/sio-registry/context.test.ts
+++ b/packages/server/src/ws/sio-registry/context.test.ts
@@ -72,7 +72,6 @@ describe("emitToRunner", () => {
     });
 
     test("delivers to an unjoined local runner exactly once via direct fallback", () => {
-        let roomDeliveries = 0;
         let UNJOINED_LOCAL_DELIVERIES = 0;
         const localSocket = {
             connected: true,
@@ -89,7 +88,7 @@ describe("emitToRunner", () => {
                         expect(room).toBe(runnerRoom("runner-unjoined"));
                         expect(event).toBe("session_ended");
                         expect(data).toEqual({ sessionId: "session-1" });
-                        roomDeliveries++;
+                        // An unjoined local socket is not reached by the room emit.
                     },
                 }),
             }),
@@ -97,8 +96,30 @@ describe("emitToRunner", () => {
 
         emitToRunner("runner-unjoined", "session_ended", { sessionId: "session-1" });
 
-        expect(roomDeliveries).toBe(1);
         expect(UNJOINED_LOCAL_DELIVERIES).toBe(1);
+        expect(localSocket.emit).toHaveBeenCalledTimes(1);
+        localRunnerSockets.clear();
+    });
+
+    test("falls back directly when a joined local runner room emit fails", () => {
+        const localSocket = {
+            connected: true,
+            rooms: new Set([runnerRoom("runner-failed-room")]),
+            emit: mock(() => {}),
+        } as any;
+        localRunnerSockets.set("runner-failed-room", localSocket);
+        initSioRegistry({
+            of: () => ({
+                to: () => ({
+                    emit: () => {
+                        throw new Error("adapter unavailable");
+                    },
+                }),
+            }),
+        } as any);
+
+        emitToRunner("runner-failed-room", "service_message", { requestId: "req-2" });
+
         expect(localSocket.emit).toHaveBeenCalledTimes(1);
         localRunnerSockets.clear();
     });

--- a/packages/server/src/ws/sio-registry/context.test.ts
+++ b/packages/server/src/ws/sio-registry/context.test.ts
@@ -5,6 +5,10 @@ import {
     deleteRunnerSecret,
     getRunnerSecret,
     _resetRunnerSecretsForTesting,
+    initSioRegistry,
+    localRunnerSockets,
+    runnerRoom,
+    emitToRunner,
 } from "./context";
 import {
     _injectRedisForTesting,
@@ -41,6 +45,32 @@ function resetState() {
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("emitToRunner", () => {
+    test("delivers service_message to a local runner once via its room", () => {
+        let roomDeliveries = 0;
+        const localSocket = { connected: true, emit: mock(() => {}) } as any;
+        localRunnerSockets.set("runner-local", localSocket);
+        initSioRegistry({
+            of: () => ({
+                to: (room: string) => ({
+                    emit: (event: string, data: unknown) => {
+                        expect(room).toBe(runnerRoom("runner-local"));
+                        expect(event).toBe("service_message");
+                        expect(data).toEqual({ requestId: "req-1" });
+                        roomDeliveries++;
+                    },
+                }),
+            }),
+        } as any);
+
+        emitToRunner("runner-local", "service_message", { requestId: "req-1" });
+
+        expect(roomDeliveries).toBe(1);
+        expect(localSocket.emit).not.toHaveBeenCalled();
+        localRunnerSockets.clear();
+    });
+});
 
 describe("runner secret persistence", () => {
     beforeEach(resetState);

--- a/packages/server/src/ws/sio-registry/context.test.ts
+++ b/packages/server/src/ws/sio-registry/context.test.ts
@@ -49,7 +49,7 @@ function resetState() {
 describe("emitToRunner", () => {
     test("delivers service_message to a local runner once via its room", () => {
         let roomDeliveries = 0;
-        const localSocket = { connected: true, emit: mock(() => {}) } as any;
+        const localSocket = { connected: true, rooms: new Set([runnerRoom("runner-local")]), emit: mock(() => {}) } as any;
         localRunnerSockets.set("runner-local", localSocket);
         initSioRegistry({
             of: () => ({
@@ -68,6 +68,38 @@ describe("emitToRunner", () => {
 
         expect(roomDeliveries).toBe(1);
         expect(localSocket.emit).not.toHaveBeenCalled();
+        localRunnerSockets.clear();
+    });
+
+    test("delivers to an unjoined local runner exactly once via direct fallback", () => {
+        let roomDeliveries = 0;
+        let UNJOINED_LOCAL_DELIVERIES = 0;
+        const localSocket = {
+            connected: true,
+            rooms: new Set<string>(),
+            emit: mock(() => {
+                UNJOINED_LOCAL_DELIVERIES++;
+            }),
+        } as any;
+        localRunnerSockets.set("runner-unjoined", localSocket);
+        initSioRegistry({
+            of: () => ({
+                to: (room: string) => ({
+                    emit: (event: string, data: unknown) => {
+                        expect(room).toBe(runnerRoom("runner-unjoined"));
+                        expect(event).toBe("session_ended");
+                        expect(data).toEqual({ sessionId: "session-1" });
+                        roomDeliveries++;
+                    },
+                }),
+            }),
+        } as any);
+
+        emitToRunner("runner-unjoined", "session_ended", { sessionId: "session-1" });
+
+        expect(roomDeliveries).toBe(1);
+        expect(UNJOINED_LOCAL_DELIVERIES).toBe(1);
+        expect(localSocket.emit).toHaveBeenCalledTimes(1);
         localRunnerSockets.clear();
     });
 });

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -189,12 +189,14 @@ export function emitToRunner(runnerId: string, eventName: string, data: unknown)
     // The room reaches joined runners on any relay node through the Redis
     // adapter. Unjoined local sockets need the direct fallback, but joined
     // sockets must not receive the event twice.
+    let roomEmitSucceeded = false;
     try {
         io.of("/runner").to(room).emit(eventName, data);
+        roomEmitSucceeded = true;
     } catch (err) {
         log.warn("emitToRunner room emit failed:", (err as Error)?.message);
     }
-    if (local?.connected && !local.rooms?.has(room)) {
+    if (local?.connected && (!roomEmitSucceeded || !local.rooms?.has(room))) {
         try { local.emit(eventName, data); } catch { /* best-effort */ }
     }
 }

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -184,23 +184,15 @@ export const lastTouchTimes = new Map<string, number>();
 /** Export for use in cleanup paths that need cluster-wide runner notification. */
 export function emitToRunner(runnerId: string, eventName: string, data: unknown): void {
     if (!io) return;
-    // Primary path: cluster-wide via per-runner room (joined on registration).
-    // Reaches runners on any relay node through the Redis adapter.
+    // The per-runner room includes local sockets and reaches runners on any
+    // relay node through the Redis adapter. Do not also emit to the local
+    // socket: that delivers the same event twice.
     try {
         io.of("/runner")
             .to(runnerRoom(runnerId))
             .emit(eventName, data);
     } catch (err) {
         log.warn("emitToRunner room emit failed:", (err as Error)?.message);
-    }
-    // Compatibility fallback: direct local socket emit.
-    // Handles runners on this node that haven't joined the room yet
-    // (e.g. older daemon versions during a rolling deploy, or runners that
-    // connected before this server was upgraded).  The daemon's handler is
-    // idempotent via endedSessionIds, so double-delivery is safe.
-    const local = localRunnerSockets.get(runnerId);
-    if (local?.connected) {
-        try { local.emit(eventName, data); } catch { /* best-effort */ }
     }
 }
 

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -184,15 +184,18 @@ export const lastTouchTimes = new Map<string, number>();
 /** Export for use in cleanup paths that need cluster-wide runner notification. */
 export function emitToRunner(runnerId: string, eventName: string, data: unknown): void {
     if (!io) return;
-    // The per-runner room includes local sockets and reaches runners on any
-    // relay node through the Redis adapter. Do not also emit to the local
-    // socket: that delivers the same event twice.
+    const room = runnerRoom(runnerId);
+    const local = localRunnerSockets.get(runnerId);
+    // The room reaches joined runners on any relay node through the Redis
+    // adapter. Unjoined local sockets need the direct fallback, but joined
+    // sockets must not receive the event twice.
     try {
-        io.of("/runner")
-            .to(runnerRoom(runnerId))
-            .emit(eventName, data);
+        io.of("/runner").to(room).emit(eventName, data);
     } catch (err) {
         log.warn("emitToRunner room emit failed:", (err as Error)?.message);
+    }
+    if (local?.connected && !local.rooms?.has(room)) {
+        try { local.emit(eventName, data); } catch { /* best-effort */ }
     }
 }
 


### PR DESCRIPTION
## Night Shift — deduplicate server-side emitToRunner delivery

`emitToRunner` was double-delivering every event to local runners: once via the per-runner `/runner` room broadcast and again via an unconditional direct emit to the same local socket. This caused `service_message`, `kill_session`, and `session_ended` to be delivered at-least-once.

- Broadcast to the runner room remains the primary path.
- Added a conditional direct emit to a connected local socket only when that socket is not already in the runner room.
- Joined local runners receive exactly once (room only).
- Unjoined local runners receive exactly once (direct fallback).
- Added regression tests covering both cases.

**Verification:** `bun run typecheck` exit 0; affected server tests 20 pass, 0 fail.

Reviewed by GPT-5.6 Sol critic: LGTM (round 2).

Godmother: EBisjUji. 🌙 Autonomous night shift — queued for human review, not auto-merged.
