### PR TITLE
feat(ui): add quote popover for selected text

### DIFF
--- a/packages/ui/src/components/session-viewer/message-item.test.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.test.tsx
@@ -55,7 +55,7 @@ describe("SessionMessageItem custom messages", () => {
     expect(quoted).toBe("Select this sentence");
   });
 
-  test("quotes text parts from an assistant message when nothing is selected", () => {
+  test("does not quote an assistant message when nothing is selected", () => {
     const message: RelayMessage = {
       key: "assistant-quote-parts",
       role: "assistant",
@@ -78,8 +78,7 @@ describe("SessionMessageItem custom messages", () => {
 
     fireEvent.click(view.getByRole("button", { name: "Quote" }));
 
-    expect(quoted).not.toContain("## 🤖 Assistant");
-    expect(quoted).toContain("First part second part");
+    expect(quoted).toBe("");
   });
 
   test("shows the full custom message key and collapses content by default", () => {

--- a/packages/ui/src/components/session-viewer/message-item.test.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import type { RelayMessage } from "./types";
 
@@ -47,10 +47,13 @@ describe("SessionMessageItem custom messages", () => {
     const text = view.getByText("Select this sentence");
     const range = document.createRange();
     range.selectNodeContents(text);
-    window.getSelection()?.removeAllRanges();
-    window.getSelection()?.addRange(range);
+    act(() => {
+      window.getSelection()?.removeAllRanges();
+      window.getSelection()?.addRange(range);
+      fireEvent.mouseUp(text);
+    });
 
-    fireEvent.click(view.getByRole("button", { name: "Quote" }));
+    fireEvent.click(view.getByRole("button", { name: "Quote selected text" }));
 
     expect(quoted).toBe("Select this sentence");
   });
@@ -76,8 +79,7 @@ describe("SessionMessageItem custom messages", () => {
       </SessionActionsProvider>,
     );
 
-    fireEvent.click(view.getByRole("button", { name: "Quote" }));
-
+    expect(view.queryByRole("button", { name: "Quote selected text" })).toBeNull();
     expect(quoted).toBe("");
   });
 

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -51,19 +51,58 @@ export const SessionMessageItem = React.memo(
     onActionSigilResponse,
   }: SessionMessageItemProps) => {
     const [customExpanded, setCustomExpanded] = React.useState(false);
+    const [quotePopover, setQuotePopover] = React.useState<{
+      text: string;
+      top: number;
+      left: number;
+    } | null>(null);
     const quoteContentRef = React.useRef<HTMLDivElement>(null);
     const sessionActions = useSessionActions();
-    const quoteMessage = React.useCallback(() => {
+    const updateQuotePopover = React.useCallback(() => {
       const content = quoteContentRef.current;
       const selection = window.getSelection();
-      if (!content || !selection?.rangeCount) return;
+      if (!sessionActions?.quote || !content || !selection?.rangeCount) {
+        setQuotePopover((current) => (current ? null : current));
+        return;
+      }
 
       const range = selection.getRangeAt(0);
       const text = selection.toString().trim();
-      if (!text || !content.contains(range.commonAncestorContainer)) return;
+      if (!text || !content.contains(range.commonAncestorContainer)) {
+        setQuotePopover((current) => (current ? null : current));
+        return;
+      }
 
-      sessionActions?.quote?.(text, message.timestamp);
-    }, [message.timestamp, sessionActions]);
+      const rect = range.getBoundingClientRect();
+      const popoverWidth = 76;
+      const popoverHeight = 32;
+      const gap = 6;
+      const left = Math.min(
+        Math.max(8, rect.left),
+        Math.max(8, window.innerWidth - popoverWidth - 8),
+      );
+      const top =
+        rect.bottom + gap + popoverHeight <= window.innerHeight
+          ? rect.bottom + gap
+          : Math.max(8, rect.top - gap - popoverHeight);
+      setQuotePopover({ text, top, left });
+    }, [sessionActions]);
+
+    React.useEffect(() => {
+      if (message.role !== "assistant") return;
+      document.addEventListener("selectionchange", updateQuotePopover);
+      window.addEventListener("scroll", updateQuotePopover, true);
+      return () => {
+        document.removeEventListener("selectionchange", updateQuotePopover);
+        window.removeEventListener("scroll", updateQuotePopover, true);
+      };
+    }, [message.role, updateQuotePopover]);
+
+    const quoteMessage = React.useCallback(() => {
+      if (!quotePopover) return;
+      sessionActions?.quote?.(quotePopover.text, message.timestamp);
+      setQuotePopover(null);
+    }, [message.timestamp, quotePopover, sessionActions]);
 
     // System messages with structured command result data → standalone card
     if (message.role === "system" && isCommandResult(message.content)) {
@@ -198,15 +237,6 @@ export const SessionMessageItem = React.memo(
                 <span>• {new Date(message.timestamp).toLocaleTimeString()}</span>
               )}
               {message.isError && <span className="text-destructive">• Error</span>}
-              {message.role === "assistant" && sessionActions?.quote && (
-                <button
-                  type="button"
-                  className="rounded px-1.5 py-0.5 text-[10px] normal-case text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-foreground group-hover/msg:opacity-100 focus-visible:opacity-100"
-                  onClick={quoteMessage}
-                >
-                  Quote
-                </button>
-              )}
               <MessageCopyButton
                 text={exportToMarkdown([message])}
                 className="ml-auto opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity"
@@ -251,24 +281,44 @@ export const SessionMessageItem = React.memo(
                   </div>
                 )}
               </div>
-            ) : <div ref={quoteContentRef}>
+            ) : <div
+              ref={quoteContentRef}
+              onMouseUp={message.role === "assistant" ? updateQuotePopover : undefined}
+              onTouchEnd={message.role === "assistant" ? updateQuotePopover : undefined}
+            >
               {renderContent(
-              message.content,
-              activeToolCalls,
-              message.role,
-              message.toolName,
-              message.isError,
-              message.toolInput,
-              message.toolCallId ?? message.key,
-              // Only treat thinking as still-streaming when the agent is active,
-              // this is the last message, AND the message has no timestamp yet
-              agentActive && isLast && message.timestamp === undefined,
-              message.thinking,
-              message.thinkingDuration,
-              undefined, // subAgentTurns
-              message.details,
-              onTriggerResponse,
-              onActionSigilResponse,
+                message.content,
+                activeToolCalls,
+                message.role,
+                message.toolName,
+                message.isError,
+                message.toolInput,
+                message.toolCallId ?? message.key,
+                // Only treat thinking as still-streaming when the agent is active,
+                // this is the last message, AND the message has no timestamp yet
+                agentActive && isLast && message.timestamp === undefined,
+                message.thinking,
+                message.thinkingDuration,
+                undefined, // subAgentTurns
+                message.details,
+                onTriggerResponse,
+                onActionSigilResponse,
+              )}
+              {quotePopover && (
+                <div
+                  className="fixed z-50 rounded-md border border-border bg-popover p-0.5 text-popover-foreground shadow-md"
+                  style={{ top: quotePopover.top, left: quotePopover.left }}
+                >
+                  <button
+                    type="button"
+                    className="rounded px-2 py-1 text-xs font-medium hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
+                    aria-label="Quote selected text"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={quoteMessage}
+                  >
+                    Quote
+                  </button>
+                </div>
               )}
             </div>}
             {message.stopReason === "error" && message.errorMessage && (

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -20,22 +20,6 @@ import { useSessionActions } from "@/components/session-viewer/session-actions-c
 
 // ── SessionMessageItem ───────────────────────────────────────────────────────
 
-function getQuoteText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-
-  return content
-    .filter(
-      (part): part is { type: "text"; text: string } =>
-        typeof part === "object" &&
-        part !== null &&
-        (part as { type?: unknown }).type === "text" &&
-        typeof (part as { text?: unknown }).text === "string",
-    )
-    .map((part) => part.text)
-    .join("");
-}
-
 interface SessionMessageItemProps {
   message: RelayMessage;
   activeToolCalls?: Map<string, string>;
@@ -72,11 +56,14 @@ export const SessionMessageItem = React.memo(
     const quoteMessage = React.useCallback(() => {
       const content = quoteContentRef.current;
       const selection = window.getSelection();
-      const selected = selection?.toString().trim();
-      const hasSelection = !!selection?.rangeCount && !!content && content.contains(selection.getRangeAt(0).commonAncestorContainer);
-      const text = hasSelection && selected ? selected : getQuoteText(message.content);
+      if (!content || !selection?.rangeCount) return;
+
+      const range = selection.getRangeAt(0);
+      const text = selection.toString().trim();
+      if (!text || !content.contains(range.commonAncestorContainer)) return;
+
       sessionActions?.quote?.(text, message.timestamp);
-    }, [message]);
+    }, [message.timestamp, sessionActions]);
 
     // System messages with structured command result data → standalone card
     if (message.role === "system" && isCommandResult(message.content)) {


### PR DESCRIPTION
## Summary

- remove the message-level Quote button
- show a small Quote popover beside selected assistant text
- keep quoting limited to non-empty selections inside assistant messages
- add regression coverage for the selection popover and no-selection state

## Tests

- `cd packages/ui && bun test src`
- `bunx tsc -p packages/ui/tsconfig.json --noEmit`