### PR TITLE
fix(ui): mode/sidebar consistency and trigger panel UX fixes

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5432,6 +5432,7 @@ export function App() {
               onNewSession={handleNewSession}
               sessionModes={effectiveSessionModes}
               sessionModesRunnerId={modesSource.runnerId}
+              selectedModeId={selectedModeId}
               onSelectedModeChange={setSelectedModeId}
               onClearSelection={handleClearSelection}
               onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); lifecycleClearSelection(); }}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -112,6 +112,8 @@ export interface SessionSidebarProps {
     sessionsCompacting?: Set<string>;
     sessionModes?: ServiceModeDef[];
     sessionModesRunnerId?: string | null;
+    /** Controlled mode filter (null = Code). */
+    selectedModeId?: string | null;
     /** Notified when the user switches session mode (null = no mode filter). */
     onSelectedModeChange?: (modeId: string | null) => void;
     /** Dynamic panels announced by the runner, so launcher buttons can be rendered beneath the session list. */
@@ -236,6 +238,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     sessionsCompacting,
     sessionModes = [],
     sessionModesRunnerId,
+    selectedModeId: selectedModeIdProp = null,
     onSelectedModeChange,
     dynamicPanels = [],
     onOpenLauncherPanel,
@@ -847,15 +850,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         projects: ProjectGroup[];
     }
 
-    const [selectedMode, setSelectedMode] = React.useState<string | null>(null);
+    const selectedMode = selectedModeIdProp ?? null;
+    const setSelectedMode = React.useCallback((modeId: string | null) => onSelectedModeChange?.(modeId), [onSelectedModeChange]);
     const activeMode = sessionModes.find((mode) => mode.id === selectedMode) ?? null;
     React.useEffect(() => {
-        if (selectedMode && !sessionModes.some((mode) => mode.id === selectedMode)) setSelectedMode(null);
-    }, [selectedMode, sessionModes]);
-    // Mirror the selection outward so the host can show that mode's home view.
-    React.useEffect(() => {
-        onSelectedModeChange?.(selectedMode);
-    }, [selectedMode, onSelectedModeChange]);
+        if (selectedMode && !sessionModes.some((mode) => mode.id === selectedMode)) onSelectedModeChange?.(null);
+    }, [selectedMode, sessionModes, onSelectedModeChange]);
     const visibleSessions = React.useMemo(
         () => filterSessionsByMode(liveSessions, selectedMode, sessionModes, sessionModesRunnerId),
         [liveSessions, selectedMode, sessionModes, sessionModesRunnerId],

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -280,13 +280,14 @@ export function useServicePanelState(
     const [panelNavParams, setPanelNavParams] = useState<Map<string, PanelNavParams>>(new Map());
 
     const togglePanel = useCallback((serviceId: string, query?: string, fragment?: string) => {
+        let closing = false;
         setActivePanelIds(prev => {
             const next = new Set(prev);
             if (next.has(serviceId)) {
-                // When toggling OFF with no new nav params, just close.
-                // When toggling with new nav params, keep open and update params.
+                // Navigation params update an open panel; only a plain toggle closes it.
                 if (!query && !fragment) {
                     next.delete(serviceId);
+                    closing = true;
                 }
             } else {
                 next.add(serviceId);
@@ -306,10 +307,9 @@ export function useServicePanelState(
             next.delete(serviceId);
             return next;
         });
-        // Clear ephemeral override when closing so that the next open uses the
-        // stored preference (or a fresh auto-placement), not a stale transient.
+        // Deep-link updates must preserve a panel's transient position.
         setEphemeralPositions(prev => {
-            if (!prev.has(serviceId)) return prev;
+            if (!closing || !prev.has(serviceId)) return prev;
             const next = new Map(prev);
             next.delete(serviceId);
             return next;

--- a/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.test.tsx
@@ -137,6 +137,20 @@ describe("ModeSchedule", () => {
         expect(cancelled).toEqual([instruction]);
     });
 
+    test("guards against concurrent cancellation while the request is pending", async () => {
+        let resolveCancel!: () => void;
+        const onCancel = () => new Promise<void>((resolve) => { resolveCancel = resolve; });
+        const { getByLabelText } = render(
+            <ModeSchedule instructions={[instruction]} sessionNoun="task" onOpenSession={noop} onCancel={onCancel} />,
+        );
+        const button = getByLabelText(/Cancel Every day at 08:00/i) as HTMLButtonElement;
+        fireEvent.click(button);
+        fireEvent.click(button);
+        expect(button.disabled).toBe(true);
+        resolveCancel();
+        await new Promise((resolve) => queueMicrotask(resolve));
+    });
+
     test("an instruction with no message still says what it does", () => {
         const { getByText } = render(
             <ModeSchedule

--- a/packages/ui/src/components/session-viewer/ModeSchedule.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.tsx
@@ -168,7 +168,7 @@ export function ModeSchedule({
                 onClick={() => void cancel(instruction, i)}
                 aria-label={`Cancel ${describeSchedule(instruction.triggerType, instruction.params)}`}
               >
-                {cancelling === key ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
+                {cancelling.has(key) ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
               </Button>
             </div>
           );

--- a/packages/ui/src/components/session-viewer/ModeSchedule.tsx
+++ b/packages/ui/src/components/session-viewer/ModeSchedule.tsx
@@ -101,15 +101,19 @@ export function ModeSchedule({
   onOpenSession: (sessionId: string) => void;
   onCancel: (instruction: ScheduledInstruction) => void;
 }) {
-  const [cancelling, setCancelling] = React.useState<string | null>(null);
+  const [cancelling, setCancelling] = React.useState<Set<string>>(new Set());
 
   const cancel = async (instruction: ScheduledInstruction, index: number) => {
     const key = instructionKey(instruction, index);
-    setCancelling(key);
+    setCancelling((prev) => new Set(prev).add(key));
     try {
       await onCancel(instruction);
     } finally {
-      setCancelling(null);
+      setCancelling((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     }
   };
 
@@ -160,7 +164,7 @@ export function ModeSchedule({
                 size="icon"
                 variant="ghost"
                 className="size-7 shrink-0"
-                disabled={cancelling === key}
+                disabled={cancelling.has(key)}
                 onClick={() => void cancel(instruction, i)}
                 aria-label={`Cancel ${describeSchedule(instruction.triggerType, instruction.params)}`}
               >


### PR DESCRIPTION
Fixes the mode/sidebar consistency and smaller UX findings from the Mode/Schedules/Triggers audit (Theme 6 + misc).

- Sidebar mode filtering uses `findSessionMode` (deepest-workspace wins), matching App and server semantics — nested workspaces no longer appear in multiple modes.
- Code filter no longer hides deep-linked/restored mode sessions; mode switching is atomic (selection lifted to App, no flash of the wrong surface).
- `ModeSchedule` cancellation tracked as a Set (overlapping row cancels no longer clobber each other); double-submit guards on schedule creation.
- Filter editor preserves `contains` ops and array values instead of rewriting to `eq` comma-strings.
- Empty states for filtered history, correct dynamic aria-labels on launcher close buttons, `togglePanel` clears ephemeral dock position only on actual close.

Tests: UI suite 1491 passed / 1 skipped; root typecheck clean.
