### PR TITLE
feat(modes): support package-declared panel placement

### DIFF
--- a/packages/cli/src/overlay/manifest.test.ts
+++ b/packages/cli/src/overlay/manifest.test.ts
@@ -154,6 +154,40 @@ describe("readOverlayManifest", () => {
         expect(result.issues.some((i) => i.field === "services[0].panel.dir")).toBe(true);
     });
 
+    test("panel.placement and defaultOpen are accepted and preserved on the overlay", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", panel: { dir: "./panel", placement: "left-bottom", defaultOpen: true } }],
+        }, (d) => { mkdirSync(join(d, "panel")); });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.issues).toHaveLength(0);
+        expect(result.overlay?.services?.[0]?.panel?.placement).toBe("left-bottom");
+        expect(result.overlay?.services?.[0]?.panel?.defaultOpen).toBe(true);
+    });
+
+    test("an unknown panel dock zone is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", panel: { dir: "./panel", placement: "middle" } }],
+        }, (d) => { mkdirSync(join(d, "panel")); });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].panel.placement")).toBe(true);
+    });
+
+    test("a non-boolean panel.defaultOpen is rejected", () => {
+        const dir = fixturePkg({
+            schemaVersion: 1,
+            services: [{ id: "svc", label: "x", entry: "./service.ts", panel: { dir: "./panel", defaultOpen: "yes" } }],
+        }, (d) => { mkdirSync(join(d, "panel")); });
+        dirs.push(dir);
+        const result = readOverlayManifest(dir, provenance);
+        expect(result.overlay).toBeNull();
+        expect(result.issues.some((i) => i.field === "services[0].panel.defaultOpen")).toBe(true);
+    });
+
     // ── mcp sidecar shape/format ────────────────────────────────────────────
 
     test("mcp sidecar with malformed JSON is rejected", () => {

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -29,8 +29,14 @@ const PREFERRED_MCP_TRANSPORT_KEYS: Record<string, Set<string>> = {
     streamable: new Set(["url", "headers", "oauthClientName", "oauthClientId", "oauthClientSecret", "oauthCallbackPort"]),
 };
 const SERVICE_KEYS = new Set(["id", "label", "entry", "icon", "panel", "triggers", "sigils", "sessionModes", "modes"]);
-const PANEL_KEYS = new Set(["dir", "requires"]);
+const PANEL_KEYS = new Set(["dir", "requires", "placement", "defaultOpen"]);
 const PANEL_VARIABLES: ReadonlySet<PanelVariable> = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
+/** Valid declarative panel dock zones, mirrored from ServicePanelPlacement. */
+const PANEL_PLACEMENTS = new Set([
+    "left-top", "left-middle", "left-bottom",
+    "center-top", "center-bottom",
+    "right-top", "right-middle", "right-bottom",
+]);
 const SERVICE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const ENTRY_EXTENSIONS = [".ts", ".js", ".mts", ".mjs"];
 /** Value types allowed on a trigger param definition, mirrored from ServiceTriggerParamDef. */
@@ -863,8 +869,20 @@ function validateServices(
             } else {
                 for (const key of Object.keys(raw.panel)) {
                     if (!PANEL_KEYS.has(key)) {
-                        push(`${field}.panel.${key}`, `unknown panel key "${key}"`, `Remove "${key}" — allowed keys: dir, requires.`);
+                        push(`${field}.panel.${key}`, `unknown panel key "${key}"`, `Remove "${key}" — allowed keys: dir, requires, placement, defaultOpen.`);
                     }
+                }
+                if (raw.panel.placement !== undefined && !PANEL_PLACEMENTS.has(raw.panel.placement as string)) {
+                    push(
+                        `${field}.panel.placement`,
+                        "must be one of the eight dock zones",
+                        `Use one of: ${[...PANEL_PLACEMENTS].join(", ")}.`,
+                    );
+                    valid = false;
+                }
+                if (raw.panel.defaultOpen !== undefined && typeof raw.panel.defaultOpen !== "boolean") {
+                    push(`${field}.panel.defaultOpen`, "must be a boolean", "Set defaultOpen to true to auto-open the panel, or omit it.");
+                    valid = false;
                 }
                 if (typeof raw.panel.dir !== "string" || raw.panel.dir.length === 0) {
                     push(`${field}.panel.dir`, "must be a non-empty package-relative path", "Set panel.dir to the panel UI directory.");

--- a/packages/cli/src/runner/daemon-package-reconcile.test.ts
+++ b/packages/cli/src/runner/daemon-package-reconcile.test.ts
@@ -74,6 +74,23 @@ describe("panelEntryFromManifest (fix #3: hasPanel routing)", () => {
         expect(unscoped?.modes).toBeUndefined();
     });
 
+    test("manifest panel placement + defaultOpen are carried onto the panel entry", () => {
+        const manifest: ServiceManifest = {
+            id: "svc",
+            label: "Svc",
+            icon: "square",
+            panel: { dir: "/abs/panel", placement: "left-bottom", defaultOpen: true },
+            modes: ["work"],
+        };
+        const entry = panelEntryFromManifest("svc", manifest);
+        expect(entry?.placement).toBe("left-bottom");
+        expect(entry?.defaultOpen).toBe(true);
+        // Omitting them leaves the entry fields undefined (host uses its default).
+        const bare = panelEntryFromManifest("svc", { id: "svc", label: "Svc", icon: "square", panel: { dir: "/abs/panel" } });
+        expect(bare?.placement).toBeUndefined();
+        expect(bare?.defaultOpen).toBeUndefined();
+    });
+
     test("a service with only triggers/sigils and no panel gets hasPanel: false", () => {
         const manifest: ServiceManifest = {
             id: "svc",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -37,7 +37,7 @@ import { findSessionPathById } from "./session-list-cache.js";
 import { lookupTranscriptLink } from "./session-transcript-links.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
-import type { ServiceModeDef, ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServicePanelPlacement, ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock, patchRunnerState } from "./runner-state.js";
@@ -102,6 +102,10 @@ export type PanelEntry = {
     sessionModes?: ServiceModeDef[];
     /** Session mode ids this service's surfaces are scoped to (manifest `modes`). */
     modes?: string[];
+    /** Declarative dock zone the host places this panel in by default. */
+    placement?: ServicePanelPlacement;
+    /** Open the panel automatically in its mode(s) instead of on click. */
+    defaultOpen?: boolean;
     /**
      * Whether this service has a UI panel shown to users.
      * false = service has trigger/sigil defs but no panel (e.g. the time service).
@@ -299,6 +303,8 @@ export function panelEntryFromManifest(
         ...(hasSessionModes ? { sessionModes: manifest.sessionModes } : {}),
         ...(manifest.modes && manifest.modes.length > 0 ? { modes: manifest.modes } : {}),
         ...(manifest.panel?.requires ? { requires: manifest.panel.requires } : {}),
+        ...(manifest.panel?.placement ? { placement: manifest.panel.placement } : {}),
+        ...(manifest.panel?.defaultOpen ? { defaultOpen: true } : {}),
     };
 }
 
@@ -943,6 +949,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     icon: p.icon,
                     ...(p.requires ? { panelParams: resolveRequires(p.requires) } : {}),
                     ...(p.modes ? { modes: p.modes } : {}),
+                    ...(p.placement ? { placement: p.placement } : {}),
+                    ...(p.defaultOpen ? { defaultOpen: true } : {}),
                 }));
             // Collect all trigger defs and sigil defs across all services with manifests
             const allTriggerDefs: ServiceTriggerDef[] = [];

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -245,7 +245,12 @@ export async function discoverPackageServices(
                 // key downstream) so a service with only triggers/sigils gets
                 // announceSigilServer, not announcePanel, at init time.
                 hasPanel: !!decl.panel,
-                ...(decl.panel ? { panel: { dir: panelDir, requires: decl.panel.requires } } : {}),
+                ...(decl.panel ? { panel: {
+                    dir: panelDir,
+                    requires: decl.panel.requires,
+                    ...(decl.panel.placement ? { placement: decl.panel.placement } : {}),
+                    ...(decl.panel.defaultOpen ? { defaultOpen: true } : {}),
+                } } : {}),
                 ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
                 ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),
                 ...(Array.isArray(decl.sessionModes) && decl.sessionModes.length > 0 ? { sessionModes: decl.sessionModes } : {}),

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -18,7 +18,7 @@
  * just no longer contribute runner services.
  */
 import type { ServiceHandler } from "./service-handler.js";
-import type { ServiceModeDef, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServicePanelPlacement, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -32,6 +32,10 @@ export interface ServiceManifest {
         dir?: string;
         /** Variable names the panel requires. UI resolves and passes as query params. */
         requires?: string[];
+        /** Declarative dock zone the host places this panel in by default. */
+        placement?: ServicePanelPlacement;
+        /** Open the panel automatically in its mode(s) instead of on click. */
+        defaultOpen?: boolean;
     };
     /**
      * Whether this service has a UI panel shown to users. Set explicitly so a

--- a/packages/extension-sdk/src/overlay.ts
+++ b/packages/extension-sdk/src/overlay.ts
@@ -1,4 +1,4 @@
-import type { ServiceModeDef, ServiceSigilDef, ServiceTriggerDef } from "@pizzapi/protocol";
+import type { ServiceModeDef, ServicePanelPlacement, ServiceSigilDef, ServiceTriggerDef } from "@pizzapi/protocol";
 
 /**
  * `pi.pizzapi` package manifest overlay — schema version 1.
@@ -20,6 +20,16 @@ export interface PizzaPiServiceDeclaration {
   panel?: {
     dir: string;
     requires?: PanelVariable[];
+    /**
+     * Declarative dock zone the host places this panel in by default — a
+     * guaranteed placement such as "left-bottom". Omit to use the host default.
+     */
+    placement?: ServicePanelPlacement;
+    /**
+     * Open this panel automatically wherever it is visible (respecting `modes`)
+     * instead of only on click, so a package-owned panel is present by default.
+     */
+    defaultOpen?: boolean;
   };
   triggers?: string | ServiceTriggerDef[];
   sigils?: string | ServiceSigilDef[];

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -17,6 +17,7 @@ export type {
   Attachment,
   ServiceEnvelope,
   ServicePanelInfo,
+  ServicePanelPlacement,
   ServiceTriggerDef,
   ServiceTriggerParamDef,
   ServiceSigilDef,

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -130,6 +130,18 @@ export interface ServiceEnvelope {
 
 // ── Service panel types ───────────────────────────────────────────────────────
 
+/**
+ * Declarative dock placement for a service panel. Mirrors the host's 9-zone
+ * layout grid minus the center-middle main-content area, so a package can
+ * guarantee where its panel lands (e.g. "left-bottom") instead of inheriting
+ * the generic default or a stale user-dragged position. The host maps these
+ * values onto its own panel-position type.
+ */
+export type ServicePanelPlacement =
+  | "left-top"   | "left-middle"   | "left-bottom"
+  | "center-top" | "center-bottom"
+  | "right-top"  | "right-middle"  | "right-bottom";
+
 /** Metadata for a service panel announced by the runner. */
 export interface ServicePanelInfo {
   /** Must match the runner service's `id`. */
@@ -151,6 +163,18 @@ export interface ServicePanelInfo {
    * `modes`). Absent/empty = shown for every session.
    */
   modes?: string[];
+  /**
+   * Declarative dock zone the host places this panel in by default — a
+   * "guaranteed placement". The host uses it in place of its generic default
+   * when the user has not moved the panel. Omit to use the host default.
+   */
+  placement?: ServicePanelPlacement;
+  /**
+   * When true the host opens this panel automatically wherever it is visible
+   * (respecting `modes` scoping), so a package-owned panel is present without
+   * a click. The user can still close it. Omit for click-to-open (default).
+   */
+  defaultOpen?: boolean;
 }
 
 // ── Service trigger types ─────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/runner.service-announce.test.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.test.ts
@@ -41,6 +41,32 @@ describe("isSameServiceAnnounce", () => {
         expect(isSameServiceAnnounce(left, right)).toBe(false);
     });
 
+    test("returns false when panel placement differs", () => {
+        const left = {
+            serviceIds: ["tunnel"],
+            panels: [{ serviceId: "tunnel", port: 4173, label: "Tunnel", icon: "globe", placement: "left-bottom" as const }],
+        };
+        const right = {
+            serviceIds: ["tunnel"],
+            panels: [{ serviceId: "tunnel", port: 4173, label: "Tunnel", icon: "globe", placement: "right-top" as const }],
+        };
+
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("returns false when panel defaultOpen differs", () => {
+        const left = {
+            serviceIds: ["tunnel"],
+            panels: [{ serviceId: "tunnel", port: 4173, label: "Tunnel", icon: "globe", defaultOpen: true }],
+        };
+        const right = {
+            serviceIds: ["tunnel"],
+            panels: [{ serviceId: "tunnel", port: 4173, label: "Tunnel", icon: "globe", defaultOpen: false }],
+        };
+
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
     test("returns false when either side is null/undefined", () => {
         const valid = { serviceIds: ["tunnel"], panels: [] };
 
@@ -331,6 +357,23 @@ describe("computeServiceAnnounceDelta", () => {
         expect(delta.added.panels).toEqual([]);
         expect(delta.removed.panels).toEqual([]);
         expect(delta.updated.panels).toEqual([{ serviceId: "a", port: 8080, label: "A", icon: "box" }]);
+    });
+
+    test("detects panels updated by placement/defaultOpen only", () => {
+        const prev = {
+            serviceIds: ["a"],
+            panels: [{ serviceId: "a", port: 4173, label: "A", icon: "box" }],
+        };
+        const next = {
+            serviceIds: ["a"],
+            panels: [{ serviceId: "a", port: 4173, label: "A", icon: "box", placement: "left-bottom" as const, defaultOpen: true }],
+        };
+        const delta = computeServiceAnnounceDelta(prev, next)!;
+        expect(delta.added.panels).toEqual([]);
+        expect(delta.removed.panels).toEqual([]);
+        expect(delta.updated.panels).toEqual([
+            { serviceId: "a", port: 4173, label: "A", icon: "box", placement: "left-bottom", defaultOpen: true },
+        ]);
     });
 
     test("detects added triggerDefs", () => {

--- a/packages/server/src/ws/namespaces/runner.service-announce.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.ts
@@ -46,7 +46,9 @@ export function isSameServiceAnnounce(
             left.serviceId !== right.serviceId ||
             left.port !== right.port ||
             left.label !== right.label ||
-            left.icon !== right.icon
+            left.icon !== right.icon ||
+            left.placement !== right.placement ||
+            left.defaultOpen !== right.defaultOpen
         ) {
             return false;
         }
@@ -136,7 +138,14 @@ export function shouldSkipServiceAnnounceFanout({
 // ── Delta computation ────────────────────────────────────────────────────────
 
 function samePanelInfo(a: ServicePanelInfo, b: ServicePanelInfo): boolean {
-    if (a.serviceId !== b.serviceId || a.port !== b.port || a.label !== b.label || a.icon !== b.icon) return false;
+    if (
+        a.serviceId !== b.serviceId ||
+        a.port !== b.port ||
+        a.label !== b.label ||
+        a.icon !== b.icon ||
+        a.placement !== b.placement ||
+        a.defaultOpen !== b.defaultOpen
+    ) return false;
     const aModes = a.modes !== undefined ? JSON.stringify(a.modes) : undefined;
     const bModes = b.modes !== undefined ? JSON.stringify(b.modes) : undefined;
     return aModes === bModes;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -82,7 +82,7 @@ import { resolveFilePath } from "@/components/file-explorer/utils";
 import { ServicePanelButtons, ServicePanelOverflowItems, useServicePanelState, useVisibleServicePanels } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction } from "@/utils/servicePanelUtils";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
   ModelSelector,
@@ -4603,7 +4603,29 @@ export function App() {
     sessionNamesById: attentionSessionNames,
   });
 
-  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition, getNavParams: getServicePanelNavParams } = useServicePanelState();
+  // Package-declared "guaranteed placement" for dynamic panels
+  // (ServicePanelInfo.placement). Maps serviceId → dock zone so a package-owned
+  // panel lands where its package asked (e.g. left-bottom) instead of the
+  // generic default, unless the user has since moved it. Reactive: rebuilt
+  // whenever service_announce changes the announced panels.
+  const declaredPanelPlacements = React.useMemo(() => {
+    const zones = new Set<string>([
+      "left-top", "left-middle", "left-bottom",
+      "center-top", "center-bottom",
+      "right-top", "right-middle", "right-bottom",
+    ]);
+    const map = new Map<string, PanelPosition>();
+    for (const p of dynamicPanels) {
+      if (p.placement && zones.has(p.placement)) map.set(p.serviceId, p.placement as PanelPosition);
+    }
+    return map;
+  }, [dynamicPanels]);
+  const resolveDeclaredPanelPlacement = React.useCallback(
+    (serviceId: string) => declaredPanelPlacements.get(serviceId),
+    [declaredPanelPlacements],
+  );
+
+  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition, getNavParams: getServicePanelNavParams } = useServicePanelState(resolveDeclaredPanelPlacement);
 
   // Always-current ref so the runner-change effect below can read the active
   // panel set without listing it as a dependency (avoids a close→reopen loop).
@@ -4628,6 +4650,23 @@ export function App() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modeVisibleServices, modePanels, closeServicePanelById]);
+
+  // Auto-open package panels that ask for it (ServicePanelInfo.defaultOpen) when
+  // they become visible in the active mode, so a package-owned, mode-scoped
+  // panel is present without a click. Track which we auto-opened so a user
+  // closing one doesn't fight a reopen; forget a panel once it leaves the mode
+  // so re-entering the mode opens it again. The cleanup effect above closes
+  // panels that leave modePanels.
+  const autoOpenedPanelsRef = React.useRef<Set<string>>(new Set());
+  React.useEffect(() => {
+    const { toOpen, nextTracked } = computeAutoOpenPanels(
+      modePanels,
+      autoOpenedPanelsRef.current,
+      (id) => activeServicePanelsRef.current.has(id),
+    );
+    autoOpenedPanelsRef.current = nextTracked;
+    for (const id of toOpen) toggleServicePanel(id);
+  }, [modePanels, toggleServicePanel]);
 
   // Tell the server whether the tab is actually being looked at, so it can
   // suppress native push while a viewer is visible. "Visible" ignores window

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -22,13 +22,68 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction } from "../../utils/servicePanelUtils";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels } from "../../utils/servicePanelUtils";
 import { filterDisabledServicePanels } from "./ServicePanels";
 
 describe("filterDisabledServicePanels", () => {
     test("omits disabled service panel buttons", () => {
         const panels = [{ serviceId: "enabled" }, { serviceId: "disabled" }];
         expect(filterDisabledServicePanels(panels, new Set(["disabled"]))).toEqual([{ serviceId: "enabled" }]);
+    });
+});
+
+describe("computeAutoOpenPanels", () => {
+    const notActive = () => false;
+
+    test("opens a defaultOpen panel the first time it becomes visible", () => {
+        const { toOpen, nextTracked } = computeAutoOpenPanels(
+            [{ serviceId: "schedules", defaultOpen: true }, { serviceId: "other" }],
+            new Set(),
+            notActive,
+        );
+        expect(toOpen).toEqual(["schedules"]);
+        expect(nextTracked.has("schedules")).toBe(true);
+    });
+
+    test("does not reopen a defaultOpen panel already tracked (user may have closed it)", () => {
+        const { toOpen } = computeAutoOpenPanels(
+            [{ serviceId: "schedules", defaultOpen: true }],
+            new Set(["schedules"]),
+            notActive,
+        );
+        expect(toOpen).toEqual([]);
+    });
+
+    test("forgets a panel once it leaves the visible set so re-entry reopens it", () => {
+        // schedules was tracked but is no longer visible → dropped from tracking.
+        const gone = computeAutoOpenPanels([], new Set(["schedules"]), notActive);
+        expect(gone.nextTracked.has("schedules")).toBe(false);
+        // Re-entering the mode opens it again.
+        const back = computeAutoOpenPanels(
+            [{ serviceId: "schedules", defaultOpen: true }],
+            gone.nextTracked,
+            notActive,
+        );
+        expect(back.toOpen).toEqual(["schedules"]);
+    });
+
+    test("never toggles a panel the user already opened, but still tracks it", () => {
+        const { toOpen, nextTracked } = computeAutoOpenPanels(
+            [{ serviceId: "schedules", defaultOpen: true }],
+            new Set(),
+            (id) => id === "schedules", // already active
+        );
+        expect(toOpen).toEqual([]);
+        expect(nextTracked.has("schedules")).toBe(true);
+    });
+
+    test("ignores panels without defaultOpen", () => {
+        const { toOpen } = computeAutoOpenPanels(
+            [{ serviceId: "plain" }],
+            new Set(),
+            notActive,
+        );
+        expect(toOpen).toEqual([]);
     });
 });
 

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -231,7 +231,19 @@ export interface PanelNavParams {
     fragment?: string;
 }
 
-export function useServicePanelState() {
+/**
+ * @param resolveDeclaredPlacement Optional resolver returning a package-declared
+ *   dock position for a service panel (from `ServicePanelInfo.placement`). Used
+ *   as the guaranteed default position when the user has not moved the panel.
+ */
+export function useServicePanelState(
+    resolveDeclaredPlacement?: (serviceId: string) => PanelPosition | undefined,
+) {
+    // Keep the resolver in a ref so getPanelPosition stays referentially stable
+    // (its identity feeds panelGroups memoization) while still reading the
+    // latest declared placements after a service_announce.
+    const declaredPlacementRef = React.useRef(resolveDeclaredPlacement);
+    declaredPlacementRef.current = resolveDeclaredPlacement;
     const [activePanelIds, setActivePanelIds] = useState<Set<string>>(new Set());
     const [panelPositions, setPanelPositions] = useState<Map<string, PanelPosition>>(loadPanelPositions);
     // Ephemeral (non-persisted) position overrides used for auto-placement.
@@ -315,7 +327,9 @@ export function useServicePanelState() {
         // Migrate old 3-value positions from localStorage to new 8-value format.
         // Cast to string for comparison since localStorage may hold pre-migration values.
         const stored: string | undefined = ephemeralPositions.get(serviceId) ?? panelPositions.get(serviceId);
-        if (!stored) return "right-middle";
+        // No user-chosen position: honor the package's declared "guaranteed
+        // placement" if it supplied one, else fall back to the generic default.
+        if (!stored) return declaredPlacementRef.current?.(serviceId) ?? "right-middle";
         if (stored === "right")  return "right-middle";
         if (stored === "left")   return "left-middle";
         if (stored === "bottom") return "center-bottom";

--- a/packages/ui/src/components/service-panels/useServicePanelState.placement.test.tsx
+++ b/packages/ui/src/components/service-panels/useServicePanelState.placement.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * useServicePanelState — package-declared "guaranteed placement".
+ *
+ * A dynamic panel that declares ServicePanelInfo.placement should dock at that
+ * zone by default (instead of the generic right-middle), while a user-chosen
+ * position still wins.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { PanelPosition } from "@/hooks/usePanelLayout";
+
+const win = new Window({ url: "http://localhost/" });
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).localStorage = win.localStorage;
+
+const { useServicePanelState } = await import("./ServicePanels");
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("useServicePanelState — declared placement", () => {
+  test("uses the package-declared placement when the user has not moved the panel", () => {
+    const placements = new Map<string, PanelPosition>([["schedules", "left-bottom"]]);
+    const { result } = renderHook(() => useServicePanelState((id) => placements.get(id)));
+
+    expect(result.current.getPanelPosition("schedules")).toBe("left-bottom");
+    // No declared placement → generic default.
+    expect(result.current.getPanelPosition("other")).toBe("right-middle");
+  });
+
+  test("a user-chosen position overrides the declared placement", () => {
+    const placements = new Map<string, PanelPosition>([["schedules", "left-bottom"]]);
+    const { result } = renderHook(() => useServicePanelState((id) => placements.get(id)));
+
+    act(() => { result.current.setPanelPosition("schedules", "right-top"); });
+
+    expect(result.current.getPanelPosition("schedules")).toBe("right-top");
+  });
+});

--- a/packages/ui/src/utils/servicePanelUtils.ts
+++ b/packages/ui/src/utils/servicePanelUtils.ts
@@ -28,6 +28,36 @@ export function resolveNewPanelPosition(
 }
 
 /**
+ * Decide which package panels to auto-open (ServicePanelInfo.defaultOpen) as the
+ * set of mode-visible panels changes.
+ *
+ * Loop-safe: a panel is auto-opened at most once while it stays visible, so a
+ * user closing it does not fight a reopen. A panel that leaves the visible set
+ * is forgotten, so re-entering its mode opens it again. `isActive` prevents
+ * re-opening a panel the user opened manually.
+ *
+ * Returns the panels to open now and the next "already auto-opened" tracking
+ * set the caller should persist.
+ */
+export function computeAutoOpenPanels(
+    modePanels: ReadonlyArray<{ serviceId: string; defaultOpen?: boolean }>,
+    alreadyAutoOpened: ReadonlySet<string>,
+    isActive: (serviceId: string) => boolean,
+): { toOpen: string[]; nextTracked: Set<string> } {
+    const visible = new Set(modePanels.map((p) => p.serviceId));
+    // Forget panels no longer visible so re-entry can open them again.
+    const nextTracked = new Set([...alreadyAutoOpened].filter((id) => visible.has(id)));
+    const toOpen: string[] = [];
+    for (const panel of modePanels) {
+        if (!panel.defaultOpen) continue;
+        if (nextTracked.has(panel.serviceId)) continue;
+        nextTracked.add(panel.serviceId);
+        if (!isActive(panel.serviceId)) toOpen.push(panel.serviceId);
+    }
+    return { toOpen, nextTracked };
+}
+
+/**
  * Given an ordered list of tab IDs in a dock group and the globally-active
  * tab ID, return which tab should be highlighted in that group.
  *


### PR DESCRIPTION
## Summary
- extend the PizzaPi overlay/extension SDK with declarative service-panel placement and optional auto-open
- propagate placement metadata through the runner and service announce protocol
- honor mode-scoped package panels in the Web UI with reactive dock placement
- detect placement/defaultOpen changes in announce deltas

## Validation
- focused CLI overlay/daemon tests pass
- focused UI placement/auto-open tests pass
- server announce-delta tests pass
- full PizzaPi typecheck passes

PizzaWork-specific UI remains in the separate PizzaWork package.