### PR TITLE
perf(relay): stop caching and broadcasting streaming deltas to an empty room

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -15,6 +15,7 @@ import {
     consumePendingRecovery,
 } from "../../sio-registry.js";
 import { appendRelayEventToCache } from "../../../sessions/redis.js";
+import { isDeltaEvent, shouldPublishDelta } from "./viewer-gate.js";
 import { storeAndReplaceImagesInEvent, stripImagesFromPipelineEvent } from "../../strip-images.js";
 import { updateSessionMetaState, broadcastToSessionMeta, getSessionMetaState } from "../../sio-registry/meta.js";
 import { buildSnapshotPatchFromCapabilities, buildSnapshotPatchFromMetadata } from "../../sio-registry/snapshot-state.js";
@@ -455,6 +456,12 @@ export function registerEventHandler(socket: RelaySocket): void {
             const isMetadataOnlyUpdate = event.type === "session_metadata_update";
             if (event.type === "session_messages_chunk" || isChunkedSessionActive || isMetadataOnlyUpdate) {
                 await broadcastSessionEventToViewers(sessionId, eventToPublish);
+            } else if (isDeltaEvent(event.type) && !shouldPublishDelta(sessionId)) {
+                // Nobody is watching: drop the delta instead of rPushing a
+                // cumulative partial into the event cache and PUBLISHing it to
+                // an empty room. Skipping publish also skips incrementSeq, so
+                // no seq gap is created, and the next delta after a viewer
+                // attaches carries the whole message so far. See viewer-gate.ts.
             } else {
                 // Publish to viewers via Redis cache + Socket.IO rooms
                 await publishSessionEvent(sessionId, eventToPublish);

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -15,6 +15,7 @@ import {
 } from "../../sio-state/index.js";
 import { socketAckedSeqs } from "./ack-tracker.js";
 import { clearThinkingMaps } from "./thinking-tracker.js";
+import { forgetViewerGate } from "./viewer-gate.js";
 import { pendingChunkedStates, enqueueSessionEvent } from "./event-pipeline.js";
 import type { RelaySocket } from "./types.js";
 import { createLogger } from "@pizzapi/tools";
@@ -72,6 +73,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         }
 
         clearThinkingMaps(sessionId);
+        forgetViewerGate(sessionId);
         // Defer chunked-state cleanup until all previously-queued
         // session_messages_chunk handlers have finished.  If we deleted
         // pendingChunkedStates immediately, any chunks still queued in
@@ -123,6 +125,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             }
 
             clearThinkingMaps(sessionId);
