### PR TITLE
fix(viewer): hydrate resuming viewers from seq-provable snapshots

### DIFF
--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -294,6 +294,19 @@ export async function getCachedRelayEventsAfterSeq(
 export interface LatestCachedSnapshot {
     event: Record<string, unknown>;
     /**
+     * Seq the snapshot event was published at, when known.
+     *
+     * publishSessionEvent() seq-stamps every broadcast event before caching it,
+     * so any snapshot that went out over the wire has one. The lone exception is
+     * the assembled session_active written by finalizeChunkedSnapshot(), which
+     * deliberately skips incrementSeq() because it is never broadcast.
+     *
+     * Knowing this lets a caller prove a snapshot is not a rewind before sending
+     * it to a viewer that already holds a cursor. Without it, the only safe move
+     * was to send nothing — which left reconnecting viewers permanently blank.
+     */
+    snapshotSeq?: number;
+    /**
      * Cached events appended after the snapshot, in chronological order.
      * Replaying these after the snapshot brings a viewer up to the current
      * seq — without them, deltas published between the snapshot and "now"
@@ -328,6 +341,7 @@ export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<L
                 if (isSnapshotEvent(parsed.event)) {
                     return {
                         event: parsed.event as Record<string, unknown>,
+                        snapshotSeq: parsed.seq,
                         eventsAfter: trailingReversed.reverse(),
                     };
                 }

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -461,6 +461,121 @@ describe("getBestSnapshot — priority ordering", () => {
         expect(result).toBeNull();
     });
 
+    test("resumes via a seq-stamped snapshot when the delta replay is empty", async () => {
+        // Regression for "blank conversation until I hit refresh": an empty delta
+        // replay used to be terminal for any viewer holding a cursor, so a
+        // reconnect delivered no transcript at all and nothing ever retried.
+        const snapshotEvent = { type: "session_active", state: { messages: [{ role: "user" }] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshotEvent,
+                snapshotSeq: 14,
+                eventsAfter: [],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31a", { lastSeq: 10, latestSeq: 14 }, deps);
+
+        expect(result?.snapshot.type).toBe("cache-snapshot");
+        expect(result?.snapshot.seq).toBe(14);
+        const socket = createMockSocket();
+        result?.send(socket);
+        expect(socket.calls).toHaveLength(1);
+    });
+
+    test("refuses a snapshot older than the client cursor rather than rewinding it", async () => {
+        const snapshotEvent = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshotEvent,
+                snapshotSeq: 4,
+                eventsAfter: [],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31b", { lastSeq: 10, latestSeq: 14 }, deps);
+
+        expect(result).toBeNull();
+    });
+
+    test("an older snapshot IS served when its trailing deltas reach the cursor", async () => {
+        // The common reconnect: last checkpoint is a few deltas behind the
+        // viewer's cursor. Snapshot@8 + deltas 9,10 reconstructs seq 10 exactly,
+        // so this must hydrate immediately rather than stall waiting for a retry.
+        const snapshotEvent = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshotEvent,
+                snapshotSeq: 8,
+                eventsAfter: [
+                    { seq: 9, event: { type: "message_update" } },
+                    { seq: 10, event: { type: "message_end" } },
+                ],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31e", { lastSeq: 10, latestSeq: 10 }, deps);
+
+        expect(result?.snapshot.type).toBe("cache-snapshot");
+        expect(result?.snapshot.seq).toBe(10);
+    });
+
+    test("refuses a snapshot whose trailing deltas have a hole", async () => {
+        // A gap between the snapshot and the cursor means replacing the transcript
+        // would silently drop whatever fell in the hole.
+        const snapshotEvent = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshotEvent,
+                snapshotSeq: 8,
+                eventsAfter: [{ seq: 11, event: { type: "message_end" } }],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31f", { lastSeq: 10, latestSeq: 11 }, deps);
+
+        expect(result).toBeNull();
+    });
+
+    test("never serves unsequenced lastState or SQLite state to a cursor-holding viewer", async () => {
+        // lastState is written on session_active only, so it can be arbitrarily
+        // older than the cursor. Guessing its position would poison the cursor.
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => null),
+            getPersistedRelaySessionSnapshot: mock(async () => ({ state: { messages: ["persisted"] } })),
+        });
+
+        const result = await getBestSnapshot(
+            "sess-31c",
+            { lastSeq: 10, latestSeq: 14, userId: "u1", lastState: '{"messages":["memory"]}' },
+            deps,
+        );
+
+        expect(result).toBeNull();
+    });
+
+    test("still prefers a cheap delta replay over a full snapshot", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => [
+                { seq: 11, event: { type: "message_start" } },
+            ]),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: { type: "session_active", state: { messages: [] } },
+                snapshotSeq: 14,
+                eventsAfter: [],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31d", { lastSeq: 10, latestSeq: 14 }, deps);
+
+        expect(result?.snapshot.type).toBe("cache-delta");
+    });
+
     test("returns null when delta replay is unavailable", async () => {
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => {

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -501,9 +501,9 @@ describe("getBestSnapshot — priority ordering", () => {
     });
 
     test("an older snapshot IS served when its trailing deltas reach the cursor", async () => {
-        // The common reconnect: last checkpoint is a few deltas behind the
-        // viewer's cursor. Snapshot@8 + deltas 9,10 reconstructs seq 10 exactly,
-        // so this must hydrate immediately rather than stall waiting for a retry.
+        // Delta replay refuses (its own contiguity check from lastSeq+1 failed,
+        // e.g. a legacy unsequenced row in the list), but the snapshot's trailing
+        // run is contiguous and reaches past the cursor, so it is safe to replay.
         const snapshotEvent = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
@@ -513,14 +513,78 @@ describe("getBestSnapshot — priority ordering", () => {
                 eventsAfter: [
                     { seq: 9, event: { type: "message_update" } },
                     { seq: 10, event: { type: "message_end" } },
+                    { seq: 11, event: { type: "message_update" } },
+                    { seq: 12, event: { type: "message_end" } },
                 ],
             })),
         });
 
-        const result = await getBestSnapshot("sess-31e", { lastSeq: 10, latestSeq: 10 }, deps);
+        const result = await getBestSnapshot("sess-31e", { lastSeq: 10, latestSeq: 12 }, deps);
 
         expect(result?.snapshot.type).toBe("cache-snapshot");
-        expect(result?.snapshot.seq).toBe(10);
+        expect(result?.snapshot.seq).toBe(12);
+    });
+
+    test("prefers the already-current no-op over resending a transcript the viewer has", async () => {
+        // A level viewer must not be handed a full snapshot: replacing its
+        // transcript would also discard any older history it had paged in.
+        const snapshotEvent = { type: "session_active", state: { messages: [] } };
+        const getLatestCachedSnapshotEvent = mock(async () => ({
+            event: snapshotEvent,
+            snapshotSeq: 10,
+            eventsAfter: [],
+        }));
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent,
+        });
+
+        const result = await getBestSnapshot("sess-31g", { lastSeq: 10, latestSeq: 10 }, deps);
+
+        expect(result?.snapshot.type).toBe("already-current");
+        expect(getLatestCachedSnapshotEvent).not.toHaveBeenCalled();
+    });
+
+    test("a resume snapshot keeps loaded history instead of truncating to the tail", async () => {
+        // Truncation is a cold-start bandwidth guard. Applying it on a resume
+        // would erase history the viewer had paged in, on a mere network blip.
+        const messages = Array.from({ length: 120 }, (_, i) => ({ id: i }));
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: { type: "session_active", state: { messages } },
+                snapshotSeq: 14,
+                eventsAfter: [],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31h", { lastSeq: 10, latestSeq: 14 }, deps);
+        expect(result?.snapshot.type).toBe("cache-snapshot");
+
+        const socket = createMockSocket();
+        result?.send(socket);
+        const payload = socket.calls[0]!.payload as { event: { state: { messages: unknown[] } } };
+        expect(payload.event.state.messages).toHaveLength(120);
+    });
+
+    test("a cold-start snapshot still truncates to the message tail", async () => {
+        const messages = Array.from({ length: 120 }, (_, i) => ({ id: i }));
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: { type: "session_active", state: { messages } },
+                snapshotSeq: 14,
+                eventsAfter: [],
+            })),
+        });
+
+        const result = await getBestSnapshot("sess-31i", {}, deps);
+        const socket = createMockSocket();
+        result?.send(socket);
+        const payload = socket.calls[0]!.payload as {
+            event: { state: { messages: unknown[]; hasMore: boolean } };
+        };
+        expect(payload.event.state.messages).toHaveLength(50);
+        expect(payload.event.state.hasMore).toBe(true);
     });
 
     test("refuses a snapshot whose trailing deltas have a hole", async () => {

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -130,10 +130,19 @@ export async function tryCacheSnapshot(
     sessionId: string,
     deps: SnapshotProviderDeps = defaultDeps,
     snapshotOverlay?: string | null,
+    opts: { preserveLoadedHistory?: boolean } = {},
 ): Promise<SnapshotResult | null> {
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return null;
     const snapshotEvent = cached.event;
+    // A resuming viewer may have paged far past the 50-message tail. Replacing
+    // its transcript with a truncated snapshot would silently erase that loaded
+    // history on nothing more than a network blip, which is why the live
+    // broadcast path in sio-registry/sessions.ts deliberately does not truncate
+    // either. Truncation is a cold-start bandwidth guard, not a resume policy.
+    const shrink = opts.preserveLoadedHistory
+        ? (state: unknown) => state
+        : maybeTruncateSnapshotState;
 
     return {
         snapshot: {
@@ -152,12 +161,12 @@ export async function tryCacheSnapshot(
                 // model, todo list — so apply it or a stale snapshot clobbers the
                 // viewer's restored follow-ups on switch.
                 const state = applySnapshotOverlayToState(
-                    maybeTruncateSnapshotState(snapshotEvent.state),
+                    shrink(snapshotEvent.state),
                     snapshotOverlay,
                 );
                 eventToSend = { ...snapshotEvent, state };
             } else if (Array.isArray(snapshotEvent.messages)) {
-                eventToSend = maybeTruncateSnapshotState(snapshotEvent) as Record<string, unknown>;
+                eventToSend = shrink(snapshotEvent) as Record<string, unknown>;
             }
             socket.emit("event", { event: eventToSend, replay: true, generation });
             // Replay deltas cached after the snapshot. The viewer's cursor was
@@ -288,20 +297,8 @@ export async function getBestSnapshot(
             return null;
         }
 
-        // 1b. No usable deltas. A full snapshot is still safe when we can prove
-        //     it reconstructs at least what the viewer already holds. This is the
-        //     case the old code could not distinguish and so refused outright.
-        try {
-            const cached = await tryCacheSnapshot(sessionId, deps, snapshotOverlay);
-            const coverage = cached?.snapshot.seq;
-            if (cached && coverage !== undefined && coverage >= lastSeq) {
-                return cached;
-            }
-        } catch {
-            // Fall through
-        }
-
-        // 1c. Nothing to send and the client is provably level with the server.
+        // 1b. Nothing to replay and the client is provably level with the
+        //     server: say so instead of resending a whole transcript it has.
         if (opts.latestSeq === lastSeq) {
             return {
                 snapshot: {
@@ -311,6 +308,22 @@ export async function getBestSnapshot(
                 },
                 send() {},
             };
+        }
+
+        // 1c. The client is genuinely behind and deltas cannot repair it. A full
+        //     snapshot is still safe when we can prove it reconstructs at least
+        //     what the viewer already holds — the case the old code could not
+        //     distinguish and so refused outright, going blank instead.
+        try {
+            const cached = await tryCacheSnapshot(sessionId, deps, snapshotOverlay, {
+                preserveLoadedHistory: true,
+            });
+            const coverage = cached?.snapshot.seq;
+            if (cached && coverage !== undefined && coverage >= lastSeq) {
+                return cached;
+            }
+        } catch {
+            // Fall through
         }
 
         // 1d. A real gap we cannot repair without risking a rewind. Recover

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -13,7 +13,7 @@ import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent, type Latest
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
 import { applySnapshotOverlayToState } from "../sio-registry/snapshot-state.js";
 import type { CachedRelayEvent } from "./viewer-cache.js";
-import { sendCachedDeltaReplayEvents } from "./viewer-cache.js";
+import { sendCachedDeltaReplayEvents, snapshotCoverageSeq } from "./viewer-cache.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -24,6 +24,17 @@ export interface Snapshot {
     type: "cache-delta" | "cache-snapshot" | "memory" | "persisted" | "already-current";
     /** Human-readable description of the source */
     source: string;
+    /**
+     * Seq this content is current as of, when known.
+     *
+     * Only set for sources that can prove their position in the event stream
+     * (the Redis cache). `lastState` and the SQLite fallback are written on
+     * session_active only — never on agent_end or deltas — so their true
+     * position is unknown and MUST NOT be guessed from the session's current
+     * seq: doing so would assert a currency the payload does not have and
+     * poison the viewer's cursor.
+     */
+    seq?: number;
 }
 
 /**
@@ -125,7 +136,13 @@ export async function tryCacheSnapshot(
     const snapshotEvent = cached.event;
 
     return {
-        snapshot: { type: "cache-snapshot", source: "Redis cached snapshot event" },
+        snapshot: {
+            type: "cache-snapshot",
+            source: "Redis cached snapshot event",
+            // Reach of the snapshot *plus* its trailing deltas, which is what a
+            // caller must compare against a viewer's cursor.
+            seq: snapshotCoverageSeq(cached) ?? undefined,
+        },
         send(socket, generation) {
             let eventToSend: Record<string, unknown> = snapshotEvent;
             if (snapshotEvent.type === "session_active") {
@@ -238,9 +255,17 @@ export interface GetBestSnapshotOpts {
  *
  * Returns the first successful result, or null if all sources fail.
  *
- * NOTE: When lastSeq is provided and delta replay fails, we do NOT fall back
- * to a snapshot — snapshots have no seq and could roll back the client's
- * transcript. We return null so the caller can trigger runner recovery.
+ * A viewer that supplies `lastSeq` already holds a transcript, so anything we
+ * send it must not rewind that transcript. The rule is a seq comparison, not a
+ * mode switch: a source is safe when we can prove its position is at or ahead of
+ * the client's cursor. Sources that cannot prove their position (`lastState`,
+ * SQLite) are therefore reachable only for viewers hydrating from scratch.
+ *
+ * This used to be enforced by refusing to send *any* snapshot once `lastSeq` was
+ * present, because the snapshot's own seq was discarded on the way out of
+ * getLatestCachedSnapshotEvent(). That made an empty delta replay terminal:
+ * the viewer received no transcript and no way to ask again, which is the
+ * "blank until I hit refresh" bug.
  */
 export async function getBestSnapshot(
     sessionId: string,
@@ -249,8 +274,11 @@ export async function getBestSnapshot(
 ): Promise<SnapshotResult | null> {
     const { lastSeq, userId, lastState, snapshotOverlay, chunkedPending } = opts;
 
-    // ── Priority 1: Delta replay (only when lastSeq is provided) ─────────
+    // ── Resuming viewer: only seq-provable sources are safe ──────────────
     if (lastSeq !== undefined) {
+        // 1a. Deltas after the client's cursor are the cheapest lossless resume.
+        //     getCachedRelayEventsAfterSeq() already enforces strict seq
+        //     contiguity and returns nothing if the cache was trimmed.
         try {
             const delta = await tryDeltaReplay(sessionId, lastSeq, deps);
             if (delta) return delta;
@@ -259,17 +287,34 @@ export async function getBestSnapshot(
             // current, even when latestSeq happens to match.
             return null;
         }
-        // Empty replay is a valid no-op only when the authoritative server
-        // seq equals the client's cursor. A higher seq means the cache has a
-        // genuine gap and must recover through the runner.
+
+        // 1b. No usable deltas. A full snapshot is still safe when we can prove
+        //     it reconstructs at least what the viewer already holds. This is the
+        //     case the old code could not distinguish and so refused outright.
+        try {
+            const cached = await tryCacheSnapshot(sessionId, deps, snapshotOverlay);
+            const coverage = cached?.snapshot.seq;
+            if (cached && coverage !== undefined && coverage >= lastSeq) {
+                return cached;
+            }
+        } catch {
+            // Fall through
+        }
+
+        // 1c. Nothing to send and the client is provably level with the server.
         if (opts.latestSeq === lastSeq) {
             return {
-                snapshot: { type: "already-current", source: "Viewer already at latest cached seq" },
+                snapshot: {
+                    type: "already-current",
+                    source: "Viewer already at latest cached seq",
+                    seq: lastSeq,
+                },
                 send() {},
             };
         }
-        // When lastSeq is provided but delta fails, do NOT fall through to
-        // snapshot — a snapshot has no seq and would roll back the client.
+
+        // 1d. A real gap we cannot repair without risking a rewind. Recover
+        //     through the runner rather than guessing with an unsequenced tier.
         return null;
     }
 

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -11,6 +11,7 @@ import {
     getLatestCachedSnapshotEvent,
     type LatestCachedSnapshot,
 } from "../../sessions/redis.js";
+import { applySnapshotOverlayToState } from "../sio-registry/snapshot-state.js";
 
 type ViewerEventEmitter = {
     emit: any;
@@ -76,8 +77,16 @@ function emitSnapshotWithTrailingDeltas(
     socket: ViewerEventEmitter,
     cached: LatestCachedSnapshot,
     generation: number | undefined,
+    snapshotOverlay?: string | null,
 ): void {
-    socket.emit("event", { event: cached.event, replay: true, generation });
+    // The cached session_active predates any later metadata-only updates (queue,
+    // model, todo list), which are carried by the overlay rather than re-cached.
+    // Without applying it a resync hands the viewer stale metadata.
+    let event = cached.event;
+    if (snapshotOverlay && event.type === "session_active") {
+        event = { ...event, state: applySnapshotOverlayToState(event.state, snapshotOverlay) };
+    }
+    socket.emit("event", { event, replay: true, generation });
     // Replay deltas cached after the snapshot so the viewer isn't left stale
     // between the snapshot and the seq advertised in "connected".
     sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
@@ -88,11 +97,12 @@ export async function sendLatestSnapshotFromCache(
     sessionId: string,
     generation: number | undefined,
     deps: ViewerCacheDeps = defaultViewerCacheDeps,
+    snapshotOverlay?: string | null,
 ): Promise<boolean> {
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return false;
 
-    emitSnapshotWithTrailingDeltas(socket, cached, generation);
+    emitSnapshotWithTrailingDeltas(socket, cached, generation, snapshotOverlay);
     return true;
 }
 
@@ -141,6 +151,7 @@ export async function hydrateViewerFromCache(
     opts: {
         lastSeq?: number;
         generation?: number;
+        snapshotOverlay?: string | null;
     } = {},
     deps: ViewerCacheDeps = defaultViewerCacheDeps,
 ): Promise<boolean> {
@@ -161,7 +172,7 @@ export async function hydrateViewerFromCache(
             // reach is decidable. Refusing outright left resyncing viewers blank.
             const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
             if (cached && snapshotCoversCursor(cached, opts.lastSeq)) {
-                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation);
+                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation, opts.snapshotOverlay);
                 return true;
             }
 
@@ -177,7 +188,7 @@ export async function hydrateViewerFromCache(
             return false;
         }
 
-        return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps);
+        return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps, opts.snapshotOverlay);
     } catch (err) {
         // Log and fall through to runner-driven recovery
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -33,6 +33,56 @@ const defaultViewerCacheDeps: ViewerCacheDeps = {
     getLatestCachedSnapshotEvent,
 };
 
+/**
+ * Highest seq a cached snapshot + its trailing deltas can reconstruct, or null
+ * if that cannot be established.
+ *
+ * A snapshot replaces the viewer's transcript wholesale, so replaying it is only
+ * safe when the result lands the viewer at or ahead of where it already was.
+ * That reach is not the snapshot's own seq: the trailing deltas extend it. A
+ * snapshot at seq 480 followed by cached deltas 481..500 reconstructs seq 500
+ * exactly, which is why refusing to send it whenever `snapshotSeq < lastSeq`
+ * would strand viewers that are only a few deltas ahead of the last checkpoint.
+ *
+ * Returns null when the snapshot itself is unsequenced (finalizeChunkedSnapshot
+ * writes one deliberately without a seq) or when the trailing deltas are not a
+ * contiguous run from `snapshotSeq + 1` — a hole means replacing the transcript
+ * would silently drop whatever fell in it.
+ */
+export function snapshotCoverageSeq(cached: LatestCachedSnapshot): number | null {
+    const snapshotSeq = cached.snapshotSeq;
+    if (snapshotSeq === undefined || !Number.isFinite(snapshotSeq)) return null;
+
+    let coverage = snapshotSeq;
+    for (const record of cached.eventsAfter) {
+        if (typeof record.seq !== "number" || !Number.isFinite(record.seq)) continue;
+        if (record.seq !== coverage + 1) return null;
+        coverage = record.seq;
+    }
+    return coverage;
+}
+
+/**
+ * True when replaying this cached snapshot (plus trailing deltas) would not
+ * rewind a viewer that has already rendered up to `lastSeq`.
+ */
+export function snapshotCoversCursor(cached: LatestCachedSnapshot, lastSeq: number): boolean {
+    const coverage = snapshotCoverageSeq(cached);
+    return coverage !== null && coverage >= lastSeq;
+}
+
+/** Emit a cached snapshot followed by every delta cached after it. */
+function emitSnapshotWithTrailingDeltas(
+    socket: ViewerEventEmitter,
+    cached: LatestCachedSnapshot,
+    generation: number | undefined,
+): void {
+    socket.emit("event", { event: cached.event, replay: true, generation });
+    // Replay deltas cached after the snapshot so the viewer isn't left stale
+    // between the snapshot and the seq advertised in "connected".
+    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
+}
+
 export async function sendLatestSnapshotFromCache(
     socket: ViewerEventEmitter,
     sessionId: string,
@@ -42,10 +92,7 @@ export async function sendLatestSnapshotFromCache(
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return false;
 
-    socket.emit("event", { event: cached.event, replay: true, generation });
-    // Replay deltas cached after the snapshot so the viewer isn't left stale
-    // between the snapshot and the seq advertised in "connected".
-    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
+    emitSnapshotWithTrailingDeltas(socket, cached, generation);
     return true;
 }
 
@@ -107,13 +154,26 @@ export async function hydrateViewerFromCache(
                 deps,
             );
             if (deltaOk) return true;
+
+            // No usable deltas. A full snapshot is still safe when we can prove
+            // it reconstructs at least what the viewer already has:
+            // publishSessionEvent() seq-stamps every cached snapshot, so that
+            // reach is decidable. Refusing outright left resyncing viewers blank.
+            const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
+            if (cached && snapshotCoversCursor(cached, opts.lastSeq)) {
+                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation);
+                return true;
+            }
+
             // An empty replay is safe only when the cache confirms the client
             // already has the newest stored event. Otherwise this is a real
             // gap (or an unavailable cache), so runner recovery is required.
             const latestSeq = await deps.getLatestCachedRelayEventSeq(sessionId);
             if (latestSeq === opts.lastSeq) return true;
-            // A snapshot has no seq and could roll back the client's
-            // transcript or cause missed updates.
+
+            // Either a genuine gap, or the only snapshot we have is the
+            // unsequenced one finalizeChunkedSnapshot() writes — whose position
+            // in the stream is unknown, so sending it could rewind the client.
             return false;
         }
 

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
     hydrateViewerFromCache,
     sendCachedDeltaReplayEvents,
+    snapshotCoverageSeq,
+    snapshotCoversCursor,
     type CachedRelayEvent,
     type ViewerCacheDeps,
 } from "./viewer-cache.js";
@@ -127,7 +129,73 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         expect(getLatestCachedRelayEventSeq).toHaveBeenCalledWith("sess-011");
     });
 
