### PR TITLE
feat(ui): add Refresh buttons to panels that lacked them

### DIFF
--- a/packages/ui/src/components/RunnerServicesPanel.tsx
+++ b/packages/ui/src/components/RunnerServicesPanel.tsx
@@ -7,7 +7,7 @@
  * visibility of service panel buttons in the session header.
  */
 import * as React from "react";
-import { Loader2, Server, ExternalLink, Eye, EyeOff, Zap, Hash } from "lucide-react";
+import { Loader2, Server, ExternalLink, Eye, EyeOff, Zap, Hash, RefreshCw } from "lucide-react";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
@@ -223,37 +223,6 @@ export function RunnerServicesPanel({ runnerId }: RunnerServicesPanelProps) {
     });
   }, []);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center gap-2 p-8 text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" />
-        <span className="text-sm">Loading services…</span>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-sm text-destructive">{error}</p>
-      </div>
-    );
-  }
-
-  if (services.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
-        <Server className="size-10 text-muted-foreground/30" />
-        <div>
-          <p className="text-sm text-muted-foreground">No services installed</p>
-          <p className="text-xs text-muted-foreground/60 mt-1">
-            Drop service plugins into ~/.pizzapi/services/ to add them.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   const handleOpen = (panel: ServicePanel) => {
     // Mobile needs an absolute, token-authed relay URL (relative paths resolve
     // against the local bundle and carry no auth) — same fix as iframe panels.
@@ -265,7 +234,34 @@ export function RunnerServicesPanel({ runnerId }: RunnerServicesPanelProps) {
     );
   };
 
-  return (
+  let body: React.ReactNode;
+  if (loading && services.length === 0) {
+    body = (
+      <div className="flex items-center justify-center gap-2 p-8 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        <span className="text-sm">Loading services…</span>
+      </div>
+    );
+  } else if (error) {
+    body = (
+      <div className="flex items-center justify-center p-6">
+        <p className="text-sm text-destructive">{error}</p>
+      </div>
+    );
+  } else if (services.length === 0) {
+    body = (
+      <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
+        <Server className="size-10 text-muted-foreground/30" />
+        <div>
+          <p className="text-sm text-muted-foreground">No services installed</p>
+          <p className="text-xs text-muted-foreground/60 mt-1">
+            Drop service plugins into ~/.pizzapi/services/ to add them.
+          </p>
+        </div>
+      </div>
+    );
+  } else {
+    body = (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {toggleError && (
         <div className="col-span-1 sm:col-span-2 flex items-center gap-2 px-3 py-2 rounded-lg border border-destructive/50 bg-destructive/10 text-destructive text-sm">
@@ -408,6 +404,25 @@ export function RunnerServicesPanel({ runnerId }: RunnerServicesPanelProps) {
           </div>
         );
       })}
+    </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          onClick={fetchServices}
+          disabled={loading}
+          className="inline-flex items-center justify-center size-7 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+          title="Refresh services"
+          aria-label="Refresh services"
+        >
+          <RefreshCw className={`size-3.5 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+      {body}
     </div>
   );
 }

--- a/packages/ui/src/components/RunnerTriggersPanel.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.tsx
@@ -32,6 +32,7 @@ import {
   Cpu,
   Sliders,
   Filter,
+  RefreshCw,
   ArrowRight,
   ArrowLeft,
   CheckCircle2,
@@ -1198,15 +1199,27 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
           </div>
         </div>
 
-        {listeners.length > 0 && (
-          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
-            <span className="size-1.5 rounded-full bg-emerald-400"></span>
-            {listeners.length} listener{listeners.length !== 1 ? "s" : ""}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {listeners.length > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
+              <span className="size-1.5 rounded-full bg-emerald-400"></span>
+              {listeners.length} listener{listeners.length !== 1 ? "s" : ""}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={fetchData}
+            disabled={loading}
+            className="inline-flex items-center justify-center size-7 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+            title="Refresh triggers"
+            aria-label="Refresh triggers"
+          >
+            <RefreshCw className={`size-3.5 ${loading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
       </div>
 
-      {loading ? (
+      {loading && triggerDefs.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-36 gap-2 text-muted-foreground">
           <Loader2 className="size-5 animate-spin text-primary" />
           <span className="text-xs font-medium">Loading triggers…</span>

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -12,6 +12,7 @@
  * signed token so the absolute relay URL loads inside the Capacitor webview.
  */
 import { useEffect, useMemo, useState } from "react";
+import { RefreshCw } from "lucide-react";
 import { useTunnelSrc } from "@/hooks/useTunnelSrc";
 import { reportError } from "@/lib/frontend-log";
 
@@ -36,6 +37,8 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
     // panel that never fires onLoad within a grace window as likely-broken.
     const [loadTimedOut, setLoadTimedOut] = useState(false);
     const [loaded, setLoaded] = useState(false);
+    // Bumped to force an iframe remount (reload).
+    const [reloadKey, setReloadKey] = useState(0);
 
     const src = useMemo(() => {
         if (!base) return null;
@@ -66,7 +69,7 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
         // successful onLoad suppresses it even after the timer elapses.
         const t = setTimeout(() => setLoadTimedOut(true), 12_000);
         return () => clearTimeout(t);
-    }, [src]);
+    }, [src, reloadKey]);
 
     if (error) {
         return (
@@ -83,7 +86,17 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
 
     return (
         <div className="relative h-full w-full">
+            <button
+                type="button"
+                onClick={() => setReloadKey((k) => k + 1)}
+                className="absolute right-2 top-2 z-10 inline-flex items-center justify-center rounded bg-background/70 p-1 text-muted-foreground backdrop-blur hover:text-foreground"
+                title="Reload panel"
+                aria-label="Reload panel"
+            >
+                <RefreshCw className="size-3.5" />
+            </button>
             <iframe
+                key={reloadKey}
                 src={src}
                 className="h-full w-full border-0"
                 title={`Service panel — port ${port}`}

--- a/packages/ui/src/components/session-viewer/SessionAnalyzerPanel.tsx
+++ b/packages/ui/src/components/session-viewer/SessionAnalyzerPanel.tsx
@@ -1,6 +1,6 @@
 /** Live context & cache analysis panel inside SessionViewer. */
 import * as React from "react";
-import { BarChart3, Info } from "lucide-react";
+import { BarChart3, Info, RefreshCw } from "lucide-react";
 import { CombinedPanel } from "@/components/CombinedPanel";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Treemap } from "../session-inspector/Treemap";
@@ -158,6 +158,8 @@ function Sparkline({
 export function SessionAnalyzerBody({ analysis, runnerId, sessionId }: SessionAnalyzerBodyProps) {
   const [hoveredBlock, setHoveredBlock] = React.useState<ContextBlock | null>(null);
   const [fetchedAnalysis, setFetchedAnalysis] = React.useState<SessionAnalysis | null>(null);
+  const [refreshKey, setRefreshKey] = React.useState(0);
+  const [refreshing, setRefreshing] = React.useState(false);
 
   React.useEffect(() => {
     if (!runnerId || !sessionId) {
@@ -167,6 +169,7 @@ export function SessionAnalyzerBody({ analysis, runnerId, sessionId }: SessionAn
 
     let cancelled = false;
     setFetchedAnalysis(null);
+    setRefreshing(true);
 
     void fetch(`/api/runners/${encodeURIComponent(runnerId)}/analysis/${encodeURIComponent(sessionId)}`, {
       headers: { Accept: "application/json" },
@@ -181,10 +184,13 @@ export function SessionAnalyzerBody({ analysis, runnerId, sessionId }: SessionAn
       })
       .catch(() => {
         if (!cancelled) setFetchedAnalysis(null);
+      })
+      .finally(() => {
+        if (!cancelled) setRefreshing(false);
       });
 
     return () => { cancelled = true; };
-  }, [runnerId, sessionId]);
+  }, [runnerId, sessionId, refreshKey]);
 
   const effectiveAnalysis = analysis ?? fetchedAnalysis;
 
@@ -239,8 +245,23 @@ export function SessionAnalyzerBody({ analysis, runnerId, sessionId }: SessionAn
   );
   const latestGrowth = growthPoints.length ? growthPoints[growthPoints.length - 1]!.value : null;
 
+  const canRefresh = !!runnerId && !!sessionId;
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 overflow-auto px-3 py-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">Analysis</span>
+        <button
+          type="button"
+          onClick={() => setRefreshKey((k) => k + 1)}
+          disabled={!canRefresh || refreshing}
+          className="inline-flex items-center justify-center size-7 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+          title={canRefresh ? "Refresh analysis" : "Live analysis — nothing to refetch"}
+          aria-label="Refresh analysis"
+        >
+          <RefreshCw className={`size-3.5 ${refreshing ? "animate-spin" : ""}`} />
+        </button>
+      </div>
       {!effectiveAnalysis ? (
         <p className="text-xs text-muted-foreground py-1">Waiting for first response…</p>
       ) : (


### PR DESCRIPTION
## What

Adds Refresh buttons to the four session-viewer panels that previously had no way to reload their data. Each button lives in that panel's own header, matching its existing style (Tunnel/Triggers/Process/Memory/Git already had refresh, so those are untouched).

## Panels

- **RunnerServicesPanel** — right-aligned refresh in a new header row; re-runs `fetchServices`. The service grid now stays visible during a refresh (the full-panel spinner only shows on first load).
- **RunnerTriggersPanel** — refresh added beside the listener-count badge; re-runs `fetchData`. Full "Loading triggers…" now only replaces content before any defs exist, so a refresh no longer blanks the accordions.
- **SessionAnalyzerPanel** — refresh in a new top row; bumps a `refreshKey` to re-run the analysis fetch. Disabled when there's no runner/session to refetch (the live-analysis-only case).
- **IframeServicePanel** — corner reload button that remounts the iframe via a `key` bump.

## Notes

- The Analyzer's data is normally live-streamed via its `analysis` prop, so refresh only re-pulls in the fallback case (prop null, runner + session known) — hence the button disables otherwise.
- No new tests: refresh handlers are one-liners and the existing suites (22 tests across the 4 files) still pass.

## Verification

- `bun test` on all 4 affected test files: **22 pass**
- `bunx tsc --noEmit` (packages/ui): **exit 0**