+            forgetViewerGate(sessionId);
             // Drain chunk handlers before deleting their assembly state or the
             // last queued chunk can lose the durable checkpoint on disconnect.
             await enqueueSessionEvent(sessionId, async () => {

--- a/packages/server/src/ws/namespaces/relay/viewer-gate.test.ts
+++ b/packages/server/src/ws/namespaces/relay/viewer-gate.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// ── Stubs for the two things the gate reads ──────────────────────────────────
+// Local room membership (sync, via the io adapter) and the cluster-wide count.
+
+let localRoomSizes = new Map<string, number>();
+let clusterCount: number | Error = 0;
+let clusterCalls = 0;
+let ioAvailable = true;
+
+mock.module("../../sio-registry/context.js", () => ({
+    getIo: () => {
+        if (!ioAvailable) return undefined;
+        return {
+            of: () => ({
+                adapter: {
+                    rooms: {
+                        get: (room: string) =>
+                            localRoomSizes.has(room)
+                                ? new Set(Array.from({ length: localRoomSizes.get(room)! }, (_, i) => `s${i}`))
+                                : undefined,
+                    },
+                },
+            }),
+        };
+    },
+    viewerSessionRoom: (sessionId: string) => `viewer:${sessionId}`,
+}));
+
+mock.module("../../sio-registry/sessions.js", () => ({
+    getViewerCount: async (_sessionId: string) => {
+        clusterCalls++;
+        if (clusterCount instanceof Error) throw clusterCount;
+        return clusterCount;
+    },
+}));
+
+const { isDeltaEvent, shouldPublishDelta, resetViewerGate, forgetViewerGate } = await import("./viewer-gate.js");
+
+/** Let the fire-and-forget cluster refresh settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+    localRoomSizes = new Map();
+    clusterCount = 0;
+    clusterCalls = 0;
+    ioAvailable = true;
+    resetViewerGate();
+});
+
+afterEach(() => {
+    resetViewerGate();
+});
+
+describe("isDeltaEvent", () => {
+    test("only the two pure-animation event types are gated", () => {
+        expect(isDeltaEvent("message_update")).toBe(true);
+        expect(isDeltaEvent("tool_execution_update")).toBe(true);
+
+        // Everything else feeds durable state, push, or meta rooms.
+        for (const type of [
+            "message_end",
+            "turn_end",
+            "agent_end",
+            "session_active",
+            "tool_execution_start",
+            "tool_execution_end",
+            "cli_error",
+            "heartbeat",
+        ]) {
+            expect(isDeltaEvent(type)).toBe(false);
+        }
+        expect(isDeltaEvent(undefined)).toBe(false);
+        expect(isDeltaEvent(123)).toBe(false);
+    });
+});
+
+describe("shouldPublishDelta", () => {
+    test("publishes immediately when a viewer is attached to this server", async () => {
+        localRoomSizes.set("viewer:s1", 1);
+        expect(shouldPublishDelta("s1")).toBe(true);
+        // Fast path must not touch the cluster query at all.
+        expect(clusterCalls).toBe(0);
+    });
+
+    test("suppresses only after a confirmed cluster-wide zero", async () => {
+        // First call has no cached count yet — fail open.
+        expect(shouldPublishDelta("s1")).toBe(true);
+        await settle();
+
+        // Now the refresh has confirmed nobody is watching anywhere.
+        expect(shouldPublishDelta("s1")).toBe(false);
+    });
+
+    test("publishes when a viewer is attached to another server", async () => {
+        clusterCount = 1;
+        shouldPublishDelta("s1");
+        await settle();
+        expect(shouldPublishDelta("s1")).toBe(true);
+    });
+
+    test("fails open when the cluster query throws", async () => {
+        clusterCount = new Error("redis down");
+        shouldPublishDelta("s1");
+        await settle();
+        expect(shouldPublishDelta("s1")).toBe(true);
+    });
+
+    test("fails open when io is unavailable and the count never resolves", () => {
+        ioAvailable = false;
+        expect(shouldPublishDelta("s1")).toBe(true);
+    });
+
+    test("a viewer attaching locally overrides a cached zero immediately", async () => {
+        shouldPublishDelta("s1");
+        await settle();
+        expect(shouldPublishDelta("s1")).toBe(false);
+
+        // No waiting for the TTL — the local check runs first.
+        localRoomSizes.set("viewer:s1", 1);
+        expect(shouldPublishDelta("s1")).toBe(true);
+    });
+
+    test("caches the cluster count instead of querying per delta", async () => {
+        shouldPublishDelta("s1");
+        await settle();
+        const afterFirst = clusterCalls;
+
+        for (let i = 0; i < 50; i++) shouldPublishDelta("s1");
+        expect(clusterCalls).toBe(afterFirst);
+    });
+
+    test("forgetViewerGate drops cached presence so the next call fails open", async () => {
+        shouldPublishDelta("s1");
+        await settle();
+        expect(shouldPublishDelta("s1")).toBe(false);
+
+        forgetViewerGate("s1");
+        expect(shouldPublishDelta("s1")).toBe(true);
+    });
+
+    test("sessions are gated independently", async () => {
+        localRoomSizes.set("viewer:watched", 1);
+        shouldPublishDelta("unwatched");
+        await settle();
+
+        expect(shouldPublishDelta("watched")).toBe(true);
+        expect(shouldPublishDelta("unwatched")).toBe(false);
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/viewer-gate.ts
+++ b/packages/server/src/ws/namespaces/relay/viewer-gate.ts
@@ -1,0 +1,121 @@
+/**
+ * Viewer-presence gate for pure streaming deltas.
+ *
+ * `message_update` / `tool_execution_update` are the only relay events that
+ * exist purely to animate a watching UI. Every other event type feeds durable
+ * state, push notifications, or meta rooms, so those always publish.
+ *
+ * Why this is worth gating: each delta carries the CUMULATIVE in-progress
+ * message (`AssistantMessageEvent.partial` is a full `AssistantMessage`, not
+ * just the new characters). `publishSessionEvent` rPushes every one of them
+ * into a 1000-entry Redis list and PUBLISHes it through the cluster adapter —
+ * so a single long reply costs O(n²) bytes of cache writes and fan-out, even
+ * when the room is empty. Night Shift does this all night to nobody.
+ *
+ * Why dropping them is safe: because each delta is cumulative, a viewer that
+ * attaches mid-generation is repaired by the very next delta — it carries the
+ * whole message so far, not a fragment. Skipping the publish also skips
+ * `incrementSeq`, so no sequence gap is created and viewers never see a hole
+ * that would trigger a resync. Session liveness is unaffected: the pipeline
+ * already called `touchSessionActivity` (which extends ephemeral expiry and
+ * refreshes the session TTL) before reaching the publish branch.
+ *
+ * Deliberately NOT gated: `trackThinkingDeltas` consumes `message_update`
+ * server-side to bake thinking durations into the later `message_end`. It runs
+ * before this gate and must keep seeing every delta, or unwatched sessions
+ * would lose thinking times permanently in the cached transcript.
+ */
+
+import { getIo, viewerSessionRoom } from "../../sio-registry/context.js";
+import { getViewerCount } from "../../sio-registry/sessions.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("viewer-gate");
+
+/** Events that exist only to animate a live viewer. */
+const DELTA_EVENTS = new Set(["message_update", "tool_execution_update"]);
+
+/** How long a cluster-wide viewer count is trusted before re-querying. */
+const CLUSTER_CACHE_TTL_MS = 2_000;
+
+interface ClusterEntry {
+    count: number;
+    at: number;
+    refreshing: boolean;
+}
+
+const clusterViewers = new Map<string, ClusterEntry>();
+
+export function isDeltaEvent(type: unknown): boolean {
+    return typeof type === "string" && DELTA_EVENTS.has(type);
+}
+
+/** Local (this-server-only) viewer sockets in a session's room. */
+function localViewerCount(sessionId: string): number {
+    try {
+        const io = getIo();
+        if (!io) return 0;
+        return io.of("/viewer").adapter.rooms.get(viewerSessionRoom(sessionId))?.size ?? 0;
+    } catch {
+        return 0;
+    }
+}
+
+/**
+ * Refresh the cached cluster-wide count in the background.
+ *
+ * ponytail: fire-and-forget with a TTL rather than a maintained counter — the
+ * only cost of a stale "0" is that a viewer on ANOTHER server misses up to
+ * CLUSTER_CACHE_TTL_MS of deltas, which the next cumulative delta repairs.
+ * Swap for adapter join/leave bookkeeping only if that window ever matters.
+ */
+function refreshClusterCount(sessionId: string, entry: ClusterEntry | undefined): void {
+    if (entry?.refreshing) return;
+    const next: ClusterEntry = entry ?? { count: -1, at: 0, refreshing: false };
+    next.refreshing = true;
+    clusterViewers.set(sessionId, next);
+    void getViewerCount(sessionId)
+        .then((count) => {
+            next.count = count;
+            next.at = Date.now();
+        })
+        .catch((err) => {
+            // Fail open: leave the count unknown so deltas keep flowing.
+            next.count = -1;
+            next.at = 0;
+            log.warn(`viewer count refresh failed for ${sessionId}:`, err);
+        })
+        .finally(() => {
+            next.refreshing = false;
+        });
+}
+
+/**
+ * True when a streaming delta should be published.
+ *
+ * Fail-open by design: anything unknown (io missing, count never resolved,
+ * adapter error) publishes. Guessing "nobody is watching" wrong means a
+ * visibly frozen session, which is far worse than a wasted write.
+ */
+export function shouldPublishDelta(sessionId: string): boolean {
+    // Fast path: someone is attached to this server. No await, no Redis.
+    if (localViewerCount(sessionId) > 0) return true;
+
+    const entry = clusterViewers.get(sessionId);
+    const fresh = entry && entry.at > 0 && Date.now() - entry.at < CLUSTER_CACHE_TTL_MS;
+    if (!fresh) refreshClusterCount(sessionId, entry);
+
+    // Only a confirmed, fresh zero suppresses. Unknown (-1) publishes.
+    if (fresh && entry!.count === 0) return false;
+    return true;
+}
+
+/** Drop cached presence for a session that has ended. */
+export function forgetViewerGate(sessionId: string): void {
+    clusterViewers.delete(sessionId);
+}
+
+/** Test seam. */
+export function resetViewerGate(): void {
+    clusterViewers.clear();
+}


### PR DESCRIPTION
## Problem

Every session on the relay streams its token-by-token output to the server whether or not anyone has it open, and the server pays full price to store all of it.

The cost is worse than it looks, because each `message_update` carries the **cumulative** in-progress message — `AssistantMessageEvent.partial` is a full `AssistantMessage`, not just the new characters. So `publishSessionEvent` rPushes an ever-growing copy of the same message into a 1000-entry Redis list and PUBLISHes it through the cluster adapter (which broadcasts regardless of local room membership). A single long reply costs **O(n²) bytes** of cache writes and fan-out, to an empty room.

Night Shift does this all night, on every session, to nobody.

## Change

Gate the two events that exist purely to animate a live viewer — `message_update` and `tool_execution_update` — on viewer presence. Everything else always publishes.

Decision order in `viewer-gate.ts`:

1. Viewer attached to this server → publish, synchronously, no Redis touched.
2. Otherwise consult a 2s-TTL cached cluster-wide count, refreshed fire-and-forget.
3. **Only a confirmed, fresh zero suppresses.** Unknown, errored, or io-missing → publish.

Fail-open is deliberate everywhere. Guessing "nobody is watching" wrong means a visibly frozen session, which is far worse than a wasted write.

## Why this is safe

- **No sequence gaps.** Skipping the publish also skips `incrementSeq`, so viewers never see a hole and no resync is triggered.
- **Mid-generation attach self-heals.** Because deltas are cumulative, the very next delta after a viewer attaches carries the entire message so far — repair is sub-second during generation, not "wait for the next snapshot".
- **Thinking durations are preserved.** `trackThinkingDeltas` consumes `message_update` server-side to bake durations into the later `message_end`. It runs at event-pipeline.ts:422, *before* the gate at :459, so it still sees every delta. (This is the reason the gate lives server-side rather than having runners suppress their own sends — runner-side gating would silently lose thinking times on every unwatched session, permanently, in the cached transcript.)
- **Push is untouched.** `trackPushPendingState` and `checkPushNotifications` run after the gate and key off `agent_end` / `cli_error` / `tool_execution_start`, none of which are gated.
- **Session liveness is unaffected.** `touchSessionActivity` — which extends ephemeral expiry and refreshes the session TTL — already ran earlier in the pipeline, so ephemeral sessions streaming to nobody still stay alive.

## Multi-server note

The fast path checks local room membership only; cluster-wide presence comes from the TTL-cached `getViewerCount`. Worst case for a viewer attached to a *different* server is up to 2s of dropped deltas before the cache refreshes — which the next cumulative delta repairs. Swap the TTL cache for adapter join/leave bookkeeping if that window ever matters.

## Tests

10 new tests in `viewer-gate.test.ts`: local-attach fast path (asserts the cluster query is never called), cluster-attach, confirmed-zero suppression, three fail-open modes (query throws, io unavailable, count unresolved), cache reuse across 50 deltas, per-session independence, and cleanup via `forgetViewerGate`.

`bun scripts/test-isolated.ts packages/server/src/ws` → 33 passed. Typecheck clean.

## Credit

The O(n²)/cumulative-partial finding and the `trackThinkingDeltas` hazard both came out of an adversarial review pass, not the original design. The first draft of this change was aimed at the wrong layer.
