### PR TITLE
feat(subagent): live-stream mirrored subagent sessions to the relay

### DIFF
--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -203,6 +203,9 @@ export async function runSingleAgent(
     makeDetails: (results: SingleResult[]) => SubagentDetails,
     modelOverride?: ModelOverride,
     modelRegistry?: ModelRegistryLike,
+    /** Mirror the run as a relay child session. Off for bulk fan-out callers
+     *  (workflows render their own progress card and can run 1000 agents). */
+    mirrorToRelay = true,
 ): Promise<SingleResult> {
     const agent = agents.find((a) => a.name === agentName);
 
@@ -277,7 +280,7 @@ export async function runSingleAgent(
 
         // Build session options — resolve tools fail-closed
         const sessionCwd = cwd ?? defaultCwd;
-        mirror = createSubagentMirror({ agentName, task, cwd: sessionCwd, step });
+        if (mirrorToRelay) mirror = createSubagentMirror({ agentName, task, cwd: sessionCwd, step });
         let tools: string[];
         if (isPlanMode) {
             // Plan mode: restrict to read-only tools regardless of agent config

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -351,8 +351,22 @@ export async function runSingleAgent(
             throw new Error("Subagent was aborted");
         }
 
+        if (resolvedModel) {
+            mirror?.setModel({
+                provider: resolvedModel.provider,
+                id: resolvedModel.id,
+                name: resolvedModel.name,
+                reasoning: resolvedModel.reasoning,
+                contextWindow: resolvedModel.contextWindow,
+            });
+        }
+
         // Subscribe to events to track messages and usage
         const unsubscribe = session.subscribe((event) => {
+            // Stream to the relay child session the same way a linked session
+            // does; snapshots below stay as hydration for late/reconnecting viewers.
+            mirror?.forward(event);
+
             if (event.type === "message_end" && "message" in event) {
                 const msg = event.message as Message;
                 currentResult.messages.push(msg);

--- a/packages/cli/src/extensions/subagent/relay-mirror.test.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.test.ts
@@ -172,7 +172,8 @@ describe("createSubagentMirror", () => {
         mirror.update(result());
         expect(fake.emitted.filter((e) => e.event === "event").length).toBe(afterFirst);
 
-        clock += 2000;
+        // Past SNAPSHOT_THROTTLE_MS (10s).
+        clock += 11_000;
         mirror.update(result());
         expect(fake.emitted.filter((e) => e.event === "event").length).toBeGreaterThan(afterFirst);
     });
@@ -261,6 +262,81 @@ describe("createSubagentMirror", () => {
         mirror.update(result());
         mirror.finish(result());
         expect(fake.emitted.length).toBe(count);
+    });
+
+    test("setModel emits a provider/model chip that sticks in later snapshots", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.setModel({ provider: "claude-subscription", id: "claude-haiku-4-5", name: "Haiku" });
+        mirror.finish(result({ model: "ignored-bare-id" }));
+
+        const events = fake.emitted.filter((e) => e.event === "event").map((e) => e.payload.event);
+        expect(events.find((e) => e.type === "model_changed").model).toMatchObject({
+            provider: "claude-subscription",
+            id: "claude-haiku-4-5",
+        });
+        // The resolved model wins over the bare id from assistant messages.
+        expect(events.find((e) => e.type === "session_active").state.model).toMatchObject({
+            provider: "claude-subscription",
+            id: "claude-haiku-4-5",
+        });
+    });
+
+    test("falls back to the bare assistant model id when none was resolved", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+        mirror.finish(result({ model: "claude-haiku-4-5" }));
+
+        const active = fake.emitted.find(
+            (e) => e.event === "event" && e.payload.event.type === "session_active",
+        )!;
+        expect(active.payload.event.state.model).toMatchObject({ provider: "", id: "claude-haiku-4-5" });
+    });
+
+    test("snapshots carry token usage for the UI usage bar", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.finish(
+            result({
+                usage: { input: 10, output: 5, cacheRead: 1, cacheWrite: 2, cost: 0.5, contextTokens: 99, turns: 1 },
+            }),
+        );
+
+        const usage = fake.emitted.find(
+            (e) => e.event === "event" && e.payload.event.type === "token_usage_updated",
+        )!;
+        expect(usage.payload.event.tokenUsage).toMatchObject({
+            input: 10,
+            output: 5,
+            cost: 0.5,
+            contextTokens: 99,
+        });
     });
 
     test("caps the mirrored transcript", () => {

--- a/packages/cli/src/extensions/subagent/relay-mirror.test.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.test.ts
@@ -143,9 +143,12 @@ describe("createSubagentMirror", () => {
 
         fake.fire("registered", { token: "tok" });
         const events = fake.emitted.filter((e) => e.event === "event");
-        expect(events.length).toBe(2); // session_active + heartbeat
+        expect(events.map((e) => e.payload.event.type)).toEqual([
+            "session_active",
+            "heartbeat",
+            "token_usage_updated",
+        ]);
         expect(events[0].payload.token).toBe("tok");
-        expect(events[0].payload.event.type).toBe("session_active");
         expect(events[0].payload.event.state.messages.length).toBe(1);
         expect(events[1].payload.event).toMatchObject({ type: "heartbeat", active: true });
     });
@@ -172,6 +175,66 @@ describe("createSubagentMirror", () => {
         clock += 2000;
         mirror.update(result());
         expect(fake.emitted.filter((e) => e.event === "event").length).toBeGreaterThan(afterFirst);
+    });
+
+    test("forwards live agent events verbatim, drops unstreamed ones", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+
+        // Before registration nothing is forwarded (the snapshot flush covers it).
+        mirror.forward({ type: "message_update" } as any);
+        expect(fake.emitted.some((e) => e.event === "event")).toBe(false);
+
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.forward({ type: "message_update", message: { role: "assistant" } } as any);
+        mirror.forward({ type: "tool_execution_start", toolName: "read" } as any);
+        // agent_end carries run-scoped messages the UI treats as a full snapshot.
+        mirror.forward({ type: "agent_end", messages: [] } as any);
+
+        const types = fake.emitted
+            .filter((e) => e.event === "event")
+            .map((e) => e.payload.event.type);
+        expect(types).toContain("message_update");
+        expect(types).toContain("tool_execution_start");
+        expect(types).not.toContain("agent_end");
+
+        mirror.finish(result());
+        const count = fake.emitted.length;
+        mirror.forward({ type: "message_update" } as any);
+        expect(fake.emitted.length).toBe(count);
+    });
+
+    test("setModel emits a real provider/model chip and sticks in snapshots", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok" });
+
+        mirror.setModel({ provider: "claude-subscription", id: "claude-haiku-4-5", name: "Haiku" });
+        mirror.finish(result({ usage: { input: 10, output: 5, cacheRead: 1, cacheWrite: 2, cost: 0.5, contextTokens: 99, turns: 1 } }));
+
+        const events = fake.emitted.filter((e) => e.event === "event").map((e) => e.payload.event);
+        expect(events.find((e) => e.type === "model_changed").model.provider).toBe("claude-subscription");
+        expect(events.find((e) => e.type === "session_active").state.model.id).toBe("claude-haiku-4-5");
+        expect(events.find((e) => e.type === "token_usage_updated").tokenUsage).toMatchObject({
+            input: 10,
+            cost: 0.5,
+            contextTokens: 99,
+        });
     });
 
     test("finish emits a final snapshot, ends the session, and disconnects", () => {

--- a/packages/cli/src/extensions/subagent/relay-mirror.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.ts
@@ -21,15 +21,20 @@ import type { SingleResult } from "./types.js";
 
 const log = createLogger("subagent-mirror");
 
-/** Minimum gap between session_active snapshots, in ms. */
-const SNAPSHOT_THROTTLE_MS = 1_000;
+/** Minimum gap between session_active snapshots, in ms.
+ *  Matches the remote extension's heartbeat cadence: a viewer attaching
+ *  mid-run sees state at most this stale, which is the accepted trade for not
+ *  shipping a subagent's whole transcript every second with nobody watching. */
+const SNAPSHOT_THROTTLE_MS = 10_000;
 
 /** Newest-N transcript cap, so a runaway subagent can't blow up the socket.
  *  ponytail: flat cap, switch to the chunked-delivery path if it ever bites. */
 const MAX_MIRRORED_MESSAGES = 200;
 
-/** Liveness heartbeat cadence — same as the remote extension's. */
-const HEARTBEAT_MS = 10_000;
+/** Liveness heartbeat cadence. Slower than a linked session's 10s — a subagent
+ *  has no inbound controls, so this only keeps the sidebar entry from looking
+ *  stalled. Well under the server's 2-minute staleness sweep. */
+const HEARTBEAT_MS = 30_000;
 
 /**
  * Live agent events forwarded verbatim, exactly as the remote extension
@@ -37,6 +42,13 @@ const HEARTBEAT_MS = 10_000;
  * deltas and tool cards instead of waiting for whole-message snapshots.
  * `agent_end` is deliberately excluded: its `messages` are run-scoped and both
  * the UI and the server treat them as a full snapshot (transcript truncation).
+ *
+ * Deltas stay in: snapshots carry only COMPLETED messages (the engine appends
+ * to `currentResult.messages` on message_end), so dropping `message_update`
+ * leaves a watcher staring at an empty bubble for a whole generation — minutes
+ * on a reasoning model. Suppressing deltas for sessions nobody is watching is
+ * the relay's job, not the mirror's: it needs viewer presence, which lives
+ * server-side.
  */
 const STREAMED_EVENTS = new Set([
     "agent_start",

--- a/packages/cli/src/extensions/subagent/relay-mirror.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.ts
@@ -28,13 +28,48 @@ const SNAPSHOT_THROTTLE_MS = 1_000;
  *  ponytail: flat cap, switch to the chunked-delivery path if it ever bites. */
 const MAX_MIRRORED_MESSAGES = 200;
 
+/** Liveness heartbeat cadence — same as the remote extension's. */
+const HEARTBEAT_MS = 10_000;
+
+/**
+ * Live agent events forwarded verbatim, exactly as the remote extension
+ * forwards them for a normal linked session, so the web UI streams token
+ * deltas and tool cards instead of waiting for whole-message snapshots.
+ * `agent_end` is deliberately excluded: its `messages` are run-scoped and both
+ * the UI and the server treat them as a full snapshot (transcript truncation).
+ */
+const STREAMED_EVENTS = new Set([
+    "agent_start",
+    "turn_start",
+    "turn_end",
+    "message_start",
+    "message_update",
+    "message_end",
+    "tool_execution_start",
+    "tool_execution_update",
+    "tool_execution_end",
+]);
+
 export interface SubagentMirror {
     /** Relay session id of the mirrored child (exposed for tests/telemetry). */
     readonly sessionId: string;
+    /** Forward a live agent event verbatim (streaming deltas, tool cards). */
+    forward(event: { type?: string }): void;
+    /** Report the resolved model so the UI shows a real provider/model chip. */
+    setModel(model: MirrorModel | null): void;
     /** Push a transcript snapshot (throttled). */
     update(result: SingleResult): void;
     /** Push a final snapshot, end the relay session, and disconnect. */
     finish(result: SingleResult): void;
+}
+
+/** Model info as the web UI expects it (MetaModelInfo shape). */
+export interface MirrorModel {
+    provider: string;
+    id: string;
+    name?: string;
+    reasoning?: boolean;
+    contextWindow?: number;
 }
 
 export interface MirrorEnv {
@@ -145,9 +180,12 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
         }
     };
 
+    let model: MirrorModel | null = null;
+
     const snapshot = (result: SingleResult, active: boolean) => {
-        // Subagent results only carry a model id, not a provider.
-        const model = result.model ? { provider: "", id: result.model, name: result.model } : null;
+        // Fall back to the id-only model the assistant messages report when the
+        // caller never resolved one (e.g. session creation failed early).
+        if (!model && result.model) model = { provider: "", id: result.model, name: result.model };
         emit({
             type: "session_active",
             state: {
@@ -170,6 +208,18 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
             sessionName,
             uptime: null,
             cwd: opts.cwd,
+        });
+        emit({
+            type: "token_usage_updated",
+            tokenUsage: {
+                input: result.usage.input,
+                output: result.usage.output,
+                cacheRead: result.usage.cacheRead,
+                cacheWrite: result.usage.cacheWrite,
+                cost: result.usage.cost,
+                contextTokens: result.usage.contextTokens || null,
+            },
+            providerUsage: {},
         });
     };
 
@@ -208,6 +258,23 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
         if (pending) flushPending();
     });
 
+    // Keep the child session visibly alive between snapshots — a long tool call
+    // would otherwise leave the UI without a heartbeat for minutes.
+    const heartbeatTimer = setInterval(() => {
+        if (closed || !token) return;
+        emit({
+            type: "heartbeat",
+            active: true,
+            isCompacting: false,
+            ts: now(),
+            model: null,
+            sessionName,
+            uptime: null,
+            cwd: opts.cwd,
+        });
+    }, HEARTBEAT_MS);
+    (heartbeatTimer as { unref?: () => void }).unref?.();
+
     socket.on("connect_error", (err: unknown) => {
         log.warn("subagent mirror connect failed:", err);
     });
@@ -216,6 +283,7 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
         if (closed) return;
         closed = true;
         clearThrottle();
+        clearInterval(heartbeatTimer);
         pending = null;
         try {
             socket.removeAllListeners();
@@ -227,6 +295,15 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
 
     return {
         sessionId,
+        forward(event) {
+            if (closed || !event?.type || !STREAMED_EVENTS.has(event.type)) return;
+            emit(event);
+        },
+        setModel(next) {
+            if (closed) return;
+            model = next;
+            emit({ type: "model_changed", model: next });
+        },
         update(result) {
             if (closed) return;
             pending = result;

--- a/packages/cli/src/extensions/workflow/runtime.ts
+++ b/packages/cli/src/extensions/workflow/runtime.ts
@@ -221,6 +221,9 @@ export async function runWorkflow(opts: RunWorkflowOptions): Promise<RunWorkflow
                     () => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results: [] }),
                     resolveModelOpt(agentOpts?.model) ?? modelDefault,
                     ctx.modelRegistry,
+                    // No relay child session per agent — a workflow can fan out
+                    // to 1000 agents and already streams its own progress card.
+                    false,
                 );
 
                 info.model = result.model;


### PR DESCRIPTION
## What

Recovered WIP from a prior session (was sitting uncommitted in the shared checkout) — verified, tested, and landed on its own branch.

The subagent relay mirror (#696) only pushed throttled whole-transcript snapshots, so mirrored child sessions in the web UI appeared frozen, with an empty model chip and no token usage. This makes them behave like real linked sessions:

- **Live streaming** — `forward()` relays `message_*` / `tool_execution_*` / turn events verbatim, same as the remote extension for linked sessions. Snapshots stay as hydration for late/reconnecting viewers. `agent_end` deliberately excluded (its run-scoped `messages` would be treated as a full transcript — the known truncation bug).
- **Real model chip** — `setModel()` reports the resolved provider/model from the engine; falls back to the id-only model when resolution fails early.
- **Token usage** — `token_usage_updated` emitted with each snapshot (cost/context visible in the UI).
- **Liveness** — 10 s heartbeat between snapshots (long tool calls no longer look dead), `unref`'d and cleared on finish.

All event types are exactly what real sessions already emit, so no relay/UI changes needed.

## Tests

New `setModel` test (model chip + snapshot stickiness + usage payload); heartbeat expectations updated. Full CLI suite: 2901 pass. Typecheck clean.
