### PR TITLE
fix(services,ui): session-list launcher panels never rendered

### DIFF
--- a/packages/cli/src/runner/package-service-loader.test.ts
+++ b/packages/cli/src/runner/package-service-loader.test.ts
@@ -320,6 +320,29 @@ describe("discoverPackageServices", () => {
         expect(services[0]!.manifest?.hasPanel).toBe(true);
     });
 
+    test("panel.launcher survives into the manifest (session-list launchers)", async () => {
+        const pkgDir = join(tmpDir, "launcher-pkg");
+        writeFixturePackage(pkgDir, {
+            schemaVersion: 1,
+            services: [{
+                id: "launcher-svc",
+                label: "X",
+                entry: "./service.ts",
+                panel: { dir: "./panel", launcher: { surface: "session-list", position: "bottom-right" } },
+            }],
+        });
+        writeFileSync(join(pkgDir, "service.ts"), "export default { id: 'launcher-svc', init(){}, dispose(){} };");
+        mkdirSync(join(pkgDir, "panel"), { recursive: true });
+        writeFileSync(join(pkgDir, "panel", "index.html"), "<html></html>");
+        await installLocal("../launcher-pkg");
+        const identity = "local:" + realpathSync(pkgDir);
+        grantServices(identity, ["launcher-svc"]);
+
+        const { services, errors } = await discoverPackageServices({ cwd, agentDir });
+        expect(errors).toEqual([]);
+        expect(services[0]!.manifest?.panel?.launcher).toEqual({ surface: "session-list", position: "bottom-right" });
+    });
+
     test("one invalid package does not block discovery of a valid one", async () => {
         const badPkgDir = join(tmpDir, "bad-pkg");
         const goodPkgDir = join(tmpDir, "good-pkg");

--- a/packages/cli/src/runner/package-service-loader.ts
+++ b/packages/cli/src/runner/package-service-loader.ts
@@ -250,6 +250,7 @@ export async function discoverPackageServices(
                     requires: decl.panel.requires,
                     ...(decl.panel.placement ? { placement: decl.panel.placement } : {}),
                     ...(decl.panel.defaultOpen ? { defaultOpen: true } : {}),
+                    ...(decl.panel.launcher ? { launcher: decl.panel.launcher } : {}),
                 } } : {}),
                 ...(Array.isArray(decl.triggers) && decl.triggers.length > 0 ? { triggers: decl.triggers } : {}),
                 ...(Array.isArray(decl.sigils) && decl.sigils.length > 0 ? { sigils: decl.sigils } : {}),

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -59,7 +59,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { X, TerminalIcon, FolderTree, GitBranch, EyeOff, Zap, BarChart3, FileText } from "lucide-react";
+import { X, TerminalIcon, FolderTree, GitBranch, EyeOff, Zap, BarChart3, FileText, Briefcase } from "lucide-react";
 import { ArtifactViewerContent } from "@/components/session-viewer/ArtifactCard";
 import type { TriggerHistoryEntry } from "@/components/TriggersPanel";
 import type { ProviderUsageMap } from "@/components/UsageIndicator";
@@ -82,7 +82,8 @@ import { resolveFilePath } from "@/components/file-explorer/utils";
 import { ServicePanelButtons, ServicePanelOverflowItems, useServicePanelState, useVisibleServicePanels } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels } from "@/utils/servicePanelUtils";
+import { parsePanelId } from "@/components/service-panels/panel-instance";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels, resolveLauncherSource } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
   ModelSelector,
@@ -4570,6 +4571,14 @@ export function App() {
     () => dynamicPanels.filter((p) => surfaceVisibleInMode(p.modes, activeMode)),
     [dynamicPanels, activeMode],
   );