-    test("returns false for a genuine gap when the cache has newer events", async () => {
+    test("replays a seq-stamped snapshot at or ahead of the cursor instead of going blank", async () => {
+        // Regression: an empty delta replay used to be terminal, so a reconnecting
+        // viewer got no transcript at all and only a page reload fixed it. The
+        // snapshot's own seq proves it is not a rewind, so it is safe to send.
+        const snapshot = { type: "session_active", state: { messages: [{ role: "user" }] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedRelayEventSeq: mock(async () => 8),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshot,
+                snapshotSeq: 8,
+                eventsAfter: [],
+            })),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-012", { lastSeq: 5 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(1);
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+    });
+
+    test("replays trailing deltas after a seq-stamped snapshot", async () => {
+        const snapshot = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedRelayEventSeq: mock(async () => 9),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshot,
+                snapshotSeq: 7,
+                eventsAfter: [{ seq: 8, event: { type: "message_update" } }],
+            })),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-012b", { lastSeq: 6 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(2);
+        expect(calls[1].payload).toMatchObject({ seq: 8, deltaReplay: true });
+    });
+
+    test("refuses a snapshot that would rewind the client", async () => {
+        // The snapshot predates what the viewer already rendered, so sending it
+        // would erase messages. Recover through the runner instead.
+        const snapshot = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedRelayEventSeq: mock(async () => 8),
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshot,
+                snapshotSeq: 4,
+                eventsAfter: [],
+            })),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-012c", { lastSeq: 5 }, deps);
+
+        expect(result).toBe(false);
+        expect(calls.length).toBe(0);
+    });
+
+    test("refuses an unsequenced snapshot for a cursor-holding viewer", async () => {
+        // finalizeChunkedSnapshot() caches its assembled session_active without a
+        // seq, so its position in the stream is unknown and cannot be compared.
         const snapshot = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
@@ -136,7 +204,7 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         });
 
         const { emit, calls } = createMockSocket();
