### PR TITLE
Fix provider usage indicator persistence

### DIFF
--- a/packages/cli/src/extensions/remote-provider-usage.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.ts
@@ -2,14 +2,13 @@
  * Provider usage/quota fetching and caching for the remote extension.
  *
  * Self-contained subsystem — no relay state needed. Fetches quota data from
- * Anthropic, OpenAI Codex, and Google Gemini CLI, and caches results.
+ * Anthropic and OpenAI Codex, and caches results.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
-import { getAnthropicKeychainToken, parseGeminiQuotaCredential } from "../runner/usage-auth.js";
+import { getAnthropicKeychainToken } from "../runner/usage-auth.js";
 import type { UsageWindow, ProviderUsageData } from "./remote-types.js";
 
 const DEFAULT_USAGE_CACHE_TTL = 5 * 60 * 1000; // 5 min
@@ -244,73 +243,6 @@ async function refreshCodexUsage(opts: { force?: boolean } = {}): Promise<void> 
     }
 }
 
-async function refreshGeminiUsage(opts: { force?: boolean } = {}): Promise<void> {
-    if (isCached("google-gemini-cli", opts)) return;
-    let token: string;
-    let projectId: string | null;
-    try {
-        const config = loadConfig(process.cwd());
-        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-        // Accepts the oauth credential a real /login writes as well as the legacy
-        // api_key wrapper whose `key` is JSON.stringify({ token, projectId }).
-        const cred = parseGeminiQuotaCredential(readStoredCredential("google-gemini-cli", join(agentDir, "auth.json")));
-        if (!cred) return;
-        token = cred.token;
-        projectId = cred.projectId;
-    } catch {
-        return;
-    }
-
-    try {
-        const endpoint = process.env["CODE_ASSIST_ENDPOINT"] ?? "https://cloudcode-pa.googleapis.com";
-        const version = process.env["CODE_ASSIST_API_VERSION"] ?? "v1internal";
-        const res = await fetch(`${endpoint}/${version}:retrieveUserQuota`, {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${token}`,
-                "Content-Type": "application/json",
-            },
-            // `project` is optional — the endpoint resolves the caller's Code Assist
-            // project from the token, so no :loadCodeAssist round-trip is needed.
-            body: JSON.stringify(projectId ? { project: projectId } : {}),
-        });
-        if (!res.ok) {
-            // 401 = expired/invalid token, 403 = no access. Report both rather than
-            // dropping Gemini from the usage list with no explanation.
-            if (res.status === 401 || res.status === 403) {
-                usageCache.set("google-gemini-cli", {
-                    data: { windows: [], status: "unknown", errorCode: res.status },
-                    fetchedAt: Date.now(),
-                });
-            }
-            return;
-        }
-
-        const raw = (await res.json()) as {
-            buckets?: Array<{
-                remainingAmount?: string;
-                remainingFraction?: number;
-                resetTime?: string;
-                tokenType?: string;
-                modelId?: string;
-            }>;
-        };
-
-        const windows: UsageWindow[] = [];
-        for (const bucket of raw.buckets ?? []) {
-            if (bucket.remainingFraction == null || !bucket.resetTime) continue;
-            const utilization = (1 - bucket.remainingFraction) * 100;
-            const label = [bucket.tokenType, bucket.modelId].filter(Boolean).join(" / ") || "Quota";
-            windows.push({ label, utilization, resets_at: bucket.resetTime });
-        }
-        if (windows.length > 0) {
-            usageCache.set("google-gemini-cli", { data: { windows, status: "ok" }, fetchedAt: Date.now() });
-        }
-    } catch {
-        // Non-fatal
-    }
-}
-
 export async function refreshAllUsage(opts: { force?: boolean } = {}): Promise<void> {
     const force = opts.force === true;
 
@@ -322,6 +254,5 @@ export async function refreshAllUsage(opts: { force?: boolean } = {}): Promise<v
     await Promise.allSettled([
         refreshAnthropicUsage({ force }),
         refreshCodexUsage({ force }),
-        refreshGeminiUsage({ force }),
     ]);
 }

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -12,9 +12,9 @@ import { loadConfig } from "../../config.js";
 import { RELAY_BACKOFF_DEFAULTS, computeBackoffDelay } from "../../backoff.js";
 import { getMcpBridge } from "../mcp-bridge.js";
 import { messageBus } from "../session-message-bus.js";
-import { refreshAllUsage } from "../remote-provider-usage.js";
-import { startHeartbeat, stopHeartbeat } from "../remote-heartbeat.js";
-import { emitAuthSourceChanged, emitThinkingLevelChanged, emitMcpStartupReport } from "../remote-meta-events.js";
+import { buildProviderUsage, refreshAllUsage } from "../remote-provider-usage.js";
+import { buildTokenUsage, startHeartbeat, stopHeartbeat } from "../remote-heartbeat.js";
+import { emitAuthSourceChanged, emitThinkingLevelChanged, emitMcpStartupReport, emitTokenUsageUpdated } from "../remote-meta-events.js";
 import { getAuthSource } from "../remote-auth-source.js";
 import { cancelPendingAskUserQuestion, consumePendingAskUserQuestionFromWeb } from "../remote-ask-user.js";
 import { cancelPendingPlanMode, consumePendingPlanModeFromWeb } from "../remote-plan-mode.js";
@@ -385,7 +385,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         }
 
         emitSessionActive(rctx);
-        void refreshAllUsage();
+        void refreshAllUsage().then(() => {
+            emitTokenUsageUpdated(rctx, buildTokenUsage(rctx), buildProviderUsage() as any);
+        });
         startHeartbeat(rctx);
 
         // Emit initial meta values so late-joining viewers get current state.

--- a/packages/cli/src/runner/runner-usage-cache.test.ts
+++ b/packages/cli/src/runner/runner-usage-cache.test.ts
@@ -50,11 +50,10 @@ describe("runner-usage-cache child", () => {
         mock.module("./usage-auth.js", () => ({
             getOAuthAccessToken: (raw: any) => {
                 // Return token only for anthropic
-                if (!raw || raw.type !== "oauth") return null;
+                if (!raw || raw.type !== "oauth" || !raw.access.includes("custom-agent-dir")) return null;
                 return "token:" + raw.access;
             },
             getAnthropicKeychainToken: () => null,
-            parseGeminiQuotaCredential: () => null,
         }));
 
         mock.module("./logger.js", () => ({
@@ -73,6 +72,7 @@ describe("runner-usage-cache child", () => {
         }) as Response;
 
         const {
+            getRunnerAnthropicUsageData,
             runnerUsageCacheFilePath,
             startUsageRefreshLoop,
             stopUsageRefreshLoop,
@@ -112,6 +112,15 @@ describe("runner-usage-cache child", () => {
             },
         ]);
 
+        globalThis.fetch = async () => { throw new Error("temporary outage"); };
+        expect(await getRunnerAnthropicUsageData({ force: true })).toEqual(firstCache.providers.anthropic);
+
+        globalThis.fetch = async () => ({
+            ok: true,
+            json: async () => ({
+                five_hour: { utilization: 42, resets_at: "2026-01-01T00:00:00.000Z" },
+            }),
+        }) as Response;
         authCreateCalls.length = 0;
         rmSync(cachePath, { force: true });
         untrackSessionCwd("sess-1", projectCwd);

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -1,9 +1,9 @@
-import { renameSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
-import { getOAuthAccessToken, getAnthropicKeychainToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { getOAuthAccessToken, getAnthropicKeychainToken } from "./usage-auth.js";
 import { logInfo, logWarn } from "./logger.js";
 
 // ── Runner-wide usage cache (shared with worker processes via file) ───────────
@@ -126,7 +126,17 @@ async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
     }
 }
 
-async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Promise<ProviderUsageData | null> {
+export async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Promise<ProviderUsageData | null> {
+    if (!_lastAnthropicUsage) {
+        try {
+            const cached = JSON.parse(readFileSync(runnerUsageCacheFilePath(), "utf-8")) as RunnerUsageCacheFile;
+            const anthropic = cached.providers?.anthropic;
+            if (anthropic?.windows) _lastAnthropicUsage = { data: anthropic, fetchedAt: cached.fetchedAt };
+        } catch {
+            // No prior runner cache.
+        }
+    }
+
     const now = Date.now();
     const force = opts.force === true;
 
@@ -135,67 +145,13 @@ async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Prom
     }
 
     const data = await fetchAnthropicUsageData();
-    // Only cache successful fetches so transient failures don't suppress
-    // retries for the full 15-minute interval.
+    // Keep the last successful value through transient refresh failures. A failed
+    // poll must not erase Anthropic from the shared cache and every new worker.
     if (data !== null) {
         _lastAnthropicUsage = { data, fetchedAt: now };
+        return data;
     }
-    return data;
-}
-
-async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
-    let token: string | undefined;
-    let projectId: string | null = null;
-    try {
-        for (const authPath of getKnownAuthPaths()) {
-            // parseGeminiQuotaCredential handles both the oauth credential a real
-            // /login writes and the legacy api_key wrapper. It validates the
-            // result, so we must not short-circuit on the first truthy raw value —
-            // only on the first path that yields a usable Gemini credential.
-            const cred = parseGeminiQuotaCredential(readStoredCredential("google-gemini-cli", authPath));
-            if (cred) {
-                token = cred.token;
-                projectId = cred.projectId;
-                break;
-            }
-        }
-    } catch (err: any) {
-        logWarn(`failed to get Google credentials: ${err?.message ?? String(err)}`);
-        return null;
-    }
-    if (!token) return null;
-    try {
-        const endpoint = process.env["CODE_ASSIST_ENDPOINT"] ?? "https://cloudcode-pa.googleapis.com";
-        const version = process.env["CODE_ASSIST_API_VERSION"] ?? "v1internal";
-        const res = await fetch(`${endpoint}/${version}:retrieveUserQuota`, {
-            method: "POST",
-            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-            // `project` is optional — the endpoint resolves the caller's Code Assist
-            // project from the token, so no :loadCodeAssist round-trip is needed.
-            body: JSON.stringify(projectId ? { project: projectId } : {}),
-        });
-        if (!res.ok) {
-            // 401 = expired/invalid token, 403 = no access. Report both rather than
-            // dropping Gemini from the usage list with no explanation.
-            if (res.status === 401 || res.status === 403) {
-                return { windows: [], status: "unknown", errorCode: res.status };
-            }
-            return null;
-        }
-        const raw = (await res.json()) as {
-            buckets?: Array<{ remainingFraction?: number; resetTime?: string; tokenType?: string; modelId?: string }>;
-        };
-        const windows: UsageWindow[] = [];
-        for (const bucket of raw.buckets ?? []) {
-            if (bucket.remainingFraction == null || !bucket.resetTime) continue;
-            const utilization = (1 - bucket.remainingFraction) * 100;
-            const label = [bucket.tokenType, bucket.modelId].filter(Boolean).join(" / ") || "Quota";
-            windows.push({ label, utilization, resets_at: bucket.resetTime });
-        }
-        return windows.length > 0 ? { windows, status: "ok" } : null;
-    } catch {
-        return null;
-    }
+    return _lastAnthropicUsage?.data ?? null;
 }
 
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
@@ -265,18 +221,14 @@ async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
  * their own API calls.
  */
 async function refreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean } = {}): Promise<void> {
-    const [anthropicResult, geminiResult, codexResult] = await Promise.allSettled([
+    const [anthropicResult, codexResult] = await Promise.allSettled([
         getRunnerAnthropicUsageData({ force: opts.forceAnthropic === true }),
-        fetchGeminiUsageData(),
         fetchCodexUsageData(),
     ]);
 
     const providers: Record<string, ProviderUsageData> = {};
     if (anthropicResult.status === "fulfilled" && anthropicResult.value) {
         providers.anthropic = anthropicResult.value;
-    }
-    if (geminiResult.status === "fulfilled" && geminiResult.value) {
-        providers["google-gemini-cli"] = geminiResult.value;
     }
     if (codexResult.status === "fulfilled" && codexResult.value) {
         providers["openai-codex"] = codexResult.value;

--- a/packages/ui/src/components/UsageIndicator.tsx
+++ b/packages/ui/src/components/UsageIndicator.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import {
     providerUsageDisplay,
     activeWindows,
+    showsUsageIndicator,
     type UsageWindow,
     type ProviderUsageData,
     type ProviderUsageMap,
@@ -193,7 +194,10 @@ export interface UsageIndicatorProps {
 
 export function UsageIndicator({ usage, authSource: rawAuthSource, activeProvider, onRefresh, refreshing = false }: UsageIndicatorProps) {
     const entries = React.useMemo(
-        () => Object.entries(usage ?? {}).filter(([, d]) => d.status === "unknown" || activeWindows(d.windows).length > 0),
+        () => Object.entries(usage ?? {}).filter(([id, d]) =>
+            showsUsageIndicator(id) &&
+            (d.status === "unknown" || activeWindows(d.windows).length > 0),
+        ),
         [usage],
     );
 
@@ -204,7 +208,8 @@ export function UsageIndicator({ usage, authSource: rawAuthSource, activeProvide
 
     // env / auth.json → show "USAGE" badge (no subscription quota)
     // oauth → show if there's usage data, or an explicit unknown state.
-    const showApiKeyBadge = !!activeProvider && (authSource === "env" || authSource === "auth.json");
+    const showApiKeyBadge = !!activeProvider && showsUsageIndicator(activeProvider) &&
+        (authSource === "env" || authSource === "auth.json");
 
     if (entries.length === 0 && !showApiKeyBadge && !onRefresh) return null;
 

--- a/packages/ui/src/lib/provider-usage.test.ts
+++ b/packages/ui/src/lib/provider-usage.test.ts
@@ -1,7 +1,16 @@
 import { describe, test, expect } from "bun:test";
-import { activeWindows, isWindowExpired, providerUsageDisplay, type ProviderUsageData } from "./provider-usage";
+import { activeWindows, isWindowExpired, providerUsageDisplay, showsUsageIndicator, type ProviderUsageData } from "./provider-usage";
 
 const NOW = Date.parse("2026-03-10T12:00:00Z");
+
+describe("showsUsageIndicator", () => {
+    test("hides Google providers without hiding other usage", () => {
+        expect(showsUsageIndicator("google-gemini-cli")).toBe(false);
+        expect(showsUsageIndicator("Google-Vertex")).toBe(false);
+        expect(showsUsageIndicator("anthropic")).toBe(true);
+        expect(showsUsageIndicator("openai-codex")).toBe(true);
+    });
+});
 const FUTURE = "2026-03-10T17:00:00Z";
 const PAST = "2026-03-10T07:00:00Z";
 

--- a/packages/ui/src/lib/provider-usage.ts
+++ b/packages/ui/src/lib/provider-usage.ts
@@ -13,6 +13,10 @@ export interface ProviderUsageData {
 // Record<providerId, ProviderUsageData>  e.g. { anthropic: {...}, "openai-codex": {...} }
 export type ProviderUsageMap = Record<string, ProviderUsageData>;
 
+export function showsUsageIndicator(providerId: string): boolean {
+  return !providerId.toLowerCase().startsWith("google");
+}
+
 /**
  * A window whose `resets_at` has passed has already rolled over, so its cached
  * utilization is stale (the daemon caches Anthropic for 15 min and the UI only


### PR DESCRIPTION
## Summary
- remove Google/Gemini usage indicators and background quota polling
- publish refreshed provider usage immediately after runner registration
- preserve the last successful Anthropic usage snapshot through transient failures and daemon restarts

## Validation
- `bun run typecheck`
- `bun run build`
- `bun test packages/cli/src`
- `cd packages/ui && bun test src` (1,479 passed, 1 skipped)
