### PR TITLE
fix(ui,subagent): keep modes visible cross-runner; clean up subagents on /new

### DIFF
--- a/packages/cli/src/extensions/subagent-background.test.ts
+++ b/packages/cli/src/extensions/subagent-background.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { subagentExtension, type SingleResult } from "./subagent.js";
-import { hasActiveSubagents, reserveSubagentSlots } from "./subagent/background-state.js";
+import { hasActiveSubagents, reserveSubagentSlots, onSubagentsIdle } from "./subagent/background-state.js";
 
 const result: SingleResult = {
     agent: "task",
@@ -23,18 +23,25 @@ function resultFor(task: string, output: string): SingleResult {
 function harness(runAgent: (...args: any[]) => Promise<SingleResult>) {
     let tool: any;
     let shutdown: (() => void | Promise<void>) | undefined;
+    let switchTo: ((event: any) => void | Promise<void>) | undefined;
     const sent: Array<{ content: string; details?: unknown; options?: { deliverAs?: string; triggerTurn?: boolean } }> = [];
     const pi = {
         registerTool(value: any) { tool = value; },
-        on(event: string, handler: () => void) {
+        on(event: string, handler: (event?: any) => void) {
             if (event === "session_shutdown") shutdown = handler;
+            if (event === "session_switch") switchTo = handler;
         },
         sendMessage(message: { content: string; details?: unknown }, options?: { deliverAs?: string; triggerTurn?: boolean }) {
             sent.push({ content: message.content, details: message.details, options });
         },
     };
     subagentExtension(pi as any, runAgent as any);
-    return { tool, sent, shutdown: async () => { await shutdown?.(); } };
+    return {
+        tool,
+        sent,
+        shutdown: async () => { await shutdown?.(); },
+        newConversation: async () => { await switchTo?.({ reason: "new" }); },
+    };
 }
 
 const nextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -125,6 +132,32 @@ describe("background subagents", () => {
 
         expect(aborted).toBe(true);
         expect(sent).toEqual([]);
+    });
+
+    test("aborts background work on /new without injecting a result, and keeps idle listeners", async () => {
+        const runAgent = mock((...args: any[]) => new Promise<SingleResult>((_resolve, reject) => {
+            const signal = args[6] as AbortSignal;
+            signal.addEventListener("abort", () => reject(new Error("Subagent was aborted")), { once: true });
+        }));
+        const { tool, sent, newConversation } = harness(runAgent);
+
+        // A lifecycle-style idle listener that must survive a /new reset.
+        let idleFired = 0;
+        const stop = onSubagentsIdle(() => { idleFired++; });
+
+        await tool.execute("call-new", { agent: "task", task: "Investigate" }, undefined, undefined, ctx);
+        expect(hasActiveSubagents()).toBe(true);
+
+        await newConversation();
+
+        // Aborted: no result bled into the new conversation, slot released.
+        expect(sent).toEqual([]);
+        expect(hasActiveSubagents()).toBe(false);
+
+        // Listener preserved: a fresh reserve/release cycle still notifies it.
+        reserveSubagentSlots(1, 2)!();
+        expect(idleFired).toBeGreaterThan(0);
+        stop();
     });
 
     test("aborts background work on session shutdown without injecting a result", async () => {

--- a/packages/cli/src/extensions/subagent/background-state.ts
+++ b/packages/cli/src/extensions/subagent/background-state.ts
@@ -43,3 +43,15 @@ export function resetSubagentState(): void {
     followUpStarted = false;
     idleListeners.clear();
 }
+
+/**
+ * Reset the slot counters WITHOUT dropping idle listeners.
+ *
+ * Used on `/new` (session reset in place): the conversation restarts but the
+ * extension — and the lifecycle handler's onSubagentsIdle listener that gates
+ * session completion — lives on, so its listener must survive.
+ */
+export function resetSubagentCounters(): void {
+    activeSlots = 0;
+    followUpStarted = false;
+}

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -43,7 +43,7 @@ import {
 } from "./types.js";
 import { runSingleAgent, mapWithConcurrencyLimit, type ModelOverride } from "./engine.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
-import { reserveSubagentSlots, resetSubagentState } from "./background-state.js";
+import { reserveSubagentSlots, resetSubagentState, resetSubagentCounters } from "./background-state.js";
 
 // ── Tool parameter schemas (JSON Schema) ───────────────────────────────
 
@@ -115,11 +115,25 @@ const SubagentParams = {
 export const subagentExtension = (pi: ExtensionAPI, runAgent = runSingleAgent) => {
     const backgroundTasks = new Map<AbortController, Promise<void>>();
 
-    pi.on("session_shutdown", async () => {
+    // Abort every in-flight background subagent and wait for their finally
+    // blocks to release slots + end their relay mirror. `preserveListeners`
+    // keeps the lifecycle onSubagentsIdle listener alive across `/new`.
+    const abortAll = async (preserveListeners: boolean) => {
         for (const controller of backgroundTasks.keys()) controller.abort();
         await Promise.allSettled(backgroundTasks.values());
         backgroundTasks.clear();
-        resetSubagentState();
+        if (preserveListeners) resetSubagentCounters();
+        else resetSubagentState();
+    };
+
+    pi.on("session_shutdown", async () => { await abortAll(false); });
+
+    // `/new` resets the conversation in place: an aborted subagent's result
+    // (and its lingering mirror session) must not bleed into the new one, and a
+    // still-reserved slot would otherwise leave the fresh conversation looking
+    // "never settled" (hasActiveSubagents stays true across the reset).
+    pi.on("session_switch" as any, async (event: any) => {
+        if (event?.reason === "new") await abortAll(true);
     });
 
     pi.registerTool({

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4396,7 +4396,16 @@ export function App() {
   // cross-runner switch can briefly pair the old runner's modes with the new
   // runner's id — and a mode that hides chrome closes those panels for good.
   const modesSource = React.useMemo(() => {
-    if (activeRunnerInfo) {
+    // Prefer the active session's runner, but only when it actually declares
+    // modes — otherwise the mode list and mode home vanish the moment you open
+    // a session on a modeless runner (a subagent child, a plain coding runner).
+    // Modes and their owning runner id are still read from the SAME runner
+    // object, so a cross-runner switch can't pair one runner's modes with
+    // another's id. activeMode stays correct because findSessionMode requires
+    // the session's own runnerId to match modesSource.runnerId — a session on a
+    // modeless runner resolves to no mode (standard UI) even while the fallback
+    // runner's modes keep showing in the sidebar.
+    if (activeRunnerInfo && (activeRunnerInfo.sessionModes?.length ?? 0) > 0) {
       return { modes: activeRunnerInfo.sessionModes ?? [], runnerId: activeRunnerInfo.runnerId };
     }
     const runner = feedRunners.find((candidate) => (candidate.sessionModes?.length ?? 0) > 0);


### PR DESCRIPTION
## What

Two independent session-viewer / subagent fixes.

### 1. Modes should show regardless of the selected session's runner

`modesSource` in `App.tsx` only took modes from the **active session's runner**. Opening a session on a runner that declares no modes (a subagent child, a plain coding runner, etc.) blanked the entire mode list and mode home.

Now it prefers the active runner's modes **only when that runner actually declares any**, otherwise falls back to whichever connected runner declares modes. Modes and their owning `runnerId` are still read from the *same* runner object, so a cross-runner switch can't pair one runner's modes with another's id — and `findSessionMode` still requires the session's own `runnerId` to match, so a session on a modeless runner correctly resolves to the standard coding UI while the mode list stays visible in the sidebar.

### 2. Subagent sessions linger after completion → new conversation "thinks they're alive"

The subagent extension only cleaned up on `session_shutdown`, never on `/new` (`session_switch` reason `"new"`). Its module-global slot counter and any in-flight background subagents — plus their relay-mirror child sessions — survived the in-place reset, so `hasActiveSubagents()` stayed `true` and the lifecycle handler kept **deferring the new conversation's completion**. The UI never saw the session settle, i.e. it kept thinking subagents were alive.

Added a `session_switch` handler that, on `reason === "new"`, aborts in-flight subagents (each one's `finally` ends its relay mirror + releases its slot) and zeroes the counters via a new `resetSubagentCounters()`. Unlike `resetSubagentState()`, it **preserves** the lifecycle `onSubagentsIdle` listener that gates session completion (clearing it is correct on shutdown, wrong on `/new`). This mirrors the existing `background-bash` `/new` cleanup pattern.

## Testing

- `bun test packages/cli/src/extensions/subagent-background.test.ts` — 6 pass (added a `/new` case asserting no result bleeds in, slots release, and idle listeners survive).
- `bun test` for `SessionSidebar.sort`, `useRunnerServices`, `ModeHome` — 29 pass.
- `bunx tsc --noEmit -p packages/cli/tsconfig.json` — clean for touched files (two remaining errors are pre-existing, unrelated panel-type issues on `main`).

## Files

- `packages/ui/src/App.tsx` — `modesSource` fallback.
- `packages/cli/src/extensions/subagent/index.ts` — `/new` abort/cleanup.
- `packages/cli/src/extensions/subagent/background-state.ts` — `resetSubagentCounters()`.
- `packages/cli/src/extensions/subagent-background.test.ts` — `/new` test.