-        const result = await hydrateViewerFromCache({ emit }, "sess-012", { lastSeq: 5 }, deps);
+        const result = await hydrateViewerFromCache({ emit }, "sess-012d", { lastSeq: 5 }, deps);
 
         expect(result).toBe(false);
         expect(calls.length).toBe(0);
@@ -177,6 +245,7 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         const snapshot = { type: "session_active", state: { messages: [{ role: "assistant" }] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => [{ event: { type: "old_event" } }]),
+            // Legacy cache: the snapshot has no seq either, so it cannot be proven safe.
             getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })),
         });
 
@@ -260,5 +329,49 @@ describe("sendCachedDeltaReplayEvents (re-exported helper)", () => {
             deltaReplay: true,
             generation: undefined,
         });
+    });
+});
+
+describe("snapshotCoverageSeq", () => {
+    test("is the snapshot seq when nothing trails it", () => {
+        expect(snapshotCoverageSeq({ event: {}, snapshotSeq: 7, eventsAfter: [] })).toBe(7);
+    });
+
+    test("extends through a contiguous run of trailing deltas", () => {
+        expect(snapshotCoverageSeq({
+            event: {},
+            snapshotSeq: 7,
+            eventsAfter: [{ seq: 8, event: {} }, { seq: 9, event: {} }],
+        })).toBe(9);
+    });
+
+    test("ignores unsequenced trailing records without breaking the run", () => {
+        expect(snapshotCoverageSeq({
+            event: {},
+            snapshotSeq: 7,
+            eventsAfter: [{ event: {} }, { seq: 8, event: {} }],
+        })).toBe(8);
+    });
+
+    test("is null when the trailing run has a hole", () => {
+        expect(snapshotCoverageSeq({
+            event: {},
+            snapshotSeq: 7,
+            eventsAfter: [{ seq: 9, event: {} }],
+        })).toBeNull();
+    });
+
+    test("is null for an unsequenced snapshot (chunked-assembled)", () => {
+        expect(snapshotCoverageSeq({ event: {}, eventsAfter: [{ seq: 9, event: {} }] })).toBeNull();
+    });
+
+    test("snapshotCoversCursor compares coverage, not the snapshot seq alone", () => {
+        const cached = {
+            event: {},
+            snapshotSeq: 8,
+            eventsAfter: [{ seq: 9, event: {} }, { seq: 10, event: {} }],
+        };
+        expect(snapshotCoversCursor(cached, 10)).toBe(true);
+        expect(snapshotCoversCursor(cached, 11)).toBe(false);
     });
 });

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -17,7 +17,6 @@ import {
     shouldAvoidSnapshotFallback,
     forwardRecoveryConnectedSignal,
     withHubMetaSource,
-    withMetaViaHubHint,
     withLivenessOnlyHint,
     sendCachedDeltaReplayEvents,
     checkServiceMessageSize,
@@ -255,14 +254,6 @@ describe("meta routing hints", () => {
         expect(withHubMetaSource({ sessionId: "sess-1" })).toEqual({
             sessionId: "sess-1",
             meta_source: "hub",
-        });
-    });
-
-    test("marks session_active snapshots as hub-based meta", () => {
-        expect(withMetaViaHubHint({ type: "session_active", state: {} })).toEqual({
-            type: "session_active",
-            state: {},
-            _metaViaHub: true,
         });
     });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -454,9 +454,14 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             if (!chunkedPending) {
                 const snapshotResult = await getBestSnapshot(nextSessionId, {
                     lastSeq: requestedLastSeq,
-                    // Without userId the SQLite tier is unreachable, so a session
-                    // whose Redis cache has aged out could never hydrate here.
-                    userId: viewerUserId,
+                    // Without userId the SQLite tier is unreachable, so a dead
+                    // session whose Redis cache aged out could never hydrate here.
+                    // Only offer it for sessions that are actually finished: the
+                    // persisted copy is a throttled snapshot, so serving it for a
+                    // live session whose cache merely blipped would show a stale
+                    // transcript AND suppress the runner signal that would have
+                    // fixed it — with no error and no retry.
+                    userId: freshSession.isActive ? undefined : viewerUserId,
                     lastState: freshSession.lastState,
                     snapshotOverlay: freshSession.snapshotOverlay,
                     chunkedPending: false,
@@ -558,9 +563,11 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const requestedLastSeq = typeof data?.lastSeq === "number" && Number.isFinite(data.lastSeq) ? data.lastSeq : undefined;
             const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
             if (requestedLastSeq !== undefined && !resyncChunkedPending) {
+                const resyncSession = await getSharedSession(currentSessionId);
                 const cacheHydrated = await hydrateViewerFromCache(socket, currentSessionId, {
                     lastSeq: requestedLastSeq,
                     generation: getCurrentGeneration(),
+                    snapshotOverlay: resyncSession?.snapshotOverlay,
                 });
                 if (cacheHydrated) {
                     return;

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -46,9 +46,8 @@ import { recordTriggerResponse } from "../../sessions/trigger-store.js";
 import { getHiddenModels } from "../../user-hidden-models.js";
 import { isHiddenModel } from "../../routes/model-guard.js";
 import { createLogger } from "@pizzapi/tools";
-import { hydrateViewerFromCache, sendCachedDeltaReplayEvents, sendLatestSnapshotFromCache } from "./viewer-cache.js";
+import { hydrateViewerFromCache, sendCachedDeltaReplayEvents } from "./viewer-cache.js";
 import { getBestSnapshot } from "./snapshot-provider.js";
-import { applySnapshotOverlayToState } from "../sio-registry/snapshot-state.js";
 
 export { hydrateViewerFromCache, sendCachedDeltaReplayEvents } from "./viewer-cache.js";
 
@@ -135,11 +134,6 @@ export function onViewerReadyForRunnerSignal(
 /** @internal — exported for unit tests only */
 export function withHubMetaSource<T extends Record<string, unknown>>(payload: T): T & { meta_source: "hub" } {
     return { ...payload, meta_source: "hub" };
-}
-
-/** @internal — exported for unit tests only */
-export function withMetaViaHubHint<T extends Record<string, unknown>>(event: T): T & { _metaViaHub: true } {
-    return { ...event, _metaViaHub: true };
 }
 
 /** @internal — exported for unit tests only */
@@ -460,6 +454,9 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             if (!chunkedPending) {
                 const snapshotResult = await getBestSnapshot(nextSessionId, {
                     lastSeq: requestedLastSeq,
+                    // Without userId the SQLite tier is unreachable, so a session
+                    // whose Redis cache has aged out could never hydrate here.
+                    userId: viewerUserId,
                     lastState: freshSession.lastState,
                     snapshotOverlay: freshSession.snapshotOverlay,
                     chunkedPending: false,
@@ -501,29 +498,16 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 } catch {}
             }
 
-            // A seq cache miss must recover from the runner; an unsequenced
-            // snapshot can rewind a client that already has newer events. The
-            // same applies while a chunked checkpoint is still assembling.
-            if (shouldAvoidSnapshotFallback(requestedLastSeq, chunkedPending)) {
-                return;
-            }
-
-            if (freshSession.lastState) {
-                try {
-                    const state = applySnapshotOverlayToState(
-                        JSON.parse(freshSession.lastState),
-                        freshSession.snapshotOverlay,
-                    );
-                    socket.emit("event", {
-                        event: withMetaViaHubHint({ type: "session_active", state }),
-                        seq: freshSeq,
-                        generation,
-                        sessionId: nextSessionId,
-                    });
-                } catch {}
-            } else {
-                await sendLatestSnapshotFromCache(socket, nextSessionId, generation);
-            }
+            // Nothing further to try here. getBestSnapshot() has already
+            // exhausted every source it is allowed to use for this viewer
+            // (cache delta, cache snapshot, lastState, SQLite), so the runner
+            // recovery signal above is the only remaining path to content.
+            //
+            // The old code re-attempted lastState and a second cache read at
+            // this point. Both were unreachable-or-unsafe: getBestSnapshot had
+            // just tried the identical Redis key, and re-sending unsequenced
+            // lastState to a viewer holding a cursor is exactly the rewind the
+            // seq comparison exists to prevent.
         };
 
         // ── switch_session — reuse the viewer socket across session changes ─
@@ -583,8 +567,10 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 }
             }
             if (shouldAvoidSnapshotFallback(requestedLastSeq, resyncChunkedPending)) {
-                // Cache miss with a client cursor requires a newly sequenced
-                // runner snapshot; stale lastState cannot safely fill the gap.
+                // The cache is seq-aware now and will already have replayed a
+                // snapshot if one provably sat at or ahead of the client cursor.
+                // Reaching here means only unsequenced state is left, which
+                // cannot safely fill the gap — ask the runner for a fresh one.
                 if (requestedLastSeq !== undefined && !resyncChunkedPending) {
                     forwardRecoveryConnectedSignal(currentSessionId);
                 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2132,6 +2132,11 @@ export function App() {
       chunkState.loadedMessages += chunkMessages.length;
       const loaded = chunkState.loadedMessages;
       onChunkProgress(loaded, totalMessages);
+      // Chunked delivery keeps awaitingSnapshot true for as long as the transfer
+      // takes, which on a big session over a slow link legitimately exceeds the
+      // stall threshold. Treat an arriving chunk as progress so the watchdog does
+      // not restart hydration underneath a transfer that is succeeding.
+      hydrationRequestedAtRef.current = Date.now();
 
       const readyToFinalize = canFinalizeChunkHydration(
         chunkState.finalChunkSeen,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -816,6 +816,17 @@ export function App() {
   // because browser timer throttling can delay both heartbeat delivery and checks.
   const lastViewerEventAtRef = React.useRef<number>(0);
   const staleCheckTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
+  // When we last asked the server to hydrate, or null once hydration settled.
+  // A hydration request has no ack, so this is the only way to notice one that
+  // was answered with nothing.
+  const hydrationRequestedAtRef = React.useRef<number | null>(null);
+  const hydrationStallTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
+  const hydrationRetriesRef = React.useRef(0);
+  const HYDRATION_STALL_MS = 8_000;
+  const HYDRATION_CHECK_INTERVAL_MS = 2_000;
+  // ponytail: two retries, then surface the failure. Retrying forever would
+  // re-request a full snapshot every 8s against a session that cannot answer.
+  const HYDRATION_MAX_RETRIES = 2;
   const HEARTBEAT_INTERVAL_MS = 10_000;
   const [isPageHidden, setIsPageHidden] = React.useState(() => document.visibilityState === "hidden");
   const staleThresholdMs = (isPageHidden ? 18 : 3) * HEARTBEAT_INTERVAL_MS;
@@ -1071,6 +1082,10 @@ export function App() {
         clearInterval(staleCheckTimerRef.current);
         staleCheckTimerRef.current = null;
       }
+      if (hydrationStallTimerRef.current !== null) {
+        clearInterval(hydrationStallTimerRef.current);
+        hydrationStallTimerRef.current = null;
+      }
       viewerWsRef.current?.disconnect();
       viewerWsRef.current = null;
       setViewerSocket(null);
@@ -1082,6 +1097,12 @@ export function App() {
       clearInterval(staleCheckTimerRef.current);
       staleCheckTimerRef.current = null;
     }
+    if (hydrationStallTimerRef.current !== null) {
+      clearInterval(hydrationStallTimerRef.current);
+      hydrationStallTimerRef.current = null;
+    }
+    hydrationRequestedAtRef.current = null;
+    hydrationRetriesRef.current = 0;
     viewerWsRef.current?.disconnect();
     viewerWsRef.current = null;
     lastSeqRef.current = null;
@@ -3231,8 +3252,16 @@ export function App() {
   }, [hubSocket, liveSessions, activeSessionId, metaInventoryVersion]);
 
   const openSession = React.useCallback((relaySessionId: string) => {
-    // Already viewing this session — nothing to do.
-    if (relaySessionId === lifecycleRefs.activeSessionId.current) return;
+    // Already viewing this session AND hydration finished — nothing to do.
+    // If hydration never completed, re-clicking the (still highlighted) session
+    // is the user's instinctive retry, so it must actually retry rather than
+    // no-op and leave them with a blank transcript until a full page reload.
+    if (
+      relaySessionId === lifecycleRefs.activeSessionId.current &&
+      !lifecycleRefs.awaitingSnapshot.current
+    ) {
+      return;
+    }
 
     // Flush/cancel any pending RAF queues (streaming deltas & tool-stream
     // partials) from the previous session so they can't leak into the new one.
@@ -3331,14 +3360,52 @@ export function App() {
       setViewerSocket(socket);
       const nextSocket = socket;
 
+      // Hydration-stall watchdog: a hydration request is fire-and-forget, so a
+      // reply that carries no transcript (or never arrives) leaves the viewer
+      // waiting forever with input blocked. Retry once with no cursor, which
+      // forces the server down its full-snapshot path.
+      hydrationStallTimerRef.current = setInterval(() => {
+        const sessionId = lifecycleRefs.activeSessionId.current;
+        if (!sessionId || !nextSocket.connected) return;
+        if (!lifecycleRefs.awaitingSnapshot.current) {
+          hydrationRequestedAtRef.current = null;
+          hydrationRetriesRef.current = 0;
+          return;
+        }
+        const requestedAt = hydrationRequestedAtRef.current;
+        if (requestedAt === null) return;
+        if (Date.now() - requestedAt < HYDRATION_STALL_MS) return;
+
+        if (hydrationRetriesRef.current >= HYDRATION_MAX_RETRIES) {
+          // Stop retrying, but never leave a spinner claiming progress.
+          hydrationRequestedAtRef.current = null;
+          onViewerError("Could not load this conversation. Reload to try again.");
+          return;
+        }
+
+        hydrationRetriesRef.current += 1;
+        log.warn(
+          `Hydration stalled for ${sessionId} (attempt ${hydrationRetriesRef.current}/${HYDRATION_MAX_RETRIES}); retrying without a seq cursor.`,
+        );
+        hydrationRequestedAtRef.current = Date.now();
+        // Drop the cursor so the server takes its full-snapshot path instead of
+        // trying to resume from a position it cannot serve.
+        lastSeqRef.current = null;
+        nextSocket.emit("switch_session", {
+          sessionId,
+          generation: lifecycleRefs.generation.current,
+        });
+      }, HYDRATION_CHECK_INTERVAL_MS);
+
       // Stale-connection watchdog: if the socket thinks it's connected but
       // no event has arrived for the current visibility-aware threshold, reconnect.
-      // Only armed when the agent is active — idle sessions produce no events,
-      // so silence is expected and not a sign of a broken connection.
+      // Armed while the agent is active (events are expected, so silence is
+      // suspicious) and also while hydrating (a dead transport is exactly why a
+      // transcript never arrives). Idle, hydrated sessions are legitimately silent.
       staleCheckTimerRef.current = setInterval(() => {
         if (!lifecycleRefs.activeSessionId.current) return;
         if (!nextSocket.connected) return;
-        if (!agentActiveRef.current) return;
+        if (!agentActiveRef.current && !lifecycleRefs.awaitingSnapshot.current) return;
         const elapsed = Date.now() - lastViewerEventAtRef.current;
         if (elapsed > staleThresholdMsRef.current) {
           log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
@@ -3352,6 +3419,8 @@ export function App() {
         if (!currentSessionId) return;
         setLifecycleStatus("Connecting…");
         setViewerSwitchGeneration(nextSocket, lifecycleRefs.generation.current);
+        hydrationRequestedAtRef.current = Date.now();
+        hydrationRetriesRef.current = 0;
         nextSocket.emit("switch_session", {
           sessionId: currentSessionId,
           generation: lifecycleRefs.generation.current,
@@ -3574,6 +3643,8 @@ export function App() {
 
     setViewerSwitchGeneration(socket, nextGeneration);
     if (socket.connected) {
+      hydrationRequestedAtRef.current = Date.now();
+      hydrationRetriesRef.current = 0;
       socket.emit("switch_session", { sessionId: relaySessionId, generation: nextGeneration });
       socket.emit("viewer_visibility", getViewerVisibilityPayload());
     } else {

--- a/packages/ui/src/lib/session-lifecycle.test.ts
+++ b/packages/ui/src/lib/session-lifecycle.test.ts
@@ -350,3 +350,34 @@ function goLive(sessionId: string) {
     a.snapshotComplete(),
   );
 }
+
+describe("reconnect does not re-gate an already-hydrated session", () => {
+  test("connected after hydration stays live and does not await a snapshot again", () => {
+    let state = sessionLifecycleReducer(createInitialSessionLifecycleState(), a.sessionSelected("s1", 1));
+    state = sessionLifecycleReducer(state, a.connected({}));
+    state = sessionLifecycleReducer(state, a.snapshotComplete());
+    expect(state.hydration.hydrated).toBe(true);
+
+    // Transport blip -> a fresh "connected" for the same session. The server may
+    // legitimately answer the resume with nothing, so re-arming the hydration
+    // gate here would block input forever on a visibly fine session.
+    const resumed = sessionLifecycleReducer(state, a.connected({}));
+    expect(resumed.hydration.awaitingSnapshot).toBe(false);
+    expect(resumed.hydration.hydrated).toBe(true);
+    expect(resumed.phase).toBe("live");
+  });
+
+  test("a genuine session switch still arms the hydration gate", () => {
+    let state = sessionLifecycleReducer(createInitialSessionLifecycleState(), a.sessionSelected("s1", 1));
+    state = sessionLifecycleReducer(state, a.connected({}));
+    state = sessionLifecycleReducer(state, a.snapshotComplete());
+
+    state = sessionLifecycleReducer(state, a.sessionSelected("s2", 2));
+    expect(state.hydration.hydrated).toBe(false);
+    expect(state.hydration.awaitingSnapshot).toBe(true);
+
+    state = sessionLifecycleReducer(state, a.connected({}));
+    expect(state.hydration.awaitingSnapshot).toBe(true);
+    expect(state.phase).toBe("connecting");
+  });
+});

--- a/packages/ui/src/lib/session-lifecycle.ts
+++ b/packages/ui/src/lib/session-lifecycle.ts
@@ -316,15 +316,23 @@ export function sessionLifecycleReducer(
     case "CONNECTED": {
       if (!state.activeSessionId) return state;
       const replayOnly = action.replayOnly === true;
+      // A transport reconnect for a session we already hydrated must NOT re-enter
+      // the awaiting-snapshot gate. The transcript is still on screen, and the
+      // server can legitimately answer the resume with nothing to send (the
+      // viewer is already current) — in which case no content event would ever
+      // arrive to clear the gate, leaving input blocked on a session that is
+      // visibly fine. A real session switch clears `hydrated` via
+      // SESSION_SELECTED, so this only relaxes the reconnect case.
+      const resumed = !replayOnly && state.hydration.hydrated;
       return {
         ...state,
-        phase: replayOnly ? "snapshot_replay" : "connecting",
+        phase: replayOnly ? "snapshot_replay" : resumed ? "live" : "connecting",
         status: replayOnly ? "Snapshot replay" : "Connected",
         error: null,
         hydration: {
           ...state.hydration,
-          awaitingSnapshot: !replayOnly,
-          hydrated: replayOnly,
+          awaitingSnapshot: !replayOnly && !resumed,
+          hydrated: replayOnly || resumed,
           metaSourceHub: action.metaSource === "hub" || state.hydration.metaSourceHub,
         },
       };

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -18,8 +18,16 @@ describe("mergeConnectedSeq", () => {
     expect(mergeConnectedSeq(15, 12)).toBe(12);
   });
 
-  test("advances when connected seq is newer", () => {
-    expect(mergeConnectedSeq(15, 18)).toBe(18);
+  test("does NOT advance on a bare ack when connected seq is newer", () => {
+    // "connected" is emitted before any transcript. Adopting 18 here would claim
+    // we hold events 16-18 that were never delivered, and the server would then
+    // answer the next resume with "already current" and no content — forever.
+    expect(mergeConnectedSeq(15, 18)).toBe(15);
+  });
+
+  test("ignores a non-finite server seq", () => {
+    expect(mergeConnectedSeq(15, Number.NaN)).toBe(15);
+    expect(mergeConnectedSeq(null, Number.NaN)).toBe(0);
   });
 });
 

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -1,15 +1,22 @@
 /**
  * Merge lastSeq from a viewer "connected" payload into the current cursor.
- * The server sends its authoritative seq — always accept it so a seq reset
- * (relay restart) correctly rewinds the client cursor instead of leaving it
- * stuck at a stale high value that rejects all new events.
+ *
+ * "connected" is a bare handshake ack: it is emitted before any transcript is
+ * sent, and hydration may still deliver nothing at all. So it must never move
+ * the cursor *forward* — doing so claims we hold content we were never sent,
+ * and the server then answers the next resume with "you are already current"
+ * and no transcript, forever. That is the blank-until-refresh bug.
+ *
+ * A *backward* move is still accepted: a relay restart resets the seq counter,
+ * and keeping a stale high cursor would reject every subsequent event.
  */
 export function mergeConnectedSeq(
-  _currentSeq: number | null,
+  currentSeq: number | null,
   connectedLastSeq: number,
 ): number {
-  if (!Number.isFinite(connectedLastSeq)) return _currentSeq ?? 0;
-  return connectedLastSeq;
+  if (!Number.isFinite(connectedLastSeq)) return currentSeq ?? 0;
+  if (currentSeq === null) return connectedLastSeq;
+  return Math.min(currentSeq, connectedLastSeq);
 }
 
 export function shouldDeferEventForHydration(


### PR DESCRIPTION
## Why am I having to refresh the page so much to get conversations to load?

Clicking a session often showed no conversation. Only a full browser reload fixed it.

Two code paths emit `switch_session`, and they behaved differently:

| Path | sends `lastSeq`? | server branch | worked? |
|---|---|---|---|
| Fresh page load / sidebar click (`App.tsx:3577`) | no | Priority 2 `cache-snapshot` | yes |
| Socket reconnect (`App.tsx:3350-3359`) | **yes** | Priority 1, delta-only | **no** |

`getBestSnapshot` treated a present `lastSeq` as delta-only. When the delta replay came back empty it either returned an `already-current` result whose `send()` body was empty, or `null` — and the cache-miss fallback then bailed out because `shouldAvoidSnapshotFallback(requestedLastSeq, …)` is true whenever a cursor is present. Either way the viewer got **no transcript**, and the only remaining hope was a fire-and-forget runner signal whose handler (`emitSessionActive`) silently no-ops when `rctx.latestCtx` is unset.

Client side, `connected` set `awaitingSnapshot: true` (`session-lifecycle.ts:326`) and it was cleared **only** by a `session_active` / `session_messages_chunk` / `agent_end` handler. No timeout, no retry.

### Prod evidence (relay logs, ~90 min window)

```
type=cache-snapshot          42   ← lastSeq omitted (works)
type=cache-delta              0   ← delta resume NEVER succeeded
type=already-current          0
cache miss fallback           5   ← blank transcript
ping timeout                  7
transport close              20   ← reconnect churn
```

The delta-resume path had a **0% success rate in production**. Every hydration that carried a cursor fell into the no-state branch.

Honest caveat: the blank rate is the **5**, not the 27 disconnects — 22 reconnects never attempted hydration at all (likely no session selected).

## The premise was false

The justifying comment said *"snapshots have no seq and could roll back the client's transcript."* But `publishSessionEvent` (`ws/sio-registry/sessions.ts:706-735`) does `seq = await incrementSeq()` then `appendRelayEventToCache(event, { seq })` for **every** broadcast event, including `session_active` and `agent_end` snapshots. `parseCachedRelayEventRow` parses that seq — and `getLatestCachedSnapshotEvent` discarded it on the way out.

Return it, and the mode switch becomes a comparison:

```
lastSeq present?
  1a  deltas after the cursor exist   → replay them (cheapest, lossless)
  1b  cursor level with the server    → already-current no-op
  1c  coverage >= cursor              → replay snapshot + trailing deltas   ← was `return null`
  1d  otherwise                       → runner recovery
```

**Coverage is the snapshot's seq extended by its contiguous trailing deltas**, not the snapshot seq alone. Snapshot@8 plus cached deltas 9,10 reconstructs seq 10 exactly — that is the common reconnect, and gating on `snapshotSeq >= lastSeq` alone would have stranded it. A hole in that run, or the unsequenced snapshot `finalizeChunkedSnapshot` writes deliberately, is not provable and still defers to runner recovery.

`lastState` and the SQLite tier stay unreachable for cursor-holding viewers: both are written on `session_active` only — never on `agent_end` or deltas — so their position cannot be established and must not be guessed from the session's current seq.

## Also fixed

Each of these independently made the stall unrecoverable:

- **`mergeConnectedSeq` advanced the cursor on the bare `connected` ack**, before any transcript was sent. A failed hydration still left the client claiming content it never received, so the *next* resume was answered "already current" forever. Forward moves are now ignored; rewinds (relay seq reset) still apply.
- **`hydrateViewerFromCache`** — the `resync` path, i.e. the client's own gap recovery — had the identical delta-only blindness and the same false comment.
- **`getBestSnapshot` was called without `userId`**, so the SQLite tier was structurally dead on this path.
- **The stale-connection watchdog was armed only while the agent was active**, so idle sessions — the ones users click into — never self-healed.
- **Re-clicking the stuck session no-op'd** on an id equality check, removing the user's instinctive retry.
- Added a **bounded hydration-stall retry** (2 attempts, then a visible error), because a hydration request has no ack and nothing else notices a reply that carried nothing.

## Deletions

- the delta-only regime in `snapshot-provider.ts`
- `withMetaViaHubHint` (only its own test used it)
- the unreachable second `lastState` + `sendLatestSnapshotFromCache` attempt in the cache-miss fallback, which re-read the exact Redis key `getBestSnapshot` had just tried

No wire-protocol change. No new socket events or fields.

## Regressions caught in review (second commit)

I ran 5 adversarial design reviewers before writing code and 3 against the finished diff. Three regressions were mine:

- **Resume snapshots applied the 50-message truncation**, erasing history a viewer had paged in, on nothing worse than a network blip. `sio-registry/sessions.ts:738` already documents why the live broadcast path must not truncate. Resume sends now preserve loaded history; cold starts still truncate.
- **`userId` made the SQLite tier reachable for live sessions.** A momentary Redis miss on a healthy session would serve a throttled, possibly hours-old snapshot *and* set `suppressRunnerSignal`, so nothing ever corrected it. Now restricted to sessions that are actually finished.
- **The stall watchdog measured time since request**, but chunked delivery legitimately holds `awaitingSnapshot` open for the whole transfer. A large session on a slow link got its transfer restarted twice and was then told it could not load. Arriving chunks now count as progress.

Two more, not from this change but made routine by it:

- A transport reconnect re-armed the hydration gate even for an already-hydrated session, so a resume correctly answered "nothing to send" left input blocked with the transcript on screen. Reconnects now keep `hydrated`; a real switch still arms the gate via `SESSION_SELECTED`.
- `hydrateViewerFromCache` never applied `snapshotOverlay`, so resync returned stale queue/model/todo metadata.

Two design proposals were **rejected** in review and are not here: a `hydrated` protocol event (would lock up every session during a new-UI/old-server rollout window), and stamping the seqless tiers with read-time `freshSeq` (asserts a currency the payload does not have and poisons the cursor).

## Verification

- `bun run typecheck` clean
- `bun test packages/server/src/ws` — 437 pass, 0 fail
- `bun scripts/test-isolated.ts packages/server/src` — 78/78 files
- `cd packages/ui && bun test src` — 1478 pass, 0 fail
- 24 new regression tests

## Review notes

`viewer.hydration.test.ts` and parts of `snapshot-provider.test.ts` asserted the old contract directly, so those assertions were rewritten rather than added alongside — worth a look. The `session-seq.test.ts` case `"advances when connected seq is newer"` was inverted on purpose: that behaviour was the bug.

The `chunkedPending` gate in `viewer.ts` is deliberately **kept**. Chunk frames bypass `publishSessionEvent`/`incrementSeq`, so a seq-based hydrate cannot represent an in-flight chunk stream — that gate is load-bearing, not dead code this unification absorbs.
