### PR TITLE
fix(server,cli): child-session ownership state-management defects

### DIFF
--- a/packages/cli/src/extensions/subagent/relay-mirror.test.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.test.ts
@@ -375,3 +375,70 @@ describe("createSubagentMirror", () => {
         expect(name.endsWith("…")).toBe(true);
     });
 });
+
+// ── Reconnect behavior ────────────────────────────────────────────────────────
+
+describe("subagent mirror reconnect", () => {
+    test("re-registers the same sessionId after a relay blip and replays the last snapshot", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+            now: (() => { let t = 0; return () => (t += 20000); })(),
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok-1" });
+        mirror.update(result({ messages: [{ role: "assistant", content: "hi" }] as any }));
+        const firstSessionId = fake.emitted.find((e) => e.event === "register")!.payload.sessionId;
+
+        // Relay blip
+        fake.fire("disconnect");
+        const countBefore = fake.emitted.length;
+        // Emits while disconnected are suppressed (token invalidated)
+        mirror.update(result());
+        expect(fake.emitted.length).toBe(countBefore);
+
+        // Reconnect: register re-sent with the SAME session id
+        fake.fire("connect");
+        const registers = fake.emitted.filter((e) => e.event === "register");
+        expect(registers.length).toBe(2);
+        expect(registers[1].payload.sessionId).toBe(firstSessionId);
+        expect(registers[1].payload.parentSessionId).toBe("parent-session");
+
+        // New token accepted; pending/last snapshot flushed under it
+        fake.fire("registered", { token: "tok-2" });
+        const events = fake.emitted.filter((e) => e.event === "event");
+        const last = events[events.length - 1];
+        expect(last.payload.token).toBe("tok-2");
+    });
+
+    test("replays last snapshot on re-register even with no pending update", () => {
+        const fake = makeFakeSocket();
+        const mirror = createSubagentMirror({
+            agentName: "a",
+            task: "t",
+            cwd: "/repo",
+            env: ENV,
+            socketFactory: () => fake.socket,
+            now: (() => { let t = 0; return () => (t += 20000); })(),
+        })!;
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok-1" });
+        mirror.update(result({ messages: [{ role: "assistant", content: "hi" }] as any }));
+        const eventsBefore = fake.emitted.filter((e) => e.event === "event").length;
+        expect(eventsBefore).toBeGreaterThan(0);
+
+        fake.fire("disconnect");
+        fake.fire("connect");
+        fake.fire("registered", { token: "tok-2" });
+
+        const active = fake.emitted
+            .filter((e) => e.event === "event" && e.payload.event.type === "session_active")
+            .pop()!;
+        expect(active.payload.token).toBe("tok-2");
+        expect(active.payload.event.state.messages.length).toBe(1);
+    });
+});

--- a/packages/cli/src/extensions/subagent/relay-mirror.ts
+++ b/packages/cli/src/extensions/subagent/relay-mirror.ts
@@ -130,7 +130,14 @@ const defaultSocketFactory: SocketFactory = (url, apiKey): Socket =>
     io(`${url}/relay`, {
         auth: { apiKey, protocolVersion: SOCKET_PROTOCOL_VERSION },
         transports: ["websocket"],
-        reconnection: false,
+        // Controlled reconnect: a relay blip must not permanently kill subagent
+        // visibility while the subagent keeps running. On reconnect we re-emit
+        // register with the SAME sessionId (see the "connect" handler), so the
+        // server reconciles state and the mirror resumes under the same child.
+        reconnection: true,
+        reconnectionAttempts: 20,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 15000,
     });
 
 export interface MirrorOptions {
@@ -181,6 +188,8 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
     let lastSnapshotAt = 0;
     /** Snapshot held back by the throttle, flushed by the next update/finish. */
     let pending: SingleResult | null = null;
+    /** Last snapshot sent — replayed after a reconnect re-registration. */
+    let lastResult: SingleResult | null = null;
     let throttleTimer: ReturnType<typeof setTimeout> | null = null;
 
     const emit = (event: unknown) => {
@@ -247,6 +256,7 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
         if (!pending) return;
         const result = pending;
         pending = null;
+        lastResult = result;
         lastSnapshotAt = now();
         snapshot(result, true);
     };
@@ -267,7 +277,11 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
         if (closed) return;
         token = typeof data?.token === "string" ? data.token : null;
         // Flush whatever the subagent has produced while we were connecting.
+        // On a RE-registration (reconnect after a relay blip) there may be no
+        // pending update for a while — replay the last snapshot so the fresh
+        // server-side session record isn't empty until the next update.
         if (pending) flushPending();
+        else if (lastResult) snapshot(lastResult, true);
     });
 
     // Keep the child session visibly alive between snapshots — a long tool call
