### PR TITLE
fix(triggers): typed subscribe failure, delivery-state split, per-mode batching + snapshot-race regression tests

### DIFF
--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -22,7 +22,7 @@ import { cancelPendingApproval, consumePendingApprovalFromWeb } from "../remote-
 import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../remote-input.js";
 import { handleExecFromWeb } from "../remote-exec-handler.js";
 import { renderTrigger, renderTriggerBatch } from "../triggers/registry.js";
-import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck, markTriggerHandled } from "../triggers/extension.js";
+import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck, markTriggerHandled, markTriggerDelivered, markTriggerInjectionFailed, partitionTriggerBatchByDeliveryMode } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import type { RelayContext } from "../remote-types.js";
 import { emitSessionActive } from "./chunked-delivery.js";
@@ -262,20 +262,27 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         triggerBatchTimer = null;
         if (pendingTriggerBatch.length === 0) return;
         const batch = pendingTriggerBatch.splice(0);
-        // If ANY trigger in the batch explicitly requested "steer", the batch
-        // interrupts: an explicit interrupt intent (e.g. a usage-limit
-        // session_error) must not be silently downgraded just because it was
-        // debounced alongside a "followUp" trigger like session_complete.
-        const deliverAs = batch.some((b) => b.deliverAs === "steer") ? "steer" as const : "followUp" as const;
-        const rendered = renderTriggerBatch(batch.map((b) => b.trigger));
+        // Batch per delivery mode: a steering trigger must interrupt, but it
+        // must not upgrade unrelated followUp triggers that happened to arrive
+        // in the same debounce window into an interruption (and vice versa).
+        const groups = partitionTriggerBatchByDeliveryMode(batch);
         void (async () => {
-            try {
-                await waitForWorkerStartupComplete();
-                await handlers.sendUserMessage(rendered, { deliverAs });
-            } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                log.error(`pizzapi: failed to deliver trigger batch: ${message}`);
-                rctx.forwardEvent({ type: "cli_error", message: `Failed to deliver trigger batch: ${message}`, source: "remote", ts: Date.now() });
+            for (const group of groups) {
+                const rendered = renderTriggerBatch(group.items.map((b) => b.trigger));
+                try {
+                    await waitForWorkerStartupComplete();
+                    await handlers.sendUserMessage(rendered, { deliverAs: group.deliverAs });
+                    // Received → delivered: only now is deduping a redelivery safe.
+                    for (const item of group.items) markTriggerDelivered(item.trigger.triggerId);
+                } catch (err) {
+                    // Injection failed — drop the dedupe entries so a relay
+                    // redelivery of these triggerIds is accepted rather than
+                    // silently discarded as duplicates (permanent trigger loss).
+                    for (const item of group.items) markTriggerInjectionFailed(item.trigger.triggerId);
+                    const message = err instanceof Error ? err.message : String(err);
+                    log.error(`pizzapi: failed to deliver trigger batch (${group.deliverAs}): ${message}`);
+                    rctx.forwardEvent({ type: "cli_error", message: `Failed to deliver trigger batch: ${message}`, source: "remote", ts: Date.now() });
+                }
             }
         })();
     };

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -45,7 +45,7 @@ function isJsonValue(value: unknown): value is JsonValue {
  *  long time to respond must never find its own bookkeeping expired the
  *  trigger out from under it — see waitForTriggerResponse, which likewise no
  *  longer times out the child side of this same wait. */
-export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
+export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number; delivered?: boolean }>();
 // Dedup guard so a re-delivered triggerId (e.g. after escalation) isn't re-tracked as new.
 const handledTriggerTombstones = new Map<string, number>();
 
@@ -149,6 +149,35 @@ export function trackReceivedTrigger(triggerId: string, sourceSessionId: string,
     if (receivedTriggers.has(triggerId) || handledTriggerTombstones.has(triggerId)) return false;
     receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: Date.now() });
     return true;
