### PR TITLE
fix: eliminate 'still connecting' banner stalls + faster connect path

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -411,6 +411,7 @@ export function createAuthContext(config: AuthConfig = {}): AuthContext {
     const trustedOrigins = [...baseOrigins, ...extraOrigins, ...mobileOrigins];
 
     const sqliteDb = new Database(dbPath);
+    applySqlitePerfPragmas(sqliteDb);
     const dialect = new BunSqliteDialect({ database: sqliteDb });
     const db = new Kysely<DB>({ dialect });
     const auth = createBetterAuth({
@@ -502,9 +503,28 @@ export function getDisableSignupAfterFirstUser(): boolean {
 
 export type Auth = AuthInstance;
 
+/**
+ * WAL + NORMAL sync: bun:sqlite writes are synchronous on the event loop, and
+ * the default DELETE journal makes every multi-MB relay_session_state write
+ * pay journal create/fsync/delete — measured as ping-timeout churn in prod
+ * (especially on VirtioFS bind mounts). WAL appends instead, cutting write
+ * stalls dramatically. Single-process access, so WAL's shm requirements are
+ * trivial. Best-effort: a filesystem that refuses WAL keeps the default.
+ */
+function applySqlitePerfPragmas(db: Database): void {
+    try {
+        db.run("PRAGMA journal_mode = WAL");
+        db.run("PRAGMA synchronous = NORMAL");
+        db.run("PRAGMA busy_timeout = 5000");
+    } catch (err) {
+        console.warn("[auth-db] Could not apply SQLite perf pragmas (keeping defaults):", err);
+    }
+}
+
 /** Create a standalone Kysely instance for ad-hoc test setup. */
 export function createTestDatabase(dbPath: string): Kysely<DB> {
     const sqliteDb = new Database(dbPath);
+    applySqlitePerfPragmas(sqliteDb);
     return new Kysely<DB>({ dialect: new BunSqliteDialect({ database: sqliteDb }) });
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 import { createAuthContext, runWithAuthContext } from "./auth.js";
+import { isTransientRedisError } from "./transient-redis-error.js";
 import { handleFetch } from "./handler.js";
 import {
     getEphemeralSweepIntervalMs,
@@ -47,6 +48,18 @@ function handleProcessError(err: Error, origin: string): void {
     // level and continue rather than triggering a full shutdown.
     if (code === "ECONNRESET" || code === "ERR_STREAM_DESTROYED" || code === "ENOTCONN") {
         processLog.warn(`Caught transient network error (${code}) via ${origin} — logging and continuing:`, err.message);
+        return;
+    }
+
+    // node-redis transient connection errors carry NO ErrnoException code —
+    // they are plain Error subclasses identified by name. The client
+    // auto-reconnects on its own, so a dropped/slow Redis (restart, redeploy,
+    // event-loop stall past the connect timeout) must not shut the relay down;
+    // that would disconnect every viewer and runner over a blip Redis itself
+    // recovers from. Seen live: SocketClosedUnexpectedlyError during a Redis
+    // container restart fataled the whole server.
+    if (isTransientRedisError(err)) {
+        processLog.warn(`Caught transient Redis error (${err.name}) via ${origin} — logging and continuing:`, err.message);
         return;
     }
 

--- a/packages/server/src/runner-recent-folders.ts
+++ b/packages/server/src/runner-recent-folders.ts
@@ -85,6 +85,9 @@ export async function recordRecentFolder(
         .where("runnerId", "=", runnerId)
         .orderBy("usageCount", "desc")
         .orderBy("lastUsedAt", "desc")
+        // id tie-break: ISO-ms timestamps collide when writes are fast (WAL) 2014
+        // without this, which tied row survives pruning is arbitrary.
+        .orderBy("id", "desc")
         .execute();
 
     if (all.length > MAX_RECENT_FOLDERS) {
@@ -125,6 +128,9 @@ export async function getRecentFolders(
         .where("runnerId", "=", runnerId)
         .orderBy("usageCount", "desc")
         .orderBy("lastUsedAt", "desc")
+        // id tie-break: ISO-ms timestamps collide when writes are fast (WAL) 2014
+        // without this, which tied row survives pruning is arbitrary.
+        .orderBy("id", "desc")
         .limit(MAX_RECENT_FOLDERS)
         .execute();
 

--- a/packages/server/src/transient-redis-error.test.ts
+++ b/packages/server/src/transient-redis-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { isTransientRedisError } from "./transient-redis-error.js";
+
+function named(name: string, message = "x"): Error {
+    const err = new Error(message);
+    err.name = name;
+    return err;
+}
+
+describe("isTransientRedisError", () => {
+    test("matches node-redis connection error classes by name", () => {
+        expect(isTransientRedisError(named("SocketClosedUnexpectedlyError"))).toBe(true);
+        expect(isTransientRedisError(named("ConnectionTimeoutError"))).toBe(true);
+        expect(isTransientRedisError(named("ClientClosedError"))).toBe(true);
+        expect(isTransientRedisError(named("ClientOfflineError"))).toBe(true);
+    });
+
+    test("matches generic errors carrying the known messages", () => {
+        expect(isTransientRedisError(new Error("Socket closed unexpectedly"))).toBe(true);
+        expect(isTransientRedisError(new Error("Connection timeout"))).toBe(true);
+    });
+
+    test("does not match unrelated errors", () => {
+        expect(isTransientRedisError(new Error("boom"))).toBe(false);
+        expect(isTransientRedisError(named("TypeError", "x is not a function"))).toBe(false);
+        expect(isTransientRedisError(named("RangeError"))).toBe(false);
+    });
+});

--- a/packages/server/src/transient-redis-error.ts
+++ b/packages/server/src/transient-redis-error.ts
@@ -1,0 +1,20 @@
+/**
+ * node-redis transient connection errors carry NO ErrnoException `code` —
+ * they are plain Error subclasses identified only by name/message. The client
+ * auto-reconnects on its own, so these must never be classified as fatal by
+ * the process-level error handlers in index.ts: shutting the relay down over
+ * a Redis blip disconnects every viewer and runner for something Redis
+ * recovers from by itself. Seen live: SocketClosedUnexpectedlyError during a
+ * Redis container restart fataled the whole server.
+ */
+export function isTransientRedisError(err: Error): boolean {
+    return (
+        err.name === "SocketClosedUnexpectedlyError" ||
+        err.name === "ConnectionTimeoutError" ||
+        err.name === "ClientClosedError" ||
+        err.name === "ClientOfflineError" ||
+        // reconnect-strategy aborts surface as generic errors with these messages
+        err.message === "Socket closed unexpectedly" ||
+        err.message === "Connection timeout"
+    );
+}

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -287,20 +287,21 @@ describe("getPendingChunkedSnapshot — stale stream expiry", () => {
         });
     }
 
-    test("returns an active stream", () => {
+    test("returns an active stream as not stale", () => {
         seed("s-active", Date.now());
-        expect(getPendingChunkedSnapshot("s-active")).not.toBeNull();
+        expect(getPendingChunkedSnapshot("s-active")?.stale).toBe(false);
         expect(pendingChunkedStates.has("s-active")).toBe(true);
     });
 
-    test("drops a stream with no chunk activity past the stale threshold", () => {
+    test("flags a stream with no chunk activity past the stale threshold, without deleting it", () => {
         seed("s-stale", Date.now() - CHUNK_STREAM_STALE_MS - 1);
-        expect(getPendingChunkedSnapshot("s-stale")).toBeNull();
-        // Deleted so viewer hydration falls back to the snapshot cache.
-        expect(pendingChunkedStates.has("s-stale")).toBe(false);
+        expect(getPendingChunkedSnapshot("s-stale")?.stale).toBe(true);
+        // Kept: a hung runner that resumes refreshes lastActivityAt and the
+        // stream can still finalize — deleting would discard its chunks.
+        expect(pendingChunkedStates.has("s-stale")).toBe(true);
     });
 
-    test("chunk arrival refreshes activity and keeps the stream alive", () => {
+    test("chunk arrival refreshes activity and clears staleness", () => {
         seed("s-refresh", Date.now() - CHUNK_STREAM_STALE_MS - 1);
         const pending = pendingChunkedStates.get("s-refresh")!;
         applyChunkToPendingState(pending, {
@@ -309,6 +310,6 @@ describe("getPendingChunkedSnapshot — stale stream expiry", () => {
             totalChunks: 3,
             isFinalChunk: false,
         });
-        expect(getPendingChunkedSnapshot("s-refresh")).not.toBeNull();
+        expect(getPendingChunkedSnapshot("s-refresh")?.stale).toBe(false);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -5,6 +5,9 @@ import {
     canFinalizeChunkedSnapshot,
     enqueueSessionEvent,
     finalizeChunkedSnapshot,
+    getPendingChunkedSnapshot,
+    pendingChunkedStates,
+    CHUNK_STREAM_STALE_MS,
     sessionEventQueues,
     type ChunkedSessionState,
 } from "./event-pipeline.js";
@@ -29,6 +32,7 @@ function createPendingState(): ChunkedSessionState {
         totalChunks: 0,
         receivedChunkIndexes: new Set<number>(),
         finalChunkSeen: false,
+        lastActivityAt: Date.now(),
     };
 }
 
@@ -220,6 +224,7 @@ describe("chunked snapshot assembly", () => {
             totalChunks: 2,
             receivedChunkIndexes: new Set<number>([0, 1]),
             finalChunkSeen: true,
+            lastActivityAt: Date.now(),
         };
         const updateSessionState = spyOn({
             updateSessionState: async () => {},
@@ -262,5 +267,48 @@ describe("chunked snapshot assembly", () => {
         expect(hasPendingRecovery("sess-chunked-recovery")).toBe(false);
         expect(consumePendingRecovery("sess-chunked-recovery", nonce)).toBe(false);
         expect(appendRelayEventToCache).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("getPendingChunkedSnapshot — stale stream expiry", () => {
+    afterEach(() => {
+        pendingChunkedStates.clear();
+    });
+
+    function seed(sessionId: string, lastActivityAt: number): void {
+        pendingChunkedStates.set(sessionId, {
+            snapshotId: "snap-stale",
+            metadata: { totalMessages: 3 },
+            chunks: [[{ id: "m1" }]],
+            totalChunks: 3,
+            receivedChunkIndexes: new Set<number>([0]),
+            finalChunkSeen: false,
+            lastActivityAt,
+        });
+    }
+
+    test("returns an active stream", () => {
+        seed("s-active", Date.now());
+        expect(getPendingChunkedSnapshot("s-active")).not.toBeNull();
+        expect(pendingChunkedStates.has("s-active")).toBe(true);
+    });
+
+    test("drops a stream with no chunk activity past the stale threshold", () => {
+        seed("s-stale", Date.now() - CHUNK_STREAM_STALE_MS - 1);
+        expect(getPendingChunkedSnapshot("s-stale")).toBeNull();
+        // Deleted so viewer hydration falls back to the snapshot cache.
+        expect(pendingChunkedStates.has("s-stale")).toBe(false);
+    });
+
+    test("chunk arrival refreshes activity and keeps the stream alive", () => {
+        seed("s-refresh", Date.now() - CHUNK_STREAM_STALE_MS - 1);
+        const pending = pendingChunkedStates.get("s-refresh")!;
+        applyChunkToPendingState(pending, {
+            chunkIndex: 1,
+            chunkMessages: [{ id: "m2" }],
+            totalChunks: 3,
+            isFinalChunk: false,
+        });
+        expect(getPendingChunkedSnapshot("s-refresh")).not.toBeNull();
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -54,8 +54,13 @@ export interface ChunkedSessionState {
  * Left in place, the pending entry makes every viewer hydration skip the
  * snapshot cache (viewer.ts chunkedPending gate) and wait on a runner signal
  * that never comes, which is unrecoverable even across client retries.
+ *
+ * Healthy streams emit chunks sub-second (setImmediate cadence on the
+ * runner), so 15s of silence is unambiguous. Kept below the client's
+ * hydration-retry window (~8s interval, 2 retries) so the second retry
+ * passes the gate instead of erroring out behind it.
  */
-export const CHUNK_STREAM_STALE_MS = 30_000;
+export const CHUNK_STREAM_STALE_MS = 15_000;
 
 export interface PendingChunkUpdate {
     chunkIndex: number;

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -219,16 +219,21 @@ export function getPendingChunkedSnapshot(sessionId: string): {
     totalMessages: number;
     receivedChunks: number;
     totalChunks: number;
+    /**
+     * True when the stream has gone CHUNK_STREAM_STALE_MS without a chunk.
+     * Callers should stop gating hydration on it (serve the cache) AND request
+     * a fresh runner snapshot instead of suppressing recovery — but the entry
+     * is deliberately NOT deleted: a hung runner that resumes sending refreshes
+     * lastActivityAt and the stream can still finalize normally, and deleting
+     * it would silently discard chunks the runner still believes it delivered.
+     */
+    stale: boolean;
 } | null {
     const pending = pendingChunkedStates.get(sessionId);
     if (!pending) return null;
-    if (Date.now() - pending.lastActivityAt > CHUNK_STREAM_STALE_MS) {
-        // Dead stream — drop it so viewer hydration falls back to the snapshot
-        // cache instead of gating on a transfer that will never finish. If the
-        // runner comes back it starts a fresh chunk-start session_active anyway.
-        log.warn(`Dropping stale chunked snapshot for ${sessionId} (no chunk for ${CHUNK_STREAM_STALE_MS}ms)`);
-        pendingChunkedStates.delete(sessionId);
-        return null;
+    const stale = Date.now() - pending.lastActivityAt > CHUNK_STREAM_STALE_MS;
+    if (stale) {
+        log.warn(`Chunked snapshot for ${sessionId} is stale (no chunk for ${CHUNK_STREAM_STALE_MS}ms) — bypassing hydration gate`);
     }
     const messages = pending.chunks.flat();
     return {
@@ -238,6 +243,7 @@ export function getPendingChunkedSnapshot(sessionId: string): {
         totalMessages: (pending.metadata as any).totalMessages ?? messages.length,
         receivedChunks: pending.receivedChunkIndexes.size,
         totalChunks: pending.totalChunks,
+        stale,
     };
 }
 

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -44,7 +44,18 @@ export interface ChunkedSessionState {
     finalChunkSeen: boolean;
     /** Recovery nonce echoed by the runner on the chunk-start session_active. */
     recoveryNonce?: string;
+    /** Timestamp of the chunk-start SA or the most recent chunk. */
+    lastActivityAt: number;
 }
+
+/**
+ * A chunk stream that has gone this long without a new chunk is dead — the
+ * runner hung or lost the worker without its relay socket disconnecting.
+ * Left in place, the pending entry makes every viewer hydration skip the
+ * snapshot cache (viewer.ts chunkedPending gate) and wait on a runner signal
+ * that never comes, which is unrecoverable even across client retries.
+ */
+export const CHUNK_STREAM_STALE_MS = 30_000;
 
 export interface PendingChunkUpdate {
     chunkIndex: number;
@@ -78,6 +89,7 @@ export function applyChunkToPendingState(
 
     pending.receivedChunkIndexes.add(chunkIndex);
     pending.chunks[chunkIndex] = chunkMessages;
+    pending.lastActivityAt = Date.now();
     return true;
 }
 
@@ -205,6 +217,14 @@ export function getPendingChunkedSnapshot(sessionId: string): {
 } | null {
     const pending = pendingChunkedStates.get(sessionId);
     if (!pending) return null;
+    if (Date.now() - pending.lastActivityAt > CHUNK_STREAM_STALE_MS) {
+        // Dead stream — drop it so viewer hydration falls back to the snapshot
+        // cache instead of gating on a transfer that will never finish. If the
+        // runner comes back it starts a fresh chunk-start session_active anyway.
+        log.warn(`Dropping stale chunked snapshot for ${sessionId} (no chunk for ${CHUNK_STREAM_STALE_MS}ms)`);
+        pendingChunkedStates.delete(sessionId);
+        return null;
+    }
     const messages = pending.chunks.flat();
     return {
         metadata: pending.metadata,
@@ -285,6 +305,7 @@ export function registerEventHandler(socket: RelaySocket): void {
                     receivedChunkIndexes: new Set<number>(),
                     finalChunkSeen: false,
                     recoveryNonce: typeof event.recoveryNonce === "string" ? event.recoveryNonce : undefined,
+                    lastActivityAt: Date.now(),
                 });
                 // Touch activity but DON'T update lastState yet
                 await touchSessionActivity(sessionId);

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -56,11 +56,14 @@ export interface ChunkedSessionState {
  * that never comes, which is unrecoverable even across client retries.
  *
  * Healthy streams emit chunks sub-second (setImmediate cadence on the
- * runner), so 15s of silence is unambiguous. Kept below the client's
- * hydration-retry window (~8s interval, 2 retries) so the second retry
- * passes the gate instead of erroring out behind it.
+ * runner), so 10s of silence is unambiguous. Timing alignment matters: the
+ * client retries hydration at ~4s and ~12s after its last progress event,
+ * then surfaces a terminal error — the threshold must sit BELOW the final
+ * retry (12s) or the bypass is never exercised before the client gives up.
+ * Both clocks anchor to the same event (a chunk arrival), so 10s here
+ * guarantees the ~12s retry sees the stream as stale.
  */
-export const CHUNK_STREAM_STALE_MS = 15_000;
+export const CHUNK_STREAM_STALE_MS = 10_000;
 
 export interface PendingChunkUpdate {
     chunkIndex: number;

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -152,6 +152,14 @@ export async function hydrateViewerFromCache(
         lastSeq?: number;
         generation?: number;
         snapshotOverlay?: string | null;
+        /**
+         * The session's TRUE seq counter (getSessionSeq), when the caller has
+         * it. broadcastSessionEventToViewers() advances that counter without
+         * appending to the Redis event-cache list, so the cache tail can lag
+         * behind — comparing the client cursor against the tail alone can
+         * falsely report "already current" and send a gapped viewer nothing.
+         */
+        latestSessionSeq?: number;
     } = {},
     deps: ViewerCacheDeps = defaultViewerCacheDeps,
 ): Promise<boolean> {
@@ -176,11 +184,17 @@ export async function hydrateViewerFromCache(
                 return true;
             }
 
-            // An empty replay is safe only when the cache confirms the client
-            // already has the newest stored event. Otherwise this is a real
-            // gap (or an unavailable cache), so runner recovery is required.
-            const latestSeq = await deps.getLatestCachedRelayEventSeq(sessionId);
-            if (latestSeq === opts.lastSeq) return true;
+            // An empty replay is safe only when the client provably holds the
+            // newest event. Prefer the true seq counter when supplied — the
+            // cache-list tail lags it after uncached broadcasts (chunk frames,
+            // metadata updates), and matching the stale tail here answered a
+            // genuinely-behind viewer with silence.
+            if (opts.latestSessionSeq !== undefined) {
+                if (opts.lastSeq >= opts.latestSessionSeq) return true;
+            } else {
+                const latestSeq = await deps.getLatestCachedRelayEventSeq(sessionId);
+                if (latestSeq === opts.lastSeq) return true;
+            }
 
             // Either a genuine gap, or the only snapshot we have is the
             // unsequenced one finalizeChunkedSnapshot() writes — whose position

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -375,3 +375,41 @@ describe("snapshotCoverageSeq", () => {
         expect(snapshotCoversCursor(cached, 11)).toBe(false);
     });
 });
+
+describe("hydrateViewerFromCache — true-seq already-current check", () => {
+    test("uses latestSessionSeq instead of the cache-list tail when provided", async () => {
+        // broadcastSessionEventToViewers advances the true seq counter without
+        // appending to the cache list, so the tail can lag. A client matching
+        // the stale tail is genuinely behind and must NOT be told "current".
+        const getLatestCachedRelayEventSeq = mock(async () => 5); // stale tail
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => null),
+            getLatestCachedRelayEventSeq,
+        });
+
+        const { emit } = createMockSocket();
+        const result = await hydrateViewerFromCache(
+            { emit }, "sess-trueseq", { lastSeq: 5, latestSessionSeq: 8 }, deps,
+        );
+
+        // Real gap (client at 5, true seq 8) — must fall through to runner recovery.
+        expect(result).toBe(false);
+        expect(getLatestCachedRelayEventSeq).not.toHaveBeenCalled();
+    });
+
+    test("already-current when the cursor is at or ahead of the true seq", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => null),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache(
+            { emit }, "sess-trueseq-2", { lastSeq: 8, latestSessionSeq: 8 }, deps,
+        );
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(0);
+    });
+});

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -199,25 +199,33 @@ describe("viewer connected signal gating", () => {
                 calls.push(`mark:${sessionId}`);
                 return "nonce-1";
             }),
-            emitToRelaySessionVerified: mock(async (sessionId: string, event: string) => {
+            emitToRelaySessionChecked: mock(async (sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);
-                return true;
+                return "delivered";
             }) as any,
         });
 
-        expect(delivered).toBe(true);
+        expect(delivered).toBe("delivered");
         expect(calls).toEqual([
             "mark:sess-connected",
             "emit:connected:sess-connected",
         ]);
     });
 
-    test("recovery signal reports false when no runner socket is in the room", async () => {
-        const delivered = await forwardRecoveryConnectedSignal("sess-empty-room", {
+    test("recovery signal reports empty when the room is confirmed empty", async () => {
+        const result = await forwardRecoveryConnectedSignal("sess-empty-room", {
             markPendingRecovery: mock(() => "nonce-1"),
-            emitToRelaySessionVerified: mock(async () => false) as any,
+            emitToRelaySessionChecked: mock(async () => "empty") as any,
         });
-        expect(delivered).toBe(false);
+        expect(result).toBe("empty");
+    });
+
+    test("recovery signal reports unknown when the adapter lookup fails", async () => {
+        const result = await forwardRecoveryConnectedSignal("sess-degraded", {
+            markPendingRecovery: mock(() => "nonce-1"),
+            emitToRelaySessionChecked: mock(async () => "unknown") as any,
+        });
+        expect(result).toBe("unknown");
     });
 
     test("flushes pending signal when viewer becomes ready", () => {
@@ -248,9 +256,9 @@ describe("viewer connected signal gating", () => {
                 calls.push(`mark:${sessionId}`);
                 return "nonce-1";
             }),
-            emitToRelaySessionVerified: mock(async (sessionId: string, event: string) => {
+            emitToRelaySessionChecked: mock(async (sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);
-                return true;
+                return "delivered";
             }) as any,
         });
 

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -16,6 +16,7 @@ import {
     isViewerSwitchCurrent,
     shouldAvoidSnapshotFallback,
     forwardRecoveryConnectedSignal,
+    runnerLooksLive,
     withHubMetaSource,
     withLivenessOnlyHint,
     sendCachedDeltaReplayEvents,
@@ -182,7 +183,9 @@ describe("viewer connected signal gating", () => {
         });
     });
 
-    test("socket.on(\"connected\") forwarding marks recovery before emitting to relay", () => {
+
+
+    test("socket.on(\"connected\") forwarding marks recovery before emitting to relay", async () => {
         const calls: string[] = [];
         const next = onViewerConnectedSignal(true, false);
 
@@ -191,20 +194,30 @@ describe("viewer connected signal gating", () => {
             forwardNow: true,
         });
 
-        forwardRecoveryConnectedSignal("sess-connected", {
+        const delivered = await forwardRecoveryConnectedSignal("sess-connected", {
             markPendingRecovery: mock((sessionId: string) => {
                 calls.push(`mark:${sessionId}`);
                 return "nonce-1";
             }),
-            emitToRelaySession: mock((sessionId: string, event: string) => {
+            emitToRelaySessionVerified: mock(async (sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);
+                return true;
             }) as any,
         });
 
+        expect(delivered).toBe(true);
         expect(calls).toEqual([
             "mark:sess-connected",
             "emit:connected:sess-connected",
         ]);
+    });
+
+    test("recovery signal reports false when no runner socket is in the room", async () => {
+        const delivered = await forwardRecoveryConnectedSignal("sess-empty-room", {
+            markPendingRecovery: mock(() => "nonce-1"),
+            emitToRelaySessionVerified: mock(async () => false) as any,
+        });
+        expect(delivered).toBe(false);
     });
 
     test("flushes pending signal when viewer becomes ready", () => {
@@ -221,7 +234,7 @@ describe("viewer connected signal gating", () => {
         });
     });
 
-    test("ready-transition forwarding also marks recovery before emitting to relay", () => {
+    test("ready-transition forwarding also marks recovery before emitting to relay", async () => {
         const calls: string[] = [];
         const flush = onViewerReadyForRunnerSignal(true);
 
@@ -230,13 +243,14 @@ describe("viewer connected signal gating", () => {
             forwardNow: true,
         });
 
-        forwardRecoveryConnectedSignal("sess-pending", {
+        await forwardRecoveryConnectedSignal("sess-pending", {
             markPendingRecovery: mock((sessionId: string) => {
                 calls.push(`mark:${sessionId}`);
                 return "nonce-1";
             }),
-            emitToRelaySession: mock((sessionId: string, event: string) => {
+            emitToRelaySessionVerified: mock(async (sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);
+                return true;
             }) as any,
         });
 
@@ -346,5 +360,22 @@ describe("checkServiceMessageRateLimit", () => {
         const result = checkServiceMessageRateLimit(2000, state);
         expect(result.allowed).toBe(true);
         expect(state.count).toBe(1);
+    });
+});
+
+describe("runnerLooksLive", () => {
+    test("live: isActive with a fresh heartbeat", () => {
+        expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: new Date().toISOString() })).toBe(true);
+    });
+
+    test("not live: heartbeat older than the stale threshold despite isActive", () => {
+        const stale = new Date(Date.now() - 5 * 60_000).toISOString();
+        expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: stale })).toBe(false);
+    });
+
+    test("not live: isActive false, missing or malformed heartbeat", () => {
+        expect(runnerLooksLive({ isActive: false, lastHeartbeatAt: new Date().toISOString() })).toBe(false);
+        expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: null })).toBe(false);
+        expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: "not-a-date" })).toBe(false);
     });
 });

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -34,6 +34,8 @@ import {
     getLocalTuiSocket,
     emitToRelaySession,
     emitToRelaySessionVerified,
+    emitToRelaySessionChecked,
+    type RelayEmitCheckResult,
     emitToRunner,
     broadcastToSessionViewers,
     markPendingRecovery,
@@ -200,12 +202,12 @@ export function checkServiceMessageRateLimit(
 
 export interface RecoveryConnectedSignalDeps {
     markPendingRecovery: typeof markPendingRecovery;
-    emitToRelaySessionVerified: typeof emitToRelaySessionVerified;
+    emitToRelaySessionChecked: typeof emitToRelaySessionChecked;
 }
 
 const defaultRecoveryConnectedSignalDeps: RecoveryConnectedSignalDeps = {
     markPendingRecovery,
-    emitToRelaySessionVerified,
+    emitToRelaySessionChecked,
 };
 
 /**
@@ -222,15 +224,17 @@ const defaultRecoveryConnectedSignalDeps: RecoveryConnectedSignalDeps = {
 export async function forwardRecoveryConnectedSignal(
     sessionId: string,
     deps: RecoveryConnectedSignalDeps = defaultRecoveryConnectedSignalDeps,
-): Promise<boolean> {
+): Promise<RelayEmitCheckResult> {
     const recoveryNonce = deps.markPendingRecovery(sessionId);
     // The runner echoes recoveryNonce on its recovery session_active so the
     // event pipeline can distinguish it from real agent updates racing in.
-    const delivered = await deps.emitToRelaySessionVerified(sessionId, "connected" as string, { recoveryNonce });
-    if (!delivered) {
-        log.warn(`recovery signal for ${sessionId} reached no runner socket — runner offline or hung`);
+    const result = await deps.emitToRelaySessionChecked(sessionId, "connected" as string, { recoveryNonce });
+    if (result === "empty") {
+        log.warn(`recovery signal for ${sessionId}: room confirmed empty — runner offline or hung`);
+    } else if (result === "unknown") {
+        log.warn(`recovery signal for ${sessionId}: adapter lookup failed — runner state unknown, leaving recovery to client retry`);
     }
-    return delivered;
+    return result;
 }
 
 /**
@@ -255,10 +259,17 @@ function forwardRecoverySignalOrNotify(
     sessionId: string,
     socket: ViewerSocket,
     generation: number | undefined,
+    onConfirmedOffline?: () => Promise<void>,
 ): void {
-    void forwardRecoveryConnectedSignal(sessionId).then((delivered) => {
-        if (delivered) return;
+    void forwardRecoveryConnectedSignal(sessionId).then(async (result) => {
+        // "unknown" (Redis-degraded lookup) is NOT proof the runner is gone —
+        // it may be connected on another node. Do nothing; client retry covers it.
+        if (result !== "empty") return;
         if (socket.data.sessionId !== sessionId) return; // viewer moved on
+        if (onConfirmedOffline) {
+            await onConfirmedOffline();
+            return;
+        }
         socket.emit("error", {
             message: "The runner for this session is offline — the conversation will load when it reconnects.",
             generation,
@@ -389,6 +400,11 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         // runner. Every await inside activateSession re-checks the token and
         // bails if a newer activation has started.
         let activationCounter = 0;
+        // One-shot persisted-tier fallback for a CONFIRMED-offline runner, set
+        // by the active hydration attempt. Shared so both recovery-signal
+        // paths (in-activation flush and the later client "connected" echo)
+        // behave identically regardless of arrival timing.
+        let recoveryOfflineFallback: { sessionId: string; run: () => Promise<void> } | null = null;
 
         const getCurrentSessionId = (): string | null => socket.data.sessionId ?? null;
         const getCurrentGeneration = (): number | undefined =>
@@ -409,6 +425,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             suppressRunnerSignal = false;
             viewerReadyForRunnerSignal = false;
             pendingConnectedSignal = false;
+            recoveryOfflineFallback = null;
 
             if (!nextSessionId) {
                 socket.data.sessionId = undefined;
@@ -569,42 +586,54 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             viewerReadyForRunnerSignal = true;
             const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
             pendingConnectedSignal = flush.pendingConnectedSignal;
-            if (flush.forwardNow) {
-                void forwardRecoveryConnectedSignal(nextSessionId).then(async (delivered) => {
-                    if (delivered) return;
-                    // Bound to this activation: a late lookup must not clobber a
-                    // newer activation that already hydrated this socket.
-                    if (!activationCurrent() || socket.data.sessionId !== nextSessionId) return;
-                    // The runner is provably unreachable, so its recent heartbeat
-                    // is no longer evidence of liveness — the persisted (SQLite)
-                    // tier that runnerLooksLive() blocked above is now fair game.
-                    // Cursor-holding viewers skip this (a seqless snapshot could
-                    // rewind them); their watchdog retries cursorless and lands
-                    // here on the next attempt.
+
+            // Persisted-tier fallback for a CONFIRMED-offline runner: its recent
+            // heartbeat is no longer evidence of liveness, so the SQLite tier
+            // that runnerLooksLive() blocked above is fair game. One-shot, and
+            // every await re-checks that (a) this activation still owns the
+            // socket and (b) no live event advanced the session seq — a runner
+            // reconnecting mid-lookup broadcasts fresher content than anything
+            // persisted, and sending after it would rewind the transcript.
+            // Cursor-holding viewers skip the snapshot (seqless → rewind risk);
+            // their watchdog retries cursorless and lands here next attempt.
+            let fallbackAttempted = false;
+            const attemptPersistedFallback = async (): Promise<void> => {
+                if (fallbackAttempted) return;
+                fallbackAttempted = true;
+                const stillMine = () => activationCurrent() && socket.data.sessionId === nextSessionId;
+                if (!stillMine()) return;
+                try {
+                    const seqNow = await getSessionSeq(nextSessionId);
+                    if (!stillMine() || seqNow !== freshSeq) return;
                     if (requestedLastSeq === undefined) {
-                        try {
-                            const persisted = await getBestSnapshot(nextSessionId, {
-                                userId: viewerUserId,
-                                lastState: freshSession.lastState,
-                                snapshotOverlay: freshSession.snapshotOverlay,
-                                chunkedPending: false,
-                                latestSeq: freshSeq,
-                            });
-                            if (!activationCurrent() || socket.data.sessionId !== nextSessionId) return;
-                            if (persisted) {
-                                persisted.send(socket, generation);
-                                log.info(`persisted fallback after unreachable runner: sessionId=${nextSessionId} viewer=${socket.id} type=${persisted.snapshot.type}`);
-                                return;
-                            }
-                        } catch (err) {
-                            log.warn(`persisted fallback failed for ${nextSessionId}:`, (err as Error)?.message);
+                        const persisted = await getBestSnapshot(nextSessionId, {
+                            userId: viewerUserId,
+                            lastState: freshSession.lastState,
+                            snapshotOverlay: freshSession.snapshotOverlay,
+                            chunkedPending: false,
+                            latestSeq: freshSeq,
+                        });
+                        const seqAfter = await getSessionSeq(nextSessionId);
+                        if (!stillMine() || seqAfter !== freshSeq) return;
+                        if (persisted) {
+                            persisted.send(socket, generation);
+                            log.info(`persisted fallback after confirmed-offline runner: sessionId=${nextSessionId} viewer=${socket.id} type=${persisted.snapshot.type}`);
+                            return;
                         }
                     }
-                    socket.emit("error", {
-                        message: "The runner for this session is offline — the conversation will load when it reconnects.",
-                        generation,
-                    });
+                } catch (err) {
+                    log.warn(`persisted fallback failed for ${nextSessionId}:`, (err as Error)?.message);
+                }
+                if (!stillMine()) return;
+                socket.emit("error", {
+                    message: "The runner for this session is offline — the conversation will load when it reconnects.",
+                    generation,
                 });
+            };
+            recoveryOfflineFallback = { sessionId: nextSessionId, run: attemptPersistedFallback };
+
+            if (flush.forwardNow) {
+                forwardRecoverySignalOrNotify(nextSessionId, socket, generation, attemptPersistedFallback);
             }
 
             // Emit an immediate heartbeat snapshot while the runner pushes a
@@ -655,7 +684,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const next = onViewerConnectedSignal(viewerReadyForRunnerSignal, pendingConnectedSignal);
             pendingConnectedSignal = next.pendingConnectedSignal;
             if (next.forwardNow) {
-                forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                // Route through the activation's persisted fallback when one is
+                // armed — identical cold starts must not behave differently
+                // based on whether this echo raced the cache lookup.
+                const fallback = recoveryOfflineFallback?.sessionId === currentSessionId
+                    ? recoveryOfflineFallback.run
+                    : undefined;
+                forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration(), fallback);
             }
         });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -200,23 +200,70 @@ export function checkServiceMessageRateLimit(
 
 export interface RecoveryConnectedSignalDeps {
     markPendingRecovery: typeof markPendingRecovery;
-    emitToRelaySession: typeof emitToRelaySession;
+    emitToRelaySessionVerified: typeof emitToRelaySessionVerified;
 }
 
 const defaultRecoveryConnectedSignalDeps: RecoveryConnectedSignalDeps = {
     markPendingRecovery,
-    emitToRelaySession,
+    emitToRelaySessionVerified,
 };
 
-/** @internal — exported for unit tests only */
-export function forwardRecoveryConnectedSignal(
+/**
+ * Ask the runner to rebuild and re-emit a fresh session_active.
+ *
+ * Verified: this signal is the LAST fallback tier — every cache tier has
+ * already declined — so firing it into an empty room (offline/hung runner)
+ * with a fire-and-forget emit left the viewer silently spinning for the full
+ * client watchdog window. Returns false when no runner socket is in the room
+ * so callers can tell the viewer the truth instead.
+ *
+ * @internal — exported for unit tests only
+ */
+export async function forwardRecoveryConnectedSignal(
     sessionId: string,
     deps: RecoveryConnectedSignalDeps = defaultRecoveryConnectedSignalDeps,
-): void {
+): Promise<boolean> {
     const recoveryNonce = deps.markPendingRecovery(sessionId);
     // The runner echoes recoveryNonce on its recovery session_active so the
     // event pipeline can distinguish it from real agent updates racing in.
-    deps.emitToRelaySession(sessionId, "connected" as string, { recoveryNonce });
+    const delivered = await deps.emitToRelaySessionVerified(sessionId, "connected" as string, { recoveryNonce });
+    if (!delivered) {
+        log.warn(`recovery signal for ${sessionId} reached no runner socket — runner offline or hung`);
+    }
+    return delivered;
+}
+
+/**
+ * Heartbeats arrive every ~10s from a healthy runner; this many missed beats
+ * means the runner is offline or hung regardless of what isActive says.
+ */
+const RUNNER_HEARTBEAT_STALE_MS = 45_000;
+
+/** @internal — exported for unit tests only */
+export function runnerLooksLive(session: { isActive?: boolean; lastHeartbeatAt?: string | null }): boolean {
+    if (!session.isActive) return false;
+    if (typeof session.lastHeartbeatAt !== "string" || !session.lastHeartbeatAt) return false;
+    const at = Date.parse(session.lastHeartbeatAt);
+    return Number.isFinite(at) && Date.now() - at < RUNNER_HEARTBEAT_STALE_MS;
+}
+
+/**
+ * Fire the recovery signal and, when it provably reached no runner, tell the
+ * viewer instead of leaving it awaiting a snapshot that cannot arrive.
+ */
+function forwardRecoverySignalOrNotify(
+    sessionId: string,
+    socket: ViewerSocket,
+    generation: number | undefined,
+): void {
+    void forwardRecoveryConnectedSignal(sessionId).then((delivered) => {
+        if (delivered) return;
+        if (socket.data.sessionId !== sessionId) return; // viewer moved on
+        socket.emit("error", {
+            message: "The runner for this session is offline — the conversation will load when it reconnects.",
+            generation,
+        });
+    });
 }
 
 /**
@@ -461,7 +508,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     // live session whose cache merely blipped would show a stale
                     // transcript AND suppress the runner signal that would have
                     // fixed it — with no error and no retry.
-                    userId: freshSession.isActive ? undefined : viewerUserId,
+                    //
+                    // "Actually live" requires a fresh heartbeat, not just the
+                    // stored isActive flag: a hung runner keeps isActive=true
+                    // for 2+ minutes (until sweepOrphanedSessions), which
+                    // blocked the SQLite tier for exactly the sessions that
+                    // need it.
+                    userId: runnerLooksLive(freshSession) ? undefined : viewerUserId,
                     lastState: freshSession.lastState,
                     snapshotOverlay: freshSession.snapshotOverlay,
                     chunkedPending: false,
@@ -487,7 +540,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
             pendingConnectedSignal = flush.pendingConnectedSignal;
             if (flush.forwardNow) {
-                forwardRecoveryConnectedSignal(nextSessionId);
+                forwardRecoverySignalOrNotify(nextSessionId, socket, generation);
             }
 
             // Emit an immediate heartbeat snapshot while the runner pushes a
@@ -538,7 +591,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const next = onViewerConnectedSignal(viewerReadyForRunnerSignal, pendingConnectedSignal);
             pendingConnectedSignal = next.pendingConnectedSignal;
             if (next.forwardNow) {
-                forwardRecoveryConnectedSignal(currentSessionId);
+                forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
             }
         });
 
@@ -563,11 +616,15 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const requestedLastSeq = typeof data?.lastSeq === "number" && Number.isFinite(data.lastSeq) ? data.lastSeq : undefined;
             const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
             if (requestedLastSeq !== undefined && !resyncChunkedPending) {
-                const resyncSession = await getSharedSession(currentSessionId);
+                const [resyncSession, resyncSeq] = await Promise.all([
+                    getSharedSession(currentSessionId),
+                    getSessionSeq(currentSessionId),
+                ]);
                 const cacheHydrated = await hydrateViewerFromCache(socket, currentSessionId, {
                     lastSeq: requestedLastSeq,
                     generation: getCurrentGeneration(),
                     snapshotOverlay: resyncSession?.snapshotOverlay,
+                    latestSessionSeq: resyncSeq,
                 });
                 if (cacheHydrated) {
                     return;
@@ -579,7 +636,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 // Reaching here means only unsequenced state is left, which
                 // cannot safely fill the gap — ask the runner for a fresh one.
                 if (requestedLastSeq !== undefined && !resyncChunkedPending) {
-                    forwardRecoveryConnectedSignal(currentSessionId);
+                    forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
                 }
                 return;
             }

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -445,7 +445,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 touchAsync: true,
             });
             if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) {
-                if (ok) {
+                // Only leave the room when the viewer is no longer on this
+                // session. A same-session retry (re-click or watchdog, whether
+                // it bumped the generation or only the token) shares this room —
+                // Socket.IO rooms are not reference-counted, so removing here
+                // would kick the CURRENT activation out and silently detach the
+                // viewer from all live events.
+                if (ok && getCurrentSessionId() !== nextSessionId) {
                     await removeViewer(nextSessionId, socket);
                 }
                 return;
@@ -469,7 +475,11 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             ]);
 
             if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) {
-                await removeViewer(nextSessionId, socket);
+                // Same-room caveat as above: only remove when no longer on
+                // this session.
+                if (getCurrentSessionId() !== nextSessionId) {
+                    await removeViewer(nextSessionId, socket);
+                }
                 return;
             }
 
@@ -560,7 +570,41 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
             pendingConnectedSignal = flush.pendingConnectedSignal;
             if (flush.forwardNow) {
-                forwardRecoverySignalOrNotify(nextSessionId, socket, generation);
+                void forwardRecoveryConnectedSignal(nextSessionId).then(async (delivered) => {
+                    if (delivered) return;
+                    // Bound to this activation: a late lookup must not clobber a
+                    // newer activation that already hydrated this socket.
+                    if (!activationCurrent() || socket.data.sessionId !== nextSessionId) return;
+                    // The runner is provably unreachable, so its recent heartbeat
+                    // is no longer evidence of liveness — the persisted (SQLite)
+                    // tier that runnerLooksLive() blocked above is now fair game.
+                    // Cursor-holding viewers skip this (a seqless snapshot could
+                    // rewind them); their watchdog retries cursorless and lands
+                    // here on the next attempt.
+                    if (requestedLastSeq === undefined) {
+                        try {
+                            const persisted = await getBestSnapshot(nextSessionId, {
+                                userId: viewerUserId,
+                                lastState: freshSession.lastState,
+                                snapshotOverlay: freshSession.snapshotOverlay,
+                                chunkedPending: false,
+                                latestSeq: freshSeq,
+                            });
+                            if (!activationCurrent() || socket.data.sessionId !== nextSessionId) return;
+                            if (persisted) {
+                                persisted.send(socket, generation);
+                                log.info(`persisted fallback after unreachable runner: sessionId=${nextSessionId} viewer=${socket.id} type=${persisted.snapshot.type}`);
+                                return;
+                            }
+                        } catch (err) {
+                            log.warn(`persisted fallback failed for ${nextSessionId}:`, (err as Error)?.message);
+                        }
+                    }
+                    socket.emit("error", {
+                        message: "The runner for this session is offline — the conversation will load when it reconnects.",
+                        generation,
+                    });
+                });
             }
 
             // Emit an immediate heartbeat snapshot while the runner pushes a

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -615,6 +615,17 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                         });
                         const seqAfter = await getSessionSeq(nextSessionId);
                         if (!stillMine() || seqAfter !== freshSeq) return;
+                        // A runner may have joined AFTER the room was confirmed
+                        // empty but before it broadcast anything (seq unmoved).
+                        // Re-signal recovery and only fall back if the room is
+                        // STILL empty — a joined runner will push a fresh
+                        // session_active (registered → emitSessionActive) that
+                        // must not be overwritten by unsequenced persisted
+                        // state. ponytail: an instant-of-send race remains; the
+                        // runner's unconditional snapshot-on-register supersedes
+                        // it on the next broadcast.
+                        const recheck = await forwardRecoveryConnectedSignal(nextSessionId);
+                        if (!stillMine() || recheck !== "empty") return;
                         if (persisted) {
                             persisted.send(socket, generation);
                             log.info(`persisted fallback after confirmed-offline runner: sessionId=${nextSessionId} viewer=${socket.id} type=${persisted.snapshot.type}`);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -381,12 +381,22 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         // from triggering a runner signal when the viewer was already hydrated
         // from the server-side Redis cache.
         let suppressRunnerSignal = false;
+        // Monotonic activation token: generation checks alone cannot catch a
+        // watchdog retry that reuses the SAME generation. Two overlapping
+        // activations racing across getBestSnapshot()'s await could otherwise
+        // consume or overwrite each other's socket-wide signal flags
+        // (suppressRunnerSignal / pendingConnectedSignal) or double-signal the
+        // runner. Every await inside activateSession re-checks the token and
+        // bails if a newer activation has started.
+        let activationCounter = 0;
 
         const getCurrentSessionId = (): string | null => socket.data.sessionId ?? null;
         const getCurrentGeneration = (): number | undefined =>
             typeof socket.data.generation === "number" ? socket.data.generation : undefined;
 
         const activateSession = async (nextSessionId: string, generation?: number, lastSeq?: number): Promise<void> => {
+            const activationToken = ++activationCounter;
+            const activationCurrent = () => activationToken === activationCounter;
             // Reset on every session switch so a prior session's signal state
             // cannot bleed into the new session.  Specifically:
             //   - suppressRunnerSignal=true (cache hit) must not silence the
@@ -409,11 +419,11 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const previousSessionId = getCurrentSessionId();
             if (previousSessionId && previousSessionId !== nextSessionId) {
                 await removeViewer(previousSessionId, socket);
-                if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
+                if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) return;
             }
 
             const sessionSummary = await getSharedSessionSummary(nextSessionId);
-            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) return;
 
             if (!sessionSummary) {
                 socket.data.sessionId = undefined;
@@ -434,7 +444,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 sessionSummaryHint: sessionSummary,
                 touchAsync: true,
             });
-            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) {
                 if (ok) {
                     await removeViewer(nextSessionId, socket);
                 }
@@ -458,7 +468,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 getSessionSeq(nextSessionId),
             ]);
 
-            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation) || !activationCurrent()) {
                 await removeViewer(nextSessionId, socket);
                 return;
             }
@@ -521,6 +531,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     chunkedPending: false,
                     latestSeq: freshSeq,
                 });
+                if (!activationCurrent()) return; // newer activation owns the signal flags now
                 if (snapshotResult) {
                     // Cache hit — viewer is fully hydrated.  Suppress the
                     // runner "connected" signal so it doesn't rebuild and

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -498,7 +498,8 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
 
             // ── SnapshotProvider: try server-side cache before signaling the runner
             const chunkedPending = getPendingChunkedSnapshot(nextSessionId);
-            if (!chunkedPending) {
+            const staleChunkStream = chunkedPending?.stale === true;
+            if (!chunkedPending || staleChunkStream) {
                 const snapshotResult = await getBestSnapshot(nextSessionId, {
                     lastSeq: requestedLastSeq,
                     // Without userId the SQLite tier is unreachable, so a dead
@@ -527,6 +528,14 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     snapshotResult.send(socket, generation);
                     suppressRunnerSignal = true;
                     log.info(`snapshot-provider hydration: sessionId=${nextSessionId} viewer=${socket.id} type=${snapshotResult.snapshot.type}`);
+                    if (staleChunkStream) {
+                        // The cache served a pre-stream checkpoint over a wedged
+                        // chunk stream — that transcript is old. Ask the runner
+                        // for a fresh snapshot instead of suppressing recovery,
+                        // so the viewer isn't stranded on the old checkpoint if
+                        // the stream never finishes.
+                        forwardRecoverySignalOrNotify(nextSessionId, socket, generation);
+                    }
                     return;
                 }
             }
@@ -614,7 +623,12 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             // getPendingChunkedSnapshot() is node-local. Multi-node deployments
             // still need sticky routing or shared pending state for this guard.
             const requestedLastSeq = typeof data?.lastSeq === "number" && Number.isFinite(data.lastSeq) ? data.lastSeq : undefined;
-            const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
+            // A stale stream (no chunk for CHUNK_STREAM_STALE_MS) must not gate
+            // hydration — treat it as absent for the fallback decisions below,
+            // but remember it so we still nudge the runner for a fresh snapshot.
+            const resyncPendingRaw = getPendingChunkedSnapshot(currentSessionId);
+            const resyncStaleStream = resyncPendingRaw?.stale === true;
+            const resyncChunkedPending = resyncPendingRaw && !resyncStaleStream ? resyncPendingRaw : null;
             if (requestedLastSeq !== undefined && !resyncChunkedPending) {
                 const [resyncSession, resyncSeq] = await Promise.all([
                     getSharedSession(currentSessionId),
@@ -627,6 +641,9 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     latestSessionSeq: resyncSeq,
                 });
                 if (cacheHydrated) {
+                    if (resyncStaleStream) {
+                        forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                    }
                     return;
                 }
             }
@@ -651,7 +668,9 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             // Use emitToRelaySession for cluster-wide reach — the runner may
             // be on a different server node in multi-node deployments.
             const session = await getSharedSession(currentSessionId);
-            if (!session?.lastState) {
+            if (!session?.lastState || resyncStaleStream) {
+                // No usable checkpoint — or the one we just sent predates a
+                // wedged chunk stream — either way the runner should rebuild.
                 emitToRelaySession(currentSessionId, "connected" as string, {});
             }
         });

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -242,32 +242,46 @@ export function emitToRelaySession(sessionId: string, eventName: string, data: u
  * Use this for delivery-critical paths (e.g. trigger responses) where
  * falsely reporting success would leave the client stuck.
  */
-export async function emitToRelaySessionVerified(sessionId: string, eventName: string, data: unknown): Promise<boolean> {
-    if (!io) return false;
+export type RelayEmitCheckResult = "delivered" | "empty" | "unknown";
+
+/**
+ * Like emitToRelaySessionVerified, but distinguishes a CONFIRMED empty room
+ * from a lookup we could not complete. "empty" is proof the runner is not
+ * connected anywhere in the cluster; "unknown" means the Redis adapter lookup
+ * failed and no local socket exists — a runner may still be connected on
+ * another node, so callers must not treat it as offline (no stale fallbacks,
+ * no offline errors — let client-side retry handle it).
+ */
+export async function emitToRelaySessionChecked(sessionId: string, eventName: string, data: unknown): Promise<RelayEmitCheckResult> {
+    if (!io) return "unknown";
     const room = relaySessionRoom(sessionId);
     try {
         // ⚡ Bolt: Fast check on adapter avoids fetching full RemoteSocket objects across cluster
         const sockets = await io.of("/relay").adapter.sockets(new Set([room]));
-        if (sockets.size === 0) return false;
+        if (sockets.size === 0) return "empty";
         io.of("/relay").to(room).emit(eventName, data);
-        return true;
+        return "delivered";
     } catch (err) {
         // The cluster-wide lookup goes through the Redis adapter; when Redis is
         // degraded it throws or times out even though the runner may be
         // connected to THIS node. adapter.rooms is the node-local room map and
         // needs no Redis — fall back to local delivery so a Redis blip doesn't
         // falsely report the runner offline.
-        log.warn("emitToRelaySessionVerified adapter lookup failed, trying local:", (err as Error)?.message);
+        log.warn("emitToRelaySessionChecked adapter lookup failed, trying local:", (err as Error)?.message);
         try {
             const localRoom = io.of("/relay").adapter.rooms.get(room);
-            if (!localRoom || localRoom.size === 0) return false;
+            if (!localRoom || localRoom.size === 0) return "unknown";
             io.of("/relay").local.to(room).emit(eventName, data);
-            return true;
+            return "delivered";
         } catch (localErr) {
-            log.warn("emitToRelaySessionVerified local fallback failed:", (localErr as Error)?.message);
-            return false;
+            log.warn("emitToRelaySessionChecked local fallback failed:", (localErr as Error)?.message);
+            return "unknown";
         }
     }
+}
+
+export async function emitToRelaySessionVerified(sessionId: string, eventName: string, data: unknown): Promise<boolean> {
+    return (await emitToRelaySessionChecked(sessionId, eventName, data)) === "delivered";
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────────

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -254,6 +254,24 @@ export type RelayEmitCheckResult = "delivered" | "empty" | "unknown";
  */
 const RELAY_PRESENCE_LOOKUP_TIMEOUT_MS = 3_000;
 
+// One in-flight cluster presence lookup per room. See usage comment below.
+const inFlightPresenceLookups = new Map<string, Promise<number>>();
+
+function clusterPresenceLookup(nsp: ReturnType<NonNullable<typeof io>["of"]>, room: string): Promise<number> {
+    const existing = inFlightPresenceLookups.get(room);
+    if (existing) return existing;
+    const lookup = nsp.in(room).fetchSockets().then((sockets) => sockets.length);
+    inFlightPresenceLookups.set(room, lookup);
+    lookup
+        .catch(() => { /* rejection surfaces to awaiting callers; nothing to do here */ })
+        .finally(() => {
+            if (inFlightPresenceLookups.get(room) === lookup) {
+                inFlightPresenceLookups.delete(room);
+            }
+        });
+    return lookup;
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
     return new Promise<T>((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
@@ -288,8 +306,12 @@ export async function emitToRelaySessionChecked(sessionId: string, eventName: st
         // serverCount() BEFORE its own request timeout is armed, and with
         // node-redis's offline queue that await can pend for an entire Redis
         // outage — an unbounded hang here would stall recovery indefinitely.
-        const sockets = await withTimeout(nsp.in(room).fetchSockets(), RELAY_PRESENCE_LOOKUP_TIMEOUT_MS);
-        if (sockets.length === 0) return "empty";
+        // Coalesced per room: a timed-out caller leaves the underlying lookup
+        // pending in the offline queue, and retries reuse it instead of
+        // stacking a new queued command per attempt — otherwise reconnect
+        // would replay a storm of accumulated fetchSockets requests.
+        const socketCount = await withTimeout(clusterPresenceLookup(nsp, room), RELAY_PRESENCE_LOOKUP_TIMEOUT_MS);
+        if (socketCount === 0) return "empty";
         nsp.to(room).emit(eventName, data);
         // Presence ≠ delivery: the socket can drop between the check and the
         // emit. Callers needing hard delivery proof must use

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -256,10 +256,17 @@ export async function emitToRelaySessionChecked(sessionId: string, eventName: st
     if (!io) return "unknown";
     const room = relaySessionRoom(sessionId);
     try {
-        // ⚡ Bolt: Fast check on adapter avoids fetching full RemoteSocket objects across cluster
-        const sockets = await io.of("/relay").adapter.sockets(new Set([room]));
-        if (sockets.size === 0) return "empty";
+        // fetchSockets() is the cluster-aware presence check: with the Redis
+        // adapter, adapter.sockets() is inherited from the in-memory adapter
+        // and only scans LOCAL rooms, so a runner on another node would be
+        // misreported as "empty" — exactly the confirmed-offline signal this
+        // function must never fake.
+        const sockets = await io.of("/relay").in(room).fetchSockets();
+        if (sockets.length === 0) return "empty";
         io.of("/relay").to(room).emit(eventName, data);
+        // Presence ≠ delivery: the socket can drop between the check and the
+        // emit. Callers needing hard delivery proof must use
+        // emitToRelaySessionAwaitingAck instead.
         return "delivered";
     } catch (err) {
         // The cluster-wide lookup goes through the Redis adapter; when Redis is

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -252,8 +252,21 @@ export async function emitToRelaySessionVerified(sessionId: string, eventName: s
         io.of("/relay").to(room).emit(eventName, data);
         return true;
     } catch (err) {
-        log.warn("emitToRelaySessionVerified failed:", (err as Error)?.message);
-        return false;
+        // The cluster-wide lookup goes through the Redis adapter; when Redis is
+        // degraded it throws or times out even though the runner may be
+        // connected to THIS node. adapter.rooms is the node-local room map and
+        // needs no Redis — fall back to local delivery so a Redis blip doesn't
+        // falsely report the runner offline.
+        log.warn("emitToRelaySessionVerified adapter lookup failed, trying local:", (err as Error)?.message);
+        try {
+            const localRoom = io.of("/relay").adapter.rooms.get(room);
+            if (!localRoom || localRoom.size === 0) return false;
+            io.of("/relay").local.to(room).emit(eventName, data);
+            return true;
+        } catch (localErr) {
+            log.warn("emitToRelaySessionVerified local fallback failed:", (localErr as Error)?.message);
+            return false;
+        }
     }
 }
 

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -252,38 +252,54 @@ export type RelayEmitCheckResult = "delivered" | "empty" | "unknown";
  * another node, so callers must not treat it as offline (no stale fallbacks,
  * no offline errors — let client-side retry handle it).
  */
+const RELAY_PRESENCE_LOOKUP_TIMEOUT_MS = 3_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+        promise.then(
+            (value) => { clearTimeout(timer); resolve(value); },
+            (err) => { clearTimeout(timer); reject(err); },
+        );
+    });
+}
+
 export async function emitToRelaySessionChecked(sessionId: string, eventName: string, data: unknown): Promise<RelayEmitCheckResult> {
     if (!io) return "unknown";
     const room = relaySessionRoom(sessionId);
+    const nsp = io.of("/relay");
+
+    // Local fast-path FIRST: the node-local room map is synchronous and
+    // Redis-free. A locally connected runner must never depend on the cluster
+    // lookup below — during a Redis outage that lookup can hang or fail, and
+    // local recovery is exactly what has to keep working through a blip.
     try {
-        // fetchSockets() is the cluster-aware presence check: with the Redis
-        // adapter, adapter.sockets() is inherited from the in-memory adapter
-        // and only scans LOCAL rooms, so a runner on another node would be
-        // misreported as "empty" — exactly the confirmed-offline signal this
-        // function must never fake.
-        const sockets = await io.of("/relay").in(room).fetchSockets();
+        const localRoom = nsp.adapter.rooms.get(room);
+        if (localRoom && localRoom.size > 0) {
+            nsp.to(room).emit(eventName, data);
+            return "delivered";
+        }
+    } catch { /* fall through to cluster lookup */ }
+
+    try {
+        // fetchSockets() is the cluster-aware presence check (adapter.sockets()
+        // is inherited from the in-memory adapter and only scans local rooms).
+        // Bound it independently: RedisAdapter.fetchSockets() awaits
+        // serverCount() BEFORE its own request timeout is armed, and with
+        // node-redis's offline queue that await can pend for an entire Redis
+        // outage — an unbounded hang here would stall recovery indefinitely.
+        const sockets = await withTimeout(nsp.in(room).fetchSockets(), RELAY_PRESENCE_LOOKUP_TIMEOUT_MS);
         if (sockets.length === 0) return "empty";
-        io.of("/relay").to(room).emit(eventName, data);
+        nsp.to(room).emit(eventName, data);
         // Presence ≠ delivery: the socket can drop between the check and the
         // emit. Callers needing hard delivery proof must use
         // emitToRelaySessionAwaitingAck instead.
         return "delivered";
     } catch (err) {
-        // The cluster-wide lookup goes through the Redis adapter; when Redis is
-        // degraded it throws or times out even though the runner may be
-        // connected to THIS node. adapter.rooms is the node-local room map and
-        // needs no Redis — fall back to local delivery so a Redis blip doesn't
-        // falsely report the runner offline.
-        log.warn("emitToRelaySessionChecked adapter lookup failed, trying local:", (err as Error)?.message);
-        try {
-            const localRoom = io.of("/relay").adapter.rooms.get(room);
-            if (!localRoom || localRoom.size === 0) return "unknown";
-            io.of("/relay").local.to(room).emit(eventName, data);
-            return "delivered";
-        } catch (localErr) {
-            log.warn("emitToRelaySessionChecked local fallback failed:", (localErr as Error)?.message);
-            return "unknown";
-        }
+        // Lookup failure (Redis degraded, timeout) is NOT proof of an empty
+        // room — a runner may be connected on another node.
+        log.warn("emitToRelaySessionChecked cluster lookup failed — runner state unknown:", (err as Error)?.message);
+        return "unknown";
     }
 }
 

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -5,7 +5,7 @@
 // existing callers continue importing from `../sio-registry.js` unchanged.
 // ============================================================================
 
-export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom, broadcastToSessionViewers } from "./context.js";
+export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionChecked, emitToRelaySessionAwaitingAck, runnersUserRoom, broadcastToSessionViewers, type RelayEmitCheckResult } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
 export type { RegisterTuiSessionOpts, UpdateSessionStateOpts } from "./sessions.js";
 export {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -823,6 +823,10 @@ export function App() {
   const hydrationStallTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
   const hydrationRetriesRef = React.useRef(0);
   const HYDRATION_STALL_MS = 8_000;
+  // First retry fires sooner: a dropped first snapshot otherwise always costs
+  // the full stall window. Later retries keep the longer threshold so a slow
+  // link streaming a big snapshot isn't hammered with duplicate requests.
+  const HYDRATION_FIRST_RETRY_MS = 3_500;
   const HYDRATION_CHECK_INTERVAL_MS = 2_000;
   // ponytail: two retries, then surface the failure. Retrying forever would
   // re-request a full snapshot every 8s against a session that cannot answer.
@@ -845,6 +849,27 @@ export function App() {
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reconnect immediately when the tab foregrounds or the network returns.
+  // socket.io's reconnect backoff can sit up to ~30s after a background
+  // suspension; a manual connect() bypasses the backoff timer entirely and
+  // is a no-op when already connected/connecting.
+  React.useEffect(() => {
+    const kickSockets = () => {
+      if (document.visibilityState !== "visible") return;
+      const viewer = viewerWsRef.current;
+      if (viewer && !viewer.connected) viewer.connect();
+      const hub = hubSocketRef.current;
+      if (hub && !hub.connected) hub.connect();
+    };
+    window.addEventListener("online", kickSockets);
+    document.addEventListener("visibilitychange", kickSockets);
+    return () => {
+      window.removeEventListener("online", kickSockets);
+      document.removeEventListener("visibilitychange", kickSockets);
+    };
   }, []);
   // How long to ignore runner queue syncs after a local queue mutation.
   const QUEUE_SYNC_SUPPRESS_MS = 5_000;
@@ -3033,6 +3058,10 @@ export function App() {
     if (!hubAuthUserId) return;
     const socket = io(socketUrl("/hub"), {
       withCredentials: true,
+      // WebSocket first: the default polling→upgrade handshake costs 2-3 extra
+      // RTTs on every connect AND reconnect. Polling stays as a fallback for
+      // proxies that block WebSockets.
+      transports: ["websocket", "polling"],
       auth: buildSocketAuth({
         protocolVersion: SOCKET_PROTOCOL_VERSION,
         clientVersion: UI_VERSION,
@@ -3357,6 +3386,9 @@ export function App() {
         }),
         withCredentials: true,
         autoConnect: false,
+        // WebSocket first (polling fallback) — skips the polling handshake's
+        // extra round trips on every connect/reconnect.
+        transports: ["websocket", "polling"],
       });
       viewerWsRef.current = socket;
       attachServiceAnnounceListener(socket);
@@ -3387,7 +3419,8 @@ export function App() {
         }
         const requestedAt = hydrationRequestedAtRef.current;
         if (requestedAt === null) return;
-        if (Date.now() - requestedAt < HYDRATION_STALL_MS) return;
+        const stallThreshold = hydrationRetriesRef.current === 0 ? HYDRATION_FIRST_RETRY_MS : HYDRATION_STALL_MS;
+        if (Date.now() - requestedAt < stallThreshold) return;
 
         if (hydrationRetriesRef.current >= HYDRATION_MAX_RETRIES) {
           // Stop retrying, but never leave a spinner claiming progress.
@@ -4018,6 +4051,7 @@ export function App() {
         clientVersion: UI_VERSION,
       }),
       withCredentials: true,
+      transports: ["websocket", "polling"],
     });
 
     const cleanup = () => tempSocket.disconnect();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3300,8 +3300,11 @@ export function App() {
     // no-op and leave them with a blank transcript until a full page reload.
     if (
       relaySessionId === lifecycleRefs.activeSessionId.current &&
-      !lifecycleRefs.awaitingSnapshot.current
+      lifecycleRefs.hydrated.current
     ) {
+      // awaitingSnapshot alone is not "finished": chunked headers clear it
+      // while the transfer is still in flight, and a stalled transfer must
+      // remain re-clickable.
       return;
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2132,10 +2132,11 @@ export function App() {
       chunkState.loadedMessages += chunkMessages.length;
       const loaded = chunkState.loadedMessages;
       onChunkProgress(loaded, totalMessages);
-      // Chunked delivery keeps awaitingSnapshot true for as long as the transfer
-      // takes, which on a big session over a slow link legitimately exceeds the
-      // stall threshold. Treat an arriving chunk as progress so the watchdog does
-      // not restart hydration underneath a transfer that is succeeding.
+      // The chunk header cleared awaitingSnapshot, but the stall watchdog stays
+      // armed while the transfer is in flight (chunked && !hydrated). Treat an
+      // arriving chunk as progress so the watchdog does not restart hydration
+      // underneath a transfer that is succeeding — a big session over a slow
+      // link legitimately exceeds the stall threshold between retries.
       hydrationRequestedAtRef.current = Date.now();
 
       const readyToFinalize = canFinalizeChunkHydration(
@@ -3372,7 +3373,14 @@ export function App() {
       hydrationStallTimerRef.current = setInterval(() => {
         const sessionId = lifecycleRefs.activeSessionId.current;
         if (!sessionId || !nextSocket.connected) return;
-        if (!lifecycleRefs.awaitingSnapshot.current) {
+        // A chunked transfer clears awaitingSnapshot on the chunk *header*, so
+        // the transfer itself must keep the watchdog armed — a stream that
+        // stops mid-way (dropped frame, runner crash) would otherwise freeze
+        // "Loading session (x of y)…" forever with no retry. Arriving chunks
+        // reset hydrationRequestedAtRef, so a progressing transfer never trips.
+        const chunkInFlight =
+          lifecycleRefs.chunked.current !== null && !lifecycleRefs.hydrated.current;
+        if (!lifecycleRefs.awaitingSnapshot.current && !chunkInFlight) {
           hydrationRequestedAtRef.current = null;
           hydrationRetriesRef.current = 0;
           return;
@@ -3410,7 +3418,9 @@ export function App() {
       staleCheckTimerRef.current = setInterval(() => {
         if (!lifecycleRefs.activeSessionId.current) return;
         if (!nextSocket.connected) return;
-        if (!agentActiveRef.current && !lifecycleRefs.awaitingSnapshot.current) return;
+        const chunkTransferInFlight =
+          lifecycleRefs.chunked.current !== null && !lifecycleRefs.hydrated.current;
+        if (!agentActiveRef.current && !lifecycleRefs.awaitingSnapshot.current && !chunkTransferInFlight) return;
         const elapsed = Date.now() - lastViewerEventAtRef.current;
         if (elapsed > staleThresholdMsRef.current) {
           log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
@@ -3422,7 +3432,15 @@ export function App() {
       nextSocket.on("connect", () => {
         const currentSessionId = lifecycleRefs.activeSessionId.current;
         if (!currentSessionId) return;
-        setLifecycleStatus("Connecting…");
+        // A transport reconnect on an already-hydrated session must not flip the
+        // status back to "Connecting…": the composer gate and the "still
+        // connecting" banner key off the status STRING, so re-arming it here
+        // shows a scary offline banner on a session that is visibly fine every
+        // time a mobile tab backgrounds or WiFi blips. The reducer's CONNECTED
+        // action already keeps hydrated reconnects live; mirror that here.
+        if (!lifecycleRefs.hydrated.current) {
+          setLifecycleStatus("Connecting…");
+        }
         setViewerSwitchGeneration(nextSocket, lifecycleRefs.generation.current);
         hydrationRequestedAtRef.current = Date.now();
         hydrationRetriesRef.current = 0;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1957,6 +1957,13 @@ export function App() {
       // against them. Those deltas are already represented in this snapshot.
       deferredChunkEventsRef.current = [];
       onSnapshotStarted({ chunked: isChunked, snapshotId, totalMessages });
+      if (isChunked) {
+        // The header is real progress: preparing a big snapshot can consume
+        // most of the stall window, and the watchdog stays armed through the
+        // whole chunked transfer now — without this reset it could restart a
+        // healthy transfer right after a slow header, before chunk 0 arrives.
+        hydrationRequestedAtRef.current = Date.now();
+      }
 
       const stateModel = normalizeModel(state?.model);
       const stateModels = Array.isArray(state?.availableModels)


### PR DESCRIPTION
## Why

The composer banner `Still connecting to this session — the runner may be offline. Your draft is preserved.` was showing far too often. Three parallel research subagents (client / relay server / runner) mapped every path that can hold `viewerStatus` at `Connecting…` / `Loading session (x of y)…` past the 10s banner threshold, plus live prod-log evidence. This PR fixes every actionable cause and speeds up the happy path.

## Stall fixes

- **Relay no longer fatals on transient Redis errors.** `SocketClosedUnexpectedlyError` / `ConnectionTimeoutError` carry no errno `code`, so `handleProcessError` classified them fatal and shut the whole relay down (disconnecting every viewer and runner) over blips node-redis auto-recovers from. Observed live during a Redis container restart.
- **Stale mid-flight chunk streams expire (15s).** A runner that hung without disconnecting left `pendingChunkedStates` set forever; the `chunkedPending` gate then made every hydration skip the snapshot cache and wait on a runner signal that never came — unrecoverable even across client retries. TTL kept below the client's retry window so the second retry passes the gate.
- **Reconnects no longer re-arm the banner on hydrated sessions.** The socket.io `connect` handler force-wrote `Connecting…` outside the phase machine; the banner keys off the status *string*, so every mobile background / WiFi blip re-armed it on sessions that were visibly fine. Highest-frequency cause.
- **Watchdogs stay armed during chunked transfers.** The chunk header cleared `awaitingSnapshot`, disarming both the hydration-stall and stale-connection watchdogs — a stream stalling mid-way froze `Loading session (x of y)…` with no retry, ever. Chunk arrivals still count as progress.
- **`resync` "already current" now compares against the true seq counter.** `broadcastSessionEventToViewers` advances the seq counter without appending to the Redis cache list, so the cache tail lags — a genuinely-behind viewer matching the stale tail was answered with silence forever.
- **Runner recovery signal is verified.** It was fire-and-forget into a possibly-empty room; now uses `emitToRelaySessionVerified` and tells the viewer honestly when no runner socket is present instead of spinning through the full watchdog window.
- **SQLite snapshot tier unlocks on stale heartbeats.** A hung runner kept `isActive=true` for 2+ minutes (until the orphan sweep), blocking the persisted tier for exactly the sessions that need it. Now gated on a fresh heartbeat (45s = 4 missed beats).

## Speed

- WebSocket-first transport on hub/viewer sockets (polling fallback kept) — the default polling→upgrade handshake cost 2–3 extra RTTs on every connect *and* reconnect.
- Immediate `socket.connect()` on tab-foreground / network-online, bypassing socket.io's up-to-30s backoff.
- First hydration retry at 3.5s (later retries stay at 8s).
- `journal_mode=WAL` + `synchronous=NORMAL` + `busy_timeout` on auth.db — the DELETE journal made every multi-MB `relay_session_state` write pay journal create/fsync/delete on the event loop (measured as ping-timeout churn in prod on the VirtioFS bind mount).
- WAL-speed writes exposed a real nondeterminism: `runner_recent_folder` pruning tie-broke on colliding ISO-ms timestamps; added an `id` tie-break (caught by its own test).

## Deferred (captured in Godmother)

- Runner-side chunk delivery acks, connected-signal debounce, message-size caching (`ebvzX6DF`)
- Partial chunk buffers for mid-stream joiners, cluster-shared chunk-in-flight state, sweep-loop SQLite yields (`0DT6yqSo`)

## Verification

- `bun run typecheck` clean
- `bun scripts/test-isolated.ts packages/server/src` — 80/80 files
- `cd packages/ui && bun test src` — 1480 pass
- New regression tests: transient-redis classification, stale chunk expiry, true-seq resync check, `runnerLooksLive`, verified recovery signal
