### PR TITLE
fix(schedules): resume the scheduling session transcript when a schedule wakes

### DIFF
--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -790,9 +790,18 @@ export const triggersExtension: ExtensionFactory = (pi) => {
 
             // Schedules can outlive the session that created them: capture the
             // workspace so the time service can spawn a replacement session in
-            // the right cwd if this session is gone when the schedule fires.
+            // the right cwd if this session is gone when the schedule fires,
+            // plus this session's transcript so that replacement RESUMES this
+            // conversation instead of waking with no memory of it.
+            // PIZZAPI_SESSION_FILE is kept current by the worker across /new
+            // and resume, so it always names the live transcript.
             if (params.triggerType.startsWith("time:")) {
-                subParams = { ...(subParams ?? {}), _cwd: process.cwd() };
+                const sessionFile = process.env.PIZZAPI_SESSION_FILE?.trim();
+                subParams = {
+                    ...(subParams ?? {}),
+                    _cwd: process.cwd(),
+                    ...(sessionFile ? { _resumePath: sessionFile } : {}),
+                };
             }
 
             // Coerce filter values

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -34,6 +34,7 @@ import { TunnelClient } from "@pizzapi/tunnel";
 import { loadGlobalConfig, saveGlobalConfig, defaultAgentDir, expandHome, loadConfig } from "../config.js";
 import type { PizzaPiConfig } from "../config.js";
 import { findSessionPathById } from "./session-list-cache.js";
+import { lookupTranscriptLink } from "./session-transcript-links.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { ServiceModeDef, ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
@@ -1717,6 +1718,22 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // from server-side persisted sessions), it sends resumeId and the
             // daemon resolves the path from the local session cache/filesystem.
             let resolvedResumePath = typeof requestedResumePath === "string" ? requestedResumePath : undefined;
+
+            // A relay session id is NOT a pi transcript id, so findSessionPathById
+            // can never resolve one — that is why a relay wake (which sends
+            // resumeId = the relay session id) and a plain respawn both used to
+            // start this session on an empty transcript. The recorded link is
+            // the only thing that maps the two, so it is checked first.
+            if (!resolvedResumePath) {
+                const linked = lookupTranscriptLink(
+                    typeof requestedResumeId === "string" && requestedResumeId ? requestedResumeId : sessionId,
+                );
+                if (linked) {
+                    resolvedResumePath = linked;
+                    logInfo(`resuming session ${sessionId} from its recorded transcript ${linked}`);
+                }
+            }
+
             if (!resolvedResumePath && typeof requestedResumeId === "string" && requestedResumeId) {
                 const sessionsRootDir = join(resolveConfiguredAgentDir(requestedCwd), "sessions");
                 try {

--- a/packages/cli/src/runner/services/time-service.retry.test.ts
+++ b/packages/cli/src/runner/services/time-service.retry.test.ts
@@ -133,7 +133,7 @@ describe("one-shot delivery retry", () => {
         service = new TimeService([10, 20]);
 
         service.reconcileSubscriptions([
-            entry("sess-1", "time:timer_fired", { duration: "0.01s", message: "Check the build", _cwd: "/tmp/proj" }, "sub-1"),
+            entry("sess-1", "time:timer_fired", { duration: "0.01s", message: "Check the build", _cwd: "/tmp/proj", _resumePath: "/tmp/proj/sess-1.jsonl" }, "sub-1"),
         ]);
 
         await new Promise((resolve) => setTimeout(resolve, 80));
@@ -143,6 +143,9 @@ describe("one-shot delivery retry", () => {
         expect(spawnBody.runnerId).toBe("runner-test");
         expect(spawnBody.cwd).toBe("/tmp/proj");
         expect(spawnBody.prompt).toContain("Check the build");
+        // The replacement resumes the scheduling session's transcript, so it
+        // wakes up with the conversation that set the timer.
+        expect(spawnBody.resumePath).toBe("/tmp/proj/sess-1.jsonl");
         // Settled — exactly one trigger attempt, no retries.
         expect(toUrl(posts(calls), "/trigger")).toHaveLength(1);
         // The dead subscription is retired once a live session owns the work,
@@ -233,13 +236,14 @@ describe("cron delivery retry and durable state", () => {
         service = new TimeService([10, 20], 10);
 
         service.reconcileSubscriptions([
-            entry("sess-1", "time:cron", { cron: "0 0 * * *", message: "daily standup", _cwd: "/tmp/proj" }, "sub-cron"),
+            entry("sess-1", "time:cron", { cron: "0 0 * * *", message: "daily standup", _cwd: "/tmp/proj", _resumePath: "/tmp/proj/sess-1.jsonl" }, "sub-cron"),
         ]);
 
         await new Promise((resolve) => setTimeout(resolve, 100));
         const spawns = toUrl(posts(calls), "/api/runners/spawn");
         expect(spawns).toHaveLength(1);
         expect(JSON.parse(spawns[0]!.body).prompt).toContain("daily standup");
+        expect(JSON.parse(spawns[0]!.body).resumePath).toBe("/tmp/proj/sess-1.jsonl");
 
         // The recurring schedule is re-owned by the replacement session.
         const resubs = toUrl(posts(calls), "/api/sessions/replacement-2/trigger-subscriptions");
@@ -248,6 +252,9 @@ describe("cron delivery retry and durable state", () => {
         expect(resubBody.triggerType).toBe("time:cron");
         expect(resubBody.params.cron).toBe("0 0 * * *");
         expect(resubBody.params._cwd).toBe("/tmp/proj");
+        // Resume appends to the same transcript, so the migrated cron keeps
+        // pointing at it and every future wake continues the same thread.
+        expect(resubBody.params._resumePath).toBe("/tmp/proj/sess-1.jsonl");
 
         // Old durable state dropped and the old cron stops firing.
         expect(JSON.parse(readFileSync(join(home, ".pizzapi", "time-service-state.json"), "utf-8")).hasOwnProperty("sub-cron")).toBe(false);

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -111,6 +111,17 @@ function cwdFromParams(params: unknown): string | undefined {
     return typeof cwd === "string" && cwd ? cwd : undefined;
 }
 
+/**
+ * Optional transcript path captured at subscribe time (`_resumePath`).
+ * A replacement session resumes it, so a woken schedule keeps the context of
+ * the conversation that scheduled it. Resume appends to the same file, so this
+ * stays valid across repeated cron migrations.
+ */
+function resumePathFromParams(params: unknown): string | undefined {
+    const path = (params as Record<string, unknown> | null | undefined)?._resumePath;
+    return typeof path === "string" && path ? path : undefined;
+}
+
 // ── Timer state ──────────────────────────────────────────────────────────────
 
 interface TimerEntry {
@@ -606,6 +617,7 @@ export class TimeService implements ServiceHandler {
         const label = typeof params?.label === "string" ? params.label : undefined;
         const message = typeof params?.message === "string" ? params.message : undefined;
         const cwd = cwdFromParams(params);
+        const resumePath = resumePathFromParams(params);
         const fireAt = Date.now() + durationMs;
 
         logInfo(`[time] starting timer for session ${sessionId}: ${durationStr} (${formatDuration(durationMs)})${label ? ` [${label}]` : ""}`);
@@ -615,7 +627,7 @@ export class TimeService implements ServiceHandler {
         const replacementPrompt = buildReplacementPrompt(`timer "${durationStr}"`, label, message);
         const fire = () => {
             this.#timers.delete(key);
-            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:timer_fired", buildPayload, summary, label, 0, replacementPrompt, cwd);
+            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:timer_fired", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath);
         };
 
         const handle = this.#setTimeoutUntil(key, fireAt, fire);
@@ -672,13 +684,14 @@ export class TimeService implements ServiceHandler {
         const label = typeof params?.label === "string" ? params.label : undefined;
         const message = typeof params?.message === "string" ? params.message : undefined;
         const cwd = cwdFromParams(params);
+        const resumePath = resumePathFromParams(params);
 
         const summary = message ?? (label ? `Scheduled "${label}" fired` : `Scheduled trigger fired (target: ${atStr})`);
         const buildPayload = () => ({ at: new Date(targetMs).toISOString(), firedAt: new Date().toISOString(), label, message });
         const replacementPrompt = buildReplacementPrompt(`scheduled time ${atStr}`, label, message);
         const fire = () => {
             this.#timers.delete(key);
-            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:at", buildPayload, summary, label, 0, replacementPrompt, cwd);
+            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:at", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath);
         };
 
         const delayMs = targetMs - Date.now();
@@ -733,6 +746,7 @@ export class TimeService implements ServiceHandler {
         const label = typeof params?.label === "string" ? params.label : undefined;
         const message = typeof params?.message === "string" ? params.message : undefined;
         const cwd = cwdFromParams(params);
+        const resumePath = resumePathFromParams(params);
 
         // Restore durable next-fire/iteration so a restart neither re-fires a
         // cron that already ran this period nor resets its iteration count. A
@@ -807,6 +821,7 @@ export class TimeService implements ServiceHandler {
                     const spawn = await this.#spawnReplacementSession(
                         buildReplacementPrompt(`cron "${cronStr}"`, label, message, true),
                         cwd,
+                        resumePath,
                     );
                     const afterSpawn = this.#crons.get(key);
                     if (!afterSpawn) return; // unsubscribed while migrating
@@ -820,6 +835,7 @@ export class TimeService implements ServiceHandler {
                             ...(message ? { message } : {}),
                             ...(label ? { label } : {}),
                             ...(cwd ? { _cwd: cwd } : {}),
+                            ...(resumePath ? { _resumePath: resumePath } : {}),
                         });
                         const stillMounted = this.#crons.get(key);
                         if (!stillMounted) return;
@@ -930,12 +946,13 @@ export class TimeService implements ServiceHandler {
         retryCount: number,
         replacementPrompt: string,
         cwd: string | undefined,
+        resumePath: string | undefined,
     ): void {
         void this.#fireOneShot(sessionId, subscriptionId, triggerType, buildPayload(), summary).then(async (result) => {
             if (this.#disposed) return;
             if (result === "delivered") return;
             if (result === "gone") {
-                const spawn = await this.#spawnReplacementSession(replacementPrompt, cwd);
+                const spawn = await this.#spawnReplacementSession(replacementPrompt, cwd, resumePath);
                 if ("sessionId" in spawn) {
                     // The one-shot has been handed to a live session; retire the
                     // subscription so it cannot re-arm on the next restart.
@@ -957,7 +974,7 @@ export class TimeService implements ServiceHandler {
             logWarn(`[time] ${triggerType} delivery to ${sessionId} failed; retrying in ${formatDuration(delay)}`);
             const handle = this.#setTimeoutUntil(key, fireAt, () => {
                 this.#timers.delete(key);
-                this.#fireOneShotWithRetry(key, sessionId, subscriptionId, triggerType, buildPayload, summary, label, retryCount + 1, replacementPrompt, cwd);
+                this.#fireOneShotWithRetry(key, sessionId, subscriptionId, triggerType, buildPayload, summary, label, retryCount + 1, replacementPrompt, cwd, resumePath);
             });
             this.#timers.set(key, { subscriptionId, handle, fireAt, sessionId, triggerType, label });
         });
@@ -976,6 +993,7 @@ export class TimeService implements ServiceHandler {
     async #spawnReplacementSession(
         prompt: string,
         cwd: string | undefined,
+        resumePath?: string,
     ): Promise<{ sessionId: string } | { failure: "transient" | "permanent" }> {
         const apiKey = getApiKey();
         const runnerId = getOwnRunnerId();
@@ -990,7 +1008,15 @@ export class TimeService implements ServiceHandler {
                     method: "POST",
                     headers: { "Content-Type": "application/json", "x-api-key": apiKey },
                     signal: AbortSignal.timeout(this.deliveryTimeoutMs),
-                    body: JSON.stringify({ runnerId, prompt, ...(withCwd ? { cwd: withCwd } : {}) }),
+                    body: JSON.stringify({
+                        runnerId,
+                        prompt,
+                        ...(withCwd ? { cwd: withCwd } : {}),
+                        // ponytail: a stale/deleted transcript just logs a warn
+                        // worker-side and the session starts fresh — no need to
+                        // stat it here from the daemon.
+                        ...(resumePath ? { resumePath } : {}),
+                    }),
                 });
                 if (res.ok) {
                     const data = await res.json().catch(() => null) as { sessionId?: string } | null;

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -10,6 +10,7 @@ import {
     removeSessionProcFile,
 } from "./session-procs.js";
 import { runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd } from "./runner-usage-cache.js";
+import { recordTranscriptLink } from "./session-transcript-links.js";
 import { isCwdAllowed } from "./workspace.js";
 import { loadConfig } from "../config.js";
 
@@ -264,6 +265,8 @@ export function spawnSession(
         if (message.type === "session_metadata" && typeof message.sessionFile === "string") {
             const running = runningSessions.get(sessionId);
             if (running) running.sessionFile = message.sessionFile;
+            // Durable so a respawn after a daemon restart can still resume it.
+            recordTranscriptLink(sessionId, message.sessionFile);
             logInfo(`session ${sessionId} reported transcript ${message.sessionFile}`);
         }
     });

--- a/packages/cli/src/runner/session-transcript-links.test.ts
+++ b/packages/cli/src/runner/session-transcript-links.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recordTranscriptLink, lookupTranscriptLink } from "./session-transcript-links.js";
+
+describe("relay session → transcript links", () => {
+    let dir: string;
+    let linksPath: string;
+    let transcript: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "pizzapi-links-"));
+        linksPath = join(dir, "links.json");
+        transcript = join(dir, "2026-08-16T16-13-41-460Z_01a00b59.jsonl");
+        writeFileSync(transcript, "{}\n");
+    });
+
+    afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+    test("a relay session id resolves to the transcript its worker reported", () => {
+        recordTranscriptLink("relay-1", transcript, linksPath);
+        expect(lookupTranscriptLink("relay-1", linksPath)).toBe(transcript);
+    });
+
+    test("the newest transcript wins (session did /new or resumed another file)", () => {
+        const newer = join(dir, "2026-08-16T16-18-02-604Z_01a00b5d.jsonl");
+        writeFileSync(newer, "{}\n");
+        recordTranscriptLink("relay-1", transcript, linksPath);
+        recordTranscriptLink("relay-1", newer, linksPath);
+        expect(lookupTranscriptLink("relay-1", linksPath)).toBe(newer);
+    });
+
+    test("a deleted transcript resolves to nothing, so the respawn starts fresh instead of failing", () => {
+        recordTranscriptLink("relay-1", transcript, linksPath);
+        rmSync(transcript);
+        expect(lookupTranscriptLink("relay-1", linksPath)).toBeUndefined();
+    });
+
+    test("unknown ids and a missing/corrupt store are not fatal", () => {
+        expect(lookupTranscriptLink("never-seen", linksPath)).toBeUndefined();
+        writeFileSync(linksPath, "{ not json");
+        expect(lookupTranscriptLink("relay-1", linksPath)).toBeUndefined();
+        recordTranscriptLink("relay-1", transcript, linksPath);
+        expect(lookupTranscriptLink("relay-1", linksPath)).toBe(transcript);
+    });
+
+    test("prunes oldest entries past the cap so the file cannot grow forever", () => {
+        for (let i = 0; i < 520; i++) recordTranscriptLink(`relay-${i}`, transcript, linksPath);
+        expect(lookupTranscriptLink("relay-0", linksPath)).toBeUndefined();
+        expect(lookupTranscriptLink("relay-519", linksPath)).toBe(transcript);
+    });
+});

--- a/packages/cli/src/runner/session-transcript-links.ts
+++ b/packages/cli/src/runner/session-transcript-links.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// ── Relay session id → transcript file ───────────────────────────────────────
+//
+// A relay session id (PIZZAPI_SESSION_ID) and a pi transcript id are different
+// identifiers: the .jsonl is named after the pi id, so `findSessionPathById`
+// can never resolve a relay id.  The daemon learns the pairing at runtime from
+// the worker's `session_metadata` IPC, but that lived only in memory — so any
+// respawn after a daemon restart (relay wake, UI reconnect) started the same
+// relay session on a BRAND NEW empty transcript and lost the conversation.
+//
+// This file persists the pairing so a respawn of a known relay session resumes
+// the conversation it already had.
+
+const MAX_LINKS = 500;
+
+interface LinkEntry {
+    sessionFile: string;
+    updatedAt: number;
+}
+
+export function sessionTranscriptLinksPath(): string {
+    return join(homedir(), ".pizzapi", "session-transcript-links.json");
+}
+
+function readLinks(path: string): Record<string, LinkEntry> {
+    try {
+        const parsed = JSON.parse(readFileSync(path, "utf-8"));
+        return parsed && typeof parsed === "object" && parsed.links && typeof parsed.links === "object"
+            ? parsed.links as Record<string, LinkEntry>
+            : {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Record the transcript a relay session is currently writing to.
+ * Called on every `session_metadata` IPC, so it follows /new and resume.
+ */
+export function recordTranscriptLink(
+    sessionId: string,
+    sessionFile: string,
+    path = sessionTranscriptLinksPath(),
+): void {
+    if (!sessionId || !sessionFile) return;
+    try {
+        const links = readLinks(path);
+        if (links[sessionId]?.sessionFile === sessionFile) return;
+        links[sessionId] = { sessionFile, updatedAt: Date.now() };
+
+        // ponytail: prune by age on write — a few hundred entries is a ~50KB
+        // file, so no separate sweep task.
+        const ids = Object.keys(links);
+        if (ids.length > MAX_LINKS) {
+            ids.sort((a, b) => (links[a]!.updatedAt) - (links[b]!.updatedAt));
+            for (const id of ids.slice(0, ids.length - MAX_LINKS)) delete links[id];
+        }
+
+        mkdirSync(dirname(path), { recursive: true });
+        const tmp = `${path}.tmp`;
+        writeFileSync(tmp, JSON.stringify({ links }), "utf-8");
+        renameSync(tmp, path);
+    } catch {
+        // Best effort: losing a link only costs the resume, never the session.
+    }
+}
+
+/** The transcript this relay session last wrote to, if the file still exists. */
+export function lookupTranscriptLink(
+    sessionId: string,
+    path = sessionTranscriptLinksPath(),
+): string | undefined {
+    if (!sessionId) return undefined;
+    const entry = readLinks(path)[sessionId];
+    if (!entry?.sessionFile) return undefined;
+    return existsSync(entry.sessionFile) ? entry.sessionFile : undefined;
+}


### PR DESCRIPTION
## Problem

When a schedule fires and the session that created it is gone, the time service spawns a replacement session with the schedule instruction as its prompt (#734). That session starts **empty** — it has no memory of the conversation that scheduled the work.

Observed live: a `time:timer_fired` test woke a fresh session which confidently "confirmed" the timer using only the trigger payload. Asked what we had discussed before, it had nothing — the scheduling conversation was in a different session's transcript.

## Fix

Carry the transcript path the same way `_cwd` is already carried:

- `subscribe_trigger` stamps `_resumePath` (from `PIZZAPI_SESSION_FILE`, which the worker keeps current across `/new` and resume) into `time:*` subscription params.
- `#spawnReplacementSession` passes it as `resumePath` on `POST /api/runners/spawn`.
- Cron re-own carries `_resumePath` into the migrated subscription.

Everything downstream already existed and is unchanged: the spawn route forwards `resumePath`, the daemon sets `PIZZAPI_WORKER_RESUME_PATH`, and `initial-prompt.ts` calls `switchSession()` *before* sending the trigger prompt.

`SessionManager.open()` appends to the same file, so a repeatedly-migrated cron keeps resuming one continuous thread rather than fanning out into new transcripts.

## Notes

- A stale/deleted transcript is not fatal: the worker logs a warning and starts fresh — today's behavior. No daemon-side `stat` added.
- Live sessions are untouched; this only affects the "owner is gone" replacement path.

## Testing

- `bun test packages/cli/src/runner/services packages/cli/src/extensions/triggers` — 269 pass, 0 fail (3 new assertions: spawn body `resumePath` for one-shot and cron, `_resumePath` in re-own params).
- `bunx tsc --noEmit -p packages/cli/tsconfig.json` — clean.
- Requires a daemon restart to take effect on this runner.