+}
+
+/** Split a debounced trigger batch by delivery mode so a steering trigger
+ *  interrupts on its own without upgrading unrelated followUp triggers that
+ *  shared the same debounce window (and vice versa). Steer group first. */
+export function partitionTriggerBatchByDeliveryMode<T extends { deliverAs: "steer" | "followUp" }>(
+    batch: T[],
+): Array<{ deliverAs: "steer" | "followUp"; items: T[] }> {
+    return [
+        { deliverAs: "steer" as const, items: batch.filter((b) => b.deliverAs === "steer") },
+        { deliverAs: "followUp" as const, items: batch.filter((b) => b.deliverAs !== "steer") },
+    ].filter((g) => g.items.length > 0);
+}
+
+/** Mark a tracked trigger as injected into the agent conversation. Received
+ *  (tracked) and delivered (agent saw it) are distinct states: dedupe of a
+ *  redelivery is only correct once the agent actually got the message. */
+export function markTriggerDelivered(triggerId: string): void {
+    const entry = receivedTriggers.get(triggerId);
+    if (entry) entry.delivered = true;
+}
+
+/** Remove the dedupe entry for a trigger whose agent injection failed, so a
+ *  relay redelivery of the same triggerId is accepted instead of being dropped
+ *  as a duplicate — otherwise a single failed sendUserMessage is permanent
+ *  trigger loss. No tombstone is written: the agent never saw the trigger. */
+export function markTriggerInjectionFailed(triggerId: string): void {
+    const entry = receivedTriggers.get(triggerId);
+    if (entry && !entry.delivered) receivedTriggers.delete(triggerId);
 }
 
 // ── Built-in sigils ──────────────────────────────────────────────────────────