@@ -289,6 +303,12 @@ export function createSubagentMirror(opts: MirrorOptions): SubagentMirror | null
 
     socket.on("connect_error", (err: unknown) => {
         log.warn("subagent mirror connect failed:", err);
+    });
+
+    // Invalidate the token on disconnect — the server issues a fresh one on
+    // re-registration, and emitting with the stale token would be rejected.
+    socket.on("disconnect", () => {
+        if (!closed) token = null;
     });
 
     const teardown = () => {

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -83,11 +83,14 @@ export interface RelayClientToServerEvents {
   }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 
   /** Parent requests cleanup of a completed child session.
-   *  The server validates the parent↔child relationship and tears down the child. */
+   *  The server validates the parent↔child relationship and tears down the child.
+   *  Ack: `{ ok: true }` once child termination is observed; `{ ok: true,
+   *  pending: true }` when teardown was initiated but not yet confirmed
+   *  (the orphan sweeper backstops completion). */
   cleanup_child_session: (data: {
     token: string;
     childSessionId: string;
-  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
+  }, ack?: (result: { ok: boolean; pending?: boolean; error?: string }) => void) => void;
 
   /** Returns how many linked child sessions are still associated with this parent. */
   get_linked_child_count: (data: {

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ack.test.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ack.test.ts
@@ -1,0 +1,173 @@
+// ============================================================================
+// child-lifecycle.ack.test.ts — Regression tests for cleanup_child_session
+// ack ordering (ack after observed termination, pending status on timeout)
+// and stale-entry removal for already-gone children.
+// ============================================================================
+
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Mocked collaborators ─────────────────────────────────────────────────────
+
+const sessions = new Map<string, Record<string, unknown>>();
+const childSets = new Map<string, Set<string>>();
+const emittedToRelay: Array<{ sessionId: string; event: string; payload: unknown }> = [];
+const endedSessions: Array<{ sessionId: string; reason: string; opts?: unknown }> = [];
+
+mock.module("../../sio-registry.js", () => ({
+    getSharedSessionSummary: async (id: string) => sessions.get(id) ?? null,
+    emitToRelaySession: (sessionId: string, event: string, payload: unknown) => {
+        emittedToRelay.push({ sessionId, event, payload });
+    },
+    emitToRelaySessionAwaitingAck: async () => ({ hadListeners: false, acked: false }),
+    emitToRunner: () => {},
+    endSharedSession: async (sessionId: string, reason: string, opts?: unknown) => {
+        endedSessions.push({ sessionId, reason, opts });
+        sessions.delete(sessionId);
+    },
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    removeChildSession: async (parentId: string, childId: string) => {
+        childSets.get(parentId)?.delete(childId);
+    },
+    removeChildren: async () => {},
+    addPendingParentDelinkChildren: async () => {},
+    getChildSessions: async (parentId: string) => Array.from(childSets.get(parentId) ?? []),
+    getPendingParentDelinkChildren: async () => [],
+    removePendingParentDelinkChild: async () => {},
+    getSessionSummary: async (id: string) => sessions.get(id) ?? null,
+    markChildAsDelinked: async () => {},
+    isChildDelinked: async () => false,
+    isChildOfParent: async (parentId: string, childId: string) =>
+        childSets.get(parentId)?.has(childId) ?? false,
+    clearParentSessionId: async () => {},
+}));
+
+afterAll(() => mock.restore());
+
+const { registerChildLifecycleHandlers, waitForChildTermination, childTerminationWait } =
+    await import("./child-lifecycle.js");
+
+// ── Fake socket / io ─────────────────────────────────────────────────────────
+
+function makeSocket(sessionId: string, token = "tok") {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    return {
+        handlers,
+        socket: {
+            data: { sessionId, token },
+            on(event: string, cb: (...args: unknown[]) => unknown) {
+                handlers.set(event, cb);
+            },
+            emit: () => {},
+        } as never,
+        async fire(event: string, data: unknown): Promise<unknown> {
+            let ackResult: unknown;
+            await handlers.get(event)!(data, (r: unknown) => {
+                ackResult = r;
+            });
+            return ackResult;
+        },
+    };
+}
+
+/** Fake io whose adapter reports whether the child has a relay socket. */
+function makeIo(hasRecipient: boolean) {
+    return {
+        of: () => ({
+            adapter: { sockets: async () => (hasRecipient ? new Set(["sock-1"]) : new Set()) },
+        }),
+    } as never;
+}
+
+function seed(parentId: string, childId: string, extra: Record<string, unknown> = {}) {
+    sessions.set(parentId, { sessionId: parentId, userId: "u1", parentSessionId: null });
+    sessions.set(childId, { sessionId: childId, userId: "u1", parentSessionId: parentId, runnerId: null, ...extra });
+    childSets.set(parentId, new Set([childId]));
+}
+
+describe("cleanup_child_session ack ordering", () => {
+    beforeEach(() => {
+        sessions.clear();
+        childSets.clear();
+        emittedToRelay.length = 0;
+        endedSessions.length = 0;
+        childTerminationWait.timeoutMs = 300;
+        childTerminationWait.pollMs = 20;
+    });
+
+    it("acks plain ok once child termination is observed", async () => {
+        seed("parent", "child");
+        const { socket, fire } = makeSocket("parent");
+        registerChildLifecycleHandlers(socket, makeIo(true));
+
+        // Simulate the child terminating shortly after the exec is sent.
+        setTimeout(() => sessions.delete("child"), 50);
+
+        const ack = (await fire("cleanup_child_session", { token: "tok", childSessionId: "child" })) as {
+            ok: boolean;
+            pending?: boolean;
+        };
+        expect(ack.ok).toBe(true);
+        expect(ack.pending).toBeUndefined();
+        // Termination exec was dispatched before the ack.
+        expect(emittedToRelay.some((e) => e.sessionId === "child" && e.event === "exec")).toBe(true);
+    });
+
+    it("acks pending when the child does not terminate within the bounded wait", async () => {
+        seed("parent", "child");
+        const { socket, fire } = makeSocket("parent");
+        registerChildLifecycleHandlers(socket, makeIo(true));
+
+        const ack = (await fire("cleanup_child_session", { token: "tok", childSessionId: "child" })) as {
+            ok: boolean;
+            pending?: boolean;
+        };
+        expect(ack.ok).toBe(true);
+        expect(ack.pending).toBe(true);
+    });
+
+    it("ends the child directly (confirmedTerminal) when no relay recipient exists", async () => {
+        seed("parent", "child");
+        const { socket, fire } = makeSocket("parent");
+        registerChildLifecycleHandlers(socket, makeIo(false));
+
+        const ack = (await fire("cleanup_child_session", { token: "tok", childSessionId: "child" })) as {
+            ok: boolean;
+        };
+        expect(ack.ok).toBe(true);
+        expect(endedSessions).toEqual([
+            { sessionId: "child", reason: "Parent acknowledged completion", opts: { confirmedTerminal: true } },
+        ]);
+    });
+
+    it("removes the stale membership entry when the child is already gone", async () => {
+        sessions.set("parent", { sessionId: "parent", userId: "u1", parentSessionId: null });
+        childSets.set("parent", new Set(["ghost-child"]));
+        const { socket, fire } = makeSocket("parent");
+        registerChildLifecycleHandlers(socket, makeIo(false));
+
+        const ack = (await fire("cleanup_child_session", { token: "tok", childSessionId: "ghost-child" })) as {
+            ok: boolean;
+        };
+        expect(ack.ok).toBe(true);
+        expect(childSets.get("parent")?.has("ghost-child")).toBe(false);
+    });
+});
+
+describe("waitForChildTermination", () => {
+    beforeEach(() => {
+        childTerminationWait.timeoutMs = 200;
+        childTerminationWait.pollMs = 20;
+    });
+
+    it("returns true immediately when the session is already gone", async () => {
+        expect(await waitForChildTermination("nope", { getSession: async () => null })).toBe(true);
+    });
+
+    it("returns false when the session outlives the wait", async () => {
+        expect(
+            await waitForChildTermination("stuck", { getSession: async () => ({ sessionId: "stuck" }) as never }),
+        ).toBe(false);
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -65,6 +65,27 @@ export async function countLinkedChildrenForParent(
     return checks.filter(Boolean).length;
 }
 
+/** Tunable for tests. */
+export const childTerminationWait = { timeoutMs: 5000, pollMs: 200 };
+
+/**
+ * Poll until the child's Redis session record disappears (termination
+ * observed) or the bounded wait elapses. Returns true iff termination was
+ * observed.
+ */
+export async function waitForChildTermination(
+    childSessionId: string,
+    deps: { getSession?: typeof getSessionSummary } = {},
+): Promise<boolean> {
+    const _getSession = deps.getSession ?? getSessionSummary;
+    const deadline = Date.now() + childTerminationWait.timeoutMs;
+    for (;;) {
+        if (!(await _getSession(childSessionId))) return true;
+        if (Date.now() >= deadline) return false;
+        await new Promise((r) => setTimeout(r, childTerminationWait.pollMs));
+    }
+}
+
 export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIOServer): void {
     socket.on("get_linked_child_count", async (data, ack) => {
         const sessionId = socket.data.sessionId;
@@ -102,7 +123,10 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
         // Validate the sender is the parent of the target child session
         const childSession = await getSharedSessionSummary(childSessionId);
         if (!childSession) {
-            // Child already gone — nothing to clean up (idempotent)
+            // Child already gone — remove any stale membership entry so the
+            // dead ID doesn't linger in the parent's children set, then ack
+            // (idempotent).
+            await removeChildSession(sessionId, childSessionId).catch(() => {});
             if (typeof ack === "function") ack({ ok: true });
             return;
         }
@@ -159,7 +183,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
                 // the cluster, so there is no disconnect handler left to finish
                 // cleanup. Complete teardown now so acknowledged children don't
                 // linger in Redis/sidebar until the orphan sweeper runs.
-                await endSharedSession(childSessionId, "Parent acknowledged completion");
+                await endSharedSession(childSessionId, "Parent acknowledged completion", { confirmedTerminal: true });
                 if (typeof ack === "function") ack({ ok: true });
                 return;
             }
@@ -173,8 +197,19 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // before that node can process the disconnect, turning its
             // endSharedSession into a no-op and leaving adopted-session entries
             // stranded in runningSessions on the remote runner.
-
-            if (typeof ack === "function") ack({ ok: true });
+            //
+            // Ack ordering: only ack plain { ok: true } once the child's
+            // termination is actually OBSERVED (its Redis session record is
+            // gone). If it hasn't terminated within the bounded wait, ack
+            // { ok: true, pending: true } — teardown was initiated and the
+            // orphan sweeper backstops it, but the caller knows termination
+            // was not yet confirmed.
+            const terminated = await waitForChildTermination(childSessionId);
+            if (typeof ack === "function") {
+                (ack as (r: { ok: boolean; pending?: boolean; error?: string }) => void)(
+                    terminated ? { ok: true } : { ok: true, pending: true },
+                );
+            }
         } catch (err: any) {
             log.error(`cleanup_child_session failed: parent=${sessionId} child=${childSessionId}`, err);
             if (typeof ack === "function") ack({ ok: false, error: err?.message ?? "Internal error" });

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
@@ -1,0 +1,85 @@
+// ============================================================================
+// session-lifecycle.session-end.test.ts — Regression test: a graceful
+// session_end (e.g. subagent mirror finish()) is a CONFIRMED terminal end and
+// must end the session with confirmedTerminal so the child is removed from
+// its parent's membership set.
+// ============================================================================
+
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+const endedSessions: Array<{ sessionId: string; reason?: string; opts?: unknown }> = [];
+
+mock.module("../../sio-registry.js", () => ({
+    registerTuiSession: async () => ({ sessionId: "s", token: "t", shareUrl: "", parentSessionId: null, wasDelinked: false }),
+    getLocalTuiSocket: () => undefined,
+    broadcastToViewers: () => {},
+    endSharedSession: async (sessionId: string, reason?: string, opts?: unknown) => {
+        endedSessions.push({ sessionId, reason, opts });
+    },
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    clearPushPendingQuestion: async () => {},
+    deleteRunnerAssociation: async () => {},
+}));
+
+mock.module("./event-pipeline.js", () => ({
+    pendingChunkedStates: new Map(),
+    enqueueSessionEvent: async (_id: string, fn: () => Promise<void>) => fn(),
+}));
+
+mock.module("./ack-tracker.js", () => ({ socketAckedSeqs: new Map() }));
+mock.module("./thinking-tracker.js", () => ({ clearThinkingMaps: () => {} }));
+mock.module("./viewer-gate.js", () => ({ forgetViewerGate: () => {} }));
+mock.module("../../../health.js", () => ({ shouldPreserveOnSocketDisconnect: () => false }));
+mock.module("../../../user-preferences.js", () => ({
+    getUserPreference: async () => null,
+    PREF_SUBAGENT_MODEL: "subagent_model",
+}));
+
+afterAll(() => mock.restore());
+
+const { registerSessionLifecycleHandlers } = await import("./session-lifecycle.js");
+
+function makeSocket(sessionId: string, token = "tok") {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    return {
+        socket: {
+            id: "sock-1",
+            data: { sessionId, token },
+            on(event: string, cb: (...args: unknown[]) => unknown) {
+                handlers.set(event, cb);
+            },
+            emit: () => {},
+        } as never,
+        fire: async (event: string, data?: unknown) => handlers.get(event)!(data),
+    };
+}
+
+describe("session_end handler", () => {
+    beforeEach(() => {
+        endedSessions.length = 0;
+    });
+
+    it("ends the session with confirmedTerminal so parent membership is removed", async () => {
+        const { socket, fire } = makeSocket("child-mirror");
+        registerSessionLifecycleHandlers(socket);
+
+        await fire("session_end", { token: "tok" });
+
+        expect(endedSessions).toEqual([
+            { sessionId: "child-mirror", reason: "Session ended", opts: { confirmedTerminal: true } },
+        ]);
+    });
+
+    it("plain disconnect does NOT mark the end as confirmed terminal", async () => {
+        const { socket, fire } = makeSocket("child-mirror");
+        registerSessionLifecycleHandlers(socket);
+
+        await fire("disconnect", "transport close");
+
+        expect(endedSessions.length).toBe(1);
+        expect(endedSessions[0].sessionId).toBe("child-mirror");
+        expect(endedSessions[0].opts).toBeUndefined();
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -99,7 +99,9 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         // Graceful end — delete the durable runner association so it
         // isn't restored if a new session reuses this ID later.
         await deleteRunnerAssociation(sessionId);
-        await endSharedSession(sessionId);
+        // Graceful session_end is a confirmed terminal end — remove this child
+        // from its parent's membership set (fixes subagent-mirror leak).
+        await endSharedSession(sessionId, "Session ended", { confirmedTerminal: true });
         socket.data.sessionId = undefined;
         socketAckedSeqs.delete(socket.id);
     });

--- a/packages/server/src/ws/sio-registry/sessions.parent-transfer.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-transfer.test.ts
@@ -1,0 +1,216 @@
+// ============================================================================
+// sessions.parent-transfer.test.ts — Regression tests for child-session
+// ownership: atomic parent transfer on relink, and membership removal on
+// confirmed terminal end (endSharedSession confirmedTerminal).
+// Harness mirrors sessions.parent-miss-delink.test.ts.
+// ============================================================================
+
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+const store = new Map<string, string>();
+const setStore = new Map<string, Set<string>>();
+
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    getPersistedRelaySessionRunner: async () => null,
+    getRelaySessionUserId: async () => null,
+    getPersistedRelaySessionSnapshot: async () => null,
+    recordRelaySessionStart: async () => {},
+    recordRelaySessionEnd: async () => {},
+    recordRelaySessionState: async () => {},
+    recordRelaySessionStateSerialized: async () => {},
+    touchRelaySession: async () => {},
+}));
+
+mock.module("../../sessions/trigger-subscription-store.js", () => ({
+    clearSessionSubscriptions: async () => {},
+}));
+
+mock.module("../../sessions/trigger-store.js", () => ({
+    pushTriggerHistory: async () => {},
+}));
+
+const childrenKey = (p: string) => `children:${p}`;
+const pendingDelinkKey = (p: string) => `pending-delink:${p}`;
+const sessionHashKey = (s: string) => `session:${s}`;
+
+mock.module("../sio-state/index.js", () => ({
+    initStateRedis: async () => {},
+    setSession: async (sessionId: string, data: Record<string, unknown>) => {
+        store.set(sessionHashKey(sessionId), JSON.stringify(data));
+    },
+    getSession: async (sessionId: string) => {
+        const raw = store.get(sessionHashKey(sessionId));
+        return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+    },
+    getSessionSummary: async (sessionId: string) => {
+        const raw = store.get(sessionHashKey(sessionId));
+        return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+    },
+    getSessionField: async () => null,
+    updateSessionFields: async () => {},
+    deleteSession: async (sessionId: string) => {
+        store.delete(sessionHashKey(sessionId));
+    },
+    getAllSessionSummaries: async () => [],
+    refreshSessionTTL: async () => {},
+    incrementSeq: async () => 1,
+    getSeq: async () => 0,
+    setPendingRunnerLink: async () => {},
+    getPendingRunnerLink: async () => null,
+    deletePendingRunnerLink: async () => {},
+    getRunnerAssociation: async () => null,
+    setRunnerAssociation: async () => {},
+    refreshRunnerAssociationTTL: async () => {},
+    scanExpiredSessions: async () => [],
+    addChildSession: async (parentSessionId: string, childSessionId: string) => {
+        const s = setStore.get(childrenKey(parentSessionId)) ?? new Set();
+        s.add(childSessionId);
+        setStore.set(childrenKey(parentSessionId), s);
+    },
+    addChildSessionMembership: async (parentSessionId: string, childSessionId: string) => {
+        const s = setStore.get(childrenKey(parentSessionId)) ?? new Set();
+        s.add(childSessionId);
+        setStore.set(childrenKey(parentSessionId), s);
+    },
+    removeChildSession: async (parentSessionId: string, childSessionId: string) => {
+        setStore.get(childrenKey(parentSessionId))?.delete(childSessionId);
+    },
+    isChildDelinked: async (childSessionId: string) => store.has(`delinked:${childSessionId}`),
+    clearParentSessionId: async () => {},
+    refreshChildSessionsTTL: async () => {},
+    removePendingParentDelinkChild: async (parentSessionId: string, childSessionId: string) => {
+        setStore.get(pendingDelinkKey(parentSessionId))?.delete(childSessionId);
+    },
+    markChildAsDelinked: async (childSessionId: string) => {
+        store.set(`delinked:${childSessionId}`, "1");
+    },
+    getRunner: async () => null,
+}));
+
+mock.module("./hub.js", () => ({
+    broadcastToHub: async () => {},
+}));
+
+afterAll(() => mock.restore());
+
+const { registerTuiSession, endSharedSession } = await import("./sessions.js");
+const { initSioRegistry } = await import("./context.js");
+
+// Minimal fake Socket.IO server — enough for endSharedSession's viewer teardown.
+const fakeNamespace = {
+    to: () => ({ emit: () => {} }),
+    local: { to: () => ({ emit: () => {} }) },
+    in: () => ({ disconnectSockets: () => {} }),
+    emit: () => {},
+};
+initSioRegistry({ of: () => fakeNamespace } as never);
+
+function fakeSocket() {
+    return { join: async () => {}, data: {} } as never;
+}
+
+async function seedSession(sessionId: string, extra: Record<string, unknown> = {}) {
+    store.set(
+        sessionHashKey(sessionId),
+        JSON.stringify({
+            sessionId,
+            userId: "u1",
+            token: "t",
+            startedAt: new Date().toISOString(),
+            parentSessionId: null,
+            linkedParentId: null,
+            ...extra,
+        }),
+    );
+}
+
+describe("atomic parent transfer on relink", () => {
+    beforeEach(() => {
+        store.clear();
+        setStore.clear();
+    });
+
+    it("removes the child from the old parent's membership and pending-delink sets when relinked to a new parent", async () => {
+        await seedSession("parent-1");
+        await seedSession("parent-2");
+
+        // Link child to parent-1
+        await registerTuiSession(fakeSocket(), "", {
+            sessionId: "child-1",
+            userId: "u1",
+            isEphemeral: false,
+            parentSessionId: "parent-1",
+        });
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-1")).toBe(true);
+
+        // Simulate a stale pending-delink entry for the old parent too.
+        setStore.set(pendingDelinkKey("parent-1"), new Set(["child-1"]));
+
+        // Reconnect with a NEW parent
+        await registerTuiSession(fakeSocket(), "", {
+            sessionId: "child-1",
+            userId: "u1",
+            isEphemeral: false,
+            parentSessionId: "parent-2",
+        });
+
+        expect(setStore.get(childrenKey("parent-2"))?.has("child-1")).toBe(true);
+        // Old parent must no longer own the child — no dual ownership.
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-1")).toBe(false);
+        expect(setStore.get(pendingDelinkKey("parent-1"))?.has("child-1")).toBe(false);
+    });
+
+    it("keeps membership intact when reconnecting with the same parent", async () => {
+        await seedSession("parent-1");
+        await registerTuiSession(fakeSocket(), "", {
+            sessionId: "child-2",
+            userId: "u1",
+            isEphemeral: false,
+            parentSessionId: "parent-1",
+        });
+        await registerTuiSession(fakeSocket(), "", {
+            sessionId: "child-2",
+            userId: "u1",
+            isEphemeral: false,
+            parentSessionId: "parent-1",
+        });
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-2")).toBe(true);
+    });
+});
+
+describe("endSharedSession confirmedTerminal membership removal", () => {
+    beforeEach(() => {
+        store.clear();
+        setStore.clear();
+    });
+
+    it("removes the child from its parent's set on confirmed terminal end", async () => {
+        await seedSession("child-x", { parentSessionId: "parent-1" });
+        setStore.set(childrenKey("parent-1"), new Set(["child-x"]));
+
+        await endSharedSession("child-x", "Session ended", { confirmedTerminal: true });
+
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-x")).toBe(false);
+        expect(store.has(sessionHashKey("child-x"))).toBe(false);
+    });
+
+    it("uses linkedParentId when parentSessionId was cleared (parent-offline reconnect)", async () => {
+        await seedSession("child-y", { parentSessionId: null, linkedParentId: "parent-1" });
+        setStore.set(childrenKey("parent-1"), new Set(["child-y"]));
+
+        await endSharedSession("child-y", "Session ended", { confirmedTerminal: true });
+
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-y")).toBe(false);
+    });
+
+    it("preserves membership on transient disconnect (not confirmed terminal)", async () => {
+        await seedSession("child-z", { parentSessionId: "parent-1" });
+        setStore.set(childrenKey("parent-1"), new Set(["child-z"]));
+
+        await endSharedSession("child-z", "Session ended");
+
+        // Membership must survive so delink_children can still find the child.
+        expect(setStore.get(childrenKey("parent-1"))?.has("child-z")).toBe(true);
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -286,6 +286,16 @@ export async function registerTuiSession(
     // the parent's Redis key has expired) so that parent links survive restarts.
     if (resolvedParentSessionId) {
         const candidateParentId = resolvedParentSessionId;
+        // Atomic parent transfer: if this child is switching to a different
+        // parent, scrub it from every former parent's membership and
+        // pending-delink sets FIRST so the old parent stops passing
+        // isChildOfParent() the moment the new link is established.
+        for (const formerParent of new Set([previousParentSessionId, previousLinkedParentId])) {
+            if (formerParent && formerParent !== candidateParentId) {
+                await removeChildSession(formerParent, sessionId);
+                await removePendingParentDelinkChild(formerParent, sessionId);
+            }
+        }
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
             // Redis miss means the parent is temporarily offline.
@@ -885,12 +895,30 @@ function viewerDisconnectPayload(reason: string): { reason: string; code?: "sess
 }
 
 /** End a shared session: notify viewers, clean up Redis, broadcast to hub. */
-export async function endSharedSession(sessionId: string, reason: string = "Session ended"): Promise<void> {
+export async function endSharedSession(
+    sessionId: string,
+    reason: string = "Session ended",
+    opts: { confirmedTerminal?: boolean } = {},
+): Promise<void> {
     const io = getIo();
     await deletePendingRunnerLink(sessionId);
 
     const session = await getSession(sessionId);
     if (!session) return;
+
+    // On a CONFIRMED terminal end (graceful session_end, expiry, orphan sweep,
+    // parent-acknowledged cleanup) remove this child from its parent's
+    // membership set so dead child IDs don't linger until the 24h TTL.
+    // Deliberately NOT done for transient disconnects — that races with
+    // delink_children (see the disconnect handler in session-lifecycle.ts).
+    if (opts.confirmedTerminal) {
+        const parentId = session.parentSessionId || session.linkedParentId;
+        if (parentId) {
+            await removeChildSession(parentId, sessionId).catch((err) => {
+                log.warn(`endSharedSession: failed to remove child ${sessionId} from parent ${parentId}:`, err);
+            });
+        }
+    }
 
     const disconnectPayload = viewerDisconnectPayload(reason);
 
@@ -998,7 +1026,7 @@ export async function sweepExpiredSessions(nowMs: number = Date.now()): Promise<
             tuiSocket.disconnect(true);
         }
 
-        await endSharedSession(sessionId, "Session expired");
+        await endSharedSession(sessionId, "Session expired", { confirmedTerminal: true });
     }
 
     // Sweep orphaned sessions: sessions in Redis with no active relay socket
@@ -1069,7 +1097,7 @@ export async function sweepOrphanedSessions(nowMs: number): Promise<void> {
             `Sweeping orphaned session ${candidate.sessionId} ` +
             `(last activity: ${new Date(candidate.lastActivity).toISOString()})`,
         );
-        await endSharedSession(candidate.sessionId, "Session orphaned (no active relay connection)");
+        await endSharedSession(candidate.sessionId, "Session orphaned (no active relay connection)", { confirmedTerminal: true });
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the subagent/child-session ownership state-management defects from the 2026-08-20 state audit (section 5).

1. **P1 dual-parent ownership** (`sio-registry/sessions.ts`): when a child re-registers with a different `parentSessionId`, it is now atomically removed from every former parent's membership and pending-delink sets before the new link is established — both parents can no longer pass `isChildOfParent()`.
2. **P1 `cleanup_child_session` premature ack** (`child-lifecycle.ts`): added `waitForChildTermination` (bounded poll, 5s timeout / 200ms interval, tunable for tests). The handler acks `{ ok: true }` only after the child's Redis session record is observed gone; on timeout it acks `{ ok: true, pending: true }` (backward-compatible — existing callers treat `ok` as success; the orphan sweeper backstops completion). Protocol ack type extended with `pending?: boolean`.
3. **P2 stale child-set entries**: `endSharedSession(id, reason, { confirmedTerminal })` removes the child from its parent's membership set (via `parentSessionId || linkedParentId`) on graceful `session_end`, expiry, orphan sweep, and parent-acknowledged cleanup. Transient disconnects deliberately preserve membership (documented `delink_children` race). The cleanup-of-missing-child path also scrubs the stale entry.
4. **P2 subagent mirror child-set leak**: fixed server-side — the mirror's `session_end` now flows through the `confirmedTerminal` path, so every completed subagent mirror is removed from the parent's set.
5. **P2 mirror reconnect** (`relay-mirror.ts`): reconnection enabled (20 attempts, 1s→15s backoff); on reconnect the mirror re-registers the **same** session ID, invalidates its token on disconnect (suppressing stale-token emits), and replays the last snapshot after re-registration so the fresh server-side record isn't empty.

## Tests

- `sessions.parent-transfer.test.ts` — relink transfer, same-parent no-op, confirmedTerminal removal (incl. `linkedParentId` path), transient-disconnect preservation (5 pass)
- `child-lifecycle.ack.test.ts` — ack-after-termination, pending on timeout, no-recipient direct end, ghost-child scrub, `waitForChildTermination` unit (6 pass)
- `session-lifecycle.session-end.test.ts` — `session_end` passes `confirmedTerminal`; plain disconnect doesn't (2 pass)
- `relay-mirror.test.ts` — 2 new reconnect tests (18 pass in file)

Results:
- `bun run typecheck` ✅
- `bun scripts/test-isolated.ts packages/server/src` ✅ 83 files, 0 failed
- `bun test packages/cli/src` ✅ 2985 pass, 2 skip, 0 fail

Note: `child-lifecycle.ts` uses a local ack-type widening because the worktree's protocol symlink resolves to the main checkout during typecheck; the protocol type itself is updated in this PR.

## Follow-ups

1. `packages/cli/src/extensions/triggers/extension.ts` could distinguish `pending: true` acks to retain the completion handle until child termination is confirmed — deliberately left out here to avoid conflicting with PR #758, which owns that file.
2. Parent-death lease/orphan policy (bounded lease → delink/notify or ownership transfer) deliberately skipped — larger design, tracked separately.
