### PR TITLE
feat(services): mode-scoped runner service surfaces

### DIFF
--- a/docs/specs/pi-pizzapi-overlay.md
+++ b/docs/specs/pi-pizzapi-overlay.md
@@ -162,7 +162,7 @@ Each declaration describes one daemon-side `ServiceHandler` plus optional announ
 - `triggers` and `sigils` MAY be inline arrays or one explicit JSON path. A service does not implicitly scan `triggers.json` or `sigils.json`.
 - Trigger and sigil definitions retain their current protocol shapes.
 - Service IDs MUST be unique within a package.
-- `modes` MAY list session mode ids the service's UI surfaces are scoped to. When present, the daemon stamps the list onto the announced panel and trigger defs and the web UI only shows them for sessions whose resolved session mode id is in the list. Absent/empty means visible for every session. The service itself always runs daemon-wide; sigil defs are never mode-scoped (existing sigil references must keep rendering).
+- `modes` MAY list session mode ids the service's UI surfaces are scoped to. When present, the daemon stamps the list onto the announced panel and trigger defs; the web UI only shows them for sessions whose resolved session mode id is in the list, and the relay enforces the same rule server-side: mode-scoped trigger types are filtered from `available-triggers` and rejected on session subscription and runner trigger-listener create/update when the session (or listener) cwd is outside a matching mode workspace. Absent/empty means visible for every session. The service itself always runs daemon-wide; sigil defs are never mode-scoped (existing sigil references must keep rendering). Subscriptions that already existed before a service became mode-scoped are not retroactively revoked.
 
 A service with triggers or sigils but no `panel` is valid. It may call `announceSigilServer()` and remains absent from the panel grid, matching today's panel-less service behavior.
 

--- a/docs/specs/pi-pizzapi-overlay.md
+++ b/docs/specs/pi-pizzapi-overlay.md
@@ -162,6 +162,7 @@ Each declaration describes one daemon-side `ServiceHandler` plus optional announ
 - `triggers` and `sigils` MAY be inline arrays or one explicit JSON path. A service does not implicitly scan `triggers.json` or `sigils.json`.
 - Trigger and sigil definitions retain their current protocol shapes.
 - Service IDs MUST be unique within a package.
+- `modes` MAY list session mode ids the service's UI surfaces are scoped to. When present, the daemon stamps the list onto the announced panel and trigger defs and the web UI only shows them for sessions whose resolved session mode id is in the list. Absent/empty means visible for every session. The service itself always runs daemon-wide; sigil defs are never mode-scoped (existing sigil references must keep rendering).
 
 A service with triggers or sigils but no `panel` is valid. It may call `announceSigilServer()` and remains absent from the panel grid, matching today's panel-less service behavior.
 

--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -378,6 +378,18 @@ describe("readOverlayManifest", () => {
         expect(invalid.issues.some((i) => i.field.endsWith("sessionModes[1].workspace"))).toBe(true);
     });
 