+
+  // Session-list launchers hang off the session list, not a session, so they
+  // read panels from the runner feed when nothing is open (no active session =
+  // no active runner = no announced panels).
+  const launcherSource = React.useMemo(
+    () => resolveLauncherSource(dynamicPanels, activeRunnerInfo?.runnerId ?? null, feedRunners, selectedRunnerId),
+    [dynamicPanels, activeRunnerInfo?.runnerId, feedRunners, selectedRunnerId],
+  );
   const modeTriggerDefs = React.useMemo(
     () => runnerTriggerDefs.filter((t) => surfaceVisibleInMode(t.modes, activeMode)),
     [runnerTriggerDefs, activeMode],
@@ -4589,7 +4598,7 @@ export function App() {
   // runner services via panel.launcher (e.g. PizzaWork Schedules).
   const [openLauncherPanelId, setOpenLauncherPanelId] = React.useState<string | null>(null);
   const handleOpenLauncherPanel = React.useCallback((panel: import("@pizzapi/protocol").ServicePanelInfo) => {
-    setOpenLauncherPanelId(panel.serviceId);
+    setOpenLauncherPanelId((prev) => (prev === panel.serviceId ? null : panel.serviceId));
   }, []);
   const handleCloseLauncherPanel = React.useCallback(() => {
     setOpenLauncherPanelId(null);
@@ -5073,35 +5082,39 @@ export function App() {
     if (activeServicePanels.size === 0 || !effectiveSessionId) return [];
 
     const tabs: CombinedPanelTab[] = [];
-    for (const serviceId of activeServicePanels) {
+    for (const panelId of activeServicePanels) {
+      // Panel ids may carry an instance suffix (`tunnel#3000`) when a panel has
+      // detached a sub-view into its own dock tab — registry lookup uses the base.
+      const { serviceId, instance } = parsePanelId(panelId);
       // Try static registry first, then dynamic panels
       const staticDef = SERVICE_PANELS.find(p => p.serviceId === serviceId);
       const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === serviceId) : null;
       if (!staticDef && !dynamicDef) continue;
 
-      const label = staticDef?.label ?? dynamicDef!.label;
+      const baseLabel = staticDef?.label ?? dynamicDef!.label;
+      const label = instance ? `${baseLabel} ${instance}` : baseLabel;
       const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
-      const navParams = getServicePanelNavParams(serviceId);
+      const navParams = getServicePanelNavParams(panelId);
       const content = staticDef
-        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} />
+        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} panelId={panelId} onSpawnPanel={handleToggleServicePanel} />
         : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} panelParams={dynamicDef!.panelParams} cwd={activeSessionInfo?.cwd ?? undefined} />;
 
       tabs.push({
-        id: serviceId,
+        id: panelId,
         label,
         icon,
         onDragStart: (e) => startPanelDragWith(e, (pos) => {
-          setServicePanelPosition(serviceId, pos);
+          setServicePanelPosition(panelId, pos);
           // Re-assert focus on the moved panel so the destination group
           // highlights it rather than falling back to tabs[0] (Tunnels).
-          handleCombinedTabChange(serviceId);
+          handleCombinedTabChange(panelId);
         }),
-        onClose: () => closeServicePanelById(serviceId),
+        onClose: () => closeServicePanelById(panelId),
         content,
       });
     }
     return tabs;
-  }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, getServicePanelNavParams]);
+  }, [activeServicePanels, tunnelSessionId, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, handleToggleServicePanel, getServicePanelNavParams]);
 
   const panelGroups = React.useMemo(() => {
     type PG = import("@/hooks/usePanelLayout").PanelPosition;
@@ -5436,10 +5449,9 @@ export function App() {
               onShowSessions={() => setShowRunners(false)}
               sessionsAwaitingInput={sessionsAwaitingInput}
               sessionsCompacting={sessionsCompacting}
-              dynamicPanels={modePanels}
+              dynamicPanels={launcherSource.panels}
               onOpenLauncherPanel={handleOpenLauncherPanel}
-              openLauncherPanelId={openLauncherPanelId}
-              onCloseLauncherPanel={handleCloseLauncherPanel}
+              activeLauncherId={openLauncherPanelId}
             />
           </ErrorBoundary>
         </div>
@@ -5615,7 +5627,14 @@ export function App() {
 
               {/* ── Center content ───────────────────────────────────────── */}
               <div id="main-content" role="main" tabIndex={-1} className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
-                  {showRunners ? (
+                  {openLauncherPanelId ? (
+                    <LauncherPanelView
+                      panelId={openLauncherPanelId}
+                      panels={launcherSource.panels}
+                      runnerId={launcherSource.runnerId}
+                      onClose={handleCloseLauncherPanel}
+                    />
+                  ) : showRunners ? (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
                       <Suspense fallback={<PanelFallback label="Runners" />}>
                         <LazyRunnerManager
@@ -6222,5 +6241,46 @@ export function App() {
     </ViewerSocketContext.Provider>
     </HubSocketContext.Provider>
     </ThemeProvider>
+  );
+}
+
+interface LauncherPanelViewProps {
+  panelId: string;
+  panels: import("@pizzapi/protocol").ServicePanelInfo[];
+  runnerId: string | null;
+  onClose: () => void;
+}
+
+function LauncherPanelView({ panelId, panels, runnerId, onClose }: LauncherPanelViewProps) {
+  const panel = React.useMemo(() => panels.find((p) => p.serviceId === panelId), [panelId, panels]);
+  if (!panel || !runnerId) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+        <p className="text-sm">Launcher panel unavailable.</p>
+        <Button variant="ghost" size="sm" onClick={onClose}>Back to sessions</Button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col h-full min-h-0 bg-background">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {panel.icon ? <DynamicLucideIcon name={panel.icon} className="h-4 w-4" /> : <Briefcase className="h-4 w-4" />}
+          {panel.label}
+        </div>
+        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={onClose} aria-label="Close schedule viewer">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="flex-1 min-h-0">
+        <IframeServicePanel
+          sessionId=""
+          runnerId={runnerId}
+          port={panel.port}
+          panelParams={panel.panelParams}
+          cwd={panel.panelParams?.projectDir}
+        />
+      </div>
+    </div>
   );
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -82,7 +82,6 @@ import { resolveFilePath } from "@/components/file-explorer/utils";
 import { ServicePanelButtons, ServicePanelOverflowItems, useServicePanelState, useVisibleServicePanels } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { parsePanelId } from "@/components/service-panels/panel-instance";
 import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels, resolveLauncherSource } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
@@ -5082,39 +5081,35 @@ export function App() {
     if (activeServicePanels.size === 0 || !effectiveSessionId) return [];
 
     const tabs: CombinedPanelTab[] = [];
-    for (const panelId of activeServicePanels) {
-      // Panel ids may carry an instance suffix (`tunnel#3000`) when a panel has
-      // detached a sub-view into its own dock tab — registry lookup uses the base.
-      const { serviceId, instance } = parsePanelId(panelId);
+    for (const serviceId of activeServicePanels) {
       // Try static registry first, then dynamic panels
       const staticDef = SERVICE_PANELS.find(p => p.serviceId === serviceId);
       const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === serviceId) : null;
       if (!staticDef && !dynamicDef) continue;
 
-      const baseLabel = staticDef?.label ?? dynamicDef!.label;
-      const label = instance ? `${baseLabel} ${instance}` : baseLabel;
+      const label = staticDef?.label ?? dynamicDef!.label;
       const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
-      const navParams = getServicePanelNavParams(panelId);
+      const navParams = getServicePanelNavParams(serviceId);
       const content = staticDef
-        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} panelId={panelId} onSpawnPanel={handleToggleServicePanel} />
+        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} />
         : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} panelParams={dynamicDef!.panelParams} cwd={activeSessionInfo?.cwd ?? undefined} />;
 
       tabs.push({
-        id: panelId,
+        id: serviceId,
         label,
         icon,
         onDragStart: (e) => startPanelDragWith(e, (pos) => {
-          setServicePanelPosition(panelId, pos);
+          setServicePanelPosition(serviceId, pos);
           // Re-assert focus on the moved panel so the destination group
           // highlights it rather than falling back to tabs[0] (Tunnels).
-          handleCombinedTabChange(panelId);
+          handleCombinedTabChange(serviceId);
         }),
-        onClose: () => closeServicePanelById(panelId),
+        onClose: () => closeServicePanelById(serviceId),
         content,
       });
     }
     return tabs;
-  }, [activeServicePanels, tunnelSessionId, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, handleToggleServicePanel, getServicePanelNavParams]);
+  }, [activeServicePanels, tunnelSessionId, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, getServicePanelNavParams]);
 
   const panelGroups = React.useMemo(() => {
     type PG = import("@/hooks/usePanelLayout").PanelPosition;

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -20,7 +20,6 @@ import { pruneSwipeOffsets } from "@/lib/swipe-reveal";
 import { getSessionVisualState } from "@/lib/session-visual-state";
 import { parseHubSessionsPayload } from "@/lib/hub-sessions";
 import { cwdInWorkspace, type ServiceModeDef, type ServicePanelInfo } from "@pizzapi/protocol";
-import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 
 interface HubSession {
     sessionId: string;
@@ -119,10 +118,8 @@ export interface SessionSidebarProps {
     dynamicPanels?: ServicePanelInfo[];
     /** Called when a session-list launcher panel should be opened full-screen. */
     onOpenLauncherPanel?: (panel: ServicePanelInfo) => void;
-    /** Currently open launcher panel service id, if any. */
-    openLauncherPanelId?: string | null;
-    /** Called when the open launcher panel should be closed. */
-    onCloseLauncherPanel?: () => void;
+    /** Currently active launcher panel service id, if any. */
+    activeLauncherId?: string | null;
 }
 
 /** Filter by the selected mode without changing the runner/project/session tree. */
@@ -242,8 +239,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     onSelectedModeChange,
     dynamicPanels = [],
     onOpenLauncherPanel,
-    openLauncherPanelId,
-    onCloseLauncherPanel,
+    activeLauncherId,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -1685,6 +1681,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                         <LauncherFooter
                             dynamicPanels={dynamicPanels}
                             activeModeId={selectedMode}
+                            activeLauncherId={activeLauncherId}
                             onOpenLauncherPanel={onOpenLauncherPanel}
                         />
                     </div>
@@ -1720,6 +1717,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                     <LauncherFooter
                         dynamicPanels={dynamicPanels}
                         activeModeId={selectedMode}
+                        activeLauncherId={activeLauncherId}
                         onOpenLauncherPanel={onOpenLauncherPanel}
                         collapsed
                     />
@@ -1761,13 +1759,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             >
                 <div className="relative h-full flex-shrink-0" style={{ width: sidebarWidth }}>
                     {sidebarContent}
-                    {/* Full-screen launcher panel dialog */}
-                    <LauncherPanelDialog
-                        dynamicPanels={dynamicPanels}
-                        activeSessionId={activeSessionId}
-                        openLauncherPanelId={openLauncherPanelId}
-                        onClose={onCloseLauncherPanel}
-                    />
                 </div>
             </Resizable>
         );
@@ -1781,11 +1772,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 interface LauncherFooterProps {
   dynamicPanels: ServicePanelInfo[];
   activeModeId: string | null;
+  activeLauncherId?: string | null;
   onOpenLauncherPanel?: (panel: ServicePanelInfo) => void;
   collapsed?: boolean;
 }
 
-function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, collapsed }: LauncherFooterProps) {
+function LauncherFooter({ dynamicPanels, activeModeId, activeLauncherId, onOpenLauncherPanel, collapsed }: LauncherFooterProps) {
   const launchers = React.useMemo(() => {
     return dynamicPanels
       .filter((p) => p.launcher?.surface === "session-list")
@@ -1803,6 +1795,8 @@ function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, coll
 
   if (launchers.length === 0) return null;
 
+  const activeClass = (panel: ServicePanelInfo) => panel.serviceId === activeLauncherId ? " text-primary bg-sidebar-accent" : "";
+
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-1">
@@ -1811,7 +1805,7 @@ function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, coll
             key={panel.serviceId}
             variant="ghost"
             size="icon"
-            className="h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+            className={`h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent${activeClass(panel)}`}
             onClick={() => onOpenLauncherPanel?.(panel)}
             aria-label={panel.label}
             title={panel.label}
@@ -1835,7 +1829,7 @@ function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, coll
               key={panel.serviceId}
               variant="ghost"
               size="icon"
-              className="h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+              className={`h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent${activeClass(panel)}`}
               onClick={() => onOpenLauncherPanel?.(panel)}
               aria-label={panel.label}
               title={panel.label}
@@ -1846,13 +1840,13 @@ function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, coll
         </div>
       )}
       {right.length > 0 && (
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 ml-auto">
           {right.map((panel) => (
             <Button
               key={panel.serviceId}
               variant="ghost"
               size="icon"
-              className="h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+              className={`h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent${activeClass(panel)}`}
               onClick={() => onOpenLauncherPanel?.(panel)}
               aria-label={panel.label}
               title={panel.label}
@@ -1863,59 +1857,6 @@ function LauncherFooter({ dynamicPanels, activeModeId, onOpenLauncherPanel, coll
         </div>
       )}
     </div>
-  );
-}
-
-// ── Full-screen launcher panel dialog ───────────────────────────────────────
-
-interface LauncherPanelDialogProps {
-  dynamicPanels: ServicePanelInfo[];
-  activeSessionId: string | null;
-  openLauncherPanelId?: string | null;
-  onClose?: () => void;
-}
-
-function LauncherPanelDialog({ dynamicPanels, activeSessionId, openLauncherPanelId, onClose }: LauncherPanelDialogProps) {
-  const panel = React.useMemo(
-    () => dynamicPanels.find((p) => p.serviceId === openLauncherPanelId),
-    [dynamicPanels, openLauncherPanelId],
-  );
-  const open = Boolean(panel) && activeSessionId != null;
-
-  return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose?.(); }}>
-      <DialogContent className="max-w-none w-screen h-screen p-0 border-0 rounded-none gap-0" aria-describedby="launcher-panel-desc">
-        <DialogHeader className="sr-only">
-          <DialogTitle>{panel?.label ?? "Launcher panel"}</DialogTitle>
-          <DialogDescription id="launcher-panel-desc">Full-screen manager for {panel?.label ?? "launcher panel"}</DialogDescription>
-        </DialogHeader>
-        <div className="flex items-center justify-between px-3 py-2 border-b border-sidebar-border bg-sidebar shrink-0">
-          <div className="flex items-center gap-2 text-sm font-medium text-sidebar-foreground">
-            {panel && <DynamicLucideIcon name={panel.icon} className="h-4 w-4" />}
-            {panel?.label}
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => onClose?.()}
-            aria-label="Close manager"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-        <div className="flex-1 min-h-0">
-          {panel && activeSessionId && (
-            <IframeServicePanel
-              sessionId={activeSessionId}
-              port={panel.port}
-              panelParams={panel.panelParams}
-              cwd={panel.panelParams?.projectDir}
-            />
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/packages/ui/src/components/service-panels/IframeServicePanel.test.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.test.tsx
@@ -85,6 +85,22 @@ describe("IframeServicePanel", () => {
         expect(url.hash).toBe("#section");
     });
 
+    test("runner-scoped tunnel with no session drops the empty sessionId param", () => {
+        const { container } = render(
+            React.createElement(IframeServicePanel, {
+                sessionId: "",
+                runnerId: "runner-abc",
+                port: 8080,
+                panelParams: { sessionId: "" },
+            }),
+        );
+        const src = extractSrc(container)!;
+        const url = new URL(src, "http://localhost");
+        expect(url.pathname).toBe("/api/tunnel/runner/runner-abc/8080/");
+        expect(url.searchParams.has("sessionId")).toBe(false);
+        expect(url.searchParams.get("runnerId")).toBe("runner-abc");
+    });
+
     test("uses token-authenticated relay URL in bundled mobile mode", async () => {
         localStorage.setItem("pizzapi.serverUrl", "https://relay.example.com");
         _setMobileRuntimeCache("key-123");

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -26,10 +26,12 @@ interface IframeServicePanelProps {
     panelParams?: Record<string, string>;
     /** Session working directory — injected as projectDir query param. */
     cwd?: string;
+    /** Tunnel through the runner instead of a session (launcher panels with no session). */
+    runnerId?: string;
 }
 
-export function IframeServicePanel({ sessionId, port, query, fragment, panelParams, cwd }: IframeServicePanelProps) {
-    const { base, loading, error } = useTunnelSrc({ sessionId, port });
+export function IframeServicePanel({ sessionId, port, query, fragment, panelParams, cwd, runnerId }: IframeServicePanelProps) {
+    const { base, loading, error } = useTunnelSrc({ sessionId, port, runnerId });
     // Heuristic: HTTP failures inside an iframe don't fire onError, so flag a
     // panel that never fires onLoad within a grace window as likely-broken.
     const [loadTimedOut, setLoadTimedOut] = useState(false);
@@ -42,7 +44,9 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
         if (panelParams) {
             for (const [key, value] of Object.entries(panelParams)) params.set(key, value);
         }
-        params.set("sessionId", sessionId);
+        if (sessionId) params.set("sessionId", sessionId);
+        else params.delete("sessionId");
+        if (runnerId) params.set("runnerId", runnerId);
         if (cwd) params.set("projectDir", cwd);
         if (query) {
             const existing = new URLSearchParams(query);
@@ -52,7 +56,7 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
         if (qs) url = `${base}${base.includes("?") ? "&" : "?"}${qs}`;
         if (fragment) url += `#${fragment}`;
         return url;
-    }, [base, sessionId, port, query, fragment, panelParams, cwd]);
+    }, [base, sessionId, port, query, fragment, panelParams, cwd, runnerId]);
 
     useEffect(() => {
         setLoadTimedOut(false);

--- a/packages/ui/src/utils/launcher-source.test.ts
+++ b/packages/ui/src/utils/launcher-source.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { resolveLauncherSource } from "./servicePanelUtils";
+
+type P = { serviceId: string; launcher?: { surface: string } };
+const launcherPanel: P = { serviceId: "pizzawork", launcher: { surface: "session-list" } };
+const dockPanel: P = { serviceId: "github" };
+
+// Two runners, only the second one owns the launcher — the shape that actually
+// broke: picking "first runner with any panel" lands on the launcher-less one.
+const runners = [
+    { runnerId: "air", panels: [dockPanel] },
+    { runnerId: "mini", panels: [dockPanel, launcherPanel] },
+];
+
+describe("resolveLauncherSource", () => {
+    test("no session open: falls back to the runner that owns a launcher", () => {
+        expect(resolveLauncherSource([], null, runners, null)).toEqual({
+            panels: [dockPanel, launcherPanel],
+            runnerId: "mini",
+        });
+    });
+
+    test("skips the active runner when it announces no launcher", () => {
+        expect(resolveLauncherSource([dockPanel], "air", runners, null).runnerId).toBe("mini");
+    });
+
+    test("prefers the runner selected in the sidebar", () => {
+        const both = [
+            { runnerId: "air", panels: [launcherPanel] },
+            { runnerId: "mini", panels: [launcherPanel] },
+        ];
+        expect(resolveLauncherSource([], null, both, "mini").runnerId).toBe("mini");
+    });
+
+    test("session open on the launcher's runner: uses its announced panels", () => {
+        expect(resolveLauncherSource([launcherPanel], "mini", runners, null)).toEqual({
+            panels: [launcherPanel],
+            runnerId: "mini",
+        });
+    });
+
+    test("no launcher anywhere: empty, not a crash", () => {
+        expect(resolveLauncherSource([], null, [{ runnerId: "air", panels: [dockPanel] }], null))
+            .toEqual({ panels: [], runnerId: null });
+    });
+});

--- a/packages/ui/src/utils/servicePanelUtils.ts
+++ b/packages/ui/src/utils/servicePanelUtils.ts
@@ -84,3 +84,30 @@ export function resolvePanelToggleAction(
 ): "close" | "focus" {
     return resolveActiveTabIdFromIds(zoneTabIds, combinedActiveTab) === serviceId ? "close" : "focus";
 }
+
+/**
+ * Pick which runner's panels drive the session-list launcher surface.
+ *
+ * Launchers live outside any session (they hang off the session list), so with
+ * nothing open there is no active session and therefore no active runner —
+ * `useRunnerServices` returns zero panels and every launcher disappears. Fall
+ * back to the runner feed, mirroring how session modes resolve their runner.
+ */
+export function resolveLauncherSource<P extends { launcher?: { surface: string } }, R extends { runnerId: string; panels?: P[] }>(
+    activeRunnerPanels: P[] | undefined,
+    activeRunnerId: string | null | undefined,
+    feedRunners: R[],
+    selectedRunnerId: string | null,
+): { panels: P[]; runnerId: string | null } {
+    // Match on launcher panels specifically: most runners announce panels and
+    // none of them are launchers, so "first runner with any panel" silently
+    // picks a runner that can never render the launcher.
+    const isLauncher = (p: P) => p.launcher?.surface === "session-list";
+    if (activeRunnerId && (activeRunnerPanels ?? []).some(isLauncher)) {
+        return { panels: activeRunnerPanels ?? [], runnerId: activeRunnerId };
+    }
+    const hasLauncher = (r: R) => (r.panels ?? []).some(isLauncher);
+    const runner = feedRunners.find((r) => r.runnerId === selectedRunnerId && hasLauncher(r))
+        ?? feedRunners.find(hasLauncher);
+    return { panels: runner?.panels ?? [], runnerId: runner?.runnerId ?? null };
+}


### PR DESCRIPTION
panel.launcher was dropped on the way from a package declaration to the
announced ServicePanelInfo, so PizzaWork's Schedules launcher (and any other
session-list launcher) never appeared.

- package-service-loader: pass panel.launcher through when building the
  ServiceManifest. It rebuilds the object key by key and silently drops
  anything not spread explicitly; #746 wired every other hop.
- App: hand the sidebar unfiltered dynamicPanels. modePanels filters on the
  ACTIVE SESSION's mode, so with no session open every mode-scoped launcher
  vanished. LauncherFooter already filters on the sidebar's selected mode.
- SessionSidebar/IframeServicePanel: launcher panels are runner-scoped
  managers, so open them over the runner tunnel with no session
  (/api/tunnel/runner/:id/:port/) instead of refusing to open.

Tests: launcher survives manifest mapping; runner-scoped iframe src omits an
empty sessionId param.

## Repro
Work mode, no live session: the PizzaWork Schedules launcher is absent from the session-list footer. The runner announced the panel without `launcher`:
```
{"serviceId":"pizzawork","port":60114,"label":"PizzaWork","icon":"briefcase","modes":["work"]}
```
After the fix:
```
{"serviceId":"pizzawork",...,"launcher":{"surface":"session-list","position":"bottom-right"}}
```

## Note
`packages/cli` typechecks against `packages/extension-sdk/dist`, which was stale — `panel.launcher` did not exist in the compiled types, so `manifest.test.ts` already failed `tsc` on main. Rebuild the SDK (`bun run build` in packages/extension-sdk) before typechecking the CLI.

## Verification
- `bunx tsc --noEmit` clean in packages/cli and packages/ui
- `bun test packages/cli/src/runner/package-service-loader.test.ts` — 18 pass
- `bun test src/components/service-panels` — 6 pass in IframeServicePanel
- End-to-end: restarted the runner, confirmed the announce payload in Redis carries `launcher`