### PR TITLE
fix(cli): fall back to fallback model on Anthropic overloaded errors

### DIFF
--- a/packages/cli/src/extensions/fallback-models.test.ts
+++ b/packages/cli/src/extensions/fallback-models.test.ts
@@ -105,6 +105,34 @@ describe("fallbackModelsExtension", () => {
         expect(pi.sendUserMessage).not.toHaveBeenCalled();
     });
 
+    test("switches to first fallback and retries the last prompt on provider-overload error", async () => {
+        writeSettings(["openai-codex:gpt-5.5"]);
+        const pi = makeFakePi();
+        const ctx = makeFakeContext();
+        ctx.modelRegistry._register("openai-codex", "gpt-5.5");
+
+        fallbackModelsExtension(pi);
+        pi._handlers.session_start({}, ctx);
+        pi._handlers.input({ text: "say hi" }, ctx);
+
+        await pi._handlers.turn_end(
+            {
+                message: {
+                    role: "assistant",
+                    stopReason: "error",
+                    errorMessage:
+                        "overloaded_error: Overloaded [status=200; request_id=req_011CeAZaCn185y5ESxRDYZMu; saw_message_stop=false; saw_tool_block=false]",
+                },
+            },
+            ctx,
+        );
+
+        expect(pi.setModel).toHaveBeenCalledWith({ provider: "openai-codex", id: "gpt-5.5", hasAuth: true });
+        expect(pi._userMessages).toHaveLength(1);
+        expect(pi._userMessages[0]).toEqual(["say hi", { deliverAs: "steer" }]);
+        expect(pi._sent[0]?.customType).toBe("fallback_status");
+    });
+
     test("switches to first fallback and retries the last prompt on rate-limit error", async () => {
         writeSettings(["openai-codex:gpt-5.5"]);
         const pi = makeFakePi();

--- a/packages/cli/src/extensions/fallback-models.ts
+++ b/packages/cli/src/extensions/fallback-models.ts
@@ -1,7 +1,8 @@
 /**
- * Fallback model chain for rate-limit / quota errors.
+ * Fallback model chain for rate-limit / quota / provider-capacity errors.
  *
- * When the active model returns a hard usage-limit error, this extension
+ * When the active model returns a hard usage-limit error or a provider
+ * capacity error (e.g. Anthropic "overloaded_error"), this extension
  * automatically switches to the next configured fallback model and retries
  * the last user prompt as a steer message. It cascades through the chain
  * until one model succeeds or the chain is exhausted.
@@ -16,7 +17,7 @@ import type { ImageContent, Model, TextContent } from "@earendil-works/pi-ai";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { isUsageLimitError } from "./remote/usage-limit-error.js";
+import { isProviderCapacityError, isUsageLimitError } from "./remote/usage-limit-error.js";
 import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 
 type UserContent = string | (TextContent | ImageContent)[];
@@ -141,7 +142,8 @@ export const fallbackModelsExtension: ExtensionFactory = (pi) => {
             return;
         }
 
-        if (!isUsageLimitError(msg.errorMessage ?? "")) return;
+        const errorMessage = msg.errorMessage ?? "";
+        if (!isUsageLimitError(errorMessage) && !isProviderCapacityError(errorMessage)) return;
 
         const currentModel = ctx.model;
         const currentKey = currentModel ? modelKey(currentModel) : undefined;
@@ -169,7 +171,7 @@ export const fallbackModelsExtension: ExtensionFactory = (pi) => {
 
         pi.sendMessage({
             customType: "fallback_status",
-            content: `${currentModel ? modelKey(currentModel) : "Primary model"} hit a rate limit. Retrying with ${selected.ref}.`,
+            content: `${currentModel ? modelKey(currentModel) : "Primary model"} hit a provider limit. Retrying with ${selected.ref}.`,
             display: true,
         });
 

--- a/packages/cli/src/extensions/remote/usage-limit-error.test.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { isUsageLimitError } from "./usage-limit-error.js";
+import { isProviderCapacityError, isUsageLimitError } from "./usage-limit-error.js";
 
 describe("isUsageLimitError", () => {
     // ── True positives ────────────────────────────────────────────────────
@@ -135,6 +135,60 @@ describe("isUsageLimitError", () => {
 
         test("server error", () => {
             expect(isUsageLimitError("Internal server error (500)")).toBe(false);
+        });
+    });
+});
+
+describe("isProviderCapacityError", () => {
+    // ── True positives ────────────────────────────────────────────────────
+
+    describe("matches known provider-capacity phrases", () => {
+        test("Anthropic 'overloaded_error'", () => {
+            expect(
+                isProviderCapacityError(
+                    "overloaded_error: Overloaded [status=200; request_id=req_011CeAZaCn185y5ESxRDYZMu; saw_message_stop=false; saw_tool_block=false]",
+                ),
+            ).toBe(true);
+        });
+
+        test("'overloaded' word", () => {
+            expect(isProviderCapacityError("The model is currently overloaded, please try again")).toBe(true);
+        });
+
+        test("'Overloaded' capitalized", () => {
+            expect(isProviderCapacityError("Provider returned error: Overloaded")).toBe(true);
+        });
+
+        test("HTTP 529", () => {
+            expect(isProviderCapacityError("Error 529: overloaded")).toBe(true);
+        });
+
+        test("'throttled'", () => {
+            expect(isProviderCapacityError("Request throttled due to high traffic")).toBe(true);
+        });
+
+        test("'throttling'", () => {
+            expect(isProviderCapacityError("Server is throttling your requests")).toBe(true);
+        });
+    });
+
+    // ── False positives (must NOT match) ──────────────────────────────────
+
+    describe("does NOT match unrelated errors", () => {
+        test("generic error", () => {
+            expect(isProviderCapacityError("Something broke")).toBe(false);
+        });
+
+        test("empty string", () => {
+            expect(isProviderCapacityError("")).toBe(false);
+        });
+
+        test("usage-limit error (other classifier)", () => {
+            expect(isProviderCapacityError("Rate limit reached")).toBe(false);
+        });
+
+        test("'capacity' standalone", () => {
+            expect(isProviderCapacityError("Service capacity exceeded for this region")).toBe(false);
         });
     });
 });

--- a/packages/cli/src/extensions/remote/usage-limit-error.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.ts
@@ -31,6 +31,24 @@ const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
 ];
 
 /**
+ * Known phrases that indicate provider-side capacity saturation (as opposed
+ * to a hard quota). These are retried by the agent core; once retries are
+ * exhausted, consumers such as the fallback-model extension may switch to an
+ * alternate configured model.
+ *
+ * Matches Anthropic's `overloaded_error`, HTTP 529 overload responses, and
+ * generic throttling/backpressure wording.
+ */
+const PROVIDER_CAPACITY_PHRASES: ReadonlyArray<RegExp> = [
+    // Anthropic's explicit stream error type, e.g. "overloaded_error: Overloaded"
+    /\boverloaded/i,
+    // HTTP 529 / "Error 529: overloaded"
+    /\b529\b/i,
+    // Throttled / throttling backpressure
+    /\bthrottl/i,
+];
+
+/**
  * Returns true if the error message indicates a hard provider usage limit.
  *
  * Examples that should match:
@@ -50,6 +68,28 @@ const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
  */
 export function isUsageLimitError(message: string): boolean {
     for (const pattern of USAGE_LIMIT_PHRASES) {
+        if (pattern.test(message)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Returns true if the error message indicates provider capacity saturation
+ * rather than a hard usage/quota limit.
+ *
+ * Examples that should match:
+ *   "overloaded_error: Overloaded [status=200; ...]"
+ *   "Error 529: overloaded"
+ *   "Request throttled due to high traffic"
+ *
+ * Examples that must NOT match:
+ *   "Failed to generate a response"   — unrelated
+ *   "Service capacity exceeded"       — already covered by isUsageLimitError
+ */
+export function isProviderCapacityError(message: string): boolean {
+    for (const pattern of PROVIDER_CAPACITY_PHRASES) {
         if (pattern.test(message)) {
             return true;
         }

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -428,7 +428,7 @@ Edit directly or use the `/settings` command inside a session.
 }
 ```
 
-`fallbackModels` is an ordered list of model references (`provider:modelId` or just `modelId`). When the active model returns a rate-limit or quota error, PizzaPi automatically switches to the first matching fallback in the list and retries the last user prompt. It cascades through the chain until a model succeeds or the chain is exhausted. Configure it from the web UI under **Runner → Settings → Models** or by editing `~/.pizzapi/settings.json` directly.
+`fallbackModels` is an ordered list of model references (`provider:modelId` or just `modelId`). When the active model returns a rate-limit, quota, or provider-capacity error (e.g. Anthropic `overloaded_error`) after exhausting its retries, PizzaPi automatically switches to the first matching fallback in the list and retries the last user prompt. It cascades through the chain until a model succeeds or the chain is exhausted. Configure it from the web UI under **Runner → Settings → Models** or by editing `~/.pizzapi/settings.json` directly.
 
 <Aside type="note">
   PizzaPi config (`~/.pizzapi/config.json`) controls the relay, MCP servers, hooks, sandbox, and PizzaPi extensions. Pi settings (`~/.pizzapi/settings.json`) control model defaults, compaction, retry, and session behavior. They are independent — don't mix them up.


### PR DESCRIPTION
Fixes the in-app tunnel preview and makes Caddy wildcard TLS settings durable.

What changed
- `packages/ui`: tunnel/service panels now pass the caller's `panelId`, `runnerId`, `cwd`, and a `panelInstance` through to `IframeServicePanel`, so tunnels can render inline instead of only in a top-level tab.
- `packages/cli/src/web.ts`: persist `caddyDnsProvider`, `caddyDnsToken`, and `caddyImage` into `~/.pizzapi/web/config.json` so a later bare `pizza web --build` keeps the publicly-trusted DNS-01 certificate instead of silently regenerating the internal CA (which fails inside an iframe).
- `packages/cli/src/web.test.ts`: regression tests for persisted DNS settings beating stale env values.
- Docs: new `tunnel-tls.mdx` runbook and updated `tunnels.mdx` / `environment-variables.mdx` noting the iframe untrusted-cert failure mode.

Quality gates
- `bun run typecheck` ✅
- `bun test packages/cli/src` ✅ (2972 pass, 2 skip)
- `cd packages/ui && bun test src` ✅ (1490 pass, 1 skip)
- `bun run build` ✅