+    test("valid service modes scoping is accepted and malformed modes are rejected", () => {
+        const validDir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./service.ts", modes: ["work"] }] });
+        dirs.push(validDir);
+        const valid = readOverlayManifest(validDir, provenance);
+        expect(valid.overlay?.services?.[0].modes).toEqual(["work"]);
+        const invalidDir = fixturePkg({ schemaVersion: 1, services: [{ id: "svc", label: "x", entry: "./service.ts", modes: ["work", ""] }] });
+        dirs.push(invalidDir);
+        const invalid = readOverlayManifest(invalidDir, provenance);
+        expect(invalid.overlay).toBeNull();
+        expect(invalid.issues.some((i) => i.field.endsWith("services[0].modes"))).toBe(true);
+    });
+
     test("workspaces that escape the home directory are rejected", () => {
         for (const workspace of ["~/../elsewhere", "~/Documents/../../etc", "~/./x", "~", "~/", "/absolute", "~/..\\elsewhere", "~\\x"]) {
             const dir = fixturePkg({

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -28,7 +28,7 @@ const PREFERRED_MCP_TRANSPORT_KEYS: Record<string, Set<string>> = {
     http: new Set(["url", "headers"]),
     streamable: new Set(["url", "headers", "oauthClientName", "oauthClientId", "oauthClientSecret", "oauthCallbackPort"]),
 };
-const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils", "sessionModes"]);
+const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils", "sessionModes", "modes"]);
 const PANEL_KEYS = new Set(["dir", "requires"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
 const SERVICE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
@@ -847,6 +847,13 @@ function validateServices(
         if (raw.icon !== undefined && typeof raw.icon !== "string") {
             push(`${field}.icon`, "must be a string", "Set icon to a string identifier, or omit it.");
             valid = false;
+        }
+
+        if (raw.modes !== undefined) {
+            if (!Array.isArray(raw.modes) || !raw.modes.every((m: unknown) => typeof m === "string" && m.length > 0)) {
+                push(`${field}.modes`, "must be an array of non-empty session mode id strings", "Set modes to the session mode ids this service's surfaces are scoped to, or omit it for always-visible.");
+                valid = false;
+            }
         }
 
         if (raw.panel !== undefined) {

--- a/packages/cli/src/runner/daemon-package-reconcile.test.ts
+++ b/packages/cli/src/runner/daemon-package-reconcile.test.ts
@@ -66,6 +66,14 @@ describe("panelEntryFromManifest (fix #3: hasPanel routing)", () => {
         expect(entry?.hasPanel).toBe(true);
     });
 
+    test("manifest modes are carried onto the panel entry", () => {
+        const manifest: ServiceManifest = { id: "svc", label: "Svc", icon: "square", panel: { dir: "/abs/panel" }, modes: ["work"] };
+        const entry = panelEntryFromManifest("svc", manifest);
+        expect(entry?.modes).toEqual(["work"]);
+        const unscoped = panelEntryFromManifest("svc", { id: "svc", label: "Svc", icon: "square", panel: { dir: "/abs/panel" } });
+        expect(unscoped?.modes).toBeUndefined();
+    });
+
     test("a service with only triggers/sigils and no panel gets hasPanel: false", () => {
         const manifest: ServiceManifest = {
             id: "svc",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -100,6 +100,8 @@ export type PanelEntry = {
     sigils?: ServiceSigilDef[];
     /** Session modes declared by this service; workspace is resolved per runner. */
     sessionModes?: ServiceModeDef[];
+    /** Session mode ids this service's surfaces are scoped to (manifest `modes`). */
+    modes?: string[];
     /**
      * Whether this service has a UI panel shown to users.
      * false = service has trigger/sigil defs but no panel (e.g. the time service).
@@ -295,6 +297,7 @@ export function panelEntryFromManifest(
         ...(hasTriggers ? { triggers: manifest.triggers } : {}),
         ...(hasSigils ? { sigils: manifest.sigils } : {}),
         ...(hasSessionModes ? { sessionModes: manifest.sessionModes } : {}),
+        ...(manifest.modes && manifest.modes.length > 0 ? { modes: manifest.modes } : {}),
         ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
     };
 }
@@ -939,6 +942,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     label: p.label,
                     icon: p.icon,
                     ...(p.requires ? { panelParams: resolveRequires(p.requires) } : {}),
+                    ...(p.modes ? { modes: p.modes } : {}),
                 }));
             // Collect all trigger defs and sigil defs across all services with manifests
             const allTriggerDefs: ServiceTriggerDef[] = [];
@@ -947,7 +951,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             for (const entry of panelEntries.values()) {
                 if (!activeServiceIds.has(entry.serviceId)) continue;
                 if (entry.triggers && entry.triggers.length > 0) {
-                    allTriggerDefs.push(...entry.triggers);
+                    // Stamp the service's mode scoping onto each trigger def so the
+                    // UI can hide mode-scoped triggers outside their mode.
+                    allTriggerDefs.push(...(entry.modes ? entry.triggers.map((t) => ({ ...t, modes: entry.modes })) : entry.triggers));
                 }
                 if (entry.sessionModes && entry.sessionModes.length > 0) {
                     // Resolve home-relative workspaces on each runner; matching is exact cwd equality.

--- a/packages/cli/src/runner/package-service-loader.test.ts
+++ b/packages/cli/src/runner/package-service-loader.test.ts
@@ -112,6 +112,20 @@ describe("discoverPackageServices", () => {
         expect(existsSync(markerPath)).toBe(true);
     });
 
+    test("declared modes pass through to the service manifest", async () => {
+        const pkgDir = join(tmpDir, "modes-pkg");
+        const markerPath = join(tmpDir, "modes-marker.txt");
+        writeFixturePackage(pkgDir, { schemaVersion: 1, services: [{ id: "modes-svc", label: "X", entry: "./service.ts", modes: ["work"] }] });
+        writeMarkerService(pkgDir, "modes-svc", markerPath);
+        await installLocal("../modes-pkg");
+        grantServices("local:" + realpathSync(pkgDir), ["modes-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(errors).toEqual([]);
+        expect(services).toHaveLength(1);
+        expect(services[0]!.manifest?.modes).toEqual(["work"]);
+    });
+
     test("disabled service is never imported even when granted", async () => {
         const pkgDir = join(tmpDir, "disabled-pkg");
         const markerPath = join(tmpDir, "disabled-marker.txt");

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -249,6 +249,7 @@ export async function discoverPackageServices(
                 ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
                 ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),
                 ...(Array.isArray(decl.sessionModes) && decl.sessionModes.length > 0 ? { sessionModes: decl.sessionModes } : {}),
+                ...(Array.isArray(decl.modes) && decl.modes.length > 0 ? { modes: decl.modes } : {}),
             };
 
             services.push({

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -44,6 +44,11 @@ export interface ServiceManifest {
     /** Sigil types this service defines. */
     sigils?: ServiceSigilDef[];
     sessionModes?: ServiceModeDef[];
+    /**
+     * Session mode ids this service's surfaces (panel, triggers) are scoped
+     * to. Absent/empty = visible everywhere.
+     */
+    modes?: string[];
 }
 
 export interface ServicePluginResult {

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -138,7 +138,7 @@ are confined to the package root.
 | `triggers` | No | `[]` | Inline `ServiceTriggerDef[]` **or** a path to a JSON file |
 | `sigils` | No | `[]` | Inline `ServiceSigilDef[]` **or** a path to a JSON file |
 | `sessionModes` | No | `[]` | `ServiceModeDef[]` — workspaces with their own UI identity (see [Session modes](#session-modes)) |
-| `modes` | No | `[]` | Session mode ids this service's **surfaces** (panel button, trigger defs) are scoped to. Omit for always-visible. The service still runs daemon-wide; only visibility is scoped. Sigils stay unscoped so existing `[[type:id]]` references render everywhere. |
+| `modes` | No | `[]` | Session mode ids this service's **surfaces** (panel button, trigger defs) are scoped to. Omit for always-visible. The service still runs daemon-wide. Enforced server-side too: out-of-mode sessions can't list or subscribe to scoped triggers, and runner trigger listeners must set a cwd inside the mode workspace. Sigils stay unscoped so existing `[[type:id]]` references render everywhere. |
 
 ### Split files
 

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -138,6 +138,7 @@ are confined to the package root.
 | `triggers` | No | `[]` | Inline `ServiceTriggerDef[]` **or** a path to a JSON file |
 | `sigils` | No | `[]` | Inline `ServiceSigilDef[]` **or** a path to a JSON file |
 | `sessionModes` | No | `[]` | `ServiceModeDef[]` — workspaces with their own UI identity (see [Session modes](#session-modes)) |
+| `modes` | No | `[]` | Session mode ids this service's **surfaces** (panel button, trigger defs) are scoped to. Omit for always-visible. The service still runs daemon-wide; only visibility is scoped. Sigils stay unscoped so existing `[[type:id]]` references render everywhere. |
 
 ### Split files
 
@@ -444,6 +445,12 @@ PDF, CSV and sandboxed HTML; other extensions render a download card.
 
 Declaring a mode does **not** require any service code — a service whose only
 job is to declare a mode can have a no-op `init`/`dispose`.
+
+To scope another service's UI to a mode, set `"modes": ["work"]` on that
+service's declaration — its panel and triggers then only appear for sessions
+inside the mode's workspace (a "Daily report" panel only in Work Mode). The
+mode can be declared by any package on the runner, not necessarily the same
+one.
 
 ---
 

--- a/packages/extension-sdk/src/overlay.ts
+++ b/packages/extension-sdk/src/overlay.ts
@@ -24,6 +24,13 @@ export interface PizzaPiServiceDeclaration {
   triggers?: string | ServiceTriggerDef[];
   sigils?: string | ServiceSigilDef[];
   sessionModes?: ServiceModeDef[];
+  /**
+   * Session mode ids this service's UI surfaces (panel, triggers) are scoped
+   * to. Absent/empty = visible for every session (default). When set, the
+   * panel and trigger defs only appear for sessions whose active mode id is
+   * in this list; the service itself still runs daemon-wide.
+   */
+  modes?: string[];
 }
 
 export type PanelVariable = "PWD" | "SESSION_ID" | "HOME" | "USER" | "PROJECT_DIR";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -40,6 +40,7 @@ export {
   resolveModeUi,
   isArtifactPath,
   findSessionMode,
+  surfaceVisibleInMode,
   cwdInWorkspace,
   DEFAULT_ARTIFACT_EXTENSIONS,
 } from "./mode-ui.js";

--- a/packages/protocol/src/mode-ui.test.ts
+++ b/packages/protocol/src/mode-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { cwdInWorkspace, findSessionMode, isArtifactPath, resolveModeUi } from "./mode-ui.js";
 import type { ServiceModeDef } from "./shared.js";
+import { surfaceVisibleInMode } from "./mode-ui.js";
 
 const codingMode: ServiceModeDef = { id: "code", label: "Code", workspace: "/home/j/Projects" };
 const workMode: ServiceModeDef = {
@@ -170,5 +171,19 @@ describe("isArtifactPath", () => {
 
     test("is always false when artifacts are disabled", () => {
         expect(isArtifactPath("/w/report.pdf", resolveModeUi(workMode))).toBe(false);
+    });
+});
+
+describe("surfaceVisibleInMode", () => {
+    test("unscoped surface is visible everywhere", () => {
+        expect(surfaceVisibleInMode(undefined, null)).toBe(true);
+        expect(surfaceVisibleInMode([], null)).toBe(true);
+        expect(surfaceVisibleInMode(undefined, workMode)).toBe(true);
+    });
+    test("scoped surface only visible in a matching mode", () => {
+        expect(surfaceVisibleInMode(["work"], workMode)).toBe(true);
+        expect(surfaceVisibleInMode(["work"], codingMode)).toBe(false);
+        expect(surfaceVisibleInMode(["work"], null)).toBe(false);
+        expect(surfaceVisibleInMode(["work", "code"], codingMode)).toBe(true);
     });
 });

--- a/packages/protocol/src/mode-ui.ts
+++ b/packages/protocol/src/mode-ui.ts
@@ -145,6 +145,19 @@ export function cwdInWorkspace(cwd: string, workspace: string): boolean {
  * but is unambiguously in that mode. Deepest workspace wins so nested mode
  * workspaces resolve to the most specific mode.
  */
+/**
+ * Whether a mode-scoped service surface (panel, trigger def) should be shown
+ * for a session in `activeMode`. Surfaces with no `modes` list are visible
+ * everywhere; scoped surfaces require the session's mode id to match.
+ */
+export function surfaceVisibleInMode(
+  surfaceModes: string[] | undefined,
+  activeMode: { id: string } | null | undefined,
+): boolean {
+  if (!surfaceModes || surfaceModes.length === 0) return true;
+  return !!activeMode && surfaceModes.includes(activeMode.id);
+}
+
 export function findSessionMode(
   session: { cwd?: string | null; runnerId?: string | null } | null | undefined,
   modes: ServiceModeDef[],

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -146,6 +146,11 @@ export interface ServicePanelInfo {
    * and passes the resolved values here. Keys are camelCase (e.g. "projectDir", "sessionId").
    */
   panelParams?: Record<string, string>;
+  /**
+   * Session mode ids this panel is scoped to (from the service declaration's
+   * `modes`). Absent/empty = shown for every session.
+   */
+  modes?: string[];
 }
 
 // ── Service trigger types ─────────────────────────────────────────────────────
@@ -176,6 +181,11 @@ export interface ServiceTriggerDef {
    * For delivery filtering, subscribers use `filters` based on the output `schema`.
    */
   params?: ServiceTriggerParamDef[];
+  /**
+   * Session mode ids this trigger def is scoped to (stamped by the daemon
+   * from the declaring service's `modes`). Absent/empty = visible everywhere.
+   */
+  modes?: string[];
 }
 
 /**

--- a/packages/server/src/routes/mode-scope.ts
+++ b/packages/server/src/routes/mode-scope.ts
@@ -1,0 +1,27 @@
+/**
+ * Server-side enforcement for mode-scoped trigger defs (services[].modes).
+ *
+ * The web UI already hides mode-scoped surfaces, but agent tools
+ * (list_available_triggers / subscribe_trigger) and runner trigger listeners
+ * reach the relay routes directly — this is the chokepoint that makes the
+ * scoping real rather than cosmetic.
+ */
+import { findSessionMode, surfaceVisibleInMode } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServiceTriggerDef } from "@pizzapi/protocol";
+
+/**
+ * Whether a trigger def is allowed for a cwd on a runner. Unscoped defs are
+ * always allowed; scoped defs require the cwd to resolve (deepest-workspace
+ * wins, same as the UI) to one of the def's modes. A missing/empty cwd can
+ * never match a mode, so it only sees unscoped triggers.
+ */
+export function triggerAllowedForCwd(
+    def: ServiceTriggerDef,
+    sessionModes: ServiceModeDef[] | undefined,
+    cwd: string | null | undefined,
+    runnerId: string,
+): boolean {
+    if (!def.modes || def.modes.length === 0) return true;
+    const mode = findSessionMode({ cwd: cwd ?? null, runnerId }, sessionModes ?? [], runnerId);
+    return surfaceVisibleInMode(def.modes, mode);
+}

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -158,6 +158,8 @@ describe("runner trigger listener routes", () => {
         mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
         mockAddRunnerTriggerListener.mockReset();
         mockAddRunnerTriggerListener.mockReturnValue(Promise.resolve("listener-default"));
+        mockGetRunnerServices.mockReset();
+        mockGetRunnerServices.mockReturnValue(Promise.resolve(null));
         mockRemoveRunnerTriggerListener.mockReset();
         mockRemoveRunnerTriggerListener.mockReturnValue(Promise.resolve({ removed: 1, triggerType: "svc:event" }));
         mockGetRunnerTriggerListener.mockReset();
@@ -211,6 +213,59 @@ describe("runner trigger listener routes", () => {
                 params: { duration: "10m" },
             }),
         }));
+    });
+
+    test("POST rejects a mode-scoped trigger when listener cwd is outside the mode", async () => {
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["reporter"],
+            triggerDefs: [{ type: "reporter:daily", label: "Daily", modes: ["work"] }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        }));
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/trigger-listeners", {
+            triggerType: "reporter:daily",
+            prompt: "Report",
+            cwd: "/home/u/Projects/foo",
+        });
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(422);
+        const body = await res!.json();
+        expect(body.error).toContain("scoped to session mode");
+        expect(mockAddRunnerTriggerListener).not.toHaveBeenCalled();
+    });
+
+    test("POST allows a mode-scoped trigger when listener cwd is inside the mode", async () => {
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["reporter"],
+            triggerDefs: [{ type: "reporter:daily", label: "Daily", modes: ["work"] }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        }));
+        mockAddRunnerTriggerListener.mockReturnValue(Promise.resolve("listener-work"));
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/trigger-listeners", {
+            triggerType: "reporter:daily",
+            prompt: "Report",
+            cwd: "/home/u/Workspace/reports",
+        });
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        expect((await res!.json()).listenerId).toBe("listener-work");
+    });
+
+    test("PUT rejects moving a mode-scoped listener's cwd outside the mode", async () => {
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["reporter"],
+            triggerDefs: [{ type: "reporter:daily", label: "Daily", modes: ["work"] }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        }));
+        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({ listenerId: "listener-123", triggerType: "reporter:daily" }));
+
+        const [req, url] = makeReq("PUT", "/api/runners/runner-A/trigger-listeners/listener-123", {
+            cwd: "/home/u/Projects/foo",
+        });
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(422);
+        expect(mockUpdateRunnerTriggerListener).not.toHaveBeenCalled();
     });
 
     test("POST returns 500 when listener creation fails", async () => {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -17,6 +17,7 @@ import {
     registerTerminal,
 } from "../ws/sio-registry.js";
 import { getRunnerServices } from "../ws/sio-registry/runners.js";
+import { triggerAllowedForCwd } from "./mode-scope.js";
 import {
     addRunnerTriggerListener,
     getRunnerTriggerListener,
@@ -645,9 +646,21 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
 
             const autoClose = body?.autoClose === true ? true : undefined;
 
+            const listenerCwd = typeof body?.cwd === "string" ? body.cwd : undefined;
+            // Mode-scoped triggers require the listener's spawn cwd to be inside
+            // a matching mode workspace — same rule as session subscriptions.
+            const catalog = await getRunnerServices(runnerId);
+            const triggerDef = catalog?.triggerDefs?.find((d) => d.type === triggerType);
+            if (triggerDef && !triggerAllowedForCwd(triggerDef, catalog?.sessionModes, listenerCwd, runnerId)) {
+                return Response.json(
+                    { error: `Trigger type '${triggerType}' is scoped to session mode(s) [${(triggerDef.modes ?? []).join(", ")}] — set the listener's cwd inside a matching mode workspace` },
+                    { status: 422 },
+                );
+            }
+
             const listenerId = await addRunnerTriggerListener(runnerId, triggerType, {
                 prompt: typeof body?.prompt === "string" ? body.prompt : undefined,
-                cwd: typeof body?.cwd === "string" ? body.cwd : undefined,
+                cwd: listenerCwd,
                 model,
                 params,
                 autoClose,
@@ -691,6 +704,23 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             }
 
             const autoClose = typeof body.autoClose === "boolean" ? body.autoClose : undefined;
+
+            // A cwd change on a listener for a mode-scoped trigger must stay
+            // inside a matching mode workspace.
+            if (typeof body.cwd === "string") {
+                const existing = !target.includes(":") ? await getRunnerTriggerListener(runnerId, target) : null;
+                const existingType = existing?.triggerType ?? (target.includes(":") ? target : undefined);
+                if (existingType) {
+                    const catalog = await getRunnerServices(runnerId);
+                    const triggerDef = catalog?.triggerDefs?.find((d) => d.type === existingType);
+                    if (triggerDef && !triggerAllowedForCwd(triggerDef, catalog?.sessionModes, body.cwd, runnerId)) {
+                        return Response.json(
+                            { error: `Trigger type '${existingType}' is scoped to session mode(s) [${(triggerDef.modes ?? []).join(", ")}] — set cwd inside a matching mode workspace` },
+                            { status: 422 },
+                        );
+                    }
+                }
+            }
 
             const updated = await updateRunnerTriggerListener(runnerId, target, {
                 prompt: typeof body.prompt === "string" ? body.prompt : undefined,

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -545,6 +545,34 @@ describe("GET /api/sessions/:id/available-triggers", () => {
         const body = await res!.json();
         expect(body.triggerDefs).toHaveLength(0);
     });
+
+    test("filters mode-scoped trigger defs by the session's cwd", async () => {
+        const catalog = {
+            serviceIds: ["reporter"],
+            triggerDefs: [
+                { type: "reporter:daily", label: "Daily", modes: ["work"] },
+                { type: "godmother:idea_moved", label: "Idea Moved" },
+            ],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        };
+        mockGetRunnerServices.mockReturnValue(Promise.resolve(catalog));
+
+        // Out-of-mode session only sees the unscoped trigger.
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A", cwd: "/home/u/Projects/foo" } as any),
+        );
+        let [req, url] = makeReq("GET", "/api/sessions/sess-1/available-triggers");
+        let body = await (await handleTriggersRoute(req, url))!.json();
+        expect(body.triggerDefs.map((d: any) => d.type)).toEqual(["godmother:idea_moved"]);
+
+        // In-mode session sees both.
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A", cwd: "/home/u/Workspace/reports" } as any),
+        );
+        [req, url] = makeReq("GET", "/api/sessions/sess-1/available-triggers");
+        body = await (await handleTriggersRoute(req, url))!.json();
+        expect(body.triggerDefs).toHaveLength(2);
+    });
 });
 
 describe("GET /api/sessions/:id/available-sigils", () => {
@@ -701,6 +729,48 @@ describe("POST /api/sessions/:id/trigger-subscriptions", () => {
         expect(res!.status).toBe(422);
         const body = await res!.json();
         expect(body.error).toContain("not available");
+    });
+
+    test("returns 422 for a mode-scoped trigger when the session is outside the mode", async () => {
+        const catalog = {
+            serviceIds: ["reporter"],
+            triggerDefs: [{ type: "reporter:daily", label: "Daily", modes: ["work"] }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        };
+        mockGetRunnerServices.mockReturnValue(Promise.resolve(catalog));
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A", cwd: "/home/u/Projects/foo" } as any),
+        );
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-1/trigger-subscriptions", {
+            triggerType: "reporter:daily",
+        });
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(422);
+        const body = await res!.json();
+        expect(body.error).toContain("scoped to session mode");
+        expect(mockSubscribeSessionToTrigger).not.toHaveBeenCalled();
+    });
+
+    test("allows a mode-scoped trigger when the session cwd is inside the mode", async () => {
+        const catalog = {
+            serviceIds: ["reporter"],
+            triggerDefs: [{ type: "reporter:daily", label: "Daily", modes: ["work"] }],
+            sessionModes: [{ id: "work", label: "Work", workspace: "/home/u/Workspace" }],
+        };
+        mockGetRunnerServices.mockReturnValue(Promise.resolve(catalog));
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A", cwd: "/home/u/Workspace/reports" } as any),
+        );
+        mockSubscribeSessionToTrigger.mockReturnValue(Promise.resolve("sub-mode-1"));
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-1/trigger-subscriptions", {
+            triggerType: "reporter:daily",
+        });
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.ok).toBe(true);
     });
 
     test("returns 503 when runner catalog is unavailable (runner restarted)", async () => {

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -61,6 +61,7 @@ import {
     linkSessionToRunner,
 } from "../ws/sio-registry.js";
 import { getRunnerServices, getRunnerData } from "../ws/sio-registry/runners.js";
+import { triggerAllowedForCwd } from "./mode-scope.js";
 import { emitTriggerSubscriptionDelta } from "../ws/namespaces/runner.js";
 import type { RouteHandler } from "./types.js";
 import { randomUUID } from "crypto";
@@ -716,7 +717,12 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         }
 
         const services = await getRunnerServices(session.runnerId);
-        return Response.json({ triggerDefs: services?.triggerDefs ?? [] });
+        // Mode-scoped trigger defs are only listed for sessions inside a
+        // matching mode's workspace — same rule the web UI applies.
+        const runnerId = session.runnerId;
+        const triggerDefs = (services?.triggerDefs ?? []).filter((def) =>
+            triggerAllowedForCwd(def, services?.sessionModes, session.cwd, runnerId));
+        return Response.json({ triggerDefs });
     }
 
     // ── GET /api/sessions/:id/available-sigils ──────────────────────
@@ -805,6 +811,12 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         if (!triggerDef) {
             return Response.json(
                 { error: `Trigger type '${triggerType}' is not available on this session's runner` },
+                { status: 422 },
+            );
+        }
+        if (!triggerAllowedForCwd(triggerDef, services.sessionModes, session.cwd, session.runnerId)) {
+            return Response.json(
+                { error: `Trigger type '${triggerType}' is scoped to session mode(s) [${(triggerDef.modes ?? []).join(", ")}] — this session's working directory is not inside a matching mode workspace` },
                 { status: 422 },
             );
         }

--- a/packages/server/src/ws/namespaces/runner.service-announce.test.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.test.ts
@@ -369,6 +369,28 @@ describe("computeServiceAnnounceDelta", () => {
         expect(delta.removed.triggerDefs).toEqual([]);
     });
 
+    test("detects updated triggerDefs (modes change)", () => {
+        const prev = {
+            serviceIds: ["svc"],
+            triggerDefs: [{ type: "svc:event", label: "Event" }],
+        };
+        const next = {
+            serviceIds: ["svc"],
+            triggerDefs: [{ type: "svc:event", label: "Event", modes: ["work"] }],
+        };
+        const delta = computeServiceAnnounceDelta(prev, next)!;
+        expect(delta.updated.triggerDefs).toEqual([{ type: "svc:event", label: "Event", modes: ["work"] }]);
+    });
+
+    test("detects updated panels (modes change)", () => {
+        const panel = { serviceId: "svc", port: 4000, label: "P", icon: "square" };
+        const prev = { serviceIds: ["svc"], panels: [panel] };
+        const next = { serviceIds: ["svc"], panels: [{ ...panel, modes: ["work"] }] };
+        const delta = computeServiceAnnounceDelta(prev, next)!;
+        expect(delta.updated.panels).toEqual([{ ...panel, modes: ["work"] }]);
+        expect(isSameServiceAnnounce(prev, next)).toBe(false);
+    });
+
     test("detects updated triggerDefs (schema change)", () => {
         const prev = {
             serviceIds: ["svc"],

--- a/packages/server/src/ws/namespaces/runner.service-announce.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.ts
@@ -50,6 +50,9 @@ export function isSameServiceAnnounce(
         ) {
             return false;
         }
+        const leftModes = left.modes !== undefined ? JSON.stringify(left.modes) : undefined;
+        const rightModes = right.modes !== undefined ? JSON.stringify(right.modes) : undefined;
+        if (leftModes !== rightModes) return false;
     }
 
     const aDefs = a.triggerDefs ?? [];
@@ -76,6 +79,11 @@ export function isSameServiceAnnounce(
         const leftParams = left.params !== undefined ? JSON.stringify(left.params) : undefined;
         const rightParams = right.params !== undefined ? JSON.stringify(right.params) : undefined;
         if (leftParams !== rightParams) {
+            return false;
+        }
+        const leftModes = left.modes !== undefined ? JSON.stringify(left.modes) : undefined;
+        const rightModes = right.modes !== undefined ? JSON.stringify(right.modes) : undefined;
+        if (leftModes !== rightModes) {
             return false;
         }
     }
@@ -128,7 +136,10 @@ export function shouldSkipServiceAnnounceFanout({
 // ── Delta computation ────────────────────────────────────────────────────────
 
 function samePanelInfo(a: ServicePanelInfo, b: ServicePanelInfo): boolean {
-    return a.serviceId === b.serviceId && a.port === b.port && a.label === b.label && a.icon === b.icon;
+    if (a.serviceId !== b.serviceId || a.port !== b.port || a.label !== b.label || a.icon !== b.icon) return false;
+    const aModes = a.modes !== undefined ? JSON.stringify(a.modes) : undefined;
+    const bModes = b.modes !== undefined ? JSON.stringify(b.modes) : undefined;
+    return aModes === bModes;
 }
 
 function sameTriggerDef(a: ServiceTriggerDef, b: ServiceTriggerDef): boolean {
@@ -139,6 +150,9 @@ function sameTriggerDef(a: ServiceTriggerDef, b: ServiceTriggerDef): boolean {
     const aParams = a.params !== undefined ? JSON.stringify(a.params) : undefined;
     const bParams = b.params !== undefined ? JSON.stringify(b.params) : undefined;
     if (aParams !== bParams) return false;
+    const aModes = a.modes !== undefined ? JSON.stringify(a.modes) : undefined;
+    const bModes = b.modes !== undefined ? JSON.stringify(b.modes) : undefined;
+    if (aModes !== bModes) return false;
     return true;
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -23,7 +23,7 @@ import type {
   HubClientToServerEvents,
   SessionMetaState,
 } from "@pizzapi/protocol";
-import { SOCKET_PROTOCOL_VERSION, parseViewerEventEnvelope, parseViewerConnectedEnvelope, parseHubStateSnapshot, parseHubMetaEvent, parseSpawnResponse, findSessionMode, resolveModeUi } from "@pizzapi/protocol";
+import { SOCKET_PROTOCOL_VERSION, parseViewerEventEnvelope, parseViewerConnectedEnvelope, parseHubStateSnapshot, parseHubMetaEvent, parseSpawnResponse, findSessionMode, resolveModeUi, surfaceVisibleInMode } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { shouldCenterTopSpanFullWidth, shouldCenterBottomSpanFullWidth } from "@/utils/panelLayoutHelpers";
@@ -4416,6 +4416,18 @@ export function App() {
   );
   const modeUi = React.useMemo(() => resolveModeUi(activeMode), [activeMode]);
 
+  // Mode-scoped service surfaces: a service declaring `modes` in its overlay
+  // only shows its panel/triggers for sessions inside a matching mode. Sigil
+  // defs stay unfiltered so existing [[type:id]] sigils render everywhere.
+  const modePanels = React.useMemo(
+    () => dynamicPanels.filter((p) => surfaceVisibleInMode(p.modes, activeMode)),
+    [dynamicPanels, activeMode],
+  );
+  const modeTriggerDefs = React.useMemo(
+    () => runnerTriggerDefs.filter((t) => surfaceVisibleInMode(t.modes, activeMode)),
+    [runnerTriggerDefs, activeMode],
+  );
+
   // Mode selected in the sidebar, which drives the mode home shown when no
   // session is open. Independent of the active session's own mode.
   const [selectedModeId, setSelectedModeId] = React.useState<string | null>(null);
@@ -4608,14 +4620,14 @@ export function App() {
     const staticAvailable = new Set(
       SERVICE_PANELS.filter(p => modeVisibleServices.has(p.serviceId)).map(p => p.serviceId),
     );
-    const dynamicAvailable = new Set(dynamicPanels.map(p => p.serviceId));
+    const dynamicAvailable = new Set(modePanels.map(p => p.serviceId));
     for (const id of current) {
       if (!staticAvailable.has(id) && !dynamicAvailable.has(id)) {
         closeServicePanelById(id);
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modeVisibleServices, dynamicPanels, closeServicePanelById]);
+  }, [modeVisibleServices, modePanels, closeServicePanelById]);
 
   // Tell the server whether the tab is actually being looked at, so it can
   // suppress native push while a viewer is visible. "Visible" ignores window
@@ -4697,7 +4709,7 @@ export function App() {
   }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition, setServicePanelPosition]);
 
   // ── Service panel buttons in rails/strips ────────────────────────────
-  const visibleServicePanels = useVisibleServicePanels(modeVisibleServices, dynamicPanels, disabledServiceIds);
+  const visibleServicePanels = useVisibleServicePanels(modeVisibleServices, modePanels, disabledServiceIds);
   const railServicePanels = React.useMemo(
     () => visibleServicePanels.map((p) => ({ ...p, active: activeServicePanels.has(p.serviceId) })),
     [visibleServicePanels, activeServicePanels],
@@ -4808,10 +4820,10 @@ export function App() {
     onDragStart: (e) => startPanelDragWith(e, handleTriggersPositionChange),
     content: (
       <Suspense fallback={<PanelFallback label="Triggers" />}>
-        <LazyTriggersPanel sessionId={activeSessionId} triggerDefs={runnerTriggerDefs} viewerSocket={viewerSocket} />
+        <LazyTriggersPanel sessionId={activeSessionId} triggerDefs={modeTriggerDefs} viewerSocket={viewerSocket} />
       </Suspense>
     ),
-  } : null, [showTriggers, activeSessionId, runnerTriggerDefs, viewerSocket, startPanelDragWith, handleTriggersPositionChange, setShowTriggers]);
+  } : null, [showTriggers, activeSessionId, modeTriggerDefs, viewerSocket, startPanelDragWith, handleTriggersPositionChange, setShowTriggers]);
 
   const analyzerPanelTab = React.useMemo<CombinedPanelTab | null>(() => {
     if (!showAnalyzer || !activeSessionId) return null;
@@ -5509,7 +5521,7 @@ export function App() {
                           <ServicePanelButtons
                             availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
-                            dynamicPanels={dynamicPanels}
+                            dynamicPanels={modePanels}
                             activePanelIds={activeServicePanels}
                             onTogglePanel={handleToggleServicePanel}
                             onButtonDragStart={handleButtonDragStart}
@@ -5520,7 +5532,7 @@ export function App() {
                           <ServicePanelOverflowItems
                             availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
-                            dynamicPanels={dynamicPanels}
+                            dynamicPanels={modePanels}
                             activePanelIds={activeServicePanels}
                             onTogglePanel={handleToggleServicePanel}
                           />


### PR DESCRIPTION
## What

Runner services can now be **mode-scoped**: a package service declares which session modes its UI belongs to, and its panel/triggers only appear for sessions inside those modes (e.g. a "Daily report" service only in Work Mode).

```json
"services": [{
  "id": "daily-report",
  "label": "Daily Report",
  "entry": "./service.ts",
  "modes": ["work"]
}]
```

## Semantics

- `services[].modes?: string[]` in the `pi.pizzapi` overlay. Absent/empty → visible everywhere (fully backward compatible).
- **Display scoping only** — the service still runs daemon-wide; only its panel button and trigger defs are hidden outside the mode.
- Mode resolution reuses the existing `sessionModes` machinery (`findSessionMode` by session cwd vs. mode workspace).
- **Sigil defs stay unscoped** on purpose: hiding them would break rendering of existing `[[type:id]]` sigils in transcripts outside the mode.
- The referenced mode may be declared by any package on the runner, not necessarily the same one.

## How

- **Overlay schema** (`manifest.ts`): validate `modes` as an array of non-empty strings; carried through `ServiceManifest` by package discovery.
- **Daemon** (`daemon.ts`): stamps `modes` onto announced `ServicePanelInfo`s and `ServiceTriggerDef`s in `service_announce`.
- **Server** (`runner.service-announce.ts`): announce equality + delta computation compare `modes`, so a modes-only change propagates instead of being deduped.
- **UI** (`App.tsx` + new `surfaceVisibleInMode()` in `@pizzapi/protocol`): filters the dynamic panel list and trigger defs by the active session's mode; the existing "close panels that went away" effect also closes an open panel when you switch to an out-of-mode session.

## Tests

- overlay validation (valid + malformed `modes`)
- package-service-loader manifest passthrough
- `panelEntryFromManifest` carry-through
- server delta detection for modes-only panel/trigger changes
- `surfaceVisibleInMode` unit tests

`bun run typecheck` clean; protocol (265), cli overlay+runner (620), ui (1454), and server service-announce (48) tests pass.