--- a/packages/cli/src/extensions/triggers/trigger-delivery-state.test.ts
+++ b/packages/cli/src/extensions/triggers/trigger-delivery-state.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the received → delivered trigger state split and per-mode batching.
+ *
+ * Regression (P1): trackReceivedTrigger recorded the trigger ID at receipt,
+ * BEFORE the debounced sendUserMessage injected it into the agent. If that
+ * injection failed, the relay's redelivery of the same triggerId was dropped
+ * as a duplicate — permanent trigger loss. markTriggerInjectionFailed must
+ * remove the dedupe entry so redelivery is accepted, and markTriggerDelivered
+ * must pin the entry so a late injection-failure signal can't evict a
+ * successfully delivered trigger.
+ *
+ * Regression (P2): a single steering trigger upgraded the whole 80ms debounce
+ * batch to "steer". partitionTriggerBatchByDeliveryMode must keep the modes
+ * separate.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+    trackReceivedTrigger,
+    receivedTriggers,
+    markTriggerHandled,
+    markTriggerDelivered,
+    markTriggerInjectionFailed,
+    partitionTriggerBatchByDeliveryMode,
+} from "./extension.js";
+
+describe("received vs delivered trigger state", () => {
+    beforeEach(() => {
+        receivedTriggers.clear();
+    });
+
+    test("injection failure removes the dedupe entry so redelivery is accepted", () => {
+        expect(trackReceivedTrigger("t1", "child-1", "session_complete")).toBe(true);
+        // Duplicate while pending is still rejected.
+        expect(trackReceivedTrigger("t1", "child-1", "session_complete")).toBe(false);
+
+        // sendUserMessage failed — the agent never saw the trigger.
+        markTriggerInjectionFailed("t1");
+        expect(receivedTriggers.has("t1")).toBe(false);
+
+        // The relay redelivers the same triggerId: it must be accepted, not
+        // dropped as a duplicate (that was the permanent-loss bug).
+        expect(trackReceivedTrigger("t1", "child-1", "session_complete")).toBe(true);
+    });
+
+    test("delivered triggers are immune to a late injection-failure signal", () => {
+        trackReceivedTrigger("t2", "child-1", "session_complete");
+        markTriggerDelivered("t2");
+        // A stale failure signal (e.g. from a racing batch) must not evict a
+        // delivered trigger — it's still needed for response routing.
+        markTriggerInjectionFailed("t2");
+        expect(receivedTriggers.has("t2")).toBe(true);
+        expect(receivedTriggers.get("t2")?.delivered).toBe(true);
+        // And it still dedupes redelivery.
+        expect(trackReceivedTrigger("t2", "child-1", "session_complete")).toBe(false);
+    });
+
+    test("handled triggers stay tombstoned even after injection-failure signal", () => {
+        trackReceivedTrigger("t3", "child-1", "session_complete");
+        markTriggerDelivered("t3");
+        markTriggerHandled("t3");
+        markTriggerInjectionFailed("t3");
+        // The tombstone from markTriggerHandled still blocks re-tracking.
+        expect(trackReceivedTrigger("t3", "child-1", "session_complete")).toBe(false);
+    });
+
+    test("injection failure for an unknown trigger is a no-op", () => {
+        expect(() => markTriggerInjectionFailed("nope")).not.toThrow();
+    });
+});
+
+describe("partitionTriggerBatchByDeliveryMode", () => {
+    test("mixed batch splits into steer and followUp groups, steer first", () => {
+        const batch = [
+            { deliverAs: "followUp" as const, id: "a" },
+            { deliverAs: "steer" as const, id: "b" },
+            { deliverAs: "followUp" as const, id: "c" },
+        ];
+        const groups = partitionTriggerBatchByDeliveryMode(batch);
+        expect(groups).toHaveLength(2);
+        expect(groups[0].deliverAs).toBe("steer");
+        expect(groups[0].items.map((i) => i.id)).toEqual(["b"]);
+        // followUp triggers are NOT upgraded to steer by sharing the window.
+        expect(groups[1].deliverAs).toBe("followUp");
+        expect(groups[1].items.map((i) => i.id)).toEqual(["a", "c"]);
+    });
+
+    test("homogeneous batch yields a single group", () => {
+        const groups = partitionTriggerBatchByDeliveryMode([
+            { deliverAs: "followUp" as const },
+            { deliverAs: "followUp" as const },
+        ]);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].deliverAs).toBe("followUp");
+        expect(groups[0].items).toHaveLength(2);
+    });
+
+    test("empty batch yields no groups", () => {
+        expect(partitionTriggerBatchByDeliveryMode([])).toEqual([]);
+    });
+});

--- a/packages/cli/src/runner/daemon.trigger-reconciliation.test.ts
+++ b/packages/cli/src/runner/daemon.trigger-reconciliation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
-import { applyTriggerSubscriptionDeltaToCache, reconcileSnapshotSubscriptions } from "./daemon.js";
+import { applyTriggerSubscriptionDeltaToCache, reconcileSnapshotSubscriptions, replayNewerTriggerDeltas } from "./daemon.js";
 import { ServiceRegistry, type ServiceHandler, type ServiceInitOptions, type ReconcileOptions } from "./service-handler.js";
 import type { Socket } from "socket.io-client";
 
@@ -53,6 +53,59 @@ describe("applyTriggerSubscriptionDeltaToCache", () => {
             ...first,
             subscriptionId: "legacy:all:time:timer_fired",
         })).toEqual([other]);
