### PR TITLE
fix(ui): make Git worktree list scrollable

### DIFF
--- a/packages/ui/src/components/git/GitWorktreeList.test.tsx
+++ b/packages/ui/src/components/git/GitWorktreeList.test.tsx
@@ -58,6 +58,10 @@ describe("GitWorktreeList", () => {
         fireEvent.click(getByText("Worktrees"));
         expect(getByText("feat/x")).toBeTruthy();
         expect(getByText("main worktree")).toBeTruthy();
+
+        const root = getByText("Worktrees").closest("div");
+        expect(root?.className).toContain("max-h-[40%]");
+        expect(root?.querySelector(".overflow-y-auto")).toBeTruthy();
     });
 
     test("prune button calls onPrune", () => {

--- a/packages/ui/src/components/git/GitWorktreeList.tsx
+++ b/packages/ui/src/components/git/GitWorktreeList.tsx
@@ -121,7 +121,7 @@ export function GitWorktreeList({
     const totalChanges = worktrees.reduce((sum, w) => sum + w.changeCount, 0);
 
     return (
-        <div className={cn("border-t border-border", className)}>
+        <div className={cn("flex min-h-0 max-h-[40%] shrink-0 flex-col border-t border-border", className)}>
             {/* Header toggle */}
             <button
                 type="button"
@@ -156,7 +156,7 @@ export function GitWorktreeList({
 
             {/* Worktree rows */}
             {expanded && (
-                <div className="pb-1">
+                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-1 [scrollbar-width:thin]">
                     {sorted.map((wt) => (
                         <WorktreeRow
                             key={wt.path}


### PR DESCRIPTION
## Summary
- make the Git Panel worktree rows scroll within the available panel space
- add regression coverage for the scroll container

## Validation
- `cd packages/ui && bun test src/components/git` — 32 passed
- `bun x tsc --noEmit -p packages/ui/tsconfig.json` — passed
- full repository typecheck was blocked by missing dependencies in the fresh worktree
