### PR TITLE
feat(modes): declarative UI contributions for session modes

### DIFF
--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -378,6 +378,19 @@ describe("readOverlayManifest", () => {
         expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].workspace"))).toBe(true);
     });
 
+    test("workspaces that escape the home directory are rejected", () => {
+        for (const workspace of ["~/../elsewhere", "~/Documents/../../etc", "~/./x", "~", "~/", "/absolute"]) {
+            const dir = fixturePkg({
+                schemaVersion: 1,
+                services: [{ id: "svc", label: "x", entry: "./service.ts", sessionModes: [{ id: "m", label: "M", workspace }] }],
+            });
+            dirs.push(dir);
+            const result = readOverlayManifest(dir, provenance);
+            expect(result.overlay).toBeNull();
+            expect(result.issues.some((i) => i.field.endsWith("sessionModes[0].workspace"))).toBe(true);
+        }
+    });
+
     test("a full mode ui block is accepted and survives parsing", () => {
         const dir = fixturePkg({
             schemaVersion: 1,

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -378,6 +378,87 @@ describe("readOverlayManifest", () => {
         expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].workspace"))).toBe(true);
     });
 
+    test("a full mode ui block is accepted and survives parsing", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{
+                id: "svc",
+                label: "x",
+                entry: "./service.ts",
+                sessionModes: [{
+                    id: "work",
+                    label: "Work",
+                    workspace: "~/Documents/Workspace",
+                    ui: {
+                        preset: "work",
+                        chrome: { git: false, files: true },
+                        toolRendering: "activity",
+                        vocabulary: { session: "task", sessions: "tasks" },
+                        accent: "#7c3aed",
+                        composerPlaceholder: "What do you need?",
+                        home: {
+                            greeting: "Good morning",
+                            suggestions: [{ label: "Daily report", icon: "file-text", prompt: "Write my daily report" }],
+                            recent: true,
+                        },
+                        artifacts: { enabled: true, extensions: ["pdf", "docx"] },
+                        scheduled: true,
+                    },
+                }],
+            }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toEqual([]);
+        const mode = result.overlay?.services?.[0].sessionModes?.[0];
+        expect(mode?.ui?.preset).toBe("work");
+        expect(mode?.ui?.chrome?.git).toBe(false);
+        expect(mode?.ui?.home?.suggestions?.[0]?.prompt).toBe("Write my daily report");
+        expect(mode?.ui?.artifacts?.extensions).toEqual(["pdf", "docx"]);
+    });
+
+    test("malformed mode ui fields are rejected with actionable fields", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{
+                id: "svc",
+                label: "x",
+                entry: "./service.ts",
+                sessionModes: [{
+                    id: "work",
+                    label: "Work",
+                    workspace: "~/Workspace",
+                    ui: {
+                        preset: "casual",
+                        toolRendering: "terse",
+                        chrome: { git: "no", bogus: true },
+                        vocabulary: { session: "", nope: "x" },
+                        scheduled: "yes",
+                        home: { suggestions: [{ label: "x" }] },
+                        artifacts: { extensions: [""] },
+                        mystery: 1,
+                    },
+                }],
+            }],
+        });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        const fields = result.issues.map((i) => i.field);
+        expect(fields).toContain("services[0].sessionModes[0].ui.preset");
+        expect(fields).toContain("services[0].sessionModes[0].ui.toolRendering");
+        expect(fields).toContain("services[0].sessionModes[0].ui.chrome.git");
+        expect(fields).toContain("services[0].sessionModes[0].ui.chrome.bogus");
+        expect(fields).toContain("services[0].sessionModes[0].ui.vocabulary.session");
+        expect(fields).toContain("services[0].sessionModes[0].ui.vocabulary.nope");
+        expect(fields).toContain("services[0].sessionModes[0].ui.scheduled");
+        // A suggestion without a prompt is useless — the chip would do nothing.
+        expect(fields).toContain("services[0].sessionModes[0].ui.home.suggestions[0].prompt");
+        expect(fields).toContain("services[0].sessionModes[0].ui.artifacts.enabled");
+        expect(fields).toContain("services[0].sessionModes[0].ui.artifacts.extensions");
+        expect(fields).toContain("services[0].sessionModes[0].ui.mystery");
+    });
+
     test("valid inline trigger and sigil definitions are accepted", () => {
         const dir = fixturePkg({
             schemaVersion: 1,

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -379,7 +379,7 @@ describe("readOverlayManifest", () => {
     });
 
     test("workspaces that escape the home directory are rejected", () => {
-        for (const workspace of ["~/../elsewhere", "~/Documents/../../etc", "~/./x", "~", "~/", "/absolute"]) {
+        for (const workspace of ["~/../elsewhere", "~/Documents/../../etc", "~/./x", "~", "~/", "/absolute", "~/..\\elsewhere", "~\\x"]) {
             const dir = fixturePkg({
                 schemaVersion: 1,
                 services: [{ id: "svc", label: "x", entry: "./service.ts", sessionModes: [{ id: "m", label: "M", workspace }] }],

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -553,8 +553,12 @@ function validateSessionModeDef(entry: unknown, field: string, push: PushFn): vo
     if (typeof entry.id !== "string" || entry.id.length === 0) push(`${field}.id`, "must be a non-empty string", "Set id to a unique mode identifier.");
     if (typeof entry.label !== "string" || entry.label.length === 0) push(`${field}.label`, "must be a non-empty string", "Set label to a human-readable mode name.");
     if (entry.icon !== undefined && typeof entry.icon !== "string") push(`${field}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
-    if (typeof entry.workspace !== "string" || !/^~(?:\/|$)/.test(entry.workspace)) {
+    // The workspace becomes a spawn cwd, so it is a trust boundary: `~/../x`
+    // would expand by plain string substitution and escape the home directory.
+    if (typeof entry.workspace !== "string" || !/^~\/[^/]/.test(entry.workspace)) {
         push(`${field}.workspace`, "must be a home-relative path beginning with ~/", "Set workspace to a path such as ~/Documents/Workspace.");
+    } else if (entry.workspace.split("/").some((segment) => segment === "." || segment === "..")) {
+        push(`${field}.workspace`, "must not contain . or .. path segments", "Point workspace at a fixed path inside the home directory.");
     }
     if (entry.ui !== undefined) validateSessionModeUi(entry.ui, `${field}.ui`, push);
 }

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -555,9 +555,11 @@ function validateSessionModeDef(entry: unknown, field: string, push: PushFn): vo
     if (entry.icon !== undefined && typeof entry.icon !== "string") push(`${field}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
     // The workspace becomes a spawn cwd, so it is a trust boundary: `~/../x`
     // would expand by plain string substitution and escape the home directory.
-    if (typeof entry.workspace !== "string" || !/^~\/[^/]/.test(entry.workspace)) {
+    // Backslashes count as separators too — on Windows `~/..\x` escapes just as
+    // effectively, and a home-relative path never legitimately contains one.
+    if (typeof entry.workspace !== "string" || !/^~\/[^/\\]/.test(entry.workspace)) {
         push(`${field}.workspace`, "must be a home-relative path beginning with ~/", "Set workspace to a path such as ~/Documents/Workspace.");
-    } else if (entry.workspace.split("/").some((segment) => segment === "." || segment === "..")) {
+    } else if (entry.workspace.split(/[/\\]/).some((segment) => segment === "." || segment === "..")) {
         push(`${field}.workspace`, "must not contain . or .. path segments", "Point workspace at a fixed path inside the home directory.");
     }
     if (entry.ui !== undefined) validateSessionModeUi(entry.ui, `${field}.ui`, push);

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -41,7 +41,15 @@ const TRIGGER_PARAM_KEYS = new Set(["name", "label", "type", "description", "req
 const TRIGGER_KEYS = new Set(["type", "label", "description", "schema", "params"]);
 /** Allowed keys on a sigil definition, mirrored from ServiceSigilDef (excludes daemon-populated serviceId/resolvePort). */
 const SIGIL_KEYS = new Set(["type", "label", "description", "icon", "resolve", "schema", "aliases", "variants"]);
-const SESSION_MODE_KEYS = new Set(["id", "label", "icon", "workspace"]);
+const SESSION_MODE_KEYS = new Set(["id", "label", "icon", "workspace", "ui"]);
+const MODE_UI_KEYS = new Set(["preset", "chrome", "toolRendering", "vocabulary", "accent", "composerPlaceholder", "home", "artifacts", "scheduled"]);
+const MODE_CHROME_KEYS = new Set(["git", "terminal", "processes", "diffs", "files"]);
+const MODE_VOCABULARY_KEYS = new Set(["session", "sessions", "newSession"]);
+const MODE_HOME_KEYS = new Set(["greeting", "suggestions", "recent"]);
+const MODE_SUGGESTION_KEYS = new Set(["label", "icon", "prompt"]);
+const MODE_ARTIFACT_KEYS = new Set(["enabled", "extensions"]);
+const MODE_PRESETS = new Set(["coding", "work"]);
+const MODE_TOOL_RENDERING = new Set(["detailed", "activity"]);
 
 export interface PackageProvenance {
     /** Normalized package identity, e.g. "npm:@acme/pi-github". */
@@ -547,6 +555,134 @@ function validateSessionModeDef(entry: unknown, field: string, push: PushFn): vo
     if (entry.icon !== undefined && typeof entry.icon !== "string") push(`${field}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
     if (typeof entry.workspace !== "string" || !/^~(?:\/|$)/.test(entry.workspace)) {
         push(`${field}.workspace`, "must be a home-relative path beginning with ~/", "Set workspace to a path such as ~/Documents/Workspace.");
+    }
+    if (entry.ui !== undefined) validateSessionModeUi(entry.ui, `${field}.ui`, push);
+}
+
+/** Validate the declarative UI contract on a session mode. */
+function validateSessionModeUi(entry: unknown, field: string, push: PushFn): void {
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a mode UI object, or omit it.`);
+        return;
+    }
+    for (const key of Object.keys(entry)) {
+        if (!MODE_UI_KEYS.has(key)) {
+            push(`${field}.${key}`, `unknown mode ui key "${key}"`, `Remove "${key}" — allowed keys: ${[...MODE_UI_KEYS].join(", ")}.`);
+        }
+    }
+    if (entry.preset !== undefined && (typeof entry.preset !== "string" || !MODE_PRESETS.has(entry.preset))) {
+        push(`${field}.preset`, "must be \"coding\" or \"work\"", "Set preset to one of: coding, work.");
+    }
+    if (entry.toolRendering !== undefined && (typeof entry.toolRendering !== "string" || !MODE_TOOL_RENDERING.has(entry.toolRendering))) {
+        push(`${field}.toolRendering`, "must be \"detailed\" or \"activity\"", "Set toolRendering to one of: detailed, activity.");
+    }
+    if (entry.accent !== undefined && typeof entry.accent !== "string") {
+        push(`${field}.accent`, "must be a string", "Set accent to a color token or hex string, or omit it.");
+    }
+    if (entry.composerPlaceholder !== undefined && typeof entry.composerPlaceholder !== "string") {
+        push(`${field}.composerPlaceholder`, "must be a string", "Set composerPlaceholder to placeholder text, or omit it.");
+    }
+    if (entry.scheduled !== undefined && typeof entry.scheduled !== "boolean") {
+        push(`${field}.scheduled`, "must be a boolean", "Set scheduled to true or false, or omit it.");
+    }
+    validateBooleanBag(entry.chrome, `${field}.chrome`, MODE_CHROME_KEYS, "chrome", push);
+    validateStringBag(entry.vocabulary, `${field}.vocabulary`, MODE_VOCABULARY_KEYS, "vocabulary", push);
+
+    if (entry.home !== undefined) {
+        if (!isPlainObject(entry.home)) {
+            push(`${field}.home`, "must be an object", `Fix ${field}.home to a mode home object, or omit it.`);
+        } else {
+            for (const key of Object.keys(entry.home)) {
+                if (!MODE_HOME_KEYS.has(key)) {
+                    push(`${field}.home.${key}`, `unknown mode home key "${key}"`, `Remove "${key}" — allowed keys: ${[...MODE_HOME_KEYS].join(", ")}.`);
+                }
+            }
+            if (entry.home.greeting !== undefined && typeof entry.home.greeting !== "string") {
+                push(`${field}.home.greeting`, "must be a string", "Set greeting to a headline string, or omit it.");
+            }
+            if (entry.home.recent !== undefined && typeof entry.home.recent !== "boolean") {
+                push(`${field}.home.recent`, "must be a boolean", "Set recent to true or false, or omit it.");
+            }
+            if (entry.home.suggestions !== undefined) {
+                if (!Array.isArray(entry.home.suggestions)) {
+                    push(`${field}.home.suggestions`, "must be an array", "Set suggestions to an array of { label, prompt } objects.");
+                } else {
+                    entry.home.suggestions.forEach((suggestion: unknown, index: number) => {
+                        const suggestionField = `${field}.home.suggestions[${index}]`;
+                        if (!isPlainObject(suggestion)) {
+                            push(suggestionField, "must be an object", "Use { label, prompt } suggestion objects.");
+                            return;
+                        }
+                        for (const key of Object.keys(suggestion)) {
+                            if (!MODE_SUGGESTION_KEYS.has(key)) {
+                                push(`${suggestionField}.${key}`, `unknown suggestion key "${key}"`, `Remove "${key}" — allowed keys: ${[...MODE_SUGGESTION_KEYS].join(", ")}.`);
+                            }
+                        }
+                        if (typeof suggestion.label !== "string" || suggestion.label.length === 0) {
+                            push(`${suggestionField}.label`, "must be a non-empty string", "Set label to the chip text.");
+                        }
+                        if (typeof suggestion.prompt !== "string" || suggestion.prompt.length === 0) {
+                            push(`${suggestionField}.prompt`, "must be a non-empty string", "Set prompt to the text sent when the chip is chosen.");
+                        }
+                        if (suggestion.icon !== undefined && typeof suggestion.icon !== "string") {
+                            push(`${suggestionField}.icon`, "must be a string", "Set icon to a Lucide icon name, or omit it.");
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    if (entry.artifacts !== undefined) {
+        if (!isPlainObject(entry.artifacts)) {
+            push(`${field}.artifacts`, "must be an object", `Fix ${field}.artifacts to { enabled, extensions? }, or omit it.`);
+        } else {
+            for (const key of Object.keys(entry.artifacts)) {
+                if (!MODE_ARTIFACT_KEYS.has(key)) {
+                    push(`${field}.artifacts.${key}`, `unknown artifacts key "${key}"`, `Remove "${key}" — allowed keys: ${[...MODE_ARTIFACT_KEYS].join(", ")}.`);
+                }
+            }
+            if (typeof entry.artifacts.enabled !== "boolean") {
+                push(`${field}.artifacts.enabled`, "must be a boolean", "Set enabled to true or false.");
+            }
+            if (entry.artifacts.extensions !== undefined) {
+                if (!Array.isArray(entry.artifacts.extensions) || !entry.artifacts.extensions.every((ext: unknown) => typeof ext === "string" && ext.length > 0)) {
+                    push(`${field}.artifacts.extensions`, "must be an array of non-empty strings", 'Use extensions like ["pdf", "docx"] without leading dots.');
+                }
+            }
+        }
+    }
+}
+
+/** Validate an object whose known keys must all be booleans. */
+function validateBooleanBag(entry: unknown, field: string, allowed: Set<string>, kind: string, push: PushFn): void {
+    if (entry === undefined) return;
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a ${kind} object, or omit it.`);
+        return;
+    }
+    for (const [key, value] of Object.entries(entry)) {
+        if (!allowed.has(key)) {
+            push(`${field}.${key}`, `unknown ${kind} key "${key}"`, `Remove "${key}" — allowed keys: ${[...allowed].join(", ")}.`);
+        } else if (typeof value !== "boolean") {
+            push(`${field}.${key}`, "must be a boolean", `Set ${key} to true or false.`);
+        }
+    }
+}
+
+/** Validate an object whose known keys must all be non-empty strings. */
+function validateStringBag(entry: unknown, field: string, allowed: Set<string>, kind: string, push: PushFn): void {
+    if (entry === undefined) return;
+    if (!isPlainObject(entry)) {
+        push(field, "must be an object", `Fix ${field} to a ${kind} object, or omit it.`);
+        return;
+    }
+    for (const [key, value] of Object.entries(entry)) {
+        if (!allowed.has(key)) {
+            push(`${field}.${key}`, `unknown ${kind} key "${key}"`, `Remove "${key}" — allowed keys: ${[...allowed].join(", ")}.`);
+        } else if (typeof value !== "string" || value.length === 0) {
+            push(`${field}.${key}`, "must be a non-empty string", `Set ${key} to a non-empty string.`);
+        }
     }
 }
 

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -137,6 +137,7 @@ are confined to the package root.
 | `panel.requires` | No | `[]` | Vars resolved and passed to the panel iframe as query params. One or more of `PWD`, `SESSION_ID`, `HOME`, `USER`, `PROJECT_DIR` |
 | `triggers` | No | `[]` | Inline `ServiceTriggerDef[]` **or** a path to a JSON file |
 | `sigils` | No | `[]` | Inline `ServiceSigilDef[]` **or** a path to a JSON file |
+| `sessionModes` | No | `[]` | `ServiceModeDef[]` — workspaces with their own UI identity (see [Session modes](#session-modes)) |
 
 ### Split files
 
@@ -384,6 +385,65 @@ To resolve sigils, expose a matching HTTP route. If the service has **no panel**
 call `announceSigilServer(port)` (instead of `announcePanel`) so the tunnel routes
 resolve calls without listing the service in the panels grid. Sigil defs are
 advertised via `service_announce`, the same as triggers.
+
+---
+
+## Session modes
+
+A session mode claims a workspace directory and gives it its own UI identity.
+Every session whose cwd is inside that directory belongs to the mode — including
+sessions started from a terminal, not just from the mode picker.
+
+Use a mode when the package is for a **kind of work**, not a kind of tool: the
+coding chrome (git, terminal, diffs) is wrong for a research or documents
+workspace, and a mode is how you turn it off.
+
+```json
+"sessionModes": [{
+  "id": "work",
+  "label": "Work",
+  "icon": "briefcase",
+  "workspace": "~/Documents/Workspace",
+  "ui": {
+    "preset": "work",
+    "toolRendering": "activity",
+    "vocabulary": { "session": "task", "sessions": "tasks" },
+    "accent": "#7c3aed",
+    "composerPlaceholder": "What do you need done?",
+    "home": {
+      "greeting": "What are we working on?",
+      "suggestions": [
+        { "label": "Daily report", "icon": "sun", "prompt": "Write my daily report" }
+      ]
+    },
+    "artifacts": { "enabled": true },
+    "scheduled": true
+  }
+}]
+```
+
+`workspace` must be home-relative (`~/...`); the runner expands it. Everything
+under `ui` is optional — omit it and the mode renders exactly like today's
+coding UI.
+
+| `ui` field | Effect |
+|-----------|--------|
+| `preset` | `"work"` hides git/terminal/process chrome; `"coding"` (default) keeps it |
+| `chrome` | Per-flag overrides on top of the preset: `git`, `terminal`, `processes`, `diffs`, `files` |
+| `toolRendering` | `"activity"` collapses tool calls to human-language lines that expand on click |
+| `vocabulary` | Rename the noun: `session` → `"task"`, plus `sessions`, `newSession` |
+| `accent` | Color for the mode badge |
+| `composerPlaceholder` | Composer placeholder text |
+| `home` | Composer-first landing: `greeting`, `suggestions[]`, `recent` |
+| `artifacts` | `{ enabled, extensions? }` — inline previews for deliverables |
+| `scheduled` | Surface standing `time:cron` / `time:at` instructions |
+
+Suggestions **prefill** the composer rather than sending, so a partial opening
+(`"Research "`) is a good prompt. Artifact previews cover Markdown, images,
+PDF, CSV and sandboxed HTML; other extensions render a download card.
+
+Declaring a mode does **not** require any service code — a service whose only
+job is to declare a mode can have a no-op `init`/`dispose`.
 
 ---
 

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -650,6 +650,112 @@ A service doesn't need a UI panel. Omit `panel` from the manifest and skip `anno
 
 ---
 
+## Session Modes
+
+A **session mode** is a workspace with its own identity in the UI. A mode claims
+a directory; every session whose working directory is inside it belongs to that
+mode, including sessions started from the terminal.
+
+Modes exist so a package can make PizzaPi feel like the right tool for
+non-coding work. A mode **declares** what it wants and PizzaPi renders it
+natively — modes do not ship UI code.
+
+```json
+{
+  "id": "pizzawork",
+  "label": "PizzaWork",
+  "entry": "./src/service.ts",
+  "sessionModes": [
+    {
+      "id": "work",
+      "label": "Work",
+      "icon": "briefcase",
+      "workspace": "~/Documents/Workspace",
+      "ui": {
+        "preset": "work",
+        "toolRendering": "activity",
+        "vocabulary": { "session": "task", "sessions": "tasks" },
+        "accent": "#7c3aed",
+        "composerPlaceholder": "What do you need done?",
+        "home": {
+          "greeting": "What are we working on?",
+          "suggestions": [
+            { "label": "Daily report", "icon": "sun", "prompt": "Write my daily report" }
+          ]
+        },
+        "artifacts": { "enabled": true },
+        "scheduled": true
+      }
+    }
+  ]
+}
+```
+
+### Mode fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique mode ID within the package |
+| `label` | string | Name shown on the mode picker |
+| `icon` | string | Lucide icon name |
+| `workspace` | string | Home-relative path (`~/...`), resolved per runner |
+| `ui` | object | Optional — how PizzaPi should render this mode's sessions |
+
+### `ui` fields
+
+Every field is optional, and omitting `ui` entirely gives the standard coding
+UI. A mode only declares what differs.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `preset` | `"coding"` \| `"work"` | `"coding"` | `work` hides git, terminal and process chrome |
+| `chrome` | object | from preset | Per-surface overrides: `git`, `terminal`, `processes`, `diffs`, `files` |
+| `toolRendering` | `"detailed"` \| `"activity"` | preset-derived | `activity` collapses each tool call to a human-language line that expands on click |
+| `vocabulary` | object | — | `session`, `sessions`, `newSession` noun overrides |
+| `accent` | string | — | Color token or hex used for the mode badge |
+| `composerPlaceholder` | string | — | Placeholder text in the composer |
+| `home` | object | — | `greeting`, `suggestions[]` (`label`, `icon`, `prompt`), `recent` |
+| `artifacts` | object | disabled | `enabled`, plus optional `extensions[]` |
+| `scheduled` | boolean | `false` | Show standing `time:cron` / `time:at` instructions |
+
+### What each surface does
+
+**Chrome.** `preset: "work"` hides the git, terminal and process affordances. A
+hidden panel is also closed, so switching from a coding session cannot strand a
+panel with no button to reopen it. `chrome` overrides individual flags:
+
+```json
+"ui": { "preset": "work", "chrome": { "git": true } }
+```
+
+**Activity rendering.** With `toolRendering: "activity"`, a tool call renders as
+one line — `Created q3-review.md`, `Searched the web for "freight rates"` — that
+expands to the full card. Nothing is hidden; it just stops being the default
+way the transcript reads.
+
+**Artifacts.** When enabled, a file written into the workspace whose extension
+the mode claims renders as an artifact card with an inline preview: Markdown,
+images, PDF, CSV tables and sandboxed HTML. Formats browsers cannot render
+(`docx`, `pptx`, `xlsx`) get a download card. Omit `extensions` for a
+document-centric default set.
+
+**Mode home.** Selecting a mode with no session open shows a composer that
+starts a task directly in the mode's workspace, its suggestion chips, and its
+recent tasks. Suggestions prefill the composer rather than sending, so an
+opening like `"Research "` can be completed before it runs.
+
+**Scheduled.** Lists standing `time:cron` / `time:at` / `time:timer_fired`
+subscriptions across the mode's sessions, with what runs, when, which task owns
+it, and a cancel. See [Time triggers](#custom-triggers).
+
+:::note
+A mode is claimed by workspace containment, not by how a session was started.
+`cd ~/Documents/Workspace && pizza` gets the mode, and so does a task working
+in `~/Documents/Workspace/clients/acme`.
+:::
+
+---
+
 ## Connectivity Services
 
 A **connectivity service** owns a live connection to an outside network — a chat

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -21,6 +21,12 @@ export type {
   ServiceTriggerParamDef,
   ServiceSigilDef,
   ServiceModeDef,
+  ServiceModeUi,
+  ServiceModeChrome,
+  ServiceModeVocabulary,
+  ServiceModeHome,
+  ServiceModeSuggestion,
+  ServiceModeArtifacts,
   JsonValue,
   TriggerFilter,
   TriggerFilterMode,
@@ -28,6 +34,16 @@ export type {
   ServiceAnnounceDelta,
   TunnelInfo,
 } from "./shared.js";
+
+// Session mode UI resolution (shared across server, UI, CLI)
+export {
+  resolveModeUi,
+  isArtifactPath,
+  findSessionMode,
+  cwdInWorkspace,
+  DEFAULT_ARTIFACT_EXTENSIONS,
+} from "./mode-ui.js";
+export type { ResolvedModeUi } from "./mode-ui.js";
 
 // Password validation (shared across server, UI, CLI)
 export {

--- a/packages/protocol/src/mode-ui.test.ts
+++ b/packages/protocol/src/mode-ui.test.ts
@@ -144,6 +144,15 @@ describe("findSessionMode", () => {
         expect(findSessionMode(session, modes, "runner-a")).toBeNull();
         expect(findSessionMode(session, modes, "runner-b")?.id).toBe("work");
     });
+
+    test("a session with no runner does not inherit a runner's mode", () => {
+        // Paths only mean anything on the machine that announced the mode; a
+        // runnerless session cannot be shown to be on it.
+        expect(findSessionMode({ cwd: "/home/j/Workspace" }, modes, "runner-a")).toBeNull();
+        expect(findSessionMode({ cwd: "/home/j/Workspace", runnerId: null }, modes, "runner-a")).toBeNull();
+        // With no mode owner to compare against, containment still applies.
+        expect(findSessionMode({ cwd: "/home/j/Workspace" }, modes)?.id).toBe("work");
+    });
 });
 
 describe("isArtifactPath", () => {

--- a/packages/protocol/src/mode-ui.test.ts
+++ b/packages/protocol/src/mode-ui.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { cwdInWorkspace, findSessionMode, isArtifactPath, resolveModeUi } from "./mode-ui.js";
+import type { ServiceModeDef } from "./shared.js";
+
+const codingMode: ServiceModeDef = { id: "code", label: "Code", workspace: "/home/j/Projects" };
+const workMode: ServiceModeDef = {
+    id: "work",
+    label: "Work",
+    workspace: "/home/j/Workspace",
+    ui: { preset: "work" },
+};
+
+describe("resolveModeUi", () => {
+    test("no mode resolves to today's coding UI", () => {
+        const ui = resolveModeUi(null);
+        expect(ui.git).toBe(true);
+        expect(ui.terminal).toBe(true);
+        expect(ui.processes).toBe(true);
+        expect(ui.diffs).toBe(true);
+        expect(ui.toolRendering).toBe("detailed");
+        expect(ui.sessionNoun).toBe("session");
+        expect(ui.sessionNounPlural).toBe("sessions");
+        expect(ui.newSessionLabel).toBe("New session");
+        expect(ui.artifacts).toBe(false);
+        expect(ui.scheduled).toBe(false);
+    });
+
+    test("a mode without a ui block is unchanged from the coding default", () => {
+        expect(resolveModeUi(codingMode)).toEqual(resolveModeUi(null));
+    });
+
+    test("work preset hides coding chrome and switches tool rendering", () => {
+        const ui = resolveModeUi(workMode);
+        expect(ui.git).toBe(false);
+        expect(ui.terminal).toBe(false);
+        expect(ui.processes).toBe(false);
+        expect(ui.diffs).toBe(false);
+        // Files stay: a knowledge-work mode still needs its deliverables.
+        expect(ui.files).toBe(true);
+        expect(ui.toolRendering).toBe("activity");
+    });
+
+    test("explicit chrome flags override the preset in both directions", () => {
+        const ui = resolveModeUi({
+            ...workMode,
+            ui: { preset: "work", chrome: { git: true, files: false } },
+        });
+        expect(ui.git).toBe(true);
+        expect(ui.files).toBe(false);
+        // Untouched flags still follow the preset.
+        expect(ui.terminal).toBe(false);
+    });
+
+    test("explicit toolRendering overrides the preset default", () => {
+        const ui = resolveModeUi({ ...workMode, ui: { preset: "work", toolRendering: "detailed" } });
+        expect(ui.toolRendering).toBe("detailed");
+    });
+
+    test("vocabulary drives derived plural and action labels", () => {
+        const ui = resolveModeUi({ ...workMode, ui: { vocabulary: { session: "task" } } });
+        expect(ui.sessionNoun).toBe("task");
+        expect(ui.sessionNounPlural).toBe("tasks");
+        expect(ui.newSessionLabel).toBe("New task");
+    });
+
+    test("explicit plural and action labels win over derived ones", () => {
+        const ui = resolveModeUi({
+            ...workMode,
+            ui: { vocabulary: { session: "brief", sessions: "briefs", newSession: "Start a brief" } },
+        });
+        expect(ui.sessionNounPlural).toBe("briefs");
+        expect(ui.newSessionLabel).toBe("Start a brief");
+    });
+
+    test("home defaults to showing recent with no suggestions", () => {
+        const ui = resolveModeUi(workMode);
+        expect(ui.recent).toBe(true);
+        expect(ui.suggestions).toEqual([]);
+        expect(ui.greeting).toBeNull();
+    });
+
+    test("home config is surfaced verbatim", () => {
+        const suggestions = [{ label: "Daily report", prompt: "Write my daily report", icon: "file-text" }];
+        const ui = resolveModeUi({
+            ...workMode,
+            ui: { home: { greeting: "What are we working on?", suggestions, recent: false } },
+        });
+        expect(ui.greeting).toBe("What are we working on?");
+        expect(ui.suggestions).toEqual(suggestions);
+        expect(ui.recent).toBe(false);
+    });
+
+    test("artifacts default to the document set and normalize extensions", () => {
+        const defaults = resolveModeUi({ ...workMode, ui: { artifacts: { enabled: true } } });
+        expect(defaults.artifacts).toBe(true);
+        expect(defaults.artifactExtensions).toContain("pdf");
+        expect(defaults.artifactExtensions).toContain("docx");
+
+        const custom = resolveModeUi({
+            ...workMode,
+            ui: { artifacts: { enabled: true, extensions: [".PDF", "Md"] } },
+        });
+        expect(custom.artifactExtensions).toEqual(["pdf", "md"]);
+    });
+});
+
+describe("cwdInWorkspace", () => {
+    test("matches the workspace itself and paths inside it", () => {
+        expect(cwdInWorkspace("/home/j/Workspace", "/home/j/Workspace")).toBe(true);
+        expect(cwdInWorkspace("/home/j/Workspace/clients/acme", "/home/j/Workspace")).toBe(true);
+    });
+
+    test("respects path boundaries — a sibling prefix is not a match", () => {
+        expect(cwdInWorkspace("/home/j/Workspace-old", "/home/j/Workspace")).toBe(false);
+        expect(cwdInWorkspace("/home/j/Work", "/home/j/Workspace")).toBe(false);
+    });
+
+    test("tolerates a trailing slash in the declared workspace", () => {
+        expect(cwdInWorkspace("/home/j/Workspace/a", "/home/j/Workspace/")).toBe(true);
+    });
+});
+
+describe("findSessionMode", () => {
+    const modes = [codingMode, workMode];
+
+    test("resolves a session by workspace containment", () => {
+        expect(findSessionMode({ cwd: "/home/j/Workspace/acme" }, modes)?.id).toBe("work");
+        expect(findSessionMode({ cwd: "/home/j/Projects/pizzapi" }, modes)?.id).toBe("code");
+    });
+
+    test("returns null for a session outside every workspace", () => {
+        expect(findSessionMode({ cwd: "/tmp/scratch" }, modes)).toBeNull();
+        expect(findSessionMode({ cwd: null }, modes)).toBeNull();
+        expect(findSessionMode(null, modes)).toBeNull();
+    });
+
+    test("deepest workspace wins when modes nest", () => {
+        const nested: ServiceModeDef = { id: "acme", label: "Acme", workspace: "/home/j/Workspace/acme" };
+        expect(findSessionMode({ cwd: "/home/j/Workspace/acme/q3" }, [workMode, nested])?.id).toBe("acme");
+    });
+
+    test("never applies another runner's mode to a session", () => {
+        const session = { cwd: "/home/j/Workspace", runnerId: "runner-b" };
+        expect(findSessionMode(session, modes, "runner-a")).toBeNull();
+        expect(findSessionMode(session, modes, "runner-b")?.id).toBe("work");
+    });
+});
+
+describe("isArtifactPath", () => {
+    const enabled = resolveModeUi({ ...workMode, ui: { artifacts: { enabled: true, extensions: ["pdf", "md"] } } });
+
+    test("matches configured extensions case-insensitively", () => {
+        expect(isArtifactPath("/w/report.pdf", enabled)).toBe(true);
+        expect(isArtifactPath("/w/NOTES.MD", enabled)).toBe(true);
+    });
+
+    test("rejects unconfigured extensions and extensionless paths", () => {
+        expect(isArtifactPath("/w/script.ts", enabled)).toBe(false);
+        expect(isArtifactPath("/w/Makefile", enabled)).toBe(false);
+    });
+
+    test("is always false when artifacts are disabled", () => {
+        expect(isArtifactPath("/w/report.pdf", resolveModeUi(workMode))).toBe(false);
+    });
+});

--- a/packages/protocol/src/mode-ui.ts
+++ b/packages/protocol/src/mode-ui.ts
@@ -1,0 +1,162 @@
+// ============================================================================
+// Session mode UI resolution
+//
+// Turns a mode's declarative `ui` block into the concrete flags the web UI
+// renders from. Modes declare intent; this module decides what that means.
+// Kept in @pizzapi/protocol so the UI, the daemon and tests share one answer.
+// ============================================================================
+
+import type { ServiceModeDef, ServiceModeSuggestion, ServiceModeUi } from "./shared.js";
+
+/** Fully-resolved UI configuration for a session mode. */
+export interface ResolvedModeUi {
+  /** Show the git panel/button. */
+  git: boolean;
+  /** Show the terminal affordance. */
+  terminal: boolean;
+  /** Show the process/shell panel. */
+  processes: boolean;
+  /** Render file edits as diffs. */
+  diffs: boolean;
+  /** Show the file explorer. */
+  files: boolean;
+  /** Transcript tool-call rendering style. */
+  toolRendering: "detailed" | "activity";
+  /** Singular noun for a session in this mode. */
+  sessionNoun: string;
+  /** Plural noun for sessions in this mode. */
+  sessionNounPlural: string;
+  /** Label for the new-session action. */
+  newSessionLabel: string;
+  /** Accent color token/hex, or null when the mode does not theme itself. */
+  accent: string | null;
+  /** Composer placeholder text, or null to use the app default. */
+  composerPlaceholder: string | null;
+  /** Headline for the mode home, or null. */
+  greeting: string | null;
+  /** Suggestion chips for the mode home. */
+  suggestions: ServiceModeSuggestion[];
+  /** Show the recent-sessions list on the mode home. */
+  recent: boolean;
+  /** Artifact cards + artifacts panel enabled. */
+  artifacts: boolean;
+  /** Extensions (lowercase, no dot) treated as deliverables. */
+  artifactExtensions: string[];
+  /** Show the scheduled-instructions surface. */
+  scheduled: boolean;
+}
+
+/** Chrome defaults per preset. */
+const PRESET_CHROME = {
+  coding: { git: true, terminal: true, processes: true, diffs: true, files: true },
+  work: { git: false, terminal: false, processes: false, diffs: false, files: true },
+} as const;
+
+/**
+ * Deliverable extensions assumed when a mode enables artifacts without
+ * naming any. Document-centric: the things a knowledge-work mode produces.
+ */
+export const DEFAULT_ARTIFACT_EXTENSIONS = [
+  "md",
+  "html",
+  "pdf",
+  "csv",
+  "xlsx",
+  "docx",
+  "pptx",
+  "png",
+  "jpg",
+  "jpeg",
+  "svg",
+  "json",
+] as const;
+
+/**
+ * Resolve a mode's declarative UI block into concrete flags.
+ *
+ * `undefined` (no mode / no `ui`) yields today's coding-agent UI, so sessions
+ * outside a mode and modes that predate this contract are unchanged.
+ */
+export function resolveModeUi(mode?: ServiceModeDef | null): ResolvedModeUi {
+  const ui: ServiceModeUi = mode?.ui ?? {};
+  const preset = ui.preset === "work" ? "work" : "coding";
+  const presetChrome = PRESET_CHROME[preset];
+  const chrome = ui.chrome ?? {};
+  const vocabulary = ui.vocabulary ?? {};
+  const home = ui.home ?? {};
+  const artifacts = ui.artifacts;
+
+  const sessionNoun = vocabulary.session ?? "session";
+  const sessionNounPlural = vocabulary.sessions ?? `${sessionNoun}s`;
+
+  const extensions = artifacts?.extensions?.length
+    ? artifacts.extensions.map((ext) => ext.replace(/^\./, "").toLowerCase())
+    : [...DEFAULT_ARTIFACT_EXTENSIONS];
+
+  return {
+    git: chrome.git ?? presetChrome.git,
+    terminal: chrome.terminal ?? presetChrome.terminal,
+    processes: chrome.processes ?? presetChrome.processes,
+    diffs: chrome.diffs ?? presetChrome.diffs,
+    files: chrome.files ?? presetChrome.files,
+    toolRendering: ui.toolRendering ?? (preset === "work" ? "activity" : "detailed"),
+    sessionNoun,
+    sessionNounPlural,
+    newSessionLabel: vocabulary.newSession ?? `New ${sessionNoun}`,
+    accent: ui.accent ?? null,
+    composerPlaceholder: ui.composerPlaceholder ?? null,
+    greeting: home.greeting ?? null,
+    suggestions: home.suggestions ?? [],
+    recent: home.recent ?? true,
+    artifacts: artifacts?.enabled ?? false,
+    artifactExtensions: extensions,
+    scheduled: ui.scheduled ?? false,
+  };
+}
+
+/** True when `path` looks like a deliverable for the given resolved mode. */
+export function isArtifactPath(path: string, resolved: ResolvedModeUi): boolean {
+  if (!resolved.artifacts) return false;
+  const match = /\.([A-Za-z0-9]+)$/.exec(path);
+  if (!match) return false;
+  return resolved.artifactExtensions.includes(match[1]!.toLowerCase());
+}
+
+/**
+ * True when `cwd` is the mode workspace or lives inside it.
+ *
+ * Boundary-aware: `~/Workspace` must not claim `~/Workspace-old`.
+ * Trailing slashes on the workspace are tolerated so a manifest that writes
+ * `~/Documents/Workspace/` behaves the same as one that does not.
+ */
+export function cwdInWorkspace(cwd: string, workspace: string): boolean {
+  const root = workspace.replace(/\/+$/, "");
+  if (!root) return false;
+  return cwd === root || cwd.startsWith(`${root}/`);
+}
+
+/**
+ * Find the mode a session belongs to, by workspace containment.
+ *
+ * Containment (not spawn-time stamping) is deliberate: a session started
+ * outside the web UI — `cd ~/Documents/Workspace && pizza` — carries no stamp
+ * but is unambiguously in that mode. Deepest workspace wins so nested mode
+ * workspaces resolve to the most specific mode.
+ */
+export function findSessionMode(
+  session: { cwd?: string | null; runnerId?: string | null } | null | undefined,
+  modes: ServiceModeDef[],
+  modesRunnerId?: string | null,
+): ServiceModeDef | null {
+  if (!session?.cwd || modes.length === 0) return null;
+  // A mode belongs to the runner that announced it; never apply another
+  // runner's mode chrome to a session just because the paths line up.
+  if (modesRunnerId && session.runnerId && session.runnerId !== modesRunnerId) return null;
+  const cwd = session.cwd;
+  let best: ServiceModeDef | null = null;
+  for (const mode of modes) {
+    if (!cwdInWorkspace(cwd, mode.workspace)) continue;
+    if (!best || mode.workspace.length > best.workspace.length) best = mode;
+  }
+  return best;
+}

--- a/packages/protocol/src/mode-ui.ts
+++ b/packages/protocol/src/mode-ui.ts
@@ -130,7 +130,9 @@ export function isArtifactPath(path: string, resolved: ResolvedModeUi): boolean 
  * `~/Documents/Workspace/` behaves the same as one that does not.
  */
 export function cwdInWorkspace(cwd: string, workspace: string): boolean {
-  const root = workspace.replace(/\/+$/, "");
+  // ponytail: loop, not /\/+$/ — that regex backtracks on many trailing slashes (CodeQL js/polynomial-redos)
+  let root = workspace;
+  while (root.endsWith("/")) root = root.slice(0, -1);
   if (!root) return false;
   return cwd === root || cwd.startsWith(`${root}/`);
 }

--- a/packages/protocol/src/mode-ui.ts
+++ b/packages/protocol/src/mode-ui.ts
@@ -150,8 +150,10 @@ export function findSessionMode(
 ): ServiceModeDef | null {
   if (!session?.cwd || modes.length === 0) return null;
   // A mode belongs to the runner that announced it; never apply another
-  // runner's mode chrome to a session just because the paths line up.
-  if (modesRunnerId && session.runnerId && session.runnerId !== modesRunnerId) return null;
+  // runner's mode to a session just because the paths line up. A session with
+  // no runner (local/relay-only) cannot be shown to be on that runner, so it
+  // does not qualify either — paths are only meaningful per machine.
+  if (modesRunnerId && session.runnerId !== modesRunnerId) return null;
   const cwd = session.cwd;
   let best: ServiceModeDef | null = null;
   for (const mode of modes) {

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -245,6 +245,100 @@ export interface ServiceModeDef {
   workspace: string;
   /** Service that declared this mode. */
   serviceId?: string;
+  /** Declarative UI contract — how PizzaPi should render sessions in this mode. */
+  ui?: ServiceModeUi;
+}
+
+/**
+ * Declarative UI contribution for a session mode.
+ *
+ * Everything here is rendered natively by the PizzaPi UI (web + PWA); modes
+ * declare intent, they do not ship code. Every field is optional and the
+ * defaults reproduce today's coding-agent UI, so an existing mode that omits
+ * `ui` is unchanged.
+ */
+export interface ServiceModeUi {
+  /**
+   * Chrome preset. "coding" (default) keeps git/terminal/process affordances;
+   * "work" hides them for non-coding modes. Individual flags in `chrome`
+   * override the preset.
+   */
+  preset?: "coding" | "work";
+  /** Per-surface chrome overrides, applied on top of `preset`. */
+  chrome?: ServiceModeChrome;
+  /**
+   * How tool calls render in the transcript.
+   * "detailed" (default) shows command/diff blocks; "activity" collapses each
+   * call to a human-language line that expands on demand.
+   */
+  toolRendering?: "detailed" | "activity";
+  /** Noun overrides, e.g. { session: "task", sessions: "tasks" }. */
+  vocabulary?: ServiceModeVocabulary;
+  /** Tailwind-compatible accent color token or hex, used for mode identity. */
+  accent?: string;
+  /** Placeholder text for the composer in this mode. */
+  composerPlaceholder?: string;
+  /** Mode home configuration (composer-first landing view). */
+  home?: ServiceModeHome;
+  /** Deliverable/artifact preview configuration. */
+  artifacts?: ServiceModeArtifacts;
+  /** Show the scheduled-instructions surface (time:cron / time:at) for this mode. */
+  scheduled?: boolean;
+}
+
+/** Per-surface chrome toggles for a mode. */
+export interface ServiceModeChrome {
+  /** Show the git panel/button. */
+  git?: boolean;
+  /** Show the terminal affordance. */
+  terminal?: boolean;
+  /** Show the process/shell panel. */
+  processes?: boolean;
+  /** Render file edits as diffs. */
+  diffs?: boolean;
+  /** Show the file explorer. */
+  files?: boolean;
+}
+
+/** Noun overrides so a mode can speak its own language. */
+export interface ServiceModeVocabulary {
+  /** Singular noun for a session, e.g. "task". */
+  session?: string;
+  /** Plural noun for sessions, e.g. "tasks". */
+  sessions?: string;
+  /** Label for the new-session action, e.g. "New task". */
+  newSession?: string;
+}
+
+/** Composer-first landing view for a mode. */
+export interface ServiceModeHome {
+  /** Headline shown above the composer. */
+  greeting?: string;
+  /** Suggestion chips that prefill the composer. */
+  suggestions?: ServiceModeSuggestion[];
+  /** Show the recent-sessions list on the home view. Defaults to true. */
+  recent?: boolean;
+}
+
+/** A single suggestion chip on a mode home. */
+export interface ServiceModeSuggestion {
+  /** Short button label. */
+  label: string;
+  /** Optional Lucide icon name. */
+  icon?: string;
+  /** Prompt text sent (or prefilled) when the chip is chosen. */
+  prompt: string;
+}
+
+/** Deliverable preview configuration for a mode. */
+export interface ServiceModeArtifacts {
+  /** Enable artifact cards + the artifacts panel. */
+  enabled: boolean;
+  /**
+   * File extensions (without the dot) treated as deliverables.
+   * Defaults to a document-centric set when omitted.
+   */
+  extensions?: string[];
 }
 
 export interface ServiceSigilDef {

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -26,7 +26,7 @@ import {
     deleteRunnerAssociation,
 } from "../sio-state/index.js";
 import { updateRelaySessionRunner } from "../../sessions/store.js";
-import type { RunnerInfo, RunnerSkill, RunnerAgent, RunnerHook, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { RunnerInfo, RunnerSkill, RunnerAgent, RunnerHook, ServiceTriggerDef, ServiceSigilDef, ServiceModeDef } from "@pizzapi/protocol";
 import {
     localTuiSockets,
     localRunnerSockets,
@@ -261,7 +261,7 @@ export async function updateRunnerServices(
     triggerDefs?: Array<{ type: string; label: string; description?: string; schema?: Record<string, unknown> }>,
     sigilDefs?: Array<{ type: string; label: string; description?: string; icon?: string; serviceId?: string; resolve?: string; schema?: Record<string, unknown>; aliases?: string[] }>,
     disabledServiceIds?: string[],
-    sessionModes?: Array<{ id: string; label: string; icon?: string; workspace: string; serviceId?: string }>,
+    sessionModes?: ServiceModeDef[],
 ): Promise<void> {
     const fields: Record<string, string> = {
         serviceIds: JSON.stringify(serviceIds),
@@ -307,7 +307,7 @@ export async function getRunnerServices(
     panels?: Array<{ serviceId: string; port: number; label: string; icon: string }>;
     triggerDefs?: ServiceTriggerDef[];
     sigilDefs?: ServiceSigilDef[];
-    sessionModes?: Array<{ id: string; label: string; icon?: string; workspace: string; serviceId?: string }>;
+    sessionModes?: ServiceModeDef[];
 } | null> {
     const runner = await getRunnerState(runnerId);
     if (!runner) return null;

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -19,6 +19,7 @@ import type {
     ServicePanelInfo,
     ServiceTriggerDef,
     ServiceSigilDef,
+    ServiceModeDef,
 } from "@pizzapi/protocol";
 
 import type { TestServer } from "./types.js";
@@ -108,6 +109,8 @@ export interface MockRunnerOptions {
     triggerDefs?: ServiceTriggerDef[];
     /** Sigil types declared by announced services (e.g. package-origin manifests). */
     sigilDefs?: ServiceSigilDef[];
+    /** Session modes declared by announced services (workspaces already home-expanded). */
+    sessionModes?: ServiceModeDef[];
 }
 
 export interface MockRunner {
@@ -142,6 +145,7 @@ export interface MockRunner {
         panels?: ServicePanelInfo[],
         triggerDefs?: ServiceTriggerDef[],
         sigilDefs?: ServiceSigilDef[],
+        sessionModes?: ServiceModeDef[],
     ): void;
     /** Disabled service IDs currently applied (mutated by reconfigure_services, mirrors real daemon). */
     readonly disabledServiceIds: ReadonlySet<string>;
@@ -299,6 +303,7 @@ export async function createMockRunner(
     let currentPanels: ServicePanelInfo[] = opts?.panels ?? [];
     let currentTriggerDefs: ServiceTriggerDef[] = opts?.triggerDefs ?? [];
     let currentSigilDefs: ServiceSigilDef[] = opts?.sigilDefs ?? [];
+    let currentSessionModes: ServiceModeDef[] = opts?.sessionModes ?? [];
     const disabledServiceIdsSet = new Set<string>();
     // The daemon never unloads these runtime-pinned built-ins on reconfigure.
     const nonDisableableServiceIds = new Set(["terminal", "file-explorer", "git", "time", "tunnel"]);
@@ -313,6 +318,7 @@ export async function createMockRunner(
             ...(currentPanels.length > 0 ? { panels: currentPanels.filter((panel) => activeServiceIds.has(panel.serviceId)) } : {}),
             ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs.filter((trigger) => activeServiceIds.has(trigger.type.split(":")[0])) } : {}),
             ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs.filter((sigil) => activeServiceIds.has(sigil.serviceId ?? sigil.type.split(":")[0])) } : {}),
+            ...(currentSessionModes.length > 0 ? { sessionModes: currentSessionModes.filter((mode) => !mode.serviceId || activeServiceIds.has(mode.serviceId)) } : {}),
         });
     };
 
@@ -416,15 +422,10 @@ export async function createMockRunner(
                         }
                     }
                 }
-                // Announce services after registration (like real daemon)
-                if (currentServiceIds.length > 0) {
-                    (socket as any).emit("service_announce", {
-                        serviceIds: currentServiceIds,
-                        ...(currentPanels.length > 0 ? { panels: currentPanels } : {}),
-                        ...(currentTriggerDefs.length > 0 ? { triggerDefs: currentTriggerDefs } : {}),
-                        ...(currentSigilDefs.length > 0 ? { sigilDefs: currentSigilDefs } : {}),
-                    });
-                }
+                // Announce services after registration (like real daemon).
+                // Uses the shared builder so a newly announced field can't be
+                // dropped from the registration path only.
+                if (currentServiceIds.length > 0) emitServiceAnnounce();
                 resolve();
             });
         });
@@ -1240,11 +1241,13 @@ export async function createMockRunner(
             panels?: ServicePanelInfo[],
             triggerDefs?: ServiceTriggerDef[],
             sigilDefs?: ServiceSigilDef[],
+            sessionModes?: ServiceModeDef[],
         ): void {
             currentServiceIds = serviceIds;
             currentPanels = panels ?? [];
             currentTriggerDefs = triggerDefs ?? [];
             currentSigilDefs = sigilDefs ?? [];
+            currentSessionModes = sessionModes ?? currentSessionModes;
             emitServiceAnnounce();
         },
 

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -766,7 +766,7 @@ async function main() {
         name: "sandbox-runner",
         roots: ["/Users/jordan/Documents/Projects/PizzaPi", "/Users/jordan/Documents/Workspace"],
         platform: "darwin",
-        serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor", GODMOTHER_LITE_SERVICE_ID],
+        serviceIds: ["terminal", "file-explorer", "git", "tunnel", "time", "system-monitor", GODMOTHER_LITE_SERVICE_ID],
         // A knowledge-work mode exercising the declarative mode UI contract.
         sessionModes: [{
             id: "work",
@@ -797,6 +797,26 @@ async function main() {
             { serviceId: GODMOTHER_LITE_SERVICE_ID, port: godmotherLitePort, label: "Godmother Lite", icon: "sparkles" },
         ],
         triggerDefs: [
+            {
+                type: "time:cron",
+                label: "Cron Schedule",
+                description: "Fires on a recurring 5-field cron schedule",
+                schema: { type: "object", properties: { cron: { type: "string" } } },
+                params: [
+                    { name: "cron", label: "Cron expression", type: "string", required: true },
+                    { name: "message", label: "Message", type: "string", required: false },
+                ],
+            },
+            {
+                type: "time:at",
+                label: "Scheduled Time",
+                description: "Fires once at a specific time",
+                schema: { type: "object", properties: { at: { type: "string" } } },
+                params: [
+                    { name: "at", label: "At", type: "string", required: true },
+                    { name: "message", label: "Message", type: "string", required: false },
+                ],
+            },
             {
                 type: "godmother-lite:idea_moved",
                 label: "Idea Status Changed",

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -125,6 +125,84 @@ src/config.ts:8:    trustedOrigins: ["http://localhost:5173"],`)],
     return events;
 }
 
+/**
+ * A knowledge-work conversation: research, documents, spreadsheets — the
+ * deliverable-shaped work a Work-mode session actually does. Used to exercise
+ * activity-style tool rendering and artifact cards.
+ */
+function workModeConversation(): unknown[] {
+    const events: unknown[] = [];
+    const toolId = (n: number) => `tool_work_${n}_${Date.now()}`;
+
+    events.push(buildAssistantMessage(
+        "I'll pull together the Q3 supplier review. Let me start with what we already have on file.",
+    ));
+
+    const searchId = toolId(1);
+    events.push({
+        type: "message_update",
+        role: "assistant",
+        content: [buildToolUseEvent("session_search", { query: "supplier review" }, searchId)],
+        messageId: `msg_work_${Date.now()}_1`,
+    });
+    events.push({
+        type: "tool_result_message",
+        content: [buildToolResultEvent(searchId, "3 prior sessions matched: Q1 supplier review, vendor pricing notes, logistics recap.")],
+    });
+
+    const webId = toolId(2);
+    events.push({
+        type: "message_update",
+        role: "assistant",
+        content: [buildToolUseEvent("web_search", { query: "freight rates Q3 2026" }, webId)],
+        messageId: `msg_work_${Date.now()}_2`,
+    });
+    events.push({
+        type: "tool_result_message",
+        content: [buildToolResultEvent(webId, "Container spot rates fell 12% quarter-over-quarter; carriers cite softening demand.")],
+    });
+
+    events.push(buildAssistantMessage(
+        "Freight is down 12% this quarter, which changes the pricing picture. Writing this up now.",
+    ));
+
+    const writeId = toolId(3);
+    events.push({
+        type: "message_update",
+        role: "assistant",
+        content: [buildToolUseEvent("write", {
+            file_path: "/Users/jordan/Documents/Workspace/q3-supplier-review.md",
+            content: "# Q3 Supplier Review\n\nFreight rates fell 12% QoQ.",
+        }, writeId)],
+        messageId: `msg_work_${Date.now()}_3`,
+    });
+    events.push({
+        type: "tool_result_message",
+        content: [buildToolResultEvent(writeId, "Wrote 4.2 KB to /Users/jordan/Documents/Workspace/q3-supplier-review.md")],
+    });
+
+    const sheetId = toolId(4);
+    events.push({
+        type: "message_update",
+        role: "assistant",
+        content: [buildToolUseEvent("write", {
+            file_path: "/Users/jordan/Documents/Workspace/supplier-costs.csv",
+            content: "supplier,q2,q3\nNorthwind,102400,94100\n",
+        }, sheetId)],
+        messageId: `msg_work_${Date.now()}_4`,
+    });
+    events.push({
+        type: "tool_result_message",
+        content: [buildToolResultEvent(sheetId, "Wrote 1.1 KB to /Users/jordan/Documents/Workspace/supplier-costs.csv")],
+    });
+
+    events.push(buildAssistantMessage(
+        "Done. Two deliverables:\n\n- **q3-supplier-review.md** — the write-up, with the freight change called out\n- **supplier-costs.csv** — per-supplier Q2 vs Q3 spend\n\nNorthwind is the only supplier whose costs fell faster than the freight index, so they're worth a closer look before renewal.",
+    ));
+
+    return events;
+}
+
 function toolHeavyConversation(): unknown[] {
     const events: unknown[] = [];
     const toolId = (n: number) => `tool_heavy_${n}_${Date.now()}`;
@@ -287,6 +365,7 @@ const SCENARIOS: Record<string, { name: string; builder: () => unknown[] }> = {
     review: { name: "Code Review", builder: codeReviewConversation },
     tools: { name: "Tool-Heavy (Dark Mode)", builder: toolHeavyConversation },
     subagent: { name: "Subagent Spawn", builder: subagentConversation },
+    work: { name: "Work Mode (Deliverables)", builder: workModeConversation },
 };
 
 // ── Models pool ──────────────────────────────────────────────────────────────
@@ -685,9 +764,34 @@ async function main() {
     // and service_announce reaches viewers.
     const defaultRunner = await createMockRunner(server, {
         name: "sandbox-runner",
-        roots: ["/Users/jordan/Documents/Projects/PizzaPi"],
+        roots: ["/Users/jordan/Documents/Projects/PizzaPi", "/Users/jordan/Documents/Workspace"],
         platform: "darwin",
         serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor", GODMOTHER_LITE_SERVICE_ID],
+        // A knowledge-work mode exercising the declarative mode UI contract.
+        sessionModes: [{
+            id: "work",
+            label: "Work",
+            icon: "briefcase",
+            workspace: "/Users/jordan/Documents/Workspace",
+            ui: {
+                preset: "work",
+                toolRendering: "activity",
+                vocabulary: { session: "task", sessions: "tasks" },
+                accent: "#7c3aed",
+                composerPlaceholder: "What do you need done?",
+                home: {
+                    greeting: "What are we working on?",
+                    suggestions: [
+                        { label: "Daily report", icon: "sun", prompt: "Write my daily report" },
+                        { label: "Research a topic", icon: "telescope", prompt: "Research " },
+                        { label: "Make a document", icon: "file-text", prompt: "Draft a document about " },
+                        { label: "Build a spreadsheet", icon: "table", prompt: "Build a spreadsheet of " },
+                    ],
+                },
+                artifacts: { enabled: true },
+                scheduled: true,
+            },
+        }],
         panels: [
             { serviceId: "system-monitor", port: monitorPort, label: "System Monitor", icon: "activity" },
             { serviceId: GODMOTHER_LITE_SERVICE_ID, port: godmotherLitePort, label: "Godmother Lite", icon: "sparkles" },
@@ -789,6 +893,27 @@ async function main() {
     }), 0);
     defaultRunner.emitSessionReady(s3.sessionId);
     console.log(`  🔗 Session 3: code-review-subagent (Haiku 4.5) → child of S1`);
+
+    // Session 4: Work mode — exercises the declarative mode UI contract.
+    const s4 = await scenario.addSession({
+        cwd: "/Users/jordan/Documents/Workspace",
+        collabMode: true,
+    });
+    sessionCounter++;
+    s4.relay.emitEvent(s4.sessionId, s4.token, buildHeartbeat({
+        active: false,
+        sessionName: "Q3 supplier review",
+        model: MODELS[0],
+        cwd: "/Users/jordan/Documents/Workspace",
+    }), 0);
+    s4.relay.emitEvent(s4.sessionId, s4.token, { type: "model_changed", model: MODELS[0] });
+    const workConvo = workModeConversation();
+    for (let i = 0; i < workConvo.length; i++) {
+        s4.relay.emitEvent(s4.sessionId, s4.token, workConvo[i], i + 1);
+        await sleep(40);
+    }
+    defaultRunner.emitSessionReady(s4.sessionId);
+    console.log(`  💼 Session 4: Q3 supplier review (Work mode) — ${workConvo.length} events`);
 
     // ── Start Vite dev server for HMR ──────────────────────────────────
     const vitePort = await getFreePort();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -23,7 +23,7 @@ import type {
   HubClientToServerEvents,
   SessionMetaState,
 } from "@pizzapi/protocol";
-import { SOCKET_PROTOCOL_VERSION, parseViewerEventEnvelope, parseViewerConnectedEnvelope, parseHubStateSnapshot, parseHubMetaEvent, parseSpawnResponse } from "@pizzapi/protocol";
+import { SOCKET_PROTOCOL_VERSION, parseViewerEventEnvelope, parseViewerConnectedEnvelope, parseHubStateSnapshot, parseHubMetaEvent, parseSpawnResponse, findSessionMode, resolveModeUi } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { shouldCenterTopSpanFullWidth, shouldCenterBottomSpanFullWidth } from "@/utils/panelLayoutHelpers";
@@ -4359,6 +4359,24 @@ export function App() {
   // Runner service panels — dynamically discovered
   const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs, sessionModes } = useRunnerServices(viewerSocket, activeRunnerInfo);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
+
+  // The mode the active session belongs to, and what that mode says the UI
+  // should look like. No mode (or a mode without a `ui` block) resolves to the
+  // standard coding UI, so this is inert for every existing session.
+  const activeMode = React.useMemo(
+    () => findSessionMode(activeSessionInfo, sessionModes, activeSessionInfo?.runnerId),
+    [activeSessionInfo, sessionModes],
+  );
+  const modeUi = React.useMemo(() => resolveModeUi(activeMode), [activeMode]);
+
+  // Hiding a surface has to close it too: switching from a coding session to a
+  // Work task with the git panel open would otherwise strand a panel the mode
+  // says does not exist, with no button left to close it.
+  React.useEffect(() => {
+    if (!modeUi.git) setShowGit(false);
+    if (!modeUi.terminal) setShowTerminal(false);
+    if (!modeUi.files) setShowFileExplorer(false);
+  }, [modeUi.git, modeUi.terminal, modeUi.files, setShowGit, setShowTerminal, setShowFileExplorer]);
   const attentionSessionNames = React.useMemo(() => {
     const names = new Map<string, string>();
     for (const session of liveSessions) {
@@ -5226,14 +5244,17 @@ export function App() {
                         onEditQueuedMessage={editQueuedMessage}
                         onClearMessageQueue={clearMessageQueue}
                         onToggleTerminal={() => setShowTerminal((v) => !v)}
-                        showTerminalButton
+                        showTerminalButton={modeUi.terminal}
                         isTerminalOpen={showTerminal}
                         onToggleFileExplorer={() => setShowFileExplorer((v) => !v)}
-                        showFileExplorerButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
+                        showFileExplorerButton={modeUi.files && !!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
                         isFileExplorerOpen={showFileExplorer}
                         onToggleGit={() => setShowGit((v) => !v)}
-                        showGitButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
+                        showGitButton={modeUi.git && !!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
                         isGitOpen={showGit}
+                        modeUi={modeUi}
+                        modeLabel={activeMode?.label}
+                        modeIcon={activeMode?.icon}
                         onToggleTriggers={() => setShowTriggers((v) => !v)}
                         showTriggersButton={!!activeSessionId}
                         isTriggersOpen={showTriggers}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4374,9 +4374,12 @@ export function App() {
   // The mode the active session belongs to, and what that mode says the UI
   // should look like. No mode (or a mode without a `ui` block) resolves to the
   // standard coding UI, so this is inert for every existing session.
+  // Compared against the runner that ANNOUNCED the modes, not the session's own
+  // runner — otherwise the check compares a value to itself and always passes,
+  // letting one runner's mode style another runner's identically-pathed session.
   const activeMode = React.useMemo(
-    () => findSessionMode(activeSessionInfo, effectiveSessionModes, activeSessionInfo?.runnerId),
-    [activeSessionInfo, effectiveSessionModes],
+    () => findSessionMode(activeSessionInfo, effectiveSessionModes, modesSource.runnerId),
+    [activeSessionInfo, effectiveSessionModes, modesSource.runnerId],
   );
   const modeUi = React.useMemo(() => resolveModeUi(activeMode), [activeMode]);
 
@@ -4390,34 +4393,44 @@ export function App() {
   const selectedModeUi = React.useMemo(() => resolveModeUi(selectedMode), [selectedMode]);
   const [startingTask, setStartingTask] = React.useState(false);
 
-  /** Sessions belonging to the selected mode, newest first. */
-  const selectedModeSessions = React.useMemo(() => {
+  /** Every session in the selected mode, newest first. */
+  const selectedModeAllSessions = React.useMemo(() => {
     if (!selectedMode) return [];
     return liveSessions
-      .filter((session) => findSessionMode(session, effectiveSessionModes, session.runnerId)?.id === selectedMode.id)
+      .filter((session) => findSessionMode(session, effectiveSessionModes, modesSource.runnerId)?.id === selectedMode.id)
       .slice()
-      .sort((a, b) => Date.parse(b.lastHeartbeatAt ?? b.startedAt) - Date.parse(a.lastHeartbeatAt ?? a.startedAt))
-      .slice(0, 5);
-  }, [liveSessions, selectedMode, effectiveSessionModes]);
+      .sort((a, b) => Date.parse(b.lastHeartbeatAt ?? b.startedAt) - Date.parse(a.lastHeartbeatAt ?? a.startedAt));
+  }, [liveSessions, selectedMode, effectiveSessionModes, modesSource.runnerId]);
+
+  /** The handful shown under "Recent" — display only, never the search scope. */
+  const selectedModeSessions = React.useMemo(() => selectedModeAllSessions.slice(0, 5), [selectedModeAllSessions]);
 
   // Standing scheduled work for the selected mode. Subscriptions live per
   // session, so this fans out over the mode's sessions.
   const [scheduledInstructions, setScheduledInstructions] = React.useState<ScheduledInstruction[]>([]);
   const [scheduledLoading, setScheduledLoading] = React.useState(false);
+  const [scheduledFailed, setScheduledFailed] = React.useState(0);
+  // Every mode session, not just the recent five: a schedule owned by an older
+  // task would otherwise be invisible and impossible to cancel from here.
   const scheduledSessions = React.useMemo(
-    () => selectedModeSessions.map((s) => ({ sessionId: s.sessionId, sessionName: s.sessionName ?? null })),
-    [selectedModeSessions],
+    () => selectedModeAllSessions.map((s) => ({ sessionId: s.sessionId, sessionName: s.sessionName ?? null })),
+    [selectedModeAllSessions],
   );
   const wantsSchedule = !!selectedMode && selectedModeUi.scheduled;
 
   const reloadScheduled = React.useCallback((signal?: AbortSignal) => {
     if (!wantsSchedule || scheduledSessions.length === 0) {
       setScheduledInstructions([]);
+      setScheduledFailed(0);
       return Promise.resolve();
     }
     setScheduledLoading(true);
     return fetchScheduledInstructions(scheduledSessions, signal)
-      .then((found) => { if (!signal?.aborted) setScheduledInstructions(found); })
+      .then(({ instructions, failed }) => {
+        if (signal?.aborted) return;
+        setScheduledInstructions(instructions);
+        setScheduledFailed(failed);
+      })
       .catch((err) => { if (!signal?.aborted) console.error("Failed to load scheduled work:", err); })
       .finally(() => { if (!signal?.aborted) setScheduledLoading(false); });
   }, [wantsSchedule, scheduledSessions]);
@@ -4445,17 +4458,19 @@ export function App() {
   }, [setLifecycleStatus]);
 
   /** Start a task in the selected mode's workspace with the composed prompt. */
+  // `startingTask` state lands a render too late to stop a double submit, so a
+  // ref gates the second caller synchronously.
+  const startingTaskRef = React.useRef(false);
   const handleStartModeTask = React.useCallback(async (prompt: string) => {
-    if (!selectedMode) return;
-    // A mode is announced by exactly one runner; prefer a runner already
-    // hosting sessions in this mode, else the runner that announced it.
-    const runnerId = selectedModeSessions[0]?.runnerId
-      ?? liveSessions.find((s) => s.runnerId)?.runnerId
-      ?? activeRunnerInfo?.runnerId;
+    if (!selectedMode || startingTaskRef.current) return;
+    // The mode's workspace only exists on the runner that announced it, so the
+    // task must start there — never on whichever runner happens to be first.
+    const runnerId = modesSource.runnerId;
     if (!runnerId) {
       setLifecycleStatus("No runner available to start this task");
       return;
     }
+    startingTaskRef.current = true;
     setStartingTask(true);
     try {
       const sessionId = await lifecycleSpawnSession(runnerId, selectedMode.workspace, undefined, { prompt });
@@ -4465,9 +4480,10 @@ export function App() {
       console.error("Failed to start mode task:", err);
       setLifecycleStatus(mapped.userMessage);
     } finally {
+      startingTaskRef.current = false;
       setStartingTask(false);
     }
-  }, [selectedMode, selectedModeSessions, liveSessions, activeRunnerInfo?.runnerId, lifecycleSpawnSession, handleOpenSession, setLifecycleStatus]);
+  }, [selectedMode, modesSource.runnerId, lifecycleSpawnSession, handleOpenSession, setLifecycleStatus]);
 
   // Hiding a surface has to close it too: switching from a coding session to a
   // Work task with the git panel open would otherwise strand a panel the mode
@@ -4477,6 +4493,19 @@ export function App() {
     if (!modeUi.terminal) setShowTerminal(false);
     if (!modeUi.files) setShowFileExplorer(false);
   }, [modeUi.git, modeUi.terminal, modeUi.files, setShowGit, setShowTerminal, setShowFileExplorer]);
+
+  // The same surfaces also exist as service panels. Filtering them here both
+  // hides their buttons and feeds the "close panels that went away" effect
+  // below, so a hidden panel cannot stay open.
+  const modeVisibleServices = React.useMemo(() => {
+    const hidden = new Set<string>();
+    if (!modeUi.git) hidden.add("git");
+    if (!modeUi.terminal) hidden.add("terminal");
+    if (!modeUi.files) hidden.add("file-explorer");
+    if (!modeUi.processes) hidden.add("process");
+    if (hidden.size === 0) return availableServices;
+    return new Set([...availableServices].filter((id) => !hidden.has(id)));
+  }, [availableServices, modeUi.git, modeUi.terminal, modeUi.files, modeUi.processes]);
   const attentionSessionNames = React.useMemo(() => {
     const names = new Map<string, string>();
     for (const session of liveSessions) {
@@ -4521,7 +4550,7 @@ export function App() {
     const current = activeServicePanelsRef.current;
     if (current.size === 0) return;
     const staticAvailable = new Set(
-      SERVICE_PANELS.filter(p => availableServices.has(p.serviceId)).map(p => p.serviceId),
+      SERVICE_PANELS.filter(p => modeVisibleServices.has(p.serviceId)).map(p => p.serviceId),
     );
     const dynamicAvailable = new Set(dynamicPanels.map(p => p.serviceId));
     for (const id of current) {
@@ -4530,7 +4559,7 @@ export function App() {
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableServices, dynamicPanels, closeServicePanelById]);
+  }, [modeVisibleServices, dynamicPanels, closeServicePanelById]);
 
   // Tell the server whether the tab is actually being looked at, so it can
   // suppress native push while a viewer is visible. "Visible" ignores window
@@ -5101,7 +5130,7 @@ export function App() {
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
               sessionModes={effectiveSessionModes}
-              sessionModesRunnerId={activeSessionInfo?.runnerId ?? modesSource.runnerId}
+              sessionModesRunnerId={modesSource.runnerId}
               onSelectedModeChange={setSelectedModeId}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}
@@ -5375,6 +5404,7 @@ export function App() {
                           scheduled: selectedModeUi.scheduled ? {
                             instructions: scheduledInstructions,
                             loading: scheduledLoading,
+                            failed: scheduledFailed,
                             onCancel: handleCancelScheduled,
                           } : undefined,
                         } : undefined}
@@ -5390,7 +5420,7 @@ export function App() {
                         loadingOlderMessages={loadingOlderMessages}
                         extraHeaderButtons={
                           <ServicePanelButtons
-                            availableServices={availableServices}
+                            availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
                             dynamicPanels={dynamicPanels}
                             activePanelIds={activeServicePanels}
@@ -5401,7 +5431,7 @@ export function App() {
                         }
                         extraOverflowItems={
                           <ServicePanelOverflowItems
-                            availableServices={availableServices}
+                            availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
                             dynamicPanels={dynamicPanels}
                             activePanelIds={activeServicePanels}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4358,17 +4358,23 @@ export function App() {
   }, [activeSessionId, activeSessionInfo?.runnerId, liveSessions]);
 
   // Runner service panels — dynamically discovered
-  const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs, sessionModes } = useRunnerServices(viewerSocket, activeRunnerInfo);
+  const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket, activeRunnerInfo);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
 
   // Modes come from the active session's runner, but the mode home exists for
   // when nothing is open — so with no active session fall back to a connected
   // runner that declares modes, or the picker never appears.
+  // Modes and their owning runner are read from the SAME runner object. Taking
+  // the modes from one source and the runner id from another means a
+  // cross-runner switch can briefly pair the old runner's modes with the new
+  // runner's id — and a mode that hides chrome closes those panels for good.
   const modesSource = React.useMemo(() => {
-    if (sessionModes.length > 0) return { modes: sessionModes, runnerId: activeRunnerInfo?.runnerId ?? null };
+    if (activeRunnerInfo) {
+      return { modes: activeRunnerInfo.sessionModes ?? [], runnerId: activeRunnerInfo.runnerId };
+    }
     const runner = feedRunners.find((candidate) => (candidate.sessionModes?.length ?? 0) > 0);
     return { modes: runner?.sessionModes ?? [], runnerId: runner?.runnerId ?? null };
-  }, [sessionModes, feedRunners, activeRunnerInfo?.runnerId]);
+  }, [activeRunnerInfo, feedRunners]);
   const effectiveSessionModes = modesSource.modes;
 
   // The mode the active session belongs to, and what that mode says the UI
@@ -4422,6 +4428,9 @@ export function App() {
     if (!wantsSchedule || scheduledSessions.length === 0) {
       setScheduledInstructions([]);
       setScheduledFailed(0);
+      // Clear here too: an aborted in-flight load skips its own finally, so
+      // without this the home can sit on "Checking scheduled work" forever.
+      setScheduledLoading(false);
       return Promise.resolve();
     }
     setScheduledLoading(true);
@@ -4641,7 +4650,7 @@ export function App() {
   }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition, setServicePanelPosition]);
 
   // ── Service panel buttons in rails/strips ────────────────────────────
-  const visibleServicePanels = useVisibleServicePanels(availableServices, dynamicPanels, disabledServiceIds);
+  const visibleServicePanels = useVisibleServicePanels(modeVisibleServices, dynamicPanels, disabledServiceIds);
   const railServicePanels = React.useMemo(
     () => visibleServicePanels.map((p) => ({ ...p, active: activeServicePanels.has(p.serviceId) })),
     [visibleServicePanels, activeServicePanels],

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4360,14 +4360,69 @@ export function App() {
   const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs, sessionModes } = useRunnerServices(viewerSocket, activeRunnerInfo);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
 
+  // Modes come from the active session's runner, but the mode home exists for
+  // when nothing is open — so with no active session fall back to a connected
+  // runner that declares modes, or the picker never appears.
+  const modesSource = React.useMemo(() => {
+    if (sessionModes.length > 0) return { modes: sessionModes, runnerId: activeRunnerInfo?.runnerId ?? null };
+    const runner = feedRunners.find((candidate) => (candidate.sessionModes?.length ?? 0) > 0);
+    return { modes: runner?.sessionModes ?? [], runnerId: runner?.runnerId ?? null };
+  }, [sessionModes, feedRunners, activeRunnerInfo?.runnerId]);
+  const effectiveSessionModes = modesSource.modes;
+
   // The mode the active session belongs to, and what that mode says the UI
   // should look like. No mode (or a mode without a `ui` block) resolves to the
   // standard coding UI, so this is inert for every existing session.
   const activeMode = React.useMemo(
-    () => findSessionMode(activeSessionInfo, sessionModes, activeSessionInfo?.runnerId),
-    [activeSessionInfo, sessionModes],
+    () => findSessionMode(activeSessionInfo, effectiveSessionModes, activeSessionInfo?.runnerId),
+    [activeSessionInfo, effectiveSessionModes],
   );
   const modeUi = React.useMemo(() => resolveModeUi(activeMode), [activeMode]);
+
+  // Mode selected in the sidebar, which drives the mode home shown when no
+  // session is open. Independent of the active session's own mode.
+  const [selectedModeId, setSelectedModeId] = React.useState<string | null>(null);
+  const selectedMode = React.useMemo(
+    () => effectiveSessionModes.find((mode) => mode.id === selectedModeId) ?? null,
+    [effectiveSessionModes, selectedModeId],
+  );
+  const selectedModeUi = React.useMemo(() => resolveModeUi(selectedMode), [selectedMode]);
+  const [startingTask, setStartingTask] = React.useState(false);
+
+  /** Sessions belonging to the selected mode, newest first. */
+  const selectedModeSessions = React.useMemo(() => {
+    if (!selectedMode) return [];
+    return liveSessions
+      .filter((session) => findSessionMode(session, effectiveSessionModes, session.runnerId)?.id === selectedMode.id)
+      .slice()
+      .sort((a, b) => Date.parse(b.lastHeartbeatAt ?? b.startedAt) - Date.parse(a.lastHeartbeatAt ?? a.startedAt))
+      .slice(0, 5);
+  }, [liveSessions, selectedMode, effectiveSessionModes]);
+
+  /** Start a task in the selected mode's workspace with the composed prompt. */
+  const handleStartModeTask = React.useCallback(async (prompt: string) => {
+    if (!selectedMode) return;
+    // A mode is announced by exactly one runner; prefer a runner already
+    // hosting sessions in this mode, else the runner that announced it.
+    const runnerId = selectedModeSessions[0]?.runnerId
+      ?? liveSessions.find((s) => s.runnerId)?.runnerId
+      ?? activeRunnerInfo?.runnerId;
+    if (!runnerId) {
+      setLifecycleStatus("No runner available to start this task");
+      return;
+    }
+    setStartingTask(true);
+    try {
+      const sessionId = await lifecycleSpawnSession(runnerId, selectedMode.workspace, undefined, { prompt });
+      handleOpenSession(sessionId);
+    } catch (err) {
+      const mapped = mapUserError({ error: err, context: "session_spawn" });
+      console.error("Failed to start mode task:", err);
+      setLifecycleStatus(mapped.userMessage);
+    } finally {
+      setStartingTask(false);
+    }
+  }, [selectedMode, selectedModeSessions, liveSessions, activeRunnerInfo?.runnerId, lifecycleSpawnSession, handleOpenSession, setLifecycleStatus]);
 
   // Hiding a surface has to close it too: switching from a coding session to a
   // Work task with the git panel open would otherwise strand a panel the mode
@@ -5000,8 +5055,9 @@ export function App() {
             <SessionSidebar
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
-              sessionModes={sessionModes}
-              sessionModesRunnerId={activeSessionInfo?.runnerId}
+              sessionModes={effectiveSessionModes}
+              sessionModesRunnerId={activeSessionInfo?.runnerId ?? modesSource.runnerId}
+              onSelectedModeChange={setSelectedModeId}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}
               activeSessionId={activeSessionId}
@@ -5256,6 +5312,22 @@ export function App() {
                         modeLabel={activeMode?.label}
                         modeIcon={activeMode?.icon}
                         onOpenArtifact={modeUi.files ? handleOpenFileInExplorer : undefined}
+                        modeHome={selectedMode ? {
+                          label: selectedMode.label,
+                          icon: selectedMode.icon,
+                          ui: selectedModeUi,
+                          recentSessions: selectedModeSessions.map((s) => ({
+                            sessionId: s.sessionId,
+                            sessionName: s.sessionName ?? null,
+                            cwd: s.cwd,
+                            lastHeartbeatAt: s.lastHeartbeatAt ?? null,
+                            startedAt: s.startedAt,
+                            isActive: s.isActive ?? false,
+                          })),
+                          busy: startingTask,
+                          onStartTask: (prompt: string) => { void handleStartModeTask(prompt); },
+                          onOpenSession: handleOpenSession,
+                        } : undefined}
                         onToggleTriggers={() => setShowTriggers((v) => !v)}
                         showTriggersButton={!!activeSessionId}
                         isTriggersOpen={showTriggers}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -165,6 +165,7 @@ const LazyTriggersPanel = React.lazy(() => import("@/components/TriggersPanel").
 const LazyTerminalManager = React.lazy(() => import("@/components/TerminalManager").then((m) => ({ default: m.TerminalManager })));
 const LazyFileExplorer = React.lazy(() => import("@/components/FileExplorer").then((m) => ({ default: m.FileExplorer })));
 const LazyGitPanel = React.lazy(() => import("@/components/git").then((m) => ({ default: m.GitPanel })));
+import { fetchScheduledInstructions, type ScheduledInstruction } from "@/components/session-viewer/ModeSchedule";
 const LazyChangePasswordDialog = React.lazy(() => import("@/components/ChangePasswordDialog").then((m) => ({ default: m.ChangePasswordDialog })));
 const LazyShortcutsDialog = React.lazy(() => import("@/components/ShortcutsDialog").then((m) => ({ default: m.ShortcutsDialog })));
 
@@ -4399,6 +4400,50 @@ export function App() {
       .slice(0, 5);
   }, [liveSessions, selectedMode, effectiveSessionModes]);
 
+  // Standing scheduled work for the selected mode. Subscriptions live per
+  // session, so this fans out over the mode's sessions.
+  const [scheduledInstructions, setScheduledInstructions] = React.useState<ScheduledInstruction[]>([]);
+  const [scheduledLoading, setScheduledLoading] = React.useState(false);
+  const scheduledSessions = React.useMemo(
+    () => selectedModeSessions.map((s) => ({ sessionId: s.sessionId, sessionName: s.sessionName ?? null })),
+    [selectedModeSessions],
+  );
+  const wantsSchedule = !!selectedMode && selectedModeUi.scheduled;
+
+  const reloadScheduled = React.useCallback((signal?: AbortSignal) => {
+    if (!wantsSchedule || scheduledSessions.length === 0) {
+      setScheduledInstructions([]);
+      return Promise.resolve();
+    }
+    setScheduledLoading(true);
+    return fetchScheduledInstructions(scheduledSessions, signal)
+      .then((found) => { if (!signal?.aborted) setScheduledInstructions(found); })
+      .catch((err) => { if (!signal?.aborted) console.error("Failed to load scheduled work:", err); })
+      .finally(() => { if (!signal?.aborted) setScheduledLoading(false); });
+  }, [wantsSchedule, scheduledSessions]);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void reloadScheduled(controller.signal);
+    return () => controller.abort();
+  }, [reloadScheduled]);
+
+  const handleCancelScheduled = React.useCallback(async (instruction: ScheduledInstruction) => {
+    const query = instruction.subscriptionId ? `?subscriptionId=${encodeURIComponent(instruction.subscriptionId)}` : "";
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(instruction.sessionId)}/trigger-subscriptions/${encodeURIComponent(instruction.triggerType)}${query}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      // Drop it locally so the row goes away even if a refetch is slow.
+      setScheduledInstructions((prev) => prev.filter((entry) => entry !== instruction));
+    } catch (err) {
+      console.error("Failed to cancel scheduled work:", err);
+      setLifecycleStatus("Could not cancel that scheduled item");
+    }
+  }, [setLifecycleStatus]);
+
   /** Start a task in the selected mode's workspace with the composed prompt. */
   const handleStartModeTask = React.useCallback(async (prompt: string) => {
     if (!selectedMode) return;
@@ -5327,6 +5372,11 @@ export function App() {
                           busy: startingTask,
                           onStartTask: (prompt: string) => { void handleStartModeTask(prompt); },
                           onOpenSession: handleOpenSession,
+                          scheduled: selectedModeUi.scheduled ? {
+                            instructions: scheduledInstructions,
+                            loading: scheduledLoading,
+                            onCancel: handleCancelScheduled,
+                          } : undefined,
                         } : undefined}
                         onToggleTriggers={() => setShowTriggers((v) => !v)}
                         showTriggersButton={!!activeSessionId}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5255,6 +5255,7 @@ export function App() {
                         modeUi={modeUi}
                         modeLabel={activeMode?.label}
                         modeIcon={activeMode?.icon}
+                        onOpenArtifact={modeUi.files ? handleOpenFileInExplorer : undefined}
                         onToggleTriggers={() => setShowTriggers((v) => !v)}
                         showTriggersButton={!!activeSessionId}
                         isTriggersOpen={showTriggers}

--- a/packages/ui/src/components/SessionSidebar.sort.test.ts
+++ b/packages/ui/src/components/SessionSidebar.sort.test.ts
@@ -66,6 +66,17 @@ describe("session mode filtering", () => {
         expect(filterSessionsByMode(sessions, null, modes, "runner-a").map((s) => s.sessionId)).toEqual(["code", "work-child"]);
     });
 
+    it("claims sessions working inside the mode workspace", () => {
+        const nested = [
+            { sessionId: "root", cwd: "/work", runnerId: "runner-a" },
+            { sessionId: "nested", cwd: "/work/clients/acme", runnerId: "runner-a" },
+            { sessionId: "sibling", cwd: "/work-other", runnerId: "runner-a" },
+        ];
+        expect(filterSessionsByMode(nested, "work", modes, "runner-a").map((s) => s.sessionId)).toEqual(["root", "nested"]);
+        // ...and the same sessions must not also show up unfiltered.
+        expect(filterSessionsByMode(nested, null, modes, "runner-a").map((s) => s.sessionId)).toEqual(["sibling"]);
+    });
+
     it("matches a selected mode by exact cwd on its runner", () => {
         const scopedSessions = [
             { sessionId: "runner-a", cwd: "/work", runnerId: "runner-a" },

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1169,7 +1169,13 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                         <div className="flex rounded-md border border-sidebar-border/60 p-0.5" role="group" aria-label="Session mode">
                             <button
                                 className={cn("flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-xs font-medium", !selectedMode && "bg-sidebar-accent text-sidebar-foreground")}
-                                onClick={() => setSelectedMode(null)}
+                                onClick={() => {
+                                    // Leaving a mode must also leave its session, or its
+                                    // transcript stays on screen while the sidebar filters
+                                    // it away.
+                                    if (selectedMode !== null) onClearSelection();
+                                    setSelectedMode(null);
+                                }}
                                 aria-pressed={!selectedMode}
                             >
                                 <Code2 className="h-3.5 w-3.5" />

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -19,7 +19,7 @@ import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSe
 import { pruneSwipeOffsets } from "@/lib/swipe-reveal";
 import { getSessionVisualState } from "@/lib/session-visual-state";
 import { parseHubSessionsPayload } from "@/lib/hub-sessions";
-import type { ServiceModeDef } from "@pizzapi/protocol";
+import { cwdInWorkspace, type ServiceModeDef } from "@pizzapi/protocol";
 
 interface HubSession {
     sessionId: string;
@@ -123,12 +123,17 @@ export function filterSessionsByMode<T extends { cwd: string; runnerId?: string 
 ): T[] {
     const belongsToModeRunner = (session: T) =>
         Boolean(modeRunnerId) && session.runnerId === modeRunnerId;
+    // Containment, not equality: a task working in ~/Workspace/clients/acme is
+    // still a Work task, so it must not leak into the unfiltered list.
     if (!selectedModeId) {
-        const claimed = new Set(modes.map((mode) => mode.workspace));
-        return sessions.filter((session) => !belongsToModeRunner(session) || !claimed.has(session.cwd));
+        return sessions.filter(
+            (session) => !belongsToModeRunner(session) || !modes.some((mode) => cwdInWorkspace(session.cwd, mode.workspace)),
+        );
     }
     const mode = modes.find((candidate) => candidate.id === selectedModeId);
-    return mode ? sessions.filter((session) => belongsToModeRunner(session) && session.cwd === mode.workspace) : sessions;
+    return mode
+        ? sessions.filter((session) => belongsToModeRunner(session) && cwdInWorkspace(session.cwd, mode.workspace))
+        : sessions;
 }
 
 function formatRelativeDate(isoString: string): string {

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1179,7 +1179,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                 <button
                                     key={mode.id}
                                     className={cn("flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-xs font-medium", selectedMode === mode.id && "bg-sidebar-accent text-sidebar-foreground")}
-                                    onClick={() => setSelectedMode(mode.id)}
+                                    onClick={() => {
+                                        setSelectedMode(mode.id);
+                                        // Switching mode means "show me this mode", and its home
+                                        // only renders when no session is open.
+                                        if (selectedMode !== mode.id) onClearSelection();
+                                    }}
                                     aria-pressed={selectedMode === mode.id}
                                 >
                                     {mode.icon ? <DynamicLucideIcon name={mode.icon} className="h-3.5 w-3.5" /> : <FolderOpen className="h-3.5 w-3.5" />}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -112,6 +112,8 @@ export interface SessionSidebarProps {
     sessionsCompacting?: Set<string>;
     sessionModes?: ServiceModeDef[];
     sessionModesRunnerId?: string | null;
+    /** Notified when the user switches session mode (null = no mode filter). */
+    onSelectedModeChange?: (modeId: string | null) => void;
 }
 
 /** Filter by the selected mode without changing the runner/project/session tree. */
@@ -228,6 +230,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     sessionsCompacting,
     sessionModes = [],
     sessionModesRunnerId,
+    onSelectedModeChange,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -840,6 +843,10 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     React.useEffect(() => {
         if (selectedMode && !sessionModes.some((mode) => mode.id === selectedMode)) setSelectedMode(null);
     }, [selectedMode, sessionModes]);
+    // Mirror the selection outward so the host can show that mode's home view.
+    React.useEffect(() => {
+        onSelectedModeChange?.(selectedMode);
+    }, [selectedMode, onSelectedModeChange]);
     const visibleSessions = React.useMemo(
         () => filterSessionsByMode(liveSessions, selectedMode, sessionModes, sessionModesRunnerId),
         [liveSessions, selectedMode, sessionModes, sessionModesRunnerId],

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -102,7 +102,7 @@ import { SessionMessageItem, PaginationSentinel } from "@/components/session-vie
 import { GoalStatusBadge } from "@/components/session-viewer/goal-status-badge";
 import { DraggableToolbarButton } from "@/components/session-viewer/DraggableToolbarButton";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { ModeUiContext } from "@/components/session-viewer/ModeUiContext";
+import { ArtifactHostContext, ModeUiContext, type ArtifactHost } from "@/components/session-viewer/ModeUiContext";
 import type { ToolbarButtonId } from "@/hooks/useButtonPosition";
 
 // ── Public re-exports (existing consumers import these from SessionViewer) ────
@@ -153,6 +153,7 @@ export function SessionViewer({
   modeUi,
   modeLabel,
   modeIcon,
+  onOpenArtifact,
   isTerminalOpen,
   isFileExplorerOpen,
   isGitOpen,
@@ -413,6 +414,12 @@ export function SessionViewer({
 
   // ── Session actions + MCP toggle context ─────────────────────────────────
   const { sessionActions, handleMcpToggle } = useSessionActionsSetup(onExec);
+
+  // What artifact cards need to fetch a preview and open the real file.
+  const artifactHost = React.useMemo<ArtifactHost>(
+    () => ({ runnerId, onOpenFile: onOpenArtifact }),
+    [runnerId, onOpenArtifact],
+  );
   const sessionActionsWithQuote = React.useMemo(() => {
     if (!sessionActions) return null;
     return {
@@ -584,6 +591,7 @@ export function SessionViewer({
     <SessionActionsProvider value={sessionActionsWithQuote}>
       <McpToggleContext.Provider value={onExec ? handleMcpToggle : null}>
         <ModeUiContext.Provider value={modeUi ?? null}>
+        <ArtifactHostContext.Provider value={artifactHost}>
         <div className="flex flex-col flex-1 min-h-0">
 
           {/* ── Session info bar ─────────────────────────────────────────── */}
@@ -1852,6 +1860,7 @@ export function SessionViewer({
           </Dialog>
 
         </div>
+        </ArtifactHostContext.Provider>
         </ModeUiContext.Provider>
       </McpToggleContext.Provider>
     </SessionActionsProvider>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -898,6 +898,7 @@ export function SessionViewer({
                 busy={modeHome.busy}
                 onStartTask={modeHome.onStartTask}
                 onOpenSession={modeHome.onOpenSession}
+                scheduled={modeHome.scheduled}
               />
             ) : !sessionId ? (
               <ConversationEmptyState>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -101,6 +101,8 @@ import { ComposerSubmitButton } from "@/components/session-viewer/composer-submi
 import { SessionMessageItem, PaginationSentinel } from "@/components/session-viewer/message-item";
 import { GoalStatusBadge } from "@/components/session-viewer/goal-status-badge";
 import { DraggableToolbarButton } from "@/components/session-viewer/DraggableToolbarButton";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { ModeUiContext } from "@/components/session-viewer/ModeUiContext";
 import type { ToolbarButtonId } from "@/hooks/useButtonPosition";
 
 // ── Public re-exports (existing consumers import these from SessionViewer) ────
@@ -148,6 +150,9 @@ export function SessionViewer({
   showFileExplorerButton,
   onToggleGit,
   showGitButton,
+  modeUi,
+  modeLabel,
+  modeIcon,
   isTerminalOpen,
   isFileExplorerOpen,
   isGitOpen,
@@ -578,6 +583,7 @@ export function SessionViewer({
   return (
     <SessionActionsProvider value={sessionActionsWithQuote}>
       <McpToggleContext.Provider value={onExec ? handleMcpToggle : null}>
+        <ModeUiContext.Provider value={modeUi ?? null}>
         <div className="flex flex-col flex-1 min-h-0">
 
           {/* ── Session info bar ─────────────────────────────────────────── */}
@@ -621,6 +627,18 @@ export function SessionViewer({
                 <span className="text-sm font-medium truncate leading-none">
                   {sessionName || `Session ${sessionId.slice(0, 8)}…`}
                 </span>
+                {modeLabel && (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[0.65rem] font-medium flex-shrink-0"
+                    style={modeUi?.accent
+                      ? { borderColor: `${modeUi.accent}59`, backgroundColor: `${modeUi.accent}1a`, color: modeUi.accent }
+                      : undefined}
+                    title={`${modeLabel} mode`}
+                  >
+                    {modeIcon ? <DynamicLucideIcon name={modeIcon} className="size-3" /> : null}
+                    {modeLabel}
+                  </span>
+                )}
                 {activeModel?.provider && (
                   <span
                     className="hidden sm:inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[0.65rem] text-muted-foreground flex-shrink-0"
@@ -1721,10 +1739,12 @@ export function SessionViewer({
                             ? deliveryMode === "steer"
                               ? "Type to steer the agent…"
                               : "Type a follow-up message…"
-                            : isTouchDevice
-                              ? "Send a message…"
-                              : "Send a message to this session…"
-                        : "Pick a session to chat"
+                            : modeUi?.composerPlaceholder
+                              ? modeUi.composerPlaceholder
+                              : isTouchDevice
+                                ? "Send a message…"
+                                : `Send a message to this ${modeUi?.sessionNoun ?? "session"}`
+                        : `Pick a ${modeUi?.sessionNoun ?? "session"} to chat`
                     }
                     className="min-h-12 max-h-36"
                   />
@@ -1832,6 +1852,7 @@ export function SessionViewer({
           </Dialog>
 
         </div>
+        </ModeUiContext.Provider>
       </McpToggleContext.Provider>
     </SessionActionsProvider>
   );

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -103,6 +103,7 @@ import { GoalStatusBadge } from "@/components/session-viewer/goal-status-badge";
 import { DraggableToolbarButton } from "@/components/session-viewer/DraggableToolbarButton";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
 import { ArtifactHostContext, ModeUiContext, type ArtifactHost } from "@/components/session-viewer/ModeUiContext";
+import { ModeHome } from "@/components/session-viewer/ModeHome";
 import type { ToolbarButtonId } from "@/hooks/useButtonPosition";
 
 // ── Public re-exports (existing consumers import these from SessionViewer) ────
@@ -154,6 +155,7 @@ export function SessionViewer({
   modeLabel,
   modeIcon,
   onOpenArtifact,
+  modeHome,
   isTerminalOpen,
   isFileExplorerOpen,
   isGitOpen,
@@ -887,7 +889,17 @@ export function SessionViewer({
 
           {/* ── Conversation area ─────────────────────────────────────────── */}
           <div className="relative flex flex-col flex-1 min-h-0">
-            {!sessionId ? (
+            {!sessionId && modeHome ? (
+              <ModeHome
+                modeLabel={modeHome.label}
+                modeIcon={modeHome.icon}
+                modeUi={modeHome.ui}
+                recentSessions={modeHome.recentSessions}
+                busy={modeHome.busy}
+                onStartTask={modeHome.onStartTask}
+                onOpenSession={modeHome.onOpenSession}
+              />
+            ) : !sessionId ? (
               <ConversationEmptyState>
                 <MessageSquare className="size-8 opacity-40 text-muted-foreground" aria-hidden="true" />
                 <div className="space-y-1">
@@ -952,7 +964,12 @@ export function SessionViewer({
           </div>
 
           {/* ── Composer area ─────────────────────────────────────────────── */}
-          <div className="border-t border-border bg-background px-3 py-2 pp-safe-bottom">
+          {/* The mode home carries its own composer; a second, disabled one
+              below it would just be dead chrome. */}
+          <div className={cn(
+            "border-t border-border bg-background px-3 py-2 pp-safe-bottom",
+            !sessionId && modeHome && "hidden",
+          )}>
 
             {/* Message queue */}
             {sessionId && messageQueue && messageQueue.length > 0 && (

--- a/packages/ui/src/components/session-viewer/ActivityToolCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/ActivityToolCard.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for ActivityToolCard — the collapsed, human-language rendering of a
+ * tool call used by modes with toolRendering: "activity".
+ */
+import { afterEach, describe, test, expect } from "bun:test";
+import { Window } from "happy-dom";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+// happy-dom's selector parser constructs window.SyntaxError; without this the
+// first querySelectorAll throws "undefined is not a constructor".
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = (win as any).HTMLElement;
+(globalThis as any).Element = (win as any).Element;
+(globalThis as any).Node = (win as any).Node;
+(globalThis as any).getComputedStyle = (win as any).getComputedStyle;
+
+const { ActivityToolCard } = await import("./ActivityToolCard");
+
+afterEach(() => cleanup());
+
+describe("ActivityToolCard", () => {
+    test("renders the tool call as one human-language line", () => {
+        const { getByRole } = render(
+            <ActivityToolCard toolName="write" toolInput={{ file_path: "/w/q3-review.md" }}>
+                <div>detailed card</div>
+            </ActivityToolCard>,
+        );
+        expect(getByRole("button").textContent).toContain("Created q3-review.md");
+    });
+
+    test("hides the detailed card until expanded, then shows it", () => {
+        const { getByRole, queryByText } = render(
+            <ActivityToolCard toolName="bash" toolInput={{ command: "ls -la" }}>
+                <div>detailed card</div>
+            </ActivityToolCard>,
+        );
+
+        // Collapsed by default — the terminal output is not what a work mode leads with.
+        expect(queryByText("detailed card")).toBeNull();
+        expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+
+        fireEvent.click(getByRole("button"));
+
+        // Nothing is hidden from the user — detail is one click away.
+        expect(queryByText("detailed card")).not.toBeNull();
+        expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    });
+
+    test("collapses again on a second click", () => {
+        const { getByRole, queryByText } = render(
+            <ActivityToolCard toolName="read" toolInput={{ path: "/w/a.md" }}>
+                <div>detailed card</div>
+            </ActivityToolCard>,
+        );
+        fireEvent.click(getByRole("button"));
+        fireEvent.click(getByRole("button"));
+        expect(queryByText("detailed card")).toBeNull();
+    });
+
+    test("shows the command as secondary detail for bash", () => {
+        const { getByRole } = render(
+            <ActivityToolCard toolName="bash" toolInput={{ command: "pandoc report.md -o report.pdf" }} />,
+        );
+        expect(getByRole("button").textContent).toContain("pandoc report.md -o report.pdf");
+    });
+
+    test("an errored tool call still renders its activity line", () => {
+        const { getByRole } = render(
+            <ActivityToolCard toolName="web_fetch" toolInput={{ url: "https://example.com" }} isError>
+                <div>detailed card</div>
+            </ActivityToolCard>,
+        );
+        expect(getByRole("button").textContent).toContain("Read example.com");
+    });
+
+    test("renders without a detailed child (nothing to expand)", () => {
+        const { getByRole } = render(<ActivityToolCard toolName="update_todo" toolInput={{}} />);
+        fireEvent.click(getByRole("button"));
+        expect(getByRole("button").textContent).toContain("Updated the plan");
+    });
+});

--- a/packages/ui/src/components/session-viewer/ActivityToolCard.tsx
+++ b/packages/ui/src/components/session-viewer/ActivityToolCard.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { ChevronRightIcon, Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { summarizeToolActivity } from "@/components/session-viewer/activity-summary";
+
+/**
+ * A tool call rendered as one line of human-language activity.
+ *
+ * Used by modes with `toolRendering: "activity"`. The detailed card is not
+ * replaced — it is the expanded state — so nothing is hidden from the user,
+ * it just stops being the default way a non-coding mode reads.
+ */
+export function ActivityToolCard({
+  toolName,
+  toolInput,
+  isError,
+  isStreaming,
+  children,
+}: {
+  toolName?: string;
+  toolInput: unknown;
+  isError?: boolean;
+  isStreaming?: boolean;
+  /** The detailed rendering, shown when the line is expanded. */
+  children?: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = React.useState(false);
+  const summary = React.useMemo(
+    () => summarizeToolActivity(toolName, toolInput, isError),
+    [toolName, toolInput, isError],
+  );
+
+  return (
+    <div className="my-0.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className={cn(
+          "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+          "hover:bg-muted/60",
+          isError && "text-destructive",
+        )}
+      >
+        {isStreaming ? (
+          <Loader2Icon className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <DynamicLucideIcon
+            name={summary.icon}
+            className={cn("size-3.5 shrink-0", isError ? "text-destructive" : "text-muted-foreground")}
+          />
+        )}
+        <span className={cn("truncate", isError ? "" : "text-foreground/90")}>{summary.label}</span>
+        {summary.detail && (
+          <span className="hidden truncate font-mono text-xs text-muted-foreground sm:inline">{summary.detail}</span>
+        )}
+        <ChevronRightIcon
+          className={cn(
+            "ml-auto size-3.5 shrink-0 text-muted-foreground/50 transition-transform",
+            "opacity-0 group-hover:opacity-100",
+            expanded && "rotate-90 opacity-100",
+          )}
+        />
+      </button>
+      {expanded && children && <div className="mt-1 pl-2">{children}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/session-viewer/ArtifactCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for ArtifactCard — the inline rendering of a deliverable produced by
+ * a session.
+ */
+import { afterEach, beforeEach, describe, test, expect } from "bun:test";
+import { Window } from "happy-dom";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = (win as any).HTMLElement;
+(globalThis as any).Element = (win as any).Element;
+(globalThis as any).Node = (win as any).Node;
+(globalThis as any).getComputedStyle = (win as any).getComputedStyle;
+
+const { ArtifactCard } = await import("./ArtifactCard");
+
+const originalFetch = globalThis.fetch;
+let requests: Array<{ path: string; encoding: string }> = [];
+
+beforeEach(() => {
+    requests = [];
+    globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        requests.push({ path: body.path, encoding: body.encoding });
+        return new Response(JSON.stringify({ content: "a,b\n1,2\n", size: 8 }), {
+            headers: { "content-type": "application/json" },
+        });
+    }) as typeof fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+});
+
+describe("ArtifactCard", () => {
+    test("shows the file name and offers to open it", () => {
+        const { getByText, getByLabelText } = render(
+            <ArtifactCard path="/w/reports/q3.csv" kind="csv" runnerId="r1" onOpen={() => {}} />,
+        );
+        expect(getByText("q3.csv")).toBeDefined();
+        expect(getByLabelText("Open q3.csv")).toBeDefined();
+    });
+
+    test("fetches text kinds as utf8 and renders the preview", async () => {
+        const { getByText } = render(<ArtifactCard path="/w/a.csv" kind="csv" runnerId="r1" />);
+        await waitFor(() => expect(requests.length).toBe(1));
+        expect(requests[0]).toEqual({ path: "/w/a.csv", encoding: "utf8" });
+        await waitFor(() => expect(getByText("1")).toBeDefined());
+    });
+
+    test("fetches binary kinds as base64", async () => {
+        render(<ArtifactCard path="/w/a.png" kind="image" runnerId="r1" />);
+        await waitFor(() => expect(requests.length).toBe(1));
+        expect(requests[0]!.encoding).toBe("base64");
+    });
+
+    test("does not eagerly fetch a file it cannot preview", async () => {
+        const { getByText } = render(<ArtifactCard path="/w/deck.pptx" kind="download" runnerId="r1" />);
+        await waitFor(() => expect(getByText(/download to open/i)).toBeDefined());
+        expect(requests.length).toBe(0);
+    });
+
+    test("a non-previewable artifact can still be downloaded", async () => {
+        // Regression: the download button was disabled for exactly the kind of
+        // file whose only affordance is downloading.
+        const { getByLabelText } = render(<ArtifactCard path="/w/deck.pptx" kind="download" runnerId="r1" />);
+        const button = getByLabelText("Download deck.pptx") as unknown as HTMLButtonElement;
+        expect(button.disabled).toBe(false);
+    });
+
+    test("without a runner there is nothing to fetch from", async () => {
+        const { getByText } = render(<ArtifactCard path="/w/a.csv" kind="csv" />);
+        await waitFor(() => expect(getByText(/No runner available/i)).toBeDefined());
+        expect(requests.length).toBe(0);
+    });
+
+    test("a failed read reports instead of hanging on a spinner", async () => {
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ error: "permission denied" }), { status: 403 })) as typeof fetch;
+        const { getByText } = render(<ArtifactCard path="/w/a.csv" kind="csv" runnerId="r1" />);
+        await waitFor(() => expect(getByText(/permission denied/i)).toBeDefined());
+    });
+});

--- a/packages/ui/src/components/session-viewer/ArtifactCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.test.tsx
@@ -4,7 +4,7 @@
  */
 import { afterEach, beforeEach, describe, test, expect } from "bun:test";
 import { Window } from "happy-dom";
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
 const win = new Window({ url: "http://localhost/" });
@@ -20,7 +20,7 @@ const win = new Window({ url: "http://localhost/" });
 const { ArtifactCard } = await import("./ArtifactCard");
 
 const originalFetch = globalThis.fetch;
-let requests: Array<{ path: string; encoding: string }> = [];
+let requests: Array<{ path: string; encoding: string; rejectTruncated?: boolean }> = [];
 
 beforeEach(() => {
     requests = [];
@@ -78,6 +78,26 @@ describe("ArtifactCard", () => {
         const { getByText } = render(<ArtifactCard path="/w/a.csv" kind="csv" />);
         await waitFor(() => expect(getByText(/No runner available/i)).toBeDefined());
         expect(requests.length).toBe(0);
+    });
+
+    test("a truncated preview says so and never becomes the downloaded file", async () => {
+        // Regression: a preview is capped by the read API, so building a
+        // download from it would silently save a corrupt prefix.
+        globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+            const body = JSON.parse(String(init?.body ?? "{}"));
+            requests.push({ path: body.path, encoding: body.encoding, rejectTruncated: body.rejectTruncated });
+            return new Response(JSON.stringify({ content: "a,b\n1,2\n", size: 999999, truncated: true }), {
+                headers: { "content-type": "application/json" },
+            });
+        }) as typeof fetch;
+
+        const { getByText, getByLabelText } = render(<ArtifactCard path="/w/big.csv" kind="csv" runnerId="r1" />);
+        await waitFor(() => expect(getByText(/download for the whole thing/i)).toBeDefined());
+
+        fireEvent.click(getByLabelText("Download big.csv"));
+        await waitFor(() => expect(requests.length).toBe(2));
+        // The download refetches the whole file and refuses a truncated one.
+        expect(requests[1]).toEqual({ path: "/w/big.csv", encoding: "base64", rejectTruncated: true });
     });
 
     test("a failed read reports instead of hanging on a spinner", async () => {

--- a/packages/ui/src/components/session-viewer/ArtifactCard.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.tsx
@@ -58,13 +58,18 @@ export function ArtifactCard({
   const [size, setSize] = React.useState<number | undefined>(undefined);
   const [error, setError] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(false);
+  // A preview may be a prefix of the file (the read API caps text at 512 KiB,
+  // binary at 10 MiB). Downloads must never be built from a prefix.
+  const [truncated, setTruncated] = React.useState(false);
 
   const fileName = path.split(/[\\/]/).filter(Boolean).pop() ?? path;
   const previewable = kind !== "download";
 
   React.useEffect(() => {
     if (!runnerId || !previewable) return;
-    let cancelled = false;
+    // Abort rather than just ignoring the result: the server propagates
+    // cancellation to the runner, so switching sessions stops the reads.
+    const controller = new AbortController();
     setLoading(true);
     setError(null);
 
@@ -72,25 +77,25 @@ export function ArtifactCard({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
+      signal: controller.signal,
       body: JSON.stringify({ path, encoding: encodingFor(kind) }),
     })
       .then((res) => (res.ok ? res.json() : res.json().then((d: any) => Promise.reject(new Error(d.error || `HTTP ${res.status}`)))))
       .then((data: any) => {
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         setContent(typeof data.content === "string" ? data.content : "");
+        setTruncated(data.truncated === true);
         if (typeof data.size === "number") setSize(data.size);
       })
       .catch((err: unknown) => {
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         setError(err instanceof Error ? err.message : String(err));
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       });
 
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [runnerId, path, kind, previewable]);
 
   const dataUrl = React.useMemo(
@@ -105,8 +110,9 @@ export function ArtifactCard({
    * bytes are only ever needed if the user actually asks for the file.
    */
   const download = async () => {
-    let href = dataUrl;
-    if (!href && content !== null && encodingFor(kind) === "utf8") {
+    // Only reuse loaded content when it is known to be the whole file.
+    let href = !truncated ? dataUrl : null;
+    if (!href && !truncated && content !== null && encodingFor(kind) === "utf8") {
       href = `data:text/plain;charset=utf-8,${encodeURIComponent(content)}`;
     }
 
@@ -118,9 +124,14 @@ export function ArtifactCard({
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
-          body: JSON.stringify({ path, encoding: "base64" }),
+          // Fail loudly rather than saving a prefix under the real filename:
+          // a truncated docx/pptx/pdf is a corrupt file, not a partial one.
+          body: JSON.stringify({ path, encoding: "base64", rejectTruncated: true }),
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          const detail = await res.json().catch(() => null) as { error?: string } | null;
+          throw new Error(detail?.error || `HTTP ${res.status}`);
+        }
         const data = (await res.json()) as { content?: string };
         if (!data.content) throw new Error("empty response");
         href = `data:application/octet-stream;base64,${data.content}`;
@@ -189,7 +200,14 @@ export function ArtifactCard({
         )}
 
         {!loading && !error && content !== null && (
-          <ArtifactPreview kind={kind} content={content} dataUrl={dataUrl} fileName={fileName} />
+          <>
+            <ArtifactPreview kind={kind} content={content} dataUrl={dataUrl} fileName={fileName} />
+            {truncated && (
+              <div className="border-t border-border px-3 py-1.5 text-center text-[0.65rem] text-muted-foreground">
+                Preview shows the start of this file — download for the whole thing.
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/packages/ui/src/components/session-viewer/ArtifactCard.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.tsx
@@ -66,7 +66,12 @@ export function ArtifactCard({
   const previewable = kind !== "download";
 
   React.useEffect(() => {
-    if (!runnerId || !previewable) return;
+    if (!runnerId || !previewable) {
+      // A previous run may have been aborted mid-flight, which skips its own
+      // finally — clear here or the card is stuck on "Loading preview…".
+      setLoading(false);
+      return;
+    }
     // Abort rather than just ignoring the result: the server propagates
     // cancellation to the runner, so switching sessions stops the reads.
     const controller = new AbortController();

--- a/packages/ui/src/components/session-viewer/ArtifactCard.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.tsx
@@ -1,0 +1,280 @@
+import * as React from "react";
+import { DownloadIcon, ExternalLinkIcon, Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { MessageResponse } from "@/components/ai-elements/message";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { formatSize } from "@/components/file-explorer/utils";
+import { parseCsv } from "@/components/session-viewer/csv";
+import type { ArtifactKind } from "@/components/session-viewer/artifact-detection";
+
+/** Icon per artifact kind, so a deliverable is identifiable before it loads. */
+const KIND_ICON: Record<ArtifactKind, string> = {
+  markdown: "file-text",
+  image: "image",
+  pdf: "file-type-2",
+  csv: "table",
+  html: "code",
+  download: "file",
+};
+
+/** Text kinds are fetched as utf8; everything else needs base64. */
+function encodingFor(kind: ArtifactKind): "utf8" | "base64" {
+  return kind === "markdown" || kind === "csv" || kind === "html" ? "utf8" : "base64";
+}
+
+const MIME_BY_KIND: Partial<Record<ArtifactKind, string>> = { pdf: "application/pdf" };
+
+function mimeFor(kind: ArtifactKind, path: string): string {
+  if (MIME_BY_KIND[kind]) return MIME_BY_KIND[kind]!;
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  if (kind === "image") return ext === "svg" ? "image/svg+xml" : `image/${ext === "jpg" ? "jpeg" : ext}`;
+  return "application/octet-stream";
+}
+
+/**
+ * A deliverable produced by the session, rendered inline.
+ *
+ * Work-shaped modes exist to produce documents, so the document is the point
+ * of the message — not a file-write buried in a tool card. Content is fetched
+ * lazily on first render so a transcript full of artifacts doesn't fan out
+ * into a dozen reads at once.
+ */
+export function ArtifactCard({
+  path,
+  kind,
+  runnerId,
+  onOpen,
+}: {
+  path: string;
+  kind: ArtifactKind;
+  /** Runner that owns the file; without it the card cannot fetch a preview. */
+  runnerId?: string;
+  /** Open the file in the file explorer panel, when the host supports it. */
+  onOpen?: (path: string) => void;
+}) {
+  const [content, setContent] = React.useState<string | null>(null);
+  const [size, setSize] = React.useState<number | undefined>(undefined);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const fileName = path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+  const previewable = kind !== "download";
+
+  React.useEffect(() => {
+    if (!runnerId || !previewable) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    void fetch(`/api/runners/${encodeURIComponent(runnerId)}/read-file`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ path, encoding: encodingFor(kind) }),
+    })
+      .then((res) => (res.ok ? res.json() : res.json().then((d: any) => Promise.reject(new Error(d.error || `HTTP ${res.status}`)))))
+      .then((data: any) => {
+        if (cancelled) return;
+        setContent(typeof data.content === "string" ? data.content : "");
+        if (typeof data.size === "number") setSize(data.size);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runnerId, path, kind, previewable]);
+
+  const dataUrl = React.useMemo(
+    () => (content && encodingFor(kind) === "base64" ? `data:${mimeFor(kind, path)};base64,${content}` : null),
+    [content, kind, path],
+  );
+
+  const [downloading, setDownloading] = React.useState(false);
+
+  /**
+   * Fetch on demand rather than eagerly: a docx/pptx has no preview, so its
+   * bytes are only ever needed if the user actually asks for the file.
+   */
+  const download = async () => {
+    let href = dataUrl;
+    if (!href && content !== null && encodingFor(kind) === "utf8") {
+      href = `data:text/plain;charset=utf-8,${encodeURIComponent(content)}`;
+    }
+
+    if (!href) {
+      if (!runnerId) return;
+      setDownloading(true);
+      try {
+        const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/read-file`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ path, encoding: "base64" }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { content?: string };
+        if (!data.content) throw new Error("empty response");
+        href = `data:application/octet-stream;base64,${data.content}`;
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err));
+        return;
+      } finally {
+        setDownloading(false);
+      }
+    }
+
+    const a = document.createElement("a");
+    a.href = href;
+    a.download = fileName;
+    a.click();
+  };
+
+  return (
+    <div className="my-2 overflow-hidden rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-2">
+        <DynamicLucideIcon name={KIND_ICON[kind]} className="size-4 shrink-0 text-muted-foreground" />
+        <span className="truncate text-sm font-medium" title={path}>
+          {fileName}
+        </span>
+        {size !== undefined && <span className="shrink-0 text-[0.65rem] tabular-nums text-muted-foreground">{formatSize(size)}</span>}
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          {onOpen && (
+            <Button size="icon" variant="ghost" className="size-7" onClick={() => onOpen(path)} aria-label={`Open ${fileName}`}>
+              <ExternalLinkIcon className="size-3.5" />
+            </Button>
+          )}
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-7"
+            onClick={() => void download()}
+            disabled={downloading || (!runnerId && content === null)}
+            aria-label={`Download ${fileName}`}
+          >
+            {downloading ? <Loader2Icon className="size-3.5 animate-spin" /> : <DownloadIcon className="size-3.5" />}
+          </Button>
+        </div>
+      </div>
+
+      <div className={cn("max-h-96 overflow-auto", kind === "pdf" && "max-h-none")}>
+        {loading && (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" /> Loading preview…
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+            Preview unavailable — {error}
+          </div>
+        )}
+
+        {!loading && !error && !previewable && (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+            {fileName.split(".").pop()?.toUpperCase()} file — download to open.
+          </div>
+        )}
+
+        {!loading && !error && !runnerId && previewable && (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">No runner available to load this file.</div>
+        )}
+
+        {!loading && !error && content !== null && (
+          <ArtifactPreview kind={kind} content={content} dataUrl={dataUrl} fileName={fileName} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactPreview({
+  kind,
+  content,
+  dataUrl,
+  fileName,
+}: {
+  kind: ArtifactKind;
+  content: string;
+  dataUrl: string | null;
+  fileName: string;
+}) {
+  if (kind === "markdown") {
+    return (
+      <div className="px-3 py-2">
+        <MessageResponse>{content}</MessageResponse>
+      </div>
+    );
+  }
+
+  if (kind === "image" && dataUrl) {
+    return (
+      <div className="flex justify-center bg-muted/20 p-3">
+        <img src={dataUrl} alt={fileName} className="max-h-80 max-w-full object-contain" />
+      </div>
+    );
+  }
+
+  if (kind === "pdf" && dataUrl) {
+    return <iframe src={dataUrl} title={fileName} className="h-[32rem] w-full border-0" />;
+  }
+
+  if (kind === "html") {
+    return (
+      <iframe
+        // Untrusted generated markup: no same-origin, no scripts, so a
+        // deliverable can never reach the session it was produced in.
+        sandbox=""
+        srcDoc={content}
+        title={fileName}
+        className="h-96 w-full border-0 bg-white"
+      />
+    );
+  }
+
+  if (kind === "csv") return <CsvPreview content={content} />;
+
+  return null;
+}
+
+/** First rows of a CSV/TSV, as a table. */
+function CsvPreview({ content }: { content: string }) {
+  const { header, rows, truncated } = React.useMemo(() => parseCsv(content, 50), [content]);
+  if (!header) return <div className="px-3 py-6 text-center text-sm text-muted-foreground">Empty file.</div>;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead className="sticky top-0 bg-muted/60">
+          <tr>
+            {header.map((cell, i) => (
+              <th key={i} className="border-b border-border px-2 py-1.5 text-left font-medium">
+                {cell}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, r) => (
+            <tr key={r} className="odd:bg-muted/20">
+              {header.map((_, c) => (
+                <td key={c} className="border-b border-border/50 px-2 py-1 tabular-nums">
+                  {row[c] ?? ""}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {truncated && <div className="px-3 py-2 text-center text-[0.65rem] text-muted-foreground">Showing the first {rows.length} rows.</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/session-viewer/ModeHome.test.tsx
+++ b/packages/ui/src/components/session-viewer/ModeHome.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for ModeHome — the composer-first landing shown when a mode is
+ * selected and no session is open.
+ */
+import { afterEach, describe, test, expect } from "bun:test";
+import { Window } from "happy-dom";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import React from "react";
+import { resolveModeUi } from "@pizzapi/protocol";
+
+const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = (win as any).HTMLElement;
+(globalThis as any).Element = (win as any).Element;
+(globalThis as any).Node = (win as any).Node;
+(globalThis as any).getComputedStyle = (win as any).getComputedStyle;
+
+const { ModeHome, formatWhen } = await import("./ModeHome");
+
+// NOTE: React's synthetic input/change events do not reach handlers under this
+// happy-dom harness (click does), so the composer cannot be typed into here.
+// The submit path is exercised through a suggestion chip, which fills the same
+// draft state via a click.
+
+const workUi = resolveModeUi({
+    id: "work",
+    label: "Work",
+    workspace: "/w",
+    ui: {
+        preset: "work",
+        vocabulary: { session: "task", sessions: "tasks" },
+        composerPlaceholder: "What do you need done?",
+        home: {
+            greeting: "What are we working on?",
+            suggestions: [{ label: "Daily report", prompt: "Write my daily report" }],
+        },
+    },
+});
+
+const noop = () => {};
+
+afterEach(() => cleanup());
+
+describe("ModeHome", () => {
+    test("greets with the mode's own words", () => {
+        const { getByText, getByPlaceholderText } = render(
+            <ModeHome modeLabel="Work" modeUi={workUi} recentSessions={[]} onStartTask={noop} onOpenSession={noop} />,
+        );
+        expect(getByText("What are we working on?")).toBeDefined();
+        expect(getByPlaceholderText("What do you need done?")).toBeDefined();
+    });
+
+    test("starts a task with the composed prompt", () => {
+        const started: string[] = [];
+        const { getByRole } = render(
+            <ModeHome
+                modeLabel="Work"
+                modeUi={workUi}
+                recentSessions={[]}
+                onStartTask={(p) => started.push(p)}
+                onOpenSession={noop}
+            />,
+        );
+        fireEvent.click(getByRole("button", { name: "Daily report" }));
+        fireEvent.click(getByRole("button", { name: /new task/i }));
+        expect(started).toEqual(["Write my daily report"]);
+    });
+
+    test("an empty prompt cannot start a task", () => {
+        const started: string[] = [];
+        const { getByPlaceholderText, getByRole } = render(
+            <ModeHome
+                modeLabel="Work"
+                modeUi={workUi}
+                recentSessions={[]}
+                onStartTask={(p) => started.push(p)}
+                onOpenSession={noop}
+            />,
+        );
+        fireEvent.keyDown(getByPlaceholderText("What do you need done?"), { key: "Enter" });
+        expect(started).toEqual([]);
+        expect((getByRole("button", { name: /new task/i }) as unknown as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    test("a suggestion prefills the composer rather than starting work", () => {
+        const started: string[] = [];
+        const { getByRole, getByPlaceholderText } = render(
+            <ModeHome
+                modeLabel="Work"
+                modeUi={workUi}
+                recentSessions={[]}
+                onStartTask={(p) => started.push(p)}
+                onOpenSession={noop}
+            />,
+        );
+        fireEvent.click(getByRole("button", { name: "Daily report" }));
+        expect(started).toEqual([]);
+        expect((getByPlaceholderText("What do you need done?") as unknown as HTMLTextAreaElement).value).toBe(
+            "Write my daily report",
+        );
+    });
+
+    test("recent tasks use the mode's vocabulary and open on click", () => {
+        const opened: string[] = [];
+        const { getByText } = render(
+            <ModeHome
+                modeLabel="Work"
+                modeUi={workUi}
+                recentSessions={[{
+                    sessionId: "s1",
+                    sessionName: "Q3 review",
+                    cwd: "/w",
+                    lastHeartbeatAt: new Date().toISOString(),
+                    startedAt: new Date().toISOString(),
+                    isActive: true,
+                }]}
+                onStartTask={noop}
+                onOpenSession={(id) => opened.push(id)}
+            />,
+        );
+        expect(getByText("Recent tasks")).toBeDefined();
+        fireEvent.click(getByText("Q3 review"));
+        expect(opened).toEqual(["s1"]);
+    });
+
+    test("while a task is starting the composer is locked", () => {
+        const started: string[] = [];
+        const { getByRole, getByPlaceholderText } = render(
+            <ModeHome
+                modeLabel="Work"
+                modeUi={workUi}
+                recentSessions={[]}
+                onStartTask={(p) => started.push(p)}
+                onOpenSession={noop}
+                busy
+            />,
+        );
+        expect((getByPlaceholderText("What do you need done?") as unknown as HTMLTextAreaElement).disabled).toBe(true);
+        // A filled draft must not start a second task while one is starting.
+        fireEvent.click(getByRole("button", { name: "Daily report" }));
+        fireEvent.click(getByRole("button", { name: /new task/i }));
+        expect(started).toEqual([]);
+    });
+
+    test("a mode with no suggestions or recents still renders the composer", () => {
+        const bare = resolveModeUi({ id: "m", label: "M", workspace: "/m" });
+        const { getByPlaceholderText } = render(
+            <ModeHome modeLabel="M" modeUi={bare} recentSessions={[]} onStartTask={noop} onOpenSession={noop} />,
+        );
+        expect(getByPlaceholderText("Start a session…")).toBeDefined();
+    });
+});
+
+describe("formatWhen", () => {
+    test("renders recent times relatively", () => {
+        expect(formatWhen(new Date().toISOString())).toBe("just now");
+        expect(formatWhen(new Date(Date.now() - 5 * 60_000).toISOString())).toBe("5m ago");
+        expect(formatWhen(new Date(Date.now() - 3 * 3_600_000).toISOString())).toBe("3h ago");
+        expect(formatWhen(new Date(Date.now() - 2 * 86_400_000).toISOString())).toBe("2d ago");
+    });
+
+    test("an unparseable timestamp renders nothing rather than NaN", () => {
+        expect(formatWhen("not a date")).toBe("");
+    });
+});

--- a/packages/ui/src/components/session-viewer/ModeHome.tsx
+++ b/packages/ui/src/components/session-viewer/ModeHome.tsx
@@ -1,0 +1,172 @@
+import * as React from "react";
+import { ArrowUpIcon, Loader2Icon } from "lucide-react";
+import type { ResolvedModeUi, ServiceModeSuggestion } from "@pizzapi/protocol";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+
+export interface ModeHomeSession {
+  sessionId: string;
+  sessionName: string | null;
+  cwd: string;
+  lastHeartbeatAt: string | null;
+  startedAt: string;
+  isActive: boolean;
+}
+
+/**
+ * Composer-first landing for a session mode.
+ *
+ * Selecting a mode should offer to start work, not show an empty transcript
+ * telling you to pick a session. The composer starts a task directly in the
+ * mode's workspace; suggestions are declared by the mode's package.
+ */
+export function ModeHome({
+  modeLabel,
+  modeIcon,
+  modeUi,
+  recentSessions,
+  onStartTask,
+  onOpenSession,
+  busy,
+}: {
+  modeLabel: string;
+  modeIcon?: string;
+  modeUi: ResolvedModeUi;
+  recentSessions: ModeHomeSession[];
+  /** Start a task in this mode with the given prompt (may be empty). */
+  onStartTask: (prompt: string) => void;
+  onOpenSession: (sessionId: string) => void;
+  /** A task is being started — the composer is locked until it resolves. */
+  busy?: boolean;
+}) {
+  const [draft, setDraft] = React.useState("");
+  const inputRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const submit = () => {
+    if (busy) return;
+    const text = draft.trim();
+    if (!text) return;
+    setDraft("");
+    onStartTask(text);
+  };
+
+  const chooseSuggestion = (suggestion: ServiceModeSuggestion) => {
+    // Prefill rather than send: suggestions are openings ("Research ..."),
+    // and sending them verbatim would start work on a half-written request.
+    setDraft(suggestion.prompt);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center overflow-y-auto px-4 py-10">
+      <div className="w-full max-w-2xl">
+        <div className="mb-6 flex items-center gap-2.5">
+          {modeIcon && (
+            <span
+              className="flex size-9 items-center justify-center rounded-lg border"
+              style={modeUi.accent ? { borderColor: `${modeUi.accent}59`, backgroundColor: `${modeUi.accent}14`, color: modeUi.accent } : undefined}
+            >
+              <DynamicLucideIcon name={modeIcon} className="size-4.5" />
+            </span>
+          )}
+          <div>
+            <h2 className="text-lg font-semibold leading-tight">{modeUi.greeting ?? `${modeLabel}`}</h2>
+            <p className="text-xs text-muted-foreground">
+              Starts a new {modeUi.sessionNoun} in {modeLabel}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border bg-card p-2 shadow-sm focus-within:border-ring/60">
+          <textarea
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            rows={3}
+            disabled={busy}
+            placeholder={modeUi.composerPlaceholder ?? `Start a ${modeUi.sessionNoun}…`}
+            aria-label={`Start a ${modeUi.sessionNoun}`}
+            className="w-full resize-none bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground disabled:opacity-60"
+          />
+          <div className="flex items-center justify-end gap-2 px-1 pb-0.5">
+            <Button size="sm" onClick={submit} disabled={busy || draft.trim().length === 0}>
+              {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <ArrowUpIcon className="size-3.5" />}
+              {modeUi.newSessionLabel}
+            </Button>
+          </div>
+        </div>
+
+        {modeUi.suggestions.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {modeUi.suggestions.map((suggestion, i) => (
+              <button
+                key={`${suggestion.label}-${i}`}
+                type="button"
+                onClick={() => chooseSuggestion(suggestion)}
+                disabled={busy}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs",
+                  "text-foreground/80 transition-colors hover:bg-muted disabled:opacity-60",
+                )}
+              >
+                {suggestion.icon && <DynamicLucideIcon name={suggestion.icon} className="size-3.5 text-muted-foreground" />}
+                {suggestion.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {modeUi.recent && recentSessions.length > 0 && (
+          <div className="mt-8">
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Recent {modeUi.sessionNounPlural}
+            </h3>
+            <div className="overflow-hidden rounded-lg border border-border">
+              {recentSessions.map((session, i) => (
+                <button
+                  key={session.sessionId}
+                  type="button"
+                  onClick={() => onOpenSession(session.sessionId)}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-muted/60",
+                    i > 0 && "border-t border-border",
+                  )}
+                >
+                  <span
+                    className={cn("size-1.5 shrink-0 rounded-full", session.isActive ? "bg-emerald-500" : "bg-muted-foreground/40")}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate">{session.sessionName?.trim() || `Untitled ${modeUi.sessionNoun}`}</span>
+                  <span className="ml-auto shrink-0 text-[0.65rem] text-muted-foreground">
+                    {formatWhen(session.lastHeartbeatAt ?? session.startedAt)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Compact relative time for the recent list. */
+export function formatWhen(iso: string): string {
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return "";
+  const mins = Math.floor((Date.now() - then) / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return days < 7 ? `${days}d ago` : new Date(then).toLocaleDateString();
+}

--- a/packages/ui/src/components/session-viewer/ModeHome.tsx
+++ b/packages/ui/src/components/session-viewer/ModeHome.tsx
@@ -5,6 +5,7 @@ import type { ResolvedModeUi, ServiceModeSuggestion } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { ModeSchedule, type ScheduledInstruction } from "@/components/session-viewer/ModeSchedule";
 
 export interface ModeHomeSession {
   sessionId: string;
@@ -30,6 +31,7 @@ export function ModeHome({
   onStartTask,
   onOpenSession,
   busy,
+  scheduled,
 }: {
   modeLabel: string;
   modeIcon?: string;
@@ -40,6 +42,12 @@ export function ModeHome({
   onOpenSession: (sessionId: string) => void;
   /** A task is being started — the composer is locked until it resolves. */
   busy?: boolean;
+  /** Standing scheduled work, when the mode declares `scheduled`. */
+  scheduled?: {
+    instructions: ScheduledInstruction[];
+    loading?: boolean;
+    onCancel: (instruction: ScheduledInstruction) => void;
+  };
 }) {
   const [draft, setDraft] = React.useState("");
   const inputRef = React.useRef<HTMLTextAreaElement>(null);
@@ -122,6 +130,16 @@ export function ModeHome({
               </button>
             ))}
           </div>
+        )}
+
+        {modeUi.scheduled && scheduled && (
+          <ModeSchedule
+            instructions={scheduled.instructions}
+            loading={scheduled.loading}
+            sessionNoun={modeUi.sessionNoun}
+            onOpenSession={onOpenSession}
+            onCancel={scheduled.onCancel}
+          />
         )}
 
         {modeUi.recent && recentSessions.length > 0 && (

--- a/packages/ui/src/components/session-viewer/ModeHome.tsx
+++ b/packages/ui/src/components/session-viewer/ModeHome.tsx
@@ -46,6 +46,7 @@ export function ModeHome({
   scheduled?: {
     instructions: ScheduledInstruction[];
     loading?: boolean;
+    failed?: number;
     onCancel: (instruction: ScheduledInstruction) => void;
   };
 }) {
@@ -56,7 +57,9 @@ export function ModeHome({
     if (busy) return;
     const text = draft.trim();
     if (!text) return;
-    setDraft("");
+    // The draft is kept, not cleared: a successful start opens the new task and
+    // unmounts this view, while a failed one would otherwise throw away what
+    // the user typed.
     onStartTask(text);
   };
 
@@ -136,6 +139,7 @@ export function ModeHome({
           <ModeSchedule
             instructions={scheduled.instructions}
             loading={scheduled.loading}
+            failed={scheduled.failed}
             sessionNoun={modeUi.sessionNoun}
             onOpenSession={onOpenSession}
             onCancel={scheduled.onCancel}

--- a/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
@@ -46,12 +46,13 @@ describe("fetchScheduledInstructions", () => {
     });
 
     test("collects time-based subscriptions across sessions and drops the rest", async () => {
-        const found = await fetchScheduledInstructions([
+        const { instructions, failed } = await fetchScheduledInstructions([
             { sessionId: "sess-1", sessionName: "One" },
             { sessionId: "sess-2", sessionName: "Two" },
         ]);
-        expect(found.map((f) => f.subscriptionId)).toEqual(["a", "c"]);
-        expect(found[0]!.sessionName).toBe("One");
+        expect(instructions.map((f) => f.subscriptionId)).toEqual(["a", "c"]);
+        expect(instructions[0]!.sessionName).toBe("One");
+        expect(failed).toBe(0);
     });
 
     test("an unreachable session does not blank the whole schedule", async () => {
@@ -62,16 +63,18 @@ describe("fetchScheduledInstructions", () => {
             }));
         }) as typeof fetch;
 
-        const found = await fetchScheduledInstructions([
+        const { instructions, failed } = await fetchScheduledInstructions([
             { sessionId: "sess-1", sessionName: "One" },
             { sessionId: "sess-2", sessionName: "Two" },
         ]);
-        expect(found.map((f) => f.subscriptionId)).toEqual(["c"]);
+        expect(instructions.map((f) => f.subscriptionId)).toEqual(["c"]);
+        // The unreachable session is reported, not passed off as "nothing scheduled".
+        expect(failed).toBe(1);
     });
 
     test("a non-ok response contributes nothing", async () => {
         globalThis.fetch = (async () => new Response("nope", { status: 500 })) as typeof fetch;
-        expect(await fetchScheduledInstructions([{ sessionId: "s", sessionName: null }])).toEqual([]);
+        expect(await fetchScheduledInstructions([{ sessionId: "s", sessionName: null }])).toEqual({ instructions: [], failed: 1 });
     });
 });
 
@@ -98,6 +101,20 @@ describe("ModeSchedule", () => {
             <ModeSchedule instructions={[]} sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
         );
         expect(container.textContent).toBe("");
+    });
+
+    test("an all-failed check is not shown as an empty schedule", () => {
+        const { getByText } = render(
+            <ModeSchedule instructions={[]} failed={2} sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
+        );
+        expect(getByText(/Could not check scheduled work for 2 tasks/i)).toBeDefined();
+    });
+
+    test("a partial failure warns that the list may be incomplete", () => {
+        const { getByText } = render(
+            <ModeSchedule instructions={[instruction]} failed={1} sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
+        );
+        expect(getByText(/list may be incomplete/i)).toBeDefined();
     });
 
     test("shows a loading state instead of an empty list", () => {

--- a/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Tests for the mode-wide scheduled-work surface.
+ */
+import { afterEach, beforeEach, describe, test, expect } from "bun:test";
+import { Window } from "happy-dom";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = (win as any).HTMLElement;
+(globalThis as any).Element = (win as any).Element;
+(globalThis as any).Node = (win as any).Node;
+(globalThis as any).getComputedStyle = (win as any).getComputedStyle;
+
+const { ModeSchedule, fetchScheduledInstructions } = await import("./ModeSchedule");
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+});
+
+describe("fetchScheduledInstructions", () => {
+    beforeEach(() => {
+        globalThis.fetch = (async (input: any) => {
+            const url = String(input);
+            if (url.includes("sess-1")) {
+                return new Response(JSON.stringify({
+                    subscriptions: [
+                        { subscriptionId: "a", triggerType: "time:cron", params: { cron: "0 8 * * *" } },
+                        { subscriptionId: "b", triggerType: "github:pr_comment" },
+                    ],
+                }));
+            }
+            if (url.includes("sess-2")) {
+                return new Response(JSON.stringify({
+                    subscriptions: [{ subscriptionId: "c", triggerType: "time:at", params: { at: "9:00" } }],
+                }));
+            }
+            return new Response(JSON.stringify({ subscriptions: [] }));
+        }) as typeof fetch;
+    });
+
+    test("collects time-based subscriptions across sessions and drops the rest", async () => {
+        const found = await fetchScheduledInstructions([
+            { sessionId: "sess-1", sessionName: "One" },
+            { sessionId: "sess-2", sessionName: "Two" },
+        ]);
+        expect(found.map((f) => f.subscriptionId)).toEqual(["a", "c"]);
+        expect(found[0]!.sessionName).toBe("One");
+    });
+
+    test("an unreachable session does not blank the whole schedule", async () => {
+        globalThis.fetch = (async (input: any) => {
+            if (String(input).includes("sess-1")) throw new Error("offline");
+            return new Response(JSON.stringify({
+                subscriptions: [{ subscriptionId: "c", triggerType: "time:cron", params: { cron: "0 9 * * *" } }],
+            }));
+        }) as typeof fetch;
+
+        const found = await fetchScheduledInstructions([
+            { sessionId: "sess-1", sessionName: "One" },
+            { sessionId: "sess-2", sessionName: "Two" },
+        ]);
+        expect(found.map((f) => f.subscriptionId)).toEqual(["c"]);
+    });
+
+    test("a non-ok response contributes nothing", async () => {
+        globalThis.fetch = (async () => new Response("nope", { status: 500 })) as typeof fetch;
+        expect(await fetchScheduledInstructions([{ sessionId: "s", sessionName: null }])).toEqual([]);
+    });
+});
+
+describe("ModeSchedule", () => {
+    const noop = () => {};
+    const instruction = {
+        sessionId: "s1",
+        sessionName: "Daily report",
+        subscriptionId: "sub-1",
+        triggerType: "time:cron",
+        params: { cron: "0 8 * * *", message: "Write my daily report" },
+    };
+
+    test("describes what runs and when", () => {
+        const { getByText } = render(
+            <ModeSchedule instructions={[instruction]} sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
+        );
+        expect(getByText("Write my daily report")).toBeDefined();
+        expect(getByText("Every day at 08:00")).toBeDefined();
+    });
+
+    test("renders nothing when there is no scheduled work", () => {
+        const { container } = render(
+            <ModeSchedule instructions={[]} sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
+        );
+        expect(container.textContent).toBe("");
+    });
+
+    test("shows a loading state instead of an empty list", () => {
+        const { getByText } = render(
+            <ModeSchedule instructions={[]} loading sessionNoun="task" onOpenSession={noop} onCancel={noop} />,
+        );
+        expect(getByText(/Checking scheduled work/i)).toBeDefined();
+    });
+
+    test("opens the owning session and cancels the instruction", () => {
+        const opened: string[] = [];
+        const cancelled: unknown[] = [];
+        const { getByText, getByLabelText } = render(
+            <ModeSchedule
+                instructions={[instruction]}
+                sessionNoun="task"
+                onOpenSession={(id) => opened.push(id)}
+                onCancel={(i) => cancelled.push(i)}
+            />,
+        );
+        fireEvent.click(getByText("Daily report"));
+        expect(opened).toEqual(["s1"]);
+        fireEvent.click(getByLabelText(/Cancel Every day at 08:00/i));
+        expect(cancelled).toEqual([instruction]);
+    });
+
+    test("an instruction with no message still says what it does", () => {
+        const { getByText } = render(
+            <ModeSchedule
+                instructions={[{ ...instruction, params: { cron: "0 8 * * *" } }]}
+                sessionNoun="task"
+                onOpenSession={noop}
+                onCancel={noop}
+            />,
+        );
+        expect(getByText("Wakes this task")).toBeDefined();
+    });
+});

--- a/packages/ui/src/components/session-viewer/ModeSchedule.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.tsx
@@ -23,7 +23,8 @@ export interface ScheduledInstruction {
 export async function fetchScheduledInstructions(
   sessions: Array<{ sessionId: string; sessionName: string | null }>,
   signal?: AbortSignal,
-): Promise<ScheduledInstruction[]> {
+): Promise<{ instructions: ScheduledInstruction[]; failed: number }> {
+  let failed = 0;
   const results = await Promise.all(
     sessions.map(async (session) => {
       try {
@@ -31,7 +32,10 @@ export async function fetchScheduledInstructions(
           `/api/sessions/${encodeURIComponent(session.sessionId)}/trigger-subscriptions`,
           { credentials: "include", signal },
         );
-        if (!res.ok) return [];
+        if (!res.ok) {
+          failed++;
+          return [];
+        }
         const data = (await res.json()) as { subscriptions?: Array<{ subscriptionId?: string; triggerType: string; params?: Record<string, unknown> }> };
         return (data.subscriptions ?? [])
           .filter((sub) => isScheduledTrigger(sub.triggerType))
@@ -42,13 +46,15 @@ export async function fetchScheduledInstructions(
             triggerType: sub.triggerType,
             params: sub.params,
           }));
-      } catch {
-        // One unreachable session must not blank the whole schedule.
+      } catch (err) {
+        // One unreachable session must not blank the whole schedule, but the
+        // gap is reported rather than passed off as "nothing scheduled".
+        if (!signal?.aborted) failed++;
         return [];
       }
     }),
   );
-  return results.flat();
+  return { instructions: results.flat(), failed };
 }
 
 /**
@@ -58,23 +64,37 @@ export async function fetchScheduledInstructions(
  * you are not looking at — so a mode that uses it needs somewhere to see and
  * cancel it.
  */
+/**
+ * Stable identity for a scheduled row.
+ *
+ * One function so the row key, the in-flight marker and the disabled check
+ * cannot disagree — they did, which left legacy entries (no subscriptionId)
+ * clickable while a DELETE was already in flight.
+ */
+function instructionKey(instruction: ScheduledInstruction, index: number): string {
+  return instruction.subscriptionId ?? `${instruction.sessionId}:${instruction.triggerType}:${index}`;
+}
+
 export function ModeSchedule({
   instructions,
   loading,
+  failed = 0,
   sessionNoun,
   onOpenSession,
   onCancel,
 }: {
   instructions: ScheduledInstruction[];
   loading?: boolean;
+  /** Sessions whose schedule could not be read. */
+  failed?: number;
   sessionNoun: string;
   onOpenSession: (sessionId: string) => void;
   onCancel: (instruction: ScheduledInstruction) => void;
 }) {
   const [cancelling, setCancelling] = React.useState<string | null>(null);
 
-  const cancel = async (instruction: ScheduledInstruction) => {
-    const key = instruction.subscriptionId ?? `${instruction.sessionId}:${instruction.triggerType}`;
+  const cancel = async (instruction: ScheduledInstruction, index: number) => {
+    const key = instructionKey(instruction, index);
     setCancelling(key);
     try {
       await onCancel(instruction);
@@ -91,7 +111,15 @@ export function ModeSchedule({
     );
   }
 
-  if (instructions.length === 0) return null;
+  if (instructions.length === 0 && failed === 0) return null;
+
+  if (instructions.length === 0) {
+    return (
+      <div className="mt-8 text-xs text-muted-foreground">
+        Could not check scheduled work for {failed} {failed === 1 ? sessionNoun : `${sessionNoun}s`}.
+      </div>
+    );
+  }
 
   return (
     <div className="mt-8">
@@ -100,7 +128,7 @@ export function ModeSchedule({
       </h3>
       <div className="overflow-hidden rounded-lg border border-border">
         {instructions.map((instruction, i) => {
-          const key = instruction.subscriptionId ?? `${instruction.sessionId}:${instruction.triggerType}:${i}`;
+          const key = instructionKey(instruction, i);
           const message = scheduleMessage(instruction.params);
           return (
             <div key={key} className={cn("flex items-center gap-3 px-3 py-2", i > 0 && "border-t border-border")}>
@@ -123,7 +151,7 @@ export function ModeSchedule({
                 variant="ghost"
                 className="size-7 shrink-0"
                 disabled={cancelling === key}
-                onClick={() => void cancel(instruction)}
+                onClick={() => void cancel(instruction, i)}
                 aria-label={`Cancel ${describeSchedule(instruction.triggerType, instruction.params)}`}
               >
                 {cancelling === key ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
@@ -132,6 +160,11 @@ export function ModeSchedule({
           );
         })}
       </div>
+      {failed > 0 && (
+        <p className="mt-1.5 text-[0.65rem] text-muted-foreground">
+          Could not check {failed} more {failed === 1 ? sessionNoun : `${sessionNoun}s`} — this list may be incomplete.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/session-viewer/ModeSchedule.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.tsx
@@ -1,0 +1,137 @@
+import * as React from "react";
+import { CalendarClockIcon, Loader2Icon, XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { describeSchedule, isScheduledTrigger, scheduleMessage } from "@/components/session-viewer/schedule-summary";
+
+export interface ScheduledInstruction {
+  sessionId: string;
+  sessionName: string | null;
+  subscriptionId?: string;
+  triggerType: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Fetch every standing time-based instruction across a set of sessions.
+ *
+ * Subscriptions are stored per session, so a mode-wide view fans out over the
+ * mode's sessions. Bounded by the caller: a mode home passes the sessions it
+ * already lists, not the whole history.
+ */
+export async function fetchScheduledInstructions(
+  sessions: Array<{ sessionId: string; sessionName: string | null }>,
+  signal?: AbortSignal,
+): Promise<ScheduledInstruction[]> {
+  const results = await Promise.all(
+    sessions.map(async (session) => {
+      try {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(session.sessionId)}/trigger-subscriptions`,
+          { credentials: "include", signal },
+        );
+        if (!res.ok) return [];
+        const data = (await res.json()) as { subscriptions?: Array<{ subscriptionId?: string; triggerType: string; params?: Record<string, unknown> }> };
+        return (data.subscriptions ?? [])
+          .filter((sub) => isScheduledTrigger(sub.triggerType))
+          .map((sub) => ({
+            sessionId: session.sessionId,
+            sessionName: session.sessionName,
+            subscriptionId: sub.subscriptionId,
+            triggerType: sub.triggerType,
+            params: sub.params,
+          }));
+      } catch {
+        // One unreachable session must not blank the whole schedule.
+        return [];
+      }
+    }),
+  );
+  return results.flat();
+}
+
+/**
+ * Standing instructions for a mode: what runs on a schedule, and where.
+ *
+ * Scheduled work is invisible in a chat transcript — it fires into a session
+ * you are not looking at — so a mode that uses it needs somewhere to see and
+ * cancel it.
+ */
+export function ModeSchedule({
+  instructions,
+  loading,
+  sessionNoun,
+  onOpenSession,
+  onCancel,
+}: {
+  instructions: ScheduledInstruction[];
+  loading?: boolean;
+  sessionNoun: string;
+  onOpenSession: (sessionId: string) => void;
+  onCancel: (instruction: ScheduledInstruction) => void;
+}) {
+  const [cancelling, setCancelling] = React.useState<string | null>(null);
+
+  const cancel = async (instruction: ScheduledInstruction) => {
+    const key = instruction.subscriptionId ?? `${instruction.sessionId}:${instruction.triggerType}`;
+    setCancelling(key);
+    try {
+      await onCancel(instruction);
+    } finally {
+      setCancelling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mt-8 flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2Icon className="size-3.5 animate-spin" /> Checking scheduled work…
+      </div>
+    );
+  }
+
+  if (instructions.length === 0) return null;
+
+  return (
+    <div className="mt-8">
+      <h3 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <CalendarClockIcon className="size-3.5" /> Scheduled
+      </h3>
+      <div className="overflow-hidden rounded-lg border border-border">
+        {instructions.map((instruction, i) => {
+          const key = instruction.subscriptionId ?? `${instruction.sessionId}:${instruction.triggerType}:${i}`;
+          const message = scheduleMessage(instruction.params);
+          return (
+            <div key={key} className={cn("flex items-center gap-3 px-3 py-2", i > 0 && "border-t border-border")}>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm">{message ?? `Wakes this ${sessionNoun}`}</div>
+                <div className="mt-0.5 flex items-center gap-1.5 text-[0.65rem] text-muted-foreground">
+                  <span>{describeSchedule(instruction.triggerType, instruction.params)}</span>
+                  <span aria-hidden="true">·</span>
+                  <button
+                    type="button"
+                    onClick={() => onOpenSession(instruction.sessionId)}
+                    className="truncate underline-offset-2 hover:underline"
+                  >
+                    {instruction.sessionName?.trim() || `Untitled ${sessionNoun}`}
+                  </button>
+                </div>
+              </div>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-7 shrink-0"
+                disabled={cancelling === key}
+                onClick={() => void cancel(instruction)}
+                aria-label={`Cancel ${describeSchedule(instruction.triggerType, instruction.params)}`}
+              >
+                {cancelling === key ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/session-viewer/ModeUiContext.tsx
+++ b/packages/ui/src/components/session-viewer/ModeUiContext.tsx
@@ -14,3 +14,17 @@ export const ModeUiContext = React.createContext<ResolvedModeUi | null>(null);
 export function useModeUi(): ResolvedModeUi | null {
   return React.useContext(ModeUiContext);
 }
+
+/** What an artifact card needs from the host to fetch and open a file. */
+export interface ArtifactHost {
+  /** Runner that owns the session's filesystem. */
+  runnerId?: string;
+  /** Open a path in the file explorer, when the host offers one. */
+  onOpenFile?: (path: string) => void;
+}
+
+export const ArtifactHostContext = React.createContext<ArtifactHost | null>(null);
+
+export function useArtifactHost(): ArtifactHost | null {
+  return React.useContext(ArtifactHostContext);
+}

--- a/packages/ui/src/components/session-viewer/ModeUiContext.tsx
+++ b/packages/ui/src/components/session-viewer/ModeUiContext.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import type { ResolvedModeUi } from "@pizzapi/protocol";
+
+/**
+ * Context carrying the active session's resolved mode UI to the message tree.
+ *
+ * Same reasoning as McpToggleContext: renderContent() and its callers pass
+ * positional arguments, and threading a mode object through every layer to
+ * reach the tool cards would touch every call site. Null means "no mode",
+ * which every consumer must read as the standard coding UI.
+ */
+export const ModeUiContext = React.createContext<ResolvedModeUi | null>(null);
+
+export function useModeUi(): ResolvedModeUi | null {
+  return React.useContext(ModeUiContext);
+}

--- a/packages/ui/src/components/session-viewer/activity-summary.test.ts
+++ b/packages/ui/src/components/session-viewer/activity-summary.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { baseName, summarizeToolActivity } from "./activity-summary";
+
+describe("summarizeToolActivity", () => {
+    test("file tools name the file, not the path", () => {
+        expect(summarizeToolActivity("write", { file_path: "/w/reports/q3.md" }).label).toBe("Created q3.md");
+        expect(summarizeToolActivity("edit", { file_path: "/w/reports/q3.md" }).label).toBe("Edited q3.md");
+        expect(summarizeToolActivity("read", { path: "/w/data.csv" }).label).toBe("Read data.csv");
+    });
+
+    test("file tools stay legible when the path is missing", () => {
+        expect(summarizeToolActivity("write", {}).label).toBe("Created a file");
+        expect(summarizeToolActivity("read", undefined).label).toBe("Read a file");
+    });
+
+    test("bash prefers its title and keeps the command as detail", () => {
+        const withTitle = summarizeToolActivity("bash", { command: "ls -la", title: "List the workspace" });
+        expect(withTitle.label).toBe("List the workspace");
+        expect(withTitle.detail).toBe("ls -la");
+
+        const withoutTitle = summarizeToolActivity("bash", { command: "ls -la" });
+        expect(withoutTitle.label).toBe("Ran a command");
+    });
+
+    test("search tools quote the query", () => {
+        expect(summarizeToolActivity("web_search", { query: "bond yields" }).label).toBe('Searched the web for "bond yields"');
+        expect(summarizeToolActivity("grep", { pattern: "TODO" }).label).toBe('Searched for "TODO"');
+        expect(summarizeToolActivity("session_search", { query: "acme" }).label).toBe('Searched history for "acme"');
+    });
+
+    test("web_fetch reduces a url to its host", () => {
+        expect(summarizeToolActivity("web_fetch", { url: "https://example.com/a/b?c=1" }).label).toBe("Read example.com");
+        // A malformed url must still produce a line rather than throwing.
+        expect(summarizeToolActivity("web_fetch", { url: "not a url" }).label).toBe("Read not a url");
+    });
+
+    test("input arriving as a JSON string is parsed", () => {
+        expect(summarizeToolActivity("write", JSON.stringify({ file_path: "/w/a.md" })).label).toBe("Created a.md");
+        // Non-JSON strings must not throw.
+        expect(summarizeToolActivity("write", "oops").label).toBe("Created a file");
+    });
+
+    test("namespaced mcp and plugin tools summarize like their base tool", () => {
+        expect(summarizeToolActivity("mcp__files__write", { file_path: "/w/a.md" }).label).toBe("Created a.md");
+        expect(summarizeToolActivity("plugin.read", { path: "/w/a.md" }).label).toBe("Read a.md");
+    });
+
+    test("unknown tools fall back to a humanized name", () => {
+        expect(summarizeToolActivity("capture_idea", {}).label).toBe("Capture idea");
+        expect(summarizeToolActivity("mcp__godmother__list_epics", {}).label).toBe("List epics");
+    });
+
+    test("long queries and commands are clamped rather than unbounded", () => {
+        const long = "x".repeat(200);
+        // Exact widths are a CSS concern; what matters is the raw value never
+        // reaches the line intact.
+        expect(summarizeToolActivity("bash", { command: long }).detail!.length).toBeLessThanOrEqual(80);
+        const searchLabel = summarizeToolActivity("web_search", { query: long }).label;
+        expect(searchLabel.length).toBeLessThan(100);
+        expect(searchLabel).toContain("…");
+    });
+
+    test("every summary carries an icon", () => {
+        for (const name of ["write", "edit", "read", "bash", "web_search", "update_todo", "mystery_tool"]) {
+            expect(summarizeToolActivity(name, {}).icon.length).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe("baseName", () => {
+    test("handles posix and windows separators", () => {
+        expect(baseName("/a/b/c.md")).toBe("c.md");
+        expect(baseName("a\\b\\c.md")).toBe("c.md");
+        expect(baseName("c.md")).toBe("c.md");
+    });
+});

--- a/packages/ui/src/components/session-viewer/activity-summary.ts
+++ b/packages/ui/src/components/session-viewer/activity-summary.ts
@@ -1,0 +1,153 @@
+/**
+ * Human-language summaries of tool calls, for modes that render activity
+ * instead of terminal output (ServiceModeUi.toolRendering === "activity").
+ *
+ * A knowledge-work mode should say "Created report.md", not show a bash block.
+ * Pure functions so they can be tested without mounting the message tree.
+ */
+
+import { normalizeToolName } from "@/components/session-viewer/utils";
+
+export interface ActivitySummary {
+  /** Lucide icon name for the activity line. */
+  icon: string;
+  /** Human-language label, e.g. "Created report.md". */
+  label: string;
+  /** Optional secondary text, e.g. the search query. */
+  detail?: string;
+}
+
+/** Strip an MCP/plugin namespace so "mcp__x__read" and "read" summarize alike. */
+function baseToolName(toolName?: string): string {
+  const norm = normalizeToolName(toolName);
+  const afterDot = norm.includes(".") ? norm.slice(norm.lastIndexOf(".") + 1) : norm;
+  return afterDot.includes("__") ? afterDot.slice(afterDot.lastIndexOf("__") + 2) : afterDot;
+}
+
+/** Best-effort object view of a tool's input, which may arrive as a JSON string. */
+function inputArgs(toolInput: unknown): Record<string, unknown> {
+  if (toolInput && typeof toolInput === "object" && !Array.isArray(toolInput)) {
+    return toolInput as Record<string, unknown>;
+  }
+  if (typeof toolInput === "string") {
+    try {
+      const parsed = JSON.parse(toolInput);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Not JSON — no args to read.
+    }
+  }
+  return {};
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/** Trailing path segment, so activity lines read as file names not full paths. */
+export function baseName(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+/** Truncate to a length that fits one line without wrapping on mobile. */
+function clamp(text: string, max = 80): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/** Host of a URL, or the raw string when it does not parse. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Summarize one tool call as an activity line.
+ *
+ * Falls back to a humanized tool name so an unknown tool (a new MCP server,
+ * a plugin) still renders as readable activity rather than disappearing.
+ */
+export function summarizeToolActivity(
+  toolName: string | undefined,
+  toolInput: unknown,
+  isError?: boolean,
+): ActivitySummary {
+  const name = baseToolName(toolName);
+  const args = inputArgs(toolInput);
+  const path = str(args.file_path) ?? str(args.path);
+  const file = path ? baseName(path) : null;
+
+  switch (name) {
+    case "write":
+    case "write_file":
+      return { icon: "file-plus", label: file ? `Created ${file}` : "Created a file" };
+    case "edit":
+      return { icon: "file-pen", label: file ? `Edited ${file}` : "Edited a file" };
+    case "read":
+      return { icon: "file-text", label: file ? `Read ${file}` : "Read a file" };
+    case "bash":
+    case "shell": {
+      const command = str(args.command);
+      const title = str(args.title);
+      return { icon: "terminal", label: title ?? "Ran a command", detail: command ? clamp(command) : undefined };
+    }
+    case "web_search": {
+      const query = str(args.query);
+      return { icon: "globe", label: query ? `Searched the web for "${clamp(query, 60)}"` : "Searched the web" };
+    }
+    case "web_fetch": {
+      const url = str(args.url);
+      return { icon: "globe", label: url ? `Read ${hostOf(url)}` : "Read a web page" };
+    }
+    case "search":
+    case "grep":
+    case "glob": {
+      const query = str(args.query) ?? str(args.pattern);
+      return { icon: "search", label: query ? `Searched for "${clamp(query, 60)}"` : "Searched files" };
+    }
+    case "session_search": {
+      const query = str(args.query);
+      return { icon: "history", label: query ? `Searched history for "${clamp(query, 60)}"` : "Searched history" };
+    }
+    case "update_todo":
+      return { icon: "list-checks", label: "Updated the plan" };
+    case "set_session_name":
+      return { icon: "pencil", label: "Renamed this task" };
+    case "subagent":
+    case "task":
+      return { icon: "users", label: "Delegated to a helper" };
+    case "spawn_session":
+      return { icon: "users", label: "Started a linked session" };
+    case "run_workflow":
+    case "run_saved_workflow":
+      return { icon: "workflow", label: "Ran a workflow" };
+    case "askuserquestion":
+      return { icon: "circle-question-mark", label: "Asked a question" };
+    case "plan_mode":
+    case "toggle_plan_mode":
+      return { icon: "clipboard-list", label: "Made a plan" };
+    case "memory_save":
+    case "memory_append":
+    case "memory_edit":
+      return { icon: "brain", label: "Saved a note to memory" };
+    case "memory_read":
+    case "memory_list":
+      return { icon: "brain", label: "Checked memory" };
+    case "create_tunnel":
+    case "list_tunnels":
+    case "close_tunnel":
+      return { icon: "link", label: "Managed a shared link" };
+    case "get_current_time":
+      return { icon: "clock", label: "Checked the time" };
+    default: {
+      // "capture_idea" -> "Capture idea"; keeps unknown tools legible.
+      const words = name.replace(/[_-]+/g, " ").trim();
+      const label = words ? words.charAt(0).toUpperCase() + words.slice(1) : "Did something";
+      return { icon: isError ? "circle-alert" : "sparkles", label };
+    }
+  }
+}

--- a/packages/ui/src/components/session-viewer/activity-summary.ts
+++ b/packages/ui/src/components/session-viewer/activity-summary.ts
@@ -6,7 +6,7 @@
  * Pure functions so they can be tested without mounting the message tree.
  */
 
-import { normalizeToolName } from "@/components/session-viewer/utils";
+import { baseToolName } from "@/components/session-viewer/utils";
 
 export interface ActivitySummary {
   /** Lucide icon name for the activity line. */
@@ -15,13 +15,6 @@ export interface ActivitySummary {
   label: string;
   /** Optional secondary text, e.g. the search query. */
   detail?: string;
-}
-
-/** Strip an MCP/plugin namespace so "mcp__x__read" and "read" summarize alike. */
-function baseToolName(toolName?: string): string {
-  const norm = normalizeToolName(toolName);
-  const afterDot = norm.includes(".") ? norm.slice(norm.lastIndexOf(".") + 1) : norm;
-  return afterDot.includes("__") ? afterDot.slice(afterDot.lastIndexOf("__") + 2) : afterDot;
 }
 
 /** Best-effort object view of a tool's input, which may arrive as a JSON string. */

--- a/packages/ui/src/components/session-viewer/artifact-detection.test.ts
+++ b/packages/ui/src/components/session-viewer/artifact-detection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { resolveModeUi } from "@pizzapi/protocol";
+import { artifactKindFor, detectArtifact, extensionOf, writtenPath } from "./artifact-detection";
+
+const workMode = {
+    id: "work",
+    label: "Work",
+    workspace: "/w",
+    ui: { preset: "work" as const, artifacts: { enabled: true } },
+};
+const workUi = resolveModeUi(workMode);
+const codingUi = resolveModeUi(null);
+
+describe("extensionOf / artifactKindFor", () => {
+    test("maps extensions to preview kinds", () => {
+        expect(artifactKindFor("/w/a.md")).toBe("markdown");
+        expect(artifactKindFor("/w/a.PDF")).toBe("pdf");
+        expect(artifactKindFor("/w/a.csv")).toBe("csv");
+        expect(artifactKindFor("/w/a.html")).toBe("html");
+        expect(artifactKindFor("/w/a.png")).toBe("image");
+    });
+
+    test("formats browsers cannot render inline fall back to download", () => {
+        expect(artifactKindFor("/w/a.docx")).toBe("download");
+        expect(artifactKindFor("/w/a.pptx")).toBe("download");
+        expect(artifactKindFor("/w/Makefile")).toBe("download");
+    });
+
+    test("extensionOf is case-insensitive and tolerates none", () => {
+        expect(extensionOf("/w/a.MD")).toBe("md");
+        expect(extensionOf("/w/Makefile")).toBeNull();
+    });
+});
+
+describe("writtenPath", () => {
+    test("reads the path from write-style tools", () => {
+        expect(writtenPath("write", { file_path: "/w/a.md" })).toBe("/w/a.md");
+        expect(writtenPath("edit", { path: "/w/a.md" })).toBe("/w/a.md");
+        expect(writtenPath("mcp__fs__write_file", { file_path: "/w/a.md" })).toBe("/w/a.md");
+    });
+
+    test("ignores tools that do not write files", () => {
+        expect(writtenPath("read", { file_path: "/w/a.md" })).toBeNull();
+        expect(writtenPath("bash", { command: "ls" })).toBeNull();
+    });
+
+    test("ignores blank paths", () => {
+        expect(writtenPath("write", { file_path: "   " })).toBeNull();
+        expect(writtenPath("write", {})).toBeNull();
+    });
+});
+
+describe("detectArtifact", () => {
+    test("detects a deliverable written by a work mode", () => {
+        expect(detectArtifact("write", { file_path: "/w/report.pdf" }, workUi)).toEqual({
+            path: "/w/report.pdf",
+            kind: "pdf",
+        });
+    });
+
+    test("never fires for a mode without artifacts enabled", () => {
+        expect(detectArtifact("write", { file_path: "/w/report.pdf" }, codingUi)).toBeNull();
+        expect(detectArtifact("write", { file_path: "/w/report.pdf" }, null)).toBeNull();
+    });
+
+    test("ignores extensions the mode does not claim", () => {
+        const narrow = resolveModeUi({ ...workMode, ui: { artifacts: { enabled: true, extensions: ["pdf"] } } });
+        expect(detectArtifact("write", { file_path: "/w/notes.md" }, narrow)).toBeNull();
+        expect(detectArtifact("write", { file_path: "/w/report.pdf" }, narrow)?.kind).toBe("pdf");
+    });
+
+    test("source files are not deliverables", () => {
+        expect(detectArtifact("write", { file_path: "/w/script.ts" }, workUi)).toBeNull();
+    });
+});

--- a/packages/ui/src/components/session-viewer/artifact-detection.test.ts
+++ b/packages/ui/src/components/session-viewer/artifact-detection.test.ts
@@ -73,3 +73,18 @@ describe("detectArtifact", () => {
         expect(detectArtifact("write", { file_path: "/w/script.ts" }, workUi)).toBeNull();
     });
 });
+
+describe("tool input arriving as a JSON string", () => {
+    test("still produces an artifact", () => {
+        // Some providers serialize tool input; dropping those silently lost a
+        // perfectly good deliverable.
+        expect(detectArtifact("write", JSON.stringify({ file_path: "/w/report.pdf" }), workUi)).toEqual({
+            path: "/w/report.pdf",
+            kind: "pdf",
+        });
+    });
+
+    test("non-JSON strings are ignored rather than throwing", () => {
+        expect(detectArtifact("write", "not json", workUi)).toBeNull();
+    });
+});

--- a/packages/ui/src/components/session-viewer/artifact-detection.ts
+++ b/packages/ui/src/components/session-viewer/artifact-detection.ts
@@ -8,6 +8,24 @@
 import { isArtifactPath, type ResolvedModeUi } from "@pizzapi/protocol";
 import { baseToolName, parseToolInputArgs } from "@/components/session-viewer/utils";
 
+/**
+ * Tool input as an object, including the JSON-string form some providers send.
+ * parseToolInputArgs() only handles objects, which would silently drop the
+ * artifact for a perfectly good write.
+ */
+function toolArgs(toolInput: unknown): Record<string, unknown> {
+  if (typeof toolInput === "string") {
+    try {
+      const parsed = JSON.parse(toolInput);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+    return {};
+  }
+  return parseToolInputArgs(toolInput);
+}
+
 /** How an artifact should be previewed. */
 export type ArtifactKind = "markdown" | "image" | "pdf" | "csv" | "html" | "download";
 
@@ -48,7 +66,7 @@ export function writtenPath(toolName: string | undefined, toolInput: unknown): s
   const base = baseToolName(toolName);
   const isWrite = base === "write" || base === "write_file" || base === "edit";
   if (!isWrite) return null;
-  const args = parseToolInputArgs(toolInput);
+  const args = toolArgs(toolInput);
   const path = typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : null;
   return path && path.trim().length > 0 ? path.trim() : null;
 }

--- a/packages/ui/src/components/session-viewer/artifact-detection.ts
+++ b/packages/ui/src/components/session-viewer/artifact-detection.ts
@@ -1,0 +1,71 @@
+/**
+ * Deciding when a tool call produced a deliverable worth showing as an
+ * artifact card, rather than as a file-write in a transcript.
+ *
+ * Pure so the rules are testable without rendering the message tree.
+ */
+
+import { isArtifactPath, type ResolvedModeUi } from "@pizzapi/protocol";
+import { baseToolName, parseToolInputArgs } from "@/components/session-viewer/utils";
+
+/** How an artifact should be previewed. */
+export type ArtifactKind = "markdown" | "image" | "pdf" | "csv" | "html" | "download";
+
+const KIND_BY_EXTENSION: Record<string, ArtifactKind> = {
+  md: "markdown",
+  markdown: "markdown",
+  txt: "markdown",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  pdf: "pdf",
+  csv: "csv",
+  tsv: "csv",
+  html: "html",
+  htm: "html",
+};
+
+/** File extension (lowercase, no dot), or null when there isn't one. */
+export function extensionOf(path: string): string | null {
+  const match = /\.([A-Za-z0-9]+)$/.exec(path);
+  return match ? match[1]!.toLowerCase() : null;
+}
+
+/**
+ * Preview kind for a path. Anything without a known preview is "download" —
+ * docx/pptx/xlsx are real deliverables that browsers cannot render inline.
+ */
+export function artifactKindFor(path: string): ArtifactKind {
+  const ext = extensionOf(path);
+  return (ext && KIND_BY_EXTENSION[ext]) || "download";
+}
+
+/** The file path a write-style tool call targeted, if any. */
+export function writtenPath(toolName: string | undefined, toolInput: unknown): string | null {
+  const base = baseToolName(toolName);
+  const isWrite = base === "write" || base === "write_file" || base === "edit";
+  if (!isWrite) return null;
+  const args = parseToolInputArgs(toolInput);
+  const path = typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : null;
+  return path && path.trim().length > 0 ? path.trim() : null;
+}
+
+/**
+ * The artifact a tool call produced, or null.
+ *
+ * Only fires for modes with artifacts enabled, and only for extensions the
+ * mode claims — a coding session writing `.ts` is not producing a deliverable.
+ */
+export function detectArtifact(
+  toolName: string | undefined,
+  toolInput: unknown,
+  modeUi: ResolvedModeUi | null | undefined,
+): { path: string; kind: ArtifactKind } | null {
+  if (!modeUi?.artifacts) return null;
+  const path = writtenPath(toolName, toolInput);
+  if (!path || !isArtifactPath(path, modeUi)) return null;
+  return { path, kind: artifactKindFor(path) };
+}

--- a/packages/ui/src/components/session-viewer/csv.test.ts
+++ b/packages/ui/src/components/session-viewer/csv.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { parseCsv } from "./csv";
+
+describe("parseCsv", () => {
+    test("parses a header and body rows", () => {
+        const { header, rows, truncated } = parseCsv("supplier,q2,q3\nNorthwind,102400,94100\nAcme,5,6\n");
+        expect(header).toEqual(["supplier", "q2", "q3"]);
+        expect(rows).toEqual([["Northwind", "102400", "94100"], ["Acme", "5", "6"]]);
+        expect(truncated).toBe(false);
+    });
+
+    test("keeps delimiters that live inside quoted fields", () => {
+        const { rows } = parseCsv('name,note\n"Smith, John",ok\n');
+        expect(rows[0]).toEqual(["Smith, John", "ok"]);
+    });
+
+    test("unescapes doubled quotes", () => {
+        const { rows } = parseCsv('name,note\n"She said ""hi""",fine\n');
+        expect(rows[0]).toEqual(['She said "hi"', "fine"]);
+    });
+
+    test("handles CRLF line endings", () => {
+        const { header, rows } = parseCsv("a,b\r\n1,2\r\n");
+        expect(header).toEqual(["a", "b"]);
+        expect(rows).toEqual([["1", "2"]]);
+    });
+
+    test("handles a final row without a trailing newline", () => {
+        const { rows } = parseCsv("a,b\n1,2");
+        expect(rows).toEqual([["1", "2"]]);
+    });
+
+    test("detects tab-separated input", () => {
+        const { header, rows } = parseCsv("a\tb\n1\t2\n");
+        expect(header).toEqual(["a", "b"]);
+        expect(rows).toEqual([["1", "2"]]);
+    });
+
+    test("a comma-bearing first line stays comma-delimited", () => {
+        const { header } = parseCsv("a,b\tc\n1,2\n");
+        expect(header).toEqual(["a", "b\tc"]);
+    });
+
+    test("caps rows and reports truncation", () => {
+        const body = Array.from({ length: 10 }, (_, i) => `${i},x`).join("\n");
+        const { rows, truncated } = parseCsv(`a,b\n${body}\n`, 4);
+        expect(rows.length).toBe(4);
+        expect(truncated).toBe(true);
+    });
+
+    test("empty input yields no header", () => {
+        expect(parseCsv("")).toEqual({ header: null, rows: [], truncated: false });
+    });
+
+    test("header-only input yields no body rows", () => {
+        const { header, rows } = parseCsv("a,b\n");
+        expect(header).toEqual(["a", "b"]);
+        expect(rows).toEqual([]);
+    });
+
+    test("preserves empty trailing fields", () => {
+        const { rows } = parseCsv("a,b,c\n1,,3\n");
+        expect(rows[0]).toEqual(["1", "", "3"]);
+    });
+});

--- a/packages/ui/src/components/session-viewer/csv.ts
+++ b/packages/ui/src/components/session-viewer/csv.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal RFC4180-ish CSV/TSV reader for artifact previews.
+ *
+ * Handles the things a naive split breaks on: quoted fields containing the
+ * delimiter, escaped quotes (""), and CRLF. It is a preview reader, not a
+ * data pipeline.
+ *
+ * ponytail: single-pass scanner, no streaming — previews are capped at a few
+ * dozen rows. Swap in a real CSV library if artifacts ever need full parsing.
+ */
+
+export interface ParsedCsv {
+  /** Header cells, or null when the input has no rows. */
+  header: string[] | null;
+  /** Body rows, capped by `maxRows`. */
+  rows: string[][];
+  /** True when rows were dropped to satisfy the cap. */
+  truncated: boolean;
+}
+
+/** Delimiter guess: tabs win only when the first line actually has them. */
+function detectDelimiter(text: string): string {
+  const firstLine = text.slice(0, text.indexOf("\n") === -1 ? text.length : text.indexOf("\n"));
+  return firstLine.includes("\t") && !firstLine.includes(",") ? "\t" : ",";
+}
+
+/** Parse `text`, returning at most `maxRows` body rows. */
+export function parseCsv(text: string, maxRows = 50): ParsedCsv {
+  const delimiter = detectDelimiter(text);
+  const records: string[][] = [];
+  let field = "";
+  let record: string[] = [];
+  let inQuotes = false;
+  let sawAnyChar = false;
+
+  const endField = () => {
+    record.push(field);
+    field = "";
+  };
+  const endRecord = () => {
+    endField();
+    // Skip the blank record produced by a trailing newline.
+    if (record.length > 1 || record[0] !== "") records.push(record);
+    record = [];
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!;
+    sawAnyChar = true;
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"' && field === "") {
+      inQuotes = true;
+    } else if (char === delimiter) {
+      endField();
+    } else if (char === "\n") {
+      endRecord();
+      // Read one row past the cap: that extra row is what proves there was
+      // more to show, so `truncated` is honest rather than merely "we stopped".
+      if (records.length >= maxRows + 2) break;
+    } else if (char !== "\r") {
+      field += char;
+    }
+  }
+
+  // Flush a final record that wasn't newline-terminated.
+  if (sawAnyChar && (field !== "" || record.length > 0)) endRecord();
+
+  if (records.length === 0) return { header: null, rows: [], truncated: false };
+
+  const [header, ...body] = records;
+  const truncated = body.length > maxRows;
+  return { header: header!, rows: truncated ? body.slice(0, maxRows) : body, truncated };
+}

--- a/packages/ui/src/components/session-viewer/schedule-summary.test.ts
+++ b/packages/ui/src/components/session-viewer/schedule-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { describeAt, describeCron, describeSchedule, isScheduledTrigger, scheduleMessage } from "./schedule-summary";
+
+describe("isScheduledTrigger", () => {
+    test("recognises the time service's triggers only", () => {
+        expect(isScheduledTrigger("time:cron")).toBe(true);
+        expect(isScheduledTrigger("time:at")).toBe(true);
+        expect(isScheduledTrigger("time:timer_fired")).toBe(true);
+        expect(isScheduledTrigger("github:pr_comment")).toBe(false);
+    });
+});
+
+describe("describeCron", () => {
+    test("daily", () => {
+        expect(describeCron("0 8 * * *")).toBe("Every day at 08:00");
+        expect(describeCron("30 17 * * *")).toBe("Every day at 17:30");
+    });
+
+    test("weekly and weekday patterns", () => {
+        expect(describeCron("0 9 * * 1")).toBe("Every Monday at 09:00");
+        expect(describeCron("0 9 * * 1-5")).toBe("Weekdays at 09:00");
+        expect(describeCron("0 9 * * 1,3,5")).toBe("Mon, Wed, Fri at 09:00");
+    });
+
+    test("intervals", () => {
+        expect(describeCron("*/15 * * * *")).toBe("Every 15 minutes");
+        expect(describeCron("0 * * * *")).toBe("Every hour");
+        expect(describeCron("0 */6 * * *")).toBe("Every 6 hours");
+    });
+
+    test("monthly", () => {
+        expect(describeCron("0 8 1 * *")).toBe("Monthly on day 1 at 08:00");
+    });
+
+    test("falls back to the raw expression when it isn't a shape we phrase", () => {
+        expect(describeCron("0 8 * 3 2#1")).toBe("0 8 * 3 2#1");
+        expect(describeCron("not cron")).toBe("not cron");
+        expect(describeCron("0 8 * *")).toBe("0 8 * *");
+    });
+
+    test("rejects out-of-range values rather than inventing a time", () => {
+        expect(describeCron("99 99 * * *")).toBe("99 99 * * *");
+    });
+});
+
+describe("describeAt", () => {
+    test("HH:MM shorthand, with and without UTC", () => {
+        expect(describeAt("8:00")).toBe("At 08:00");
+        expect(describeAt("14:30UTC")).toBe("At 14:30 UTC");
+    });
+
+    test("ISO timestamps render as a local date-time", () => {
+        const out = describeAt("2026-08-20T09:00:00Z");
+        expect(out.startsWith("At ")).toBe(true);
+        expect(out).not.toBe("2026-08-20T09:00:00Z");
+    });
+
+    test("unparseable input is returned unchanged", () => {
+        expect(describeAt("someday")).toBe("someday");
+    });
+});
+
+describe("describeSchedule", () => {
+    test("uses the right param per trigger type", () => {
+        expect(describeSchedule("time:cron", { cron: "0 8 * * *" })).toBe("Every day at 08:00");
+        expect(describeSchedule("time:at", { at: "9:00" })).toBe("At 09:00");
+        expect(describeSchedule("time:timer_fired", { duration: "30m" })).toBe("Once, after 30m");
+    });
+
+    test("degrades to the trigger name when params are missing", () => {
+        expect(describeSchedule("time:cron", undefined)).toBe("cron");
+        expect(describeSchedule("time:at", {})).toBe("at");
+    });
+});
+
+describe("scheduleMessage", () => {
+    test("prefers message, falls back to label, else null", () => {
+        expect(scheduleMessage({ message: "Write the daily report" })).toBe("Write the daily report");
+        expect(scheduleMessage({ label: "daily" })).toBe("daily");
+        expect(scheduleMessage({ message: "   " })).toBeNull();
+        expect(scheduleMessage(undefined)).toBeNull();
+    });
+});

--- a/packages/ui/src/components/session-viewer/schedule-summary.ts
+++ b/packages/ui/src/components/session-viewer/schedule-summary.ts
@@ -1,0 +1,109 @@
+/**
+ * Human-readable descriptions of standing time-based instructions.
+ *
+ * A mode's scheduled surface should say "Every day at 08:00", not
+ * `time:cron {"cron":"0 8 * * *"}`. Pure so the phrasing is testable.
+ */
+
+/** Trigger types the scheduled surface understands. */
+export const SCHEDULED_TRIGGER_TYPES = ["time:cron", "time:at", "time:timer_fired"] as const;
+
+/** True when a trigger type represents standing scheduled work. */
+export function isScheduledTrigger(triggerType: string): boolean {
+  return (SCHEDULED_TRIGGER_TYPES as readonly string[]).includes(triggerType);
+}
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTHLY = "Monthly";
+
+/** Zero-padded HH:MM from cron minute/hour fields, or null if not literal. */
+function literalTime(minute: string, hour: string): string | null {
+  if (!/^\d{1,2}$/.test(minute) || !/^\d{1,2}$/.test(hour)) return null;
+  const m = Number(minute);
+  const h = Number(hour);
+  if (m > 59 || h > 23) return null;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+/**
+ * Describe a 5-field cron expression.
+ *
+ * ponytail: covers the shapes a person actually writes for standing work
+ * (daily, weekly, monthly, hourly, every-N-minutes) and falls back to the raw
+ * expression otherwise — a full cron-to-English parser is not worth it here.
+ */
+export function describeCron(expression: string): string {
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) return expression;
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts as [string, string, string, string, string];
+
+  const everyMinute = minute.startsWith("*/") ? Number(minute.slice(2)) : null;
+  const everyHour = hour.startsWith("*/") ? Number(hour.slice(2)) : null;
+  const time = literalTime(minute, hour);
+  const anyDate = dayOfMonth === "*" && month === "*";
+
+  if (everyMinute && hour === "*" && anyDate && dayOfWeek === "*") {
+    return `Every ${everyMinute} minutes`;
+  }
+  if (minute === "0" && hour === "*" && anyDate && dayOfWeek === "*") return "Every hour";
+  if (everyHour && /^\d{1,2}$/.test(minute) && anyDate && dayOfWeek === "*") {
+    return `Every ${everyHour} hours`;
+  }
+
+  if (time && anyDate) {
+    if (dayOfWeek === "*") return `Every day at ${time}`;
+    if (/^\d$/.test(dayOfWeek)) return `Every ${DAY_NAMES[Number(dayOfWeek) % 7]} at ${time}`;
+    if (dayOfWeek === "1-5") return `Weekdays at ${time}`;
+    if (/^[0-6](,[0-6])+$/.test(dayOfWeek)) {
+      const days = dayOfWeek.split(",").map((d) => DAY_NAMES[Number(d) % 7]!.slice(0, 3));
+      return `${days.join(", ")} at ${time}`;
+    }
+  }
+
+  if (time && /^\d{1,2}$/.test(dayOfMonth) && month === "*" && dayOfWeek === "*") {
+    return `${MONTHLY} on day ${Number(dayOfMonth)} at ${time}`;
+  }
+
+  return expression;
+}
+
+/** Describe an absolute time, in the viewer's locale. */
+export function describeAt(value: string): string {
+  // "HH:MM" / "HH:MMUTC" shorthand, as accepted by the time service.
+  const shorthand = /^(\d{1,2}):(\d{2})\s*(UTC)?$/i.exec(value.trim());
+  if (shorthand) {
+    const [, h, m, utc] = shorthand;
+    return `At ${String(Number(h)).padStart(2, "0")}:${m}${utc ? " UTC" : ""}`;
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return `At ${new Date(parsed).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
+}
+
+/** One-line description of a scheduled subscription's cadence. */
+export function describeSchedule(
+  triggerType: string,
+  params: Record<string, unknown> | undefined,
+): string {
+  const cron = typeof params?.cron === "string" ? params.cron : null;
+  const at = typeof params?.at === "string" ? params.at : null;
+  const duration = typeof params?.duration === "string" ? params.duration : null;
+
+  if (triggerType === "time:cron" && cron) return describeCron(cron);
+  if (triggerType === "time:at" && at) return describeAt(at);
+  if (triggerType === "time:timer_fired" && duration) return `Once, after ${duration}`;
+  return triggerType.replace(/^time:/, "");
+}
+
+/** What the schedule will say when it fires, if anything was configured. */
+export function scheduleMessage(params: Record<string, unknown> | undefined): string | null {
+  const message = typeof params?.message === "string" ? params.message.trim() : "";
+  if (message) return message;
+  const label = typeof params?.label === "string" ? params.label.trim() : "";
+  return label || null;
+}

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -668,9 +668,17 @@ export function renderGroupedToolExecution(
     })();
 
     if (editPath && oldText !== null && newText !== null) {
-      card = <DiffView path={editPath} oldText={oldText} newText={newText} />;
+      card = (
+        <ModeAwareDiff path={editPath}>
+          <DiffView path={editPath} oldText={oldText} newText={newText} />
+        </ModeAwareDiff>
+      );
     } else if (editPath && editsArray) {
-      card = <MultiDiffView path={editPath} edits={editsArray} />;
+      card = (
+        <ModeAwareDiff path={editPath}>
+          <MultiDiffView path={editPath} edits={editsArray} />
+        </ModeAwareDiff>
+      );
     } else {
       const pendingPath = editPath ?? "file";
       const pendingName = pendingPath.split(/[\\/]/).filter(Boolean).pop() ?? "file";
@@ -1155,6 +1163,25 @@ export function renderGroupedToolExecution(
  * mode arrives by context, and only components can read context. Modes that
  * want "detailed" — and every session outside a mode — pass straight through.
  */
+/**
+ * Show a diff only when the active mode wants diffs.
+ *
+ * A documents mode edits prose, not source; a red/green hunk view is the wrong
+ * way to read that, so it degrades to naming the file that changed.
+ */
+function ModeAwareDiff({ path, children }: { path: string; children: React.ReactNode }) {
+  const modeUi = useModeUi();
+  if (modeUi && !modeUi.diffs) {
+    const fileName = path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+    return (
+      <EditFileCard path={path} fileName={fileName} additions={0} deletions={0}>
+        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">Updated {fileName}</div>
+      </EditFileCard>
+    );
+  }
+  return <>{children}</>;
+}
+
 function ModeAwareToolCard({
   toolName,
   toolInput,

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -25,7 +25,9 @@ import {
 } from "@/components/ai-elements/reasoning";
 import { FileTypeCard } from "@/components/ai-elements/file-type-card";
 import { ActivityToolCard } from "@/components/session-viewer/ActivityToolCard";
-import { useModeUi } from "@/components/session-viewer/ModeUiContext";
+import { ArtifactCard } from "@/components/session-viewer/ArtifactCard";
+import { detectArtifact } from "@/components/session-viewer/artifact-detection";
+import { useArtifactHost, useModeUi } from "@/components/session-viewer/ModeUiContext";
 import { EditFileCard } from "@/components/ai-elements/edit-file-card";
 import {
   estimateBase64Bytes,
@@ -1167,6 +1169,16 @@ function ModeAwareToolCard({
   children: React.ReactNode;
 }) {
   const modeUi = useModeUi();
+  const artifactHost = useArtifactHost();
+  const artifact = detectArtifact(toolName, toolInput, modeUi);
+
+  // A finished deliverable is the point of the message, so it renders in full
+  // rather than collapsed behind an activity line. While the write is still
+  // streaming there is no file to preview yet.
+  if (artifact && !isStreaming && !isError) {
+    return <ArtifactCard path={artifact.path} kind={artifact.kind} runnerId={artifactHost?.runnerId} onOpen={artifactHost?.onOpenFile} />;
+  }
+
   if (modeUi?.toolRendering !== "activity") return <>{children}</>;
   return (
     <ActivityToolCard toolName={toolName} toolInput={toolInput} isError={isError} isStreaming={isStreaming}>

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -24,6 +24,8 @@ import {
   ReasoningContent,
 } from "@/components/ai-elements/reasoning";
 import { FileTypeCard } from "@/components/ai-elements/file-type-card";
+import { ActivityToolCard } from "@/components/session-viewer/ActivityToolCard";
+import { useModeUi } from "@/components/session-viewer/ModeUiContext";
 import { EditFileCard } from "@/components/ai-elements/edit-file-card";
 import {
   estimateBase64Bytes,
@@ -1121,6 +1123,12 @@ export function renderGroupedToolExecution(
     );
   }
 
+  const body = (
+    <ModeAwareToolCard toolName={toolName} toolInput={toolInput} isError={isError} isStreaming={isStreaming}>
+      {card}
+    </ModeAwareToolCard>
+  );
+
   if (thinking) {
     return (
       <div className="flex flex-col gap-2">
@@ -1130,10 +1138,39 @@ export function renderGroupedToolExecution(
                <ReasoningContent>{thinking}</ReasoningContent>
             </Reasoning>
          </div>
-         {card}
+         {body}
       </div>
     );
   }
 
-  return card;
+  return body;
+}
+
+/**
+ * Renders a tool card the way the active mode asks for.
+ *
+ * A component (not a branch inside renderGroupedToolExecution) because the
+ * mode arrives by context, and only components can read context. Modes that
+ * want "detailed" — and every session outside a mode — pass straight through.
+ */
+function ModeAwareToolCard({
+  toolName,
+  toolInput,
+  isError,
+  isStreaming,
+  children,
+}: {
+  toolName?: string;
+  toolInput: unknown;
+  isError?: boolean;
+  isStreaming: boolean;
+  children: React.ReactNode;
+}) {
+  const modeUi = useModeUi();
+  if (modeUi?.toolRendering !== "activity") return <>{children}</>;
+  return (
+    <ActivityToolCard toolName={toolName} toolInput={toolInput} isError={isError} isStreaming={isStreaming}>
+      {children}
+    </ActivityToolCard>
+  );
 }

--- a/packages/ui/src/components/session-viewer/utils.ts
+++ b/packages/ui/src/components/session-viewer/utils.ts
@@ -66,6 +66,16 @@ export function normalizeToolName(toolName?: string): string {
   return (toolName ?? "").trim().toLowerCase();
 }
 
+/**
+ * Tool name with any namespace stripped, so "mcp__fs__write", "plugin.write"
+ * and "write" all reduce to "write".
+ */
+export function baseToolName(toolName?: string): string {
+  const norm = normalizeToolName(toolName);
+  const afterDot = norm.includes(".") ? norm.slice(norm.lastIndexOf(".") + 1) : norm;
+  return afterDot.includes("__") ? afterDot.slice(afterDot.lastIndexOf("__") + 2) : afterDot;
+}
+
 export function extractTextFromToolContent(content: unknown): string | null {
   if (typeof content === "string") return content;
 

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -5,7 +5,7 @@ import type { TriggerCounts } from "@/hooks/useTriggerCount";
 import type { QuestionDisplayMode } from "@/lib/ask-user-questions";
 import type { CommandResultData } from "@/components/session-viewer/rendering";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import type { MetaGoalStatus } from "@pizzapi/protocol";
+import type { MetaGoalStatus, ResolvedModeUi } from "@pizzapi/protocol";
 
 export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption, ForkMessageOption };
 
@@ -88,6 +88,16 @@ export interface SessionViewerProps {
   isFileExplorerOpen?: boolean;
   /** Whether the git panel is currently open (used for mobile overflow menu state indicator) */
   isGitOpen?: boolean;
+  /**
+   * Resolved UI contract for the mode this session belongs to.
+   * Omitted for sessions outside any mode — callers should treat that as the
+   * standard coding UI (see resolveModeUi in @pizzapi/protocol).
+   */
+  modeUi?: ResolvedModeUi;
+  /** Label of the mode this session belongs to, when it is in one. */
+  modeLabel?: string;
+  /** Lucide icon name for the mode this session belongs to. */
+  modeIcon?: string;
   /** Toggle the triggers panel */
   onToggleTriggers?: () => void;
   /** Whether to show the triggers button */

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -98,6 +98,8 @@ export interface SessionViewerProps {
   modeLabel?: string;
   /** Lucide icon name for the mode this session belongs to. */
   modeIcon?: string;
+  /** Open a deliverable in the file explorer. Omitted when the mode hides files. */
+  onOpenArtifact?: (path: string) => void;
   /** Toggle the triggers panel */
   onToggleTriggers?: () => void;
   /** Whether to show the triggers button */

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -6,6 +6,7 @@ import type { QuestionDisplayMode } from "@/lib/ask-user-questions";
 import type { CommandResultData } from "@/components/session-viewer/rendering";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { MetaGoalStatus, ResolvedModeUi } from "@pizzapi/protocol";
+import type { ModeHomeSession } from "@/components/session-viewer/ModeHome";
 
 export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption, ForkMessageOption };
 
@@ -100,6 +101,19 @@ export interface SessionViewerProps {
   modeIcon?: string;
   /** Open a deliverable in the file explorer. Omitted when the mode hides files. */
   onOpenArtifact?: (path: string) => void;
+  /**
+   * Mode home shown instead of the empty state when a mode is selected and no
+   * session is open. Omitted when no mode is selected.
+   */
+  modeHome?: {
+    label: string;
+    icon?: string;
+    ui: ResolvedModeUi;
+    recentSessions: ModeHomeSession[];
+    busy?: boolean;
+    onStartTask: (prompt: string) => void;
+    onOpenSession: (sessionId: string) => void;
+  };
   /** Toggle the triggers panel */
   onToggleTriggers?: () => void;
   /** Whether to show the triggers button */

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -7,6 +7,7 @@ import type { CommandResultData } from "@/components/session-viewer/rendering";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { MetaGoalStatus, ResolvedModeUi } from "@pizzapi/protocol";
 import type { ModeHomeSession } from "@/components/session-viewer/ModeHome";
+import type { ScheduledInstruction } from "@/components/session-viewer/ModeSchedule";
 
 export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption, ForkMessageOption };
 
@@ -113,6 +114,11 @@ export interface SessionViewerProps {
     busy?: boolean;
     onStartTask: (prompt: string) => void;
     onOpenSession: (sessionId: string) => void;
+    scheduled?: {
+      instructions: ScheduledInstruction[];
+      loading?: boolean;
+      onCancel: (instruction: ScheduledInstruction) => void;
+    };
   };
   /** Toggle the triggers panel */
   onToggleTriggers?: () => void;

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -117,6 +117,7 @@ export interface SessionViewerProps {
     scheduled?: {
       instructions: ScheduledInstruction[];
       loading?: boolean;
+      failed?: number;
       onCancel: (instruction: ScheduledInstruction) => void;
     };
   };

--- a/packages/ui/src/lib/use-session-lifecycle.ts
+++ b/packages/ui/src/lib/use-session-lifecycle.ts
@@ -87,6 +87,7 @@ export interface UseSessionLifecycleResult {
       tools?: string;
       disallowedTools?: string;
     },
+    opts?: { prompt?: string },
   ) => Promise<string>;
   /** Lifecycle callback: viewer socket received `connected`. */
   onViewerConnected: (data: {
@@ -240,12 +241,16 @@ export function useSessionLifecycle(
         tools?: string;
         disallowedTools?: string;
       },
+      opts?: { prompt?: string },
     ): Promise<string> => {
       dispatch(lifecycleActions.spawnRequested(runnerId, cwd));
 
       const payload: Record<string, unknown> = { runnerId };
       if (cwd) payload.cwd = cwd;
       if (agent) payload.agent = agent;
+      // Sent with the spawn so the task starts immediately, instead of
+      // spawning empty and racing a follow-up message against session start.
+      if (opts?.prompt?.trim()) payload.prompt = opts.prompt.trim();
 
       let res: Response;
       let body: unknown;


### PR DESCRIPTION
## Why

A package can declare a session mode, but a mode was only a workspace path with a label — every session still rendered the coding-agent UI. PizzaWork (a non-coding personal workspace) got git panels, diff views and terminal output for work that produces documents.

This makes **session modes a real UI contribution surface**: a package declares what its sessions should look like, and PizzaPi renders it natively. The goal is that a *second* mode costs a manifest and some skills — no UI fork.

## What a mode can declare

```json
"sessionModes": [{
  "id": "work",
  "label": "Work",
  "icon": "briefcase",
  "workspace": "~/Documents/Workspace",
  "ui": {
    "preset": "work",
    "toolRendering": "activity",
    "vocabulary": { "session": "task", "sessions": "tasks" },
    "accent": "#7c3aed",
    "composerPlaceholder": "What do you need done?",
    "home": {
      "greeting": "What are we working on?",
      "suggestions": [{ "label": "Daily report", "icon": "sun", "prompt": "Write my daily report" }]
    },
    "artifacts": { "enabled": true },
    "scheduled": true
  }
}]
```

Omit `ui` and nothing changes — `resolveModeUi(undefined)` is today's coding UI, so every existing mode and session is unaffected.

## Surfaces

| Surface | Behaviour |
|---|---|
| **Chrome** | `preset: "work"` hides git/terminal/processes/diffs; hidden panels are also closed, so switching sessions can't strand a panel with no button to close it |
| **Activity rendering** | Tool calls collapse to one line — `Created q3-review.md`, `Searched the web for "freight rates"` — expanding to the existing detailed card. Nothing is hidden, it just stops being the default way the transcript reads |
| **Artifacts** | Files written into the workspace render as cards with inline previews: Markdown, images, PDF, CSV tables, sandboxed HTML. `docx`/`pptx`/`xlsx` get download cards |
| **Mode home** | Selecting a mode with no session open shows a composer that starts a task in the workspace, suggestion chips, and recent tasks — instead of "No session selected" |
| **Scheduled** | Standing `time:cron` / `time:at` instructions across the mode's sessions, in English ("Weekdays at 08:00"), with cancel |

## Design notes

**Mode membership is workspace containment, not a spawn-time stamp.** Containment also classifies sessions started outside the web UI (`cd ~/Documents/Workspace && pizza`), which stamping could not, and correctly claims work done in subdirectories. It's boundary-aware — `~/Workspace` does not claim `~/Workspace-old`.

**The mode reaches the message tree by context** (`ModeUiContext`), following the existing `McpToggleContext` precedent, because `renderContent()` and its callers pass positional args.

**No new server endpoints.** The scheduled surface fans out over the existing per-session subscription API; artifact previews use the existing `read-file` route.

## Verification

Verified in the sandbox with a real browser at each phase (screenshots taken for chrome/identity, activity lines, artifact cards, mode home, and the scheduled list). The sandbox gained a Work mode, a deliverable-shaped conversation, and the time triggers, so this is exercisable end to end.

- `bun run typecheck` clean
- ui **1391 pass**, cli **2905 pass**, protocol/tools **420 pass**, server **78 pass**
- docs site builds

An independent review pass raised 6×P1 / 5×P2; all are fixed in the final commit, notably: cross-runner mode leakage (the ownership check compared a value to itself), silently-corrupt downloads of truncated binaries, schedules only discovered on the 5 most recent sessions, duplicate spawns on double-submit, and two declared-but-dead chrome flags (`processes`, `diffs`).

## Also fixed along the way

- Registration-time `service_announce` in the test harness built its own payload and dropped `sessionModes`, so modes only appeared after a re-announce.
- Stale inline `sessionModes` structural types in the server registry replaced with `ServiceModeDef`, so new fields can't be silently dropped.
- Manifest `workspace` accepted `~/../elsewhere`, which expanded by string substitution and escaped `$HOME`.

## Docs

Session modes were entirely undocumented. Both `customization/runner-services.mdx` and the `creating-runner-services` skill now cover the contract. PizzaWork's own manifest adopts every field.