+    });
+});
+
+describe("replayNewerTriggerDeltas — snapshot/delta race", () => {
+    // Regression: the server reserves snapshotRevision BEFORE the async
+    // subscription read, so a delta at revision N+1 can be applied by the
+    // daemon and then overwritten by a snapshot at revision N that predates
+    // it. Replaying buffered deltas with revision > snapshot revision must
+    // restore the newer state.
+    test("a subscribe delta newer than the snapshot survives snapshot install", () => {
+        const preexisting = entry("session-1", "time:cron", "sub-old");
+        const newSub = entry("session-2", "github:pr_comment", "sub-new");
+        // Snapshot at revision 10 was read before sub-new was stored.
+        const result = replayNewerTriggerDeltas([preexisting], 10, [
+            { revision: 11, action: "subscribe", subscription: newSub },
+        ]);
+        expect(result).toEqual([preexisting, newSub]);
+    });
+
+    test("an unsubscribe delta newer than the snapshot survives snapshot install", () => {
+        const kept = entry("session-1", "time:cron", "sub-kept");
+        const removed = entry("session-1", "time:at", "sub-removed");
+        // Snapshot (rev 10) still contains sub-removed because the store read
+        // happened before the unsubscribe (rev 12) landed.
+        const result = replayNewerTriggerDeltas([kept, removed], 10, [
+            { revision: 12, action: "unsubscribe", subscription: removed },
+        ]);
+        expect(result).toEqual([kept]);
+    });
+
+    test("deltas at or below the snapshot revision are NOT replayed", () => {
+        const current = entry("session-1", "time:cron", "sub-1");
+        const stale = entry("session-1", "time:cron", "sub-1");
+        // A delta already reflected in the snapshot (revision ≤ snapshot) must
+        // not be re-applied — e.g. an old unsubscribe would wrongly delete a
+        // re-created subscription the snapshot carries.
+        const result = replayNewerTriggerDeltas([current], 10, [
+            { revision: 9, action: "unsubscribe", subscription: stale },
+            { revision: 10, action: "unsubscribe", subscription: stale },
+        ]);
+        expect(result).toEqual([current]);
+    });
+
+    test("multiple newer deltas replay in order on top of the baseline", () => {
+        const base = entry("session-1", "time:cron", "sub-a");
+        const added = entry("session-2", "svc:event", "sub-b");
+        const updated = { ...added, params: { x: "1" } };
+        const result = replayNewerTriggerDeltas([base], 5, [
+            { revision: 6, action: "subscribe", subscription: added },
+            { revision: 7, action: "update", subscription: updated },
+            { revision: 8, action: "unsubscribe", subscription: base },
+        ]);
+        expect(result).toEqual([updated]);
     });
 });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -484,6 +484,25 @@ export function applyTriggerSubscriptionDeltaToCache(
     return action === "unsubscribe" ? next : [...next, subscription];
 }
 
