### PR TITLE
fix(mobile): open external links in the system browser from the Capacitor webview

### DIFF
--- a/android/app/src/main/java/dev/pizzapi/app/ExternalLinkWebChromeClient.java
+++ b/android/app/src/main/java/dev/pizzapi/app/ExternalLinkWebChromeClient.java
@@ -1,0 +1,43 @@
+package dev.pizzapi.app;
+
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.os.Message;
+
+import com.getcapacitor.Bridge;
+import com.getcapacitor.BridgeWebChromeClient;
+
+/**
+ * Capacitor's BridgeWebChromeClient never overrides onCreateWindow, so
+ * target="_blank" anchors and window.open() calls (including from inside
+ * sandboxed artifact/service-panel iframes, once they carry allow-popups)
+ * are silently dropped by Android's WebView -- nothing happens. This
+ * subclass implements it: a throwaway WebView is handed to the caller as
+ * the new-window "transport"; the first URL it tries to load is routed
+ * through the bridge's normal external-URL handling (system browser
+ * Intent via Bridge#launchIntent), then the fake window is discarded.
+ */
+public class ExternalLinkWebChromeClient extends BridgeWebChromeClient {
+    private final Bridge bridge;
+
+    public ExternalLinkWebChromeClient(Bridge bridge) {
+        super(bridge);
+        this.bridge = bridge;
+    }
+
+    @Override
+    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+        WebView transport = new WebView(view.getContext());
+        transport.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
+                bridge.launchIntent(request.getUrl());
+                return true;
+            }
+        });
+        ((WebView.WebViewTransport) resultMsg.obj).setWebView(transport);
+        resultMsg.sendToTarget();
+        return true;
+    }
+}

--- a/android/app/src/main/java/dev/pizzapi/app/MainActivity.java
+++ b/android/app/src/main/java/dev/pizzapi/app/MainActivity.java
@@ -13,6 +13,11 @@ public class MainActivity extends BridgeActivity {
         // bridge initializes. registerPlugin must be called before super.onCreate.
         registerPlugin(NtfyPushPlugin.class);
         super.onCreate(savedInstanceState);
+        // WebView drops target="_blank"/window.open() by default (no
+        // onCreateWindow handler, multi-window unsupported) — route them to
+        // the system browser instead. See ExternalLinkWebChromeClient.
+        getBridge().getWebView().getSettings().setSupportMultipleWindows(true);
+        getBridge().getWebView().setWebChromeClient(new ExternalLinkWebChromeClient(getBridge()));
         // Cold start: the launch intent may already carry a tapped-notification
         // session id (see NtfyForegroundService#buildTapIntent).
         handleTapIntent(getIntent());

--- a/packages/ui/src/components/session-viewer/ArtifactCard.tsx
+++ b/packages/ui/src/components/session-viewer/ArtifactCard.tsx
@@ -522,8 +522,11 @@ function ArtifactPreview({
       <iframe
         // Untrusted generated markup: scripts allowed (interactive decks/charts
         // need JS) but no allow-same-origin, so the doc runs in an opaque origin
-        // and can never reach the session it was produced in.
-        sandbox="allow-scripts"
+        // and can never reach the session it was produced in. allow-popups (+
+        // escape-sandbox so the opened tab isn't itself sandboxed) lets
+        // target="_blank" links actually open — without it the browser silently
+        // drops the click (verified: no popup, no error).
+        sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
         srcDoc={content}
         title={fileName}
         className={cn("w-full border-0 bg-white", full ? "h-full" : "h-96")}


### PR DESCRIPTION
## Bug

In the mobile app (Capacitor wrapper), links inside rendered HTML artifacts/panels didn't open in the system browser — taps did nothing or stayed inside the webview.

Godmother idea `kD2sJLdq`.

## Root cause (two independent gaps)

1. **Android WebView never handles new-window requests.** Capacitor's `BridgeWebChromeClient` doesn't override `onCreateWindow`, so any `target="_blank"` anchor or `window.open()` call — anywhere in the app, including inside iframes — is silently dropped by Android's WebView. Nothing happens; no error. iOS is unaffected: `WKUIDelegate.createWebViewWith` in `@capacitor/ios` already opens such URLs via `UIApplication.shared.open`.

2. **The HTML-artifact iframe blocks popups at the sandbox layer**, independent of platform. `ArtifactCard`'s `kind === "html"` iframe uses `sandbox="allow-scripts"` with no `allow-popups`, so `target="_blank"` clicks are dropped by the browser's iframe-sandboxing model before any WebView/browser-level handling even runs. Verified empirically with a headless click test (Playwright): 0 popups without `allow-popups`, 1 with. This also affects desktop web — most testing probably went through the daily-report *service panel* iframe (`IframeServicePanel`), which already ships `allow-popups` and does work today.

## Fix

- `android/app/src/main/java/dev/pizzapi/app/ExternalLinkWebChromeClient.java` (new): overrides `onCreateWindow`, handing the caller a throwaway `WebView` as the new-window transport and routing the first URL it tries to load through `Bridge#launchIntent` — the same system-browser-Intent path Capacitor already uses for regular external navigation.
- `MainActivity.java`: enables `setSupportMultipleWindows(true)` and installs the new WebChromeClient after `super.onCreate()`.
- `packages/ui/.../ArtifactCard.tsx`: adds `allow-popups allow-popups-to-escape-sandbox` to the HTML artifact iframe's sandbox so the popup isn't itself sandboxed once opened.
- No iOS change — already correct.

## Verification

- Confirmed root cause by reading `@capacitor/android`'s `BridgeWebViewClient`/`BridgeWebChromeClient`/`Bridge.launchIntent` and `@capacitor/ios`'s `WebViewDelegationHandler.swift` sources in `node_modules`.
- Confirmed the sandbox-popup gap empirically with a Playwright headless test against a local static page (`sandbox="allow-scripts"` alone: 0 popups on click; `+ allow-popups`: 1 popup).
- `bun run typecheck` — clean.
- `cd packages/ui && bun test src` — 1475 pass / 1 pre-existing skip / 0 fail.
- `./gradlew :app:compileDebugJavaWithJavac` — compiles clean with the new Java file.
- **Not verified on a physical device** — this needs a real APK build/install to confirm the system browser actually launches for a live `target="_blank"` tap. The Android fix requires a native rebuild (Java change) — it will **not** ship via the self-hosted OTA (`CapacitorUpdater`) bundle-update path, only via a new APK.
