### PR TITLE
feat(ui): select-to-quote for assistant messages

### DIFF
--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -403,6 +403,20 @@ export function SessionViewer({
 
   // ── Session actions + MCP toggle context ─────────────────────────────────
   const { sessionActions, handleMcpToggle } = useSessionActionsSetup(onExec);
+  const sessionActionsWithQuote = React.useMemo(() => {
+    if (!sessionActions) return null;
+    return {
+      ...sessionActions,
+      quote: (text: string, messageTimestamp?: number) => {
+        const timestamp = new Date(messageTimestamp ?? Date.now()).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        const quote = `> @assistant [${timestamp}]: ${text.replace(/\n/g, "\n> ")}`;
+        setInput((current) => current ? `${current}\n${quote}` : quote);
+        requestAnimationFrame(() => {
+          document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus();
+        });
+      },
+    };
+  }, [sessionActions, setInput]);
 
   // ── Compacting guard reset ────────────────────────────────────────────────
   React.useEffect(() => {
@@ -557,7 +571,7 @@ export function SessionViewer({
 
   // ── Render ────────────────────────────────────────────────────────────────
   return (
-    <SessionActionsProvider value={sessionActions}>
+    <SessionActionsProvider value={sessionActionsWithQuote}>
       <McpToggleContext.Provider value={onExec ? handleMcpToggle : null}>
         <div className="flex flex-col flex-1 min-h-0">
 

--- a/packages/ui/src/components/session-viewer/message-item.test.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.test.tsx
@@ -55,6 +55,33 @@ describe("SessionMessageItem custom messages", () => {
     expect(quoted).toBe("Select this sentence");
   });
 
+  test("quotes text parts from an assistant message when nothing is selected", () => {
+    const message: RelayMessage = {
+      key: "assistant-quote-parts",
+      role: "assistant",
+      timestamp: 1_700_000_000_000,
+      content: [
+        { type: "text", text: "First part" },
+        { type: "toolCall", toolName: "ignored" },
+        { type: "text", text: " second part" },
+        { type: "toolResult", result: "ignored" },
+      ],
+    };
+    let quoted = "";
+    window.getSelection()?.removeAllRanges();
+
+    const view = render(
+      <SessionActionsProvider value={{ abort: () => {}, quote: (text) => { quoted = text; } }}>
+        <SessionMessageItem message={message} isLast={false} />
+      </SessionActionsProvider>,
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Quote" }));
+
+    expect(quoted).not.toContain("## 🤖 Assistant");
+    expect(quoted).toContain("First part second part");
+  });
+
   test("shows the full custom message key and collapses content by default", () => {
     const message: RelayMessage = {
       key: "custom-1",

--- a/packages/ui/src/components/session-viewer/message-item.test.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.test.tsx
@@ -26,10 +26,35 @@ const win = new Window({ url: "http://localhost/" });
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 const { SessionMessageItem } = await import("./message-item");
+const { SessionActionsProvider } = await import("./session-actions-context");
 
 afterEach(() => cleanup());
 
 describe("SessionMessageItem custom messages", () => {
+  test("quotes selected assistant text through session actions", () => {
+    const message: RelayMessage = {
+      key: "assistant-quote",
+      role: "assistant",
+      timestamp: 1_700_000_000_000,
+      content: "Select this sentence",
+    };
+    let quoted = "";
+    const view = render(
+      <SessionActionsProvider value={{ abort: () => {}, quote: (text) => { quoted = text; } }}>
+        <SessionMessageItem message={message} isLast={false} />
+      </SessionActionsProvider>,
+    );
+    const text = view.getByText("Select this sentence");
+    const range = document.createRange();
+    range.selectNodeContents(text);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+
+    fireEvent.click(view.getByRole("button", { name: "Quote" }));
+
+    expect(quoted).toBe("Select this sentence");
+  });
+
   test("shows the full custom message key and collapses content by default", () => {
     const message: RelayMessage = {
       key: "custom-1",

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -20,6 +20,22 @@ import { useSessionActions } from "@/components/session-viewer/session-actions-c
 
 // ── SessionMessageItem ───────────────────────────────────────────────────────
 
+function getQuoteText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
 interface SessionMessageItemProps {
   message: RelayMessage;
   activeToolCalls?: Map<string, string>;
@@ -58,7 +74,7 @@ export const SessionMessageItem = React.memo(
       const selection = window.getSelection();
       const selected = selection?.toString().trim();
       const hasSelection = !!selection?.rangeCount && !!content && content.contains(selection.getRangeAt(0).commonAncestorContainer);
-      const text = hasSelection && selected ? selected : typeof message.content === "string" ? message.content : exportToMarkdown([message]);
+      const text = hasSelection && selected ? selected : getQuoteText(message.content);
       sessionActions?.quote?.(text, message.timestamp);
     }, [message]);
 

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -16,6 +16,7 @@ import { MessageCopyButton } from "@/components/ai-elements/conversation";
 import { exportToMarkdown } from "@/lib/export-markdown";
 import { cn } from "@/lib/utils";
 import { useConversationScrollRef } from "@/components/ai-elements/conversation";
+import { useSessionActions } from "@/components/session-viewer/session-actions-context";
 
 // ── SessionMessageItem ───────────────────────────────────────────────────────
 
@@ -50,6 +51,16 @@ export const SessionMessageItem = React.memo(
     onActionSigilResponse,
   }: SessionMessageItemProps) => {
     const [customExpanded, setCustomExpanded] = React.useState(false);
+    const quoteContentRef = React.useRef<HTMLDivElement>(null);
+    const sessionActions = useSessionActions();
+    const quoteMessage = React.useCallback(() => {
+      const content = quoteContentRef.current;
+      const selection = window.getSelection();
+      const selected = selection?.toString().trim();
+      const hasSelection = !!selection?.rangeCount && !!content && content.contains(selection.getRangeAt(0).commonAncestorContainer);
+      const text = hasSelection && selected ? selected : typeof message.content === "string" ? message.content : exportToMarkdown([message]);
+      sessionActions?.quote?.(text, message.timestamp);
+    }, [message]);
 
     // System messages with structured command result data → standalone card
     if (message.role === "system" && isCommandResult(message.content)) {
@@ -184,6 +195,15 @@ export const SessionMessageItem = React.memo(
                 <span>• {new Date(message.timestamp).toLocaleTimeString()}</span>
               )}
               {message.isError && <span className="text-destructive">• Error</span>}
+              {message.role === "assistant" && sessionActions?.quote && (
+                <button
+                  type="button"
+                  className="rounded px-1.5 py-0.5 text-[10px] normal-case text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-foreground group-hover/msg:opacity-100 focus-visible:opacity-100"
+                  onClick={quoteMessage}
+                >
+                  Quote
+                </button>
+              )}
               <MessageCopyButton
                 text={exportToMarkdown([message])}
                 className="ml-auto opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity"
@@ -228,7 +248,8 @@ export const SessionMessageItem = React.memo(
                   </div>
                 )}
               </div>
-            ) : renderContent(
+            ) : <div ref={quoteContentRef}>
+              {renderContent(
               message.content,
               activeToolCalls,
               message.role,
@@ -245,7 +266,8 @@ export const SessionMessageItem = React.memo(
               message.details,
               onTriggerResponse,
               onActionSigilResponse,
-            )}
+              )}
+            </div>}
             {message.stopReason === "error" && message.errorMessage && (
               <div className="mt-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />

--- a/packages/ui/src/components/session-viewer/session-actions-context.tsx
+++ b/packages/ui/src/components/session-viewer/session-actions-context.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext } from "react";
 export interface SessionActions {
   /** Send an abort exec command to kill the current agent turn (and any running bash commands). */
   abort: () => void;
+  /** Insert a quoted message into the composer. */
+  quote?: (text: string, timestamp?: number) => void;
 }
 
 const SessionActionsContext = createContext<SessionActions | null>(null);


### PR DESCRIPTION
## Night Shift — select-to-quote for assistant messages

Adds a quote action for assistant messages.

- Select text inside an assistant message and click **Quote** to insert the selection into the composer as a blockquote.
- If no text is selected, the entire assistant message text is quoted (string or text parts; tool parts are excluded).
- Citation format: `> @assistant [timestamp]: ...`
- Added UI tests covering selection and array-content fallback paths.

**Verification:** `cd packages/ui && bun test src` exit 0 (1294 pass, 1 skip); root `bun run typecheck` exit 0.

Reviewed by GPT-5.6 Sol critic: LGTM (round 2).

Godmother: ZKgXguHo. 🌙 Autonomous night shift — queued for human review, not auto-merged.