+/**
+ * Replay deltas that overtook an async snapshot read: any buffered delta with a
+ * revision strictly greater than the snapshot's revision was emitted after the
+ * server reserved the snapshot revision, so the baseline must not erase it.
+ */
+export function replayNewerTriggerDeltas(
+    snapshot: TriggerSubscriptionEntry[],
+    snapshotRevision: number,
+    deltas: Array<{ revision: number; action: "subscribe" | "update" | "unsubscribe"; subscription: TriggerSubscriptionEntry }>,
+): TriggerSubscriptionEntry[] {
+    let result = snapshot;
+    for (const delta of deltas) {
+        if (delta.revision > snapshotRevision) {
+            result = applyTriggerSubscriptionDeltaToCache(result, delta.action, delta.subscription);
+        }
+    }
+    return result;
+}
+
 export function reconcileSnapshotSubscriptions(
     registry: ServiceRegistry,
     subscriptions: TriggerSubscriptionEntry[],
@@ -1609,14 +1628,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 lastAppliedRevision = revision;
 
                 logInfo(`[trigger-reconciliation] received snapshot revision=${revision} with ${subscriptions.length} subscriptions`);
-                cachedTriggerSubscriptions = subscriptions as TriggerSubscriptionEntry[];
                 // A delta may have overtaken the async snapshot read. Replay the
                 // remembered newer deltas so the baseline cannot erase them.
-                for (const delta of recentTriggerDeltas) {
-                    if (delta.revision > revision) {
-                        cachedTriggerSubscriptions = applyTriggerSubscriptionDeltaToCache(cachedTriggerSubscriptions, delta.action, delta.subscription);
-                    }
-                }
+                cachedTriggerSubscriptions = replayNewerTriggerDeltas(subscriptions as TriggerSubscriptionEntry[], revision, recentTriggerDeltas);
 
                 const { applied: totalApplied, errors: allErrors } = reconcileSnapshotSubscriptions(registry, cachedTriggerSubscriptions);
 

--- a/packages/server/src/routes/triggers.reconciliation.test.ts
+++ b/packages/server/src/routes/triggers.reconciliation.test.ts
@@ -140,7 +140,9 @@ const SESSION_WITH_RUNNER = {
 describe("trigger subscription reconciliation — delta emission", () => {
     beforeEach(() => {
         mockEmitDelta.mockClear();
+        mockBroadcastToSessionViewers.mockClear();
         mockGetSharedSession.mockReset();
+        mockSubscribeSessionToTrigger.mockReturnValue(Promise.resolve("sub-default"));
         mockRequireSession.mockReturnValue(
             Promise.resolve({ userId: "user-1", userName: "TestUser" }),
         );
@@ -285,6 +287,29 @@ describe("trigger subscription reconciliation — delta emission", () => {
             expect(delta.subscription.subscriptionId).toBe("sub-with-filters");
             expect(delta.subscription.filters?.[0].field).toBe("status");
             expect(delta.subscription.filterMode).toBe("and");
+        });
+
+        test("store failure returns 503 and emits NO delta and NO viewer broadcast", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+            // Store failure (Redis down / write error) — typed null, not "".
+            mockSubscribeSessionToTrigger.mockReturnValue(Promise.resolve(null as any));
+
+            const [req, url] = makeReq(
+                "POST",
+                "/api/sessions/sess-1/trigger-subscriptions",
+                { triggerType: "godmother:idea_moved" },
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(503);
+            const body = await res!.json() as any;
+            expect(body.ok).toBeUndefined();
+            expect(body.error).toContain("Failed to store");
+            // No empty-ID delta may reach the runner, and viewers must not be
+            // told a subscription exists.
+            expect(mockEmitDelta).not.toHaveBeenCalled();
+            expect(mockBroadcastToSessionViewers).not.toHaveBeenCalled();
         });
 
         test("does NOT emit a delta when session has no runner", async () => {

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -1162,6 +1162,13 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         }
 
         const subscriptionId = await subscribeSessionToTrigger(sessionId, session.runnerId, triggerType, undefined, subParams, subFilters, subFilterMode);
+        if (!subscriptionId) {
+            // Store failure (Redis down or write error). Do NOT report success or
+            // emit a delta — an empty-ID subscribe delta would poison the runner's
+            // subscription cache with an unremovable phantom entry.
+            log.warn(`Failed to persist trigger subscription for session ${sessionId} type '${triggerType}'`);
+            return Response.json({ error: "Failed to store trigger subscription" }, { status: 503 });
+        }
         const logParts: string[] = [];
         if (subParams) logParts.push(`params=${JSON.stringify(subParams)}`);
         if (subFilters) logParts.push(`filters=${JSON.stringify(subFilters)} mode=${subFilterMode ?? "and"}`);

--- a/packages/server/src/sessions/trigger-subscription-store.test.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.test.ts
@@ -115,6 +115,29 @@ function resetState() {
 describe("subscribeSessionToTrigger", () => {
     beforeEach(resetState);
 
+    test("returns a non-empty subscriptionId on success", async () => {
+        const id = await subscribeSessionToTrigger("session-1", "runner-A", "svc:event");
+        expect(id).toBeTruthy();
+        expect(typeof id).toBe("string");
+    });
+
+    test("returns null (typed failure) when the Redis write fails", async () => {
+        _injectRedisForTesting({
+            ...mockRedisClient,
+            multi: () => ({
+                hSet: function () { return this; },
+                sAdd: function () { return this; },
+                expire: function () { return this; },
+                exec: () => Promise.reject(new Error("redis down")),
+            }),
+        });
+        const id = await subscribeSessionToTrigger("session-1", "runner-A", "svc:event");
+        expect(id).toBeNull();
+        // Nothing half-written into the visible state.
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs).toHaveLength(0);
+    });
+
     test("adds triggerType → runnerId to session hash", async () => {
         await subscribeSessionToTrigger("session-1", "runner-A", "godmother:idea_moved");
         const subs = await listSessionSubscriptions("session-1");

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -459,9 +459,9 @@ export async function subscribeSessionToTrigger(
     params?: SubscriptionParams,
     filters?: SubscriptionFilter[],
     filterMode?: SubscriptionFilterMode,
-): Promise<string> {
+): Promise<string | null> {
     const redis = await getClient();
-    if (!redis) return "";
+    if (!redis) return null;
 
     const sessionKey = SESSION_SUBS_KEY(sessionId);
     const indexKey = RUNNER_TYPE_INDEX_KEY(runnerId, triggerType);
@@ -498,7 +498,7 @@ export async function subscribeSessionToTrigger(
         return subscriptionId;
     } catch (err) {
         log.warn("Failed to subscribe session to trigger:", err);
-        return "";
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the remaining P1/P2 trigger-system state-management defects from the 2026-08-20 state audit (section 4 "Triggers"). Three of the six audit items were already fixed on main by #756 — this PR verifies them and adds the missing regression coverage, then implements the three that were still live.

## Already fixed by #756 (regression tests added here)

- **Snapshot/delta race** — the daemon already buffers `recentTriggerDeltas` and replays deltas with revision > snapshot revision on top of the reconnect baseline. It had no test coverage, so the replay logic is extracted into a pure `replayNewerTriggerDeltas()` helper with 4 regression tests (newer subscribe/unsubscribe survive snapshot install, deltas at/below snapshot revision are not re-applied, ordered multi-delta replay).
- **Reverse-index sibling bug** — `unsubscribeSessionSubscription` already checks for surviving same-runner/same-type siblings before `SREM`.
- **Targeted unsubscribe of a nonexistent subscription** — the route already returns 404 on `removed === 0` and only emits a runner delta after confirmed deletion.

## Newly implemented

- **Typed subscribe failure (P1)** — `subscribeSessionToTrigger` returns `string | null` instead of swallowing failures as `""`. On null the POST route returns **503** and emits neither the viewer broadcast nor the runner delta, so an empty-ID subscribe delta can no longer poison the runner's subscription cache while the caller believes it succeeded.
- **Received vs delivered trigger states (P1)** — `trackReceivedTrigger` no longer acts as a permanent tombstone before agent injection. `markTriggerDelivered` pins the entry once `sendUserMessage` succeeds; `markTriggerInjectionFailed` drops the dedupe entry on failure (no tombstone), so a relay redelivery of the same triggerId is accepted instead of dropped as a duplicate — a single failed injection was previously permanent trigger loss.
- **Per-delivery-mode batching (P2)** — a steering trigger in the 80ms debounce window no longer upgrades unrelated followUp triggers to steer (and vice versa). `partitionTriggerBatchByDeliveryMode` splits the batch into steer-then-followUp groups flushed as separate messages, with per-group failure handling.

Deliberately out of scope (larger designs, per audit): SQLite as transactional source of truth, per-runner acked delta outbox.

## Test results

- `bun run typecheck` — clean
- `bun scripts/test-isolated.ts packages/server/src` (Redis up) — 80 passed, 0 failed
- `bun test packages/cli/src` — 2994 pass, 2 skip, 0 fail

New tests: store null-on-Redis-failure with nothing half-written; route 503 + zero emits on store failure; snapshot/delta replay race (4 cases); injection-failure redelivery, delivered-entry immunity, tombstone precedence; batch partitioning (mixed/homogeneous/empty).
