### PR TITLE
fix(ui): keep sidebar open when switching session mode

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4124,10 +4124,11 @@ export function App() {
     return () => window.removeEventListener("pp-navigate-session", handler);
   }, [handleOpenSession]);
 
-  const handleClearSelection = React.useCallback(() => {
+  const handleClearSelection = React.useCallback((keepSidebarOpen?: boolean) => {
     setShowRunners(false);
     clearSelection();
-    setSidebarOpen(false);
+    // ponytail: mode switching clears the session but stays in the sidebar.
+    if (!keepSidebarOpen) setSidebarOpen(false);
   }, [clearSelection]);
 
   // Global keyboard shortcuts

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -77,7 +77,7 @@ export type { HubSession };
 export interface SessionSidebarProps {
     onOpenSession: (sessionId: string) => void;
     onNewSession: (initialCwd?: string) => void;
-    onClearSelection: () => void;
+    onClearSelection: (keepSidebarOpen?: boolean) => void;
     onShowRunners: () => void;
     activeSessionId: string | null;
     showRunners?: boolean;
@@ -1173,7 +1173,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                     // Leaving a mode must also leave its session, or its
                                     // transcript stays on screen while the sidebar filters
                                     // it away.
-                                    if (selectedMode !== null) onClearSelection();
+                                    if (selectedMode !== null) onClearSelection(true);
                                     setSelectedMode(null);
                                 }}
                                 aria-pressed={!selectedMode}
@@ -1189,7 +1189,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                         setSelectedMode(mode.id);
                                         // Switching mode means "show me this mode", and its home
                                         // only renders when no session is open.
-                                        if (selectedMode !== mode.id) onClearSelection();
+                                        if (selectedMode !== mode.id) onClearSelection(true);
                                     }}
                                     aria-pressed={selectedMode === mode.id}
                                 >


### PR DESCRIPTION
Mode switcher buttons cleared the active session via `handleClearSelection`, which also closed the sidebar on mobile — switching modes kicked you out of the list you were browsing.

`onClearSelection` now takes an optional `keepSidebarOpen`; only the mode buttons pass it.
