### PR TITLE
fix(runner): service state-management defects from 2026-08-20 audit

### DIFF
--- a/packages/cli/src/extensions/service-message-bridge.test.ts
+++ b/packages/cli/src/extensions/service-message-bridge.test.ts
@@ -66,8 +66,13 @@ describe("serviceMessageBridgeExtension", () => {
         expect(pi.emitted[0].payload).toEqual({
             serviceId: "connector",
             type: "session_post",
+            // Top-level id is the dedupe handle (`env.id` per SDK guidance);
+            // payload copies remain for older services. Top-level sessionId is
+            // relay-owned and must NOT be stamped here.
+            id: "id-1",
             payload: { content: "hello", id: "id-1", sessionId: "sess-1" },
         });
+        expect(pi.emitted[0].payload.sessionId).toBeUndefined();
     });
 
     test("a package cannot spoof another session by supplying its own sessionId", () => {

--- a/packages/cli/src/extensions/service-message-bridge.ts
+++ b/packages/cli/src/extensions/service-message-bridge.ts
@@ -51,13 +51,19 @@ export function createServiceMessageBridgeExtension(
             const sessionId = deps.getRelaySessionId();
             if (!conn || !sessionId) return;
             try {
-                // Fire-and-forget: `id` lets services dedupe at-least-once relay
-                // delivery; `sessionId` is stamped by the host so a package can
-                // never spoof another session's traffic.
+                // Fire-and-forget: top-level `id` lets services dedupe
+                // at-least-once relay delivery (SDK guidance: dedupe on
+                // `env.id`). The relay is the sole owner of the top-level
+                // `sessionId` — it stamps it from the authenticated socket, so
+                // a package can never spoof another session's traffic. The
+                // payload copies are kept for services written against the old
+                // payload-stamped shape.
+                const id = deps.newId();
                 conn.socket.emit("service_message" as any, {
                     serviceId,
                     type,
-                    payload: { ...payload, id: deps.newId(), sessionId },
+                    id,
+                    payload: { ...payload, id, sessionId },
                 });
             } catch {
                 // Relay socket mid-reconnect — a dropped message is cosmetic,

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1364,7 +1364,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         // ── Service reconfiguration ───────────────────────────────────────
         // Update the disabled services list at runtime and reinitialize services.
-        socket.on("reconfigure_services", async (data: any) => {
+        // Serialized via a promise chain: overlapping reconfigures interleave
+        // async package discovery with registry/panel/port mutation and corrupt
+        // state. A queued run re-reads config fresh when it starts, so queueing
+        // (rather than coalescing) is correct.
+        let reconfigureChain: Promise<void> = Promise.resolve();
+        const runReconfigureServices = async (data: any): Promise<void> => {
             if (isShuttingDown) return;
             try {
                 const newDisabledServices = resolveReconfiguredDisabledRunnerServices(disabledServices, data);
@@ -1558,6 +1563,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             } catch (err) {
                 logError(`[services] reconfigure_services handler failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
             }
+        };
+        socket.on("reconfigure_services", (data: any) => {
+            reconfigureChain = reconfigureChain.then(() => runReconfigureServices(data));
         });
 
         // ── Trigger subscription reconciliation ──────────────────────────
@@ -1788,8 +1796,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     // On restart (exit code 43), the session already has
                     // the prompt in its history — re-sending would duplicate it.
                     const spawnOpts = isFirstSpawn
-                        ? { prompt: requestedPrompt, imageUrls: Array.isArray(requestedImageUrls) ? requestedImageUrls : undefined, model: requestedModel, hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, resumePath: resolvedResumePath, autoClose: requestedAutoClose === true }
-                        : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, autoClose: requestedAutoClose === true }; // Always pass agent + hidden models + parent + autoClose on restart
+                        ? { prompt: requestedPrompt, imageUrls: Array.isArray(requestedImageUrls) ? requestedImageUrls : undefined, model: requestedModel, hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, resumePath: resolvedResumePath, autoClose: requestedAutoClose === true, onSessionExit: cleanupSessionServices }
+                        : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, autoClose: requestedAutoClose === true, onSessionExit: cleanupSessionServices }; // Always pass agent + hidden models + parent + autoClose on restart
                     isFirstSpawn = false;
                     spawnSession(sessionId, apiKey!, relayRaw, requestedCwd, runningSessions, restartingSessions, killedSessions, doSpawn, spawnOpts);
                     setSessionCloseMetadata(sessionId, {

--- a/packages/cli/src/runner/services/memory-service.test.ts
+++ b/packages/cli/src/runner/services/memory-service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryService } from "./memory-service.js";
+
+function makeSocket() {
+    const handlers = new Map<string, (env: any) => void>();
+    const emitted: any[] = [];
+    return {
+        handlers,
+        emitted,
+        on(event: string, h: (env: any) => void) {
+            handlers.set(event, h);
+        },
+        off() {},
+        emit(_event: string, envelope: any) {
+            emitted.push(envelope);
+        },
+    };
+}
+
+describe("MemoryService", () => {
+    test("responses carry the requesting session's top-level sessionId (no runner-wide broadcast)", () => {
+        const cwd = mkdtempSync(join(tmpdir(), "memory-service-test-"));
+        try {
+            const service = new MemoryService((sessionId) => (sessionId === "sess-1" ? cwd : null));
+            const socket = makeSocket();
+            service.init(socket as any, { isShuttingDown: () => false } as any);
+
+            socket.handlers.get("service_message")!({
+                serviceId: "memory",
+                type: "memory_list",
+                requestId: "req-1",
+                sessionId: "sess-1",
+                payload: {},
+            });
+
+            expect(socket.emitted).toHaveLength(1);
+            expect(socket.emitted[0].type).toBe("memory_list_result");
+            // Regression: without a top-level sessionId the relay broadcasts
+            // this response to every session on the runner.
+            expect(socket.emitted[0].sessionId).toBe("sess-1");
+
+            // Error responses are session-scoped too.
+            socket.handlers.get("service_message")!({
+                serviceId: "memory",
+                type: "memory_read",
+                requestId: "req-2",
+                sessionId: "sess-unknown",
+                payload: {},
+            });
+            expect(socket.emitted[1].type).toBe("memory_error");
+            expect(socket.emitted[1].sessionId).toBe("sess-unknown");
+        } finally {
+            rmSync(cwd, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/cli/src/runner/services/memory-service.ts
+++ b/packages/cli/src/runner/services/memory-service.ts
@@ -75,24 +75,28 @@ export class MemoryService implements ServiceHandler {
   }
 
   private handle(envelope: ServiceEnvelope, fn: (cwd: string) => unknown): void {
+    // Trusted session id from the relay-stamped envelope — responses must be
+    // session-scoped or the relay broadcasts them to every session on the runner.
+    const sessionId = typeof envelope.sessionId === "string" ? envelope.sessionId : undefined;
     const cwd = this.resolveCwd(envelope);
     if (!cwd || !isCwdAllowed(cwd)) {
-      this.emit("memory_error", { error: "No accessible project for this session" }, envelope.requestId);
+      this.emit("memory_error", { error: "No accessible project for this session" }, envelope.requestId, sessionId);
       return;
     }
     try {
-      this.emit(`${envelope.type}_result`, fn(cwd), envelope.requestId);
+      this.emit(`${envelope.type}_result`, fn(cwd), envelope.requestId, sessionId);
     } catch (err) {
-      this.emit("memory_error", { error: err instanceof Error ? err.message : String(err) }, envelope.requestId);
+      this.emit("memory_error", { error: err instanceof Error ? err.message : String(err) }, envelope.requestId, sessionId);
     }
   }
 
-  private emit(type: string, payload: unknown, requestId?: string): void {
+  private emit(type: string, payload: unknown, requestId?: string, sessionId?: string): void {
     if (!this.socket) return;
     (this.socket as any).emit("service_message", {
       serviceId: "memory",
       type,
       ...(requestId ? { requestId } : {}),
+      ...(sessionId ? { sessionId } : {}),
       payload,
     } satisfies ServiceEnvelope);
   }

--- a/packages/cli/src/runner/services/process-service.test.ts
+++ b/packages/cli/src/runner/services/process-service.test.ts
@@ -63,12 +63,16 @@ describe("ProcessService", () => {
 
         await (service as any).handleList({ serviceId: "process", type: "process_list", sessionId: "s1", payload: {} });
         expect(sent[0].type).toBe("process_list_result");
+        // Regression: responses must be session-scoped or the relay broadcasts
+        // them to every session on the runner.
+        expect((sent[0] as any).sessionId).toBe("s1");
         expect(sent[0].payload.workerPid).toBe(pid);
         expect(sent[0].payload.processes.some((p: any) => p.pid === pid)).toBe(true);
 
         // Kill request for a pid outside the group is rejected
         await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s1", payload: { pid: process.pid } });
         expect(sent[1].type).toBe("process_error");
+        expect((sent[1] as any).sessionId).toBe("s1");
 
         // Killing the worker pid itself is refused
         await (service as any).handleKill({ serviceId: "process", type: "process_kill", sessionId: "s1", payload: { pid } });

--- a/packages/cli/src/runner/services/process-service.ts
+++ b/packages/cli/src/runner/services/process-service.ts
@@ -27,6 +27,11 @@ export interface ShellInfo extends PersistedShellJob {
 }
 
 /** Parse one `ps -o pid=,etime=,rss=,command=` output line (legacy helper). */
+/** Only the relay-stamped top-level sessionId is trusted for response routing. */
+function trustedSessionId(envelope: ServiceEnvelope): string | undefined {
+    return typeof envelope.sessionId === "string" && envelope.sessionId ? envelope.sessionId : undefined;
+}
+
 export function parsePsLine(line: string): SessionProcess | null {
     const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+(.*)$/);
     if (!m) return null;
@@ -139,12 +144,15 @@ export class ProcessService implements ServiceHandler {
         return members;
     }
 
-    private emit(type: string, payload: unknown, requestId?: string): void {
+    private emit(type: string, payload: unknown, requestId?: string, sessionId?: string): void {
         if (!this.socket) return;
+        // sessionId scopes the response to the requesting session — without it
+        // the relay broadcasts to every session on this runner.
         (this.socket as any).emit("service_message", {
             serviceId: "process",
             type,
             ...(requestId ? { requestId } : {}),
+            ...(sessionId ? { sessionId } : {}),
             payload,
         } satisfies ServiceEnvelope);
     }
@@ -176,7 +184,7 @@ export class ProcessService implements ServiceHandler {
         const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
         const processes = sessionId ? await this.listProcesses(sessionId, workerPid) : [];
         const shells = sessionId ? this.listShells(sessionId) : [];
-        this.emit("process_list_result", { workerPid, processes, shells }, envelope.requestId);
+        this.emit("process_list_result", { workerPid, processes, shells }, envelope.requestId, trustedSessionId(envelope));
     }
 
     /** Tail of a background shell's log file. Only paths from the worker-written registry are readable. */
@@ -188,10 +196,10 @@ export class ProcessService implements ServiceHandler {
             ? readSessionJobs(sessionJobsFilePath(this.getProcFilePath(sessionId))).find((j) => j.pid === pid)
             : undefined;
         if (!job) {
-            this.emit("process_error", { error: `No background shell with pid ${payload?.pid}` }, envelope.requestId);
+            this.emit("process_error", { error: `No background shell with pid ${payload?.pid}` }, envelope.requestId, trustedSessionId(envelope));
             return;
         }
-        this.emit("process_tail_result", { pid: job.pid, text: tailFile(job.logPath, 8192) }, envelope.requestId);
+        this.emit("process_tail_result", { pid: job.pid, text: tailFile(job.logPath, 8192) }, envelope.requestId, trustedSessionId(envelope));
     }
 
     private async handleKill(envelope: ServiceEnvelope): Promise<void> {
@@ -201,7 +209,7 @@ export class ProcessService implements ServiceHandler {
         const workerPid = sessionId ? this.getWorkerPid(sessionId) : null;
 
         if (!sessionId || !Number.isInteger(pid) || pid <= 0) {
-            this.emit("process_error", { error: `Invalid kill request (pid=${payload?.pid})` }, envelope.requestId);
+            this.emit("process_error", { error: `Invalid kill request (pid=${payload?.pid})` }, envelope.requestId, trustedSessionId(envelope));
             return;
         }
 
@@ -209,11 +217,11 @@ export class ProcessService implements ServiceHandler {
         // one of this session's process groups — never arbitrary system PIDs.
         const members = await this.sessionMemberPids(sessionId, workerPid);
         if (!members.has(pid)) {
-            this.emit("process_error", { error: `PID ${pid} is not part of session ${sessionId}` }, envelope.requestId);
+            this.emit("process_error", { error: `PID ${pid} is not part of session ${sessionId}` }, envelope.requestId, trustedSessionId(envelope));
             return;
         }
         if (pid === workerPid) {
-            this.emit("process_error", { error: "Refusing to kill the session worker — use Kill Session instead" }, envelope.requestId);
+            this.emit("process_error", { error: "Refusing to kill the session worker — use Kill Session instead" }, envelope.requestId, trustedSessionId(envelope));
             return;
         }
 
@@ -236,6 +244,6 @@ export class ProcessService implements ServiceHandler {
         }
         // Respond with a fresh list so the panel updates immediately.
         const processes = await this.listProcesses(sessionId, workerPid);
-        this.emit("process_list_result", { workerPid, processes }, envelope.requestId);
+        this.emit("process_list_result", { workerPid, processes }, envelope.requestId, trustedSessionId(envelope));
     }
 }

--- a/packages/cli/src/runner/services/time-service.persistence.test.ts
+++ b/packages/cli/src/runner/services/time-service.persistence.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for durable timer/cron state:
+ *   - one-shot timers keep their absolute deadline across a daemon restart
+ *     (rebuilding as now+duration would drift the deadline forever)
+ *   - a changed duration param invalidates the persisted deadline
+ *   - state file writes are atomic (temp+rename, no partial file left behind)
+ *   - corrupt state JSON is quarantined instead of silently reset
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TimeService } from "./time-service.js";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+
+const originalHome = process.env.HOME;
+let service: TimeService | undefined;
+
+afterEach(() => {
+    service?.dispose();
+    service = undefined;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+});
+
+function setupHome(): string {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-time-persist-"));
+    mkdirSync(join(home, ".pizzapi"), { recursive: true });
+    process.env.HOME = home;
+    return home;
+}
+
+const statePath = (home: string) => join(home, ".pizzapi", "time-service-state.json");
+
+function timerSub(duration: string, subscriptionId = "sub-1"): TriggerSubscriptionEntry {
+    return {
+        sessionId: "sess-1",
+        triggerType: "time:timer_fired",
+        subscriptionId,
+        runnerId: "runner-test",
+        params: { duration },
+    };
+}
+
+describe("TimeService durable timer state", () => {
+    test("persists absolute fireAt and reuses it after a restart", () => {
+        const home = setupHome();
+        service = new TimeService();
+        const before = Date.now();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+
+        const persisted = JSON.parse(readFileSync(statePath(home), "utf-8"));
+        const entry = persisted["timer:sub-1"];
+        expect(entry.duration).toBe("1h");
+        expect(entry.nextFireAt).toBeGreaterThanOrEqual(before + 3_600_000);
+        service.dispose();
+
+        // Simulate a daemon restart 100ms "later" by shrinking the persisted
+        // deadline; a drifting rebuild (now+1h) would overwrite it.
+        const shifted = entry.nextFireAt - 1000;
+        writeFileSync(statePath(home), JSON.stringify({ "timer:sub-1": { ...entry, nextFireAt: shifted } }), "utf-8");
+
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+        const after = JSON.parse(readFileSync(statePath(home), "utf-8"));
+        expect(after["timer:sub-1"].nextFireAt).toBe(shifted);
+    });
+
+    test("changed duration param recomputes and re-persists the deadline", () => {
+        const home = setupHome();
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+        const first = JSON.parse(readFileSync(statePath(home), "utf-8"))["timer:sub-1"];
+
+        service.reconcileSubscriptions([timerSub("2h")], { mode: "snapshot" });
+        const second = JSON.parse(readFileSync(statePath(home), "utf-8"))["timer:sub-1"];
+        expect(second.duration).toBe("2h");
+        expect(second.nextFireAt).toBeGreaterThan(first.nextFireAt);
+    });
+
+    test("unsubscribe and stale-snapshot removal drop persisted timer state", () => {
+        const home = setupHome();
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+        expect(JSON.parse(readFileSync(statePath(home), "utf-8"))["timer:sub-1"]).toBeDefined();
+
+        // Empty snapshot removes the in-memory timer AND its persisted state.
+        service.reconcileSubscriptions([], { mode: "snapshot" });
+        expect(JSON.parse(readFileSync(statePath(home), "utf-8"))["timer:sub-1"]).toBeUndefined();
+    });
+
+    test("snapshot prunes persisted state for subscriptions gone while the daemon was down", () => {
+        const home = setupHome();
+        writeFileSync(
+            statePath(home),
+            JSON.stringify({
+                "timer:dead-sub": { nextFireAt: Date.now() + 60_000, iteration: 0, duration: "1m" },
+                "dead-cron": { nextFireAt: Date.now() + 60_000, iteration: 3 },
+            }),
+            "utf-8",
+        );
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+        const state = JSON.parse(readFileSync(statePath(home), "utf-8"));
+        expect(state["timer:dead-sub"]).toBeUndefined();
+        expect(state["dead-cron"]).toBeUndefined();
+        expect(state["timer:sub-1"]).toBeDefined();
+    });
+
+    test("corrupt state file is quarantined, not silently reset", () => {
+        const home = setupHome();
+        writeFileSync(statePath(home), "{not json!", "utf-8");
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+
+        const files = readdirSync(join(home, ".pizzapi"));
+        expect(files.some((f) => f.startsWith("time-service-state.json.corrupt-"))).toBe(true);
+        // Fresh state written cleanly afterwards.
+        expect(JSON.parse(readFileSync(statePath(home), "utf-8"))["timer:sub-1"]).toBeDefined();
+    });
+
+    test("state writes leave no temp file behind (atomic rename)", () => {
+        const home = setupHome();
+        service = new TimeService();
+        service.reconcileSubscriptions([timerSub("1h")], { mode: "snapshot" });
+        const files = readdirSync(join(home, ".pizzapi"));
+        expect(files.filter((f) => f.includes(".tmp-"))).toEqual([]);
+    });
+});

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -17,7 +17,7 @@
  *
  * No panel — the service runs a minimal HTTP server for sigil resolve endpoints only.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { Socket } from "socket.io-client";
@@ -70,6 +70,8 @@ function buildReplacementPrompt(schedule: string, label: string | undefined, mes
 interface CronState {
     nextFireAt: number;
     iteration: number;
+    /** Timer entries only: the duration param the fireAt was computed from. */
+    duration?: string;
 }
 
 // ── Relay helpers ────────────────────────────────────────────────────────────
@@ -341,11 +343,25 @@ export class TimeService implements ServiceHandler {
     #getCronState(): Record<string, CronState> {
         if (this.#cronState === null) {
             let state: Record<string, CronState> = {};
+            const path = this.#stateFilePath();
             try {
-                const parsed = JSON.parse(readFileSync(this.#stateFilePath(), "utf-8"));
-                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) state = parsed as Record<string, CronState>;
+                const raw = readFileSync(path, "utf-8");
+                try {
+                    const parsed = JSON.parse(raw);
+                    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) state = parsed as Record<string, CronState>;
+                } catch (err) {
+                    // Corrupt JSON — quarantine instead of silently resetting so
+                    // schedule state is recoverable by hand.
+                    const quarantine = `${path}.corrupt-${Date.now()}`;
+                    try {
+                        renameSync(path, quarantine);
+                        logWarn(`[time] corrupt state file quarantined to ${quarantine}: ${err}`);
+                    } catch {
+                        logWarn(`[time] corrupt state file (quarantine failed): ${err}`);
+                    }
+                }
             } catch {
-                // missing or corrupt file — start empty
+                // missing file — start empty
             }
             this.#cronState = state;
         }
@@ -355,10 +371,43 @@ export class TimeService implements ServiceHandler {
     #saveCronState(): void {
         try {
             mkdirSync(join(process.env.HOME || homedir(), ".pizzapi"), { recursive: true });
-            writeFileSync(this.#stateFilePath(), JSON.stringify(this.#cronState ?? {}), "utf-8");
+            // Atomic temp-file + rename so a crash mid-write never leaves a
+            // truncated/corrupt state file.
+            const path = this.#stateFilePath();
+            const tmp = `${path}.tmp-${process.pid}`;
+            writeFileSync(tmp, JSON.stringify(this.#cronState ?? {}), "utf-8");
+            renameSync(tmp, path);
         } catch (err) {
             logWarn(`[time] failed to persist cron state: ${err}`);
         }
+    }
+
+    // ── Durable one-shot timer state (absolute deadlines) ─────────────────
+
+    #timerStateKey(subscriptionId: string): string {
+        return `timer:${subscriptionId}`;
+    }
+
+    #persistTimer(subscriptionId: string, fireAt: number, duration: string): void {
+        const state = this.#getCronState();
+        state[this.#timerStateKey(subscriptionId)] = { nextFireAt: fireAt, iteration: 0, duration };
+        this.#saveCronState();
+    }
+
+    #dropTimerState(subscriptionId: string): void {
+        const state = this.#getCronState();
+        const key = this.#timerStateKey(subscriptionId);
+        if (key in state) {
+            delete state[key];
+            this.#saveCronState();
+        }
+    }
+
+    /** Persisted absolute deadline for a timer, if the duration param is unchanged. */
+    #persistedTimerFireAt(subscriptionId: string, duration: string): number | null {
+        const entry = this.#getCronState()[this.#timerStateKey(subscriptionId)];
+        if (!entry || entry.duration !== duration) return null;
+        return typeof entry.nextFireAt === "number" ? entry.nextFireAt : null;
     }
 
     #persistCron(subscriptionId: string, nextFireAt: number, iteration: number): void {
@@ -461,6 +510,7 @@ export class TimeService implements ServiceHandler {
                 if (!snapshotKeys.has(key)) {
                     clearTimeout(timer.handle);
                     this.#timers.delete(key);
+                    if (timer.triggerType === "time:timer_fired") this.#dropTimerState(timer.subscriptionId);
                     logInfo(`[time] reconcile: removed stale timer ${key}`);
                 }
             }
@@ -473,6 +523,21 @@ export class TimeService implements ServiceHandler {
                     logInfo(`[time] reconcile: removed stale cron ${key}`);
                 }
             }
+
+            // Prune persisted state for subscriptions that vanished while the
+            // daemon was down (they were never in memory, so the loops above
+            // can't see them).
+            const snapshotSubIds = new Set(timeSubs.map((s) => s.subscriptionId ?? `${s.sessionId}\0${s.triggerType}`));
+            const persisted = this.#getCronState();
+            let pruned = false;
+            for (const key of Object.keys(persisted)) {
+                const subId = key.startsWith("timer:") ? key.slice("timer:".length) : key;
+                if (!snapshotSubIds.has(subId)) {
+                    delete persisted[key];
+                    pruned = true;
+                }
+            }
+            if (pruned) this.#saveCronState();
         }
 
         // Create/update/remove timers for the relevant subscriptions.
@@ -609,7 +674,10 @@ export class TimeService implements ServiceHandler {
             this.#timers.delete(key);
         }
 
-        if (action === "unsubscribe") return;
+        if (action === "unsubscribe") {
+            this.#dropTimerState(subscriptionId);
+            return;
+        }
 
         const durationStr = typeof params?.duration === "string" ? params.duration : null;
         if (!durationStr) {
@@ -627,7 +695,12 @@ export class TimeService implements ServiceHandler {
         const message = typeof params?.message === "string" ? params.message : undefined;
         const cwd = cwdFromParams(params);
         const resumePath = resumePathFromParams(params);
-        const fireAt = Date.now() + durationMs;
+        // Reuse the persisted absolute deadline (daemon restarts must not
+        // rebuild the timer as now+duration — the deadline would drift forever).
+        // A changed duration param invalidates the persisted entry.
+        const persistedFireAt = this.#persistedTimerFireAt(subscriptionId, durationStr);
+        const fireAt = persistedFireAt ?? Date.now() + durationMs;
+        if (persistedFireAt === null) this.#persistTimer(subscriptionId, fireAt, durationStr);
 
         logInfo(`[time] starting timer for session ${sessionId}: ${durationStr} (${formatDuration(durationMs)})${label ? ` [${label}]` : ""}`);
 
@@ -636,6 +709,7 @@ export class TimeService implements ServiceHandler {
         const replacementPrompt = buildReplacementPrompt(`timer "${durationStr}"`, label, message);
         const fire = () => {
             this.#timers.delete(key);
+            this.#dropTimerState(subscriptionId);
             this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:timer_fired", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath);
         };
 

--- a/packages/cli/src/runner/services/tunnel-service.test.ts
+++ b/packages/cli/src/runner/services/tunnel-service.test.ts
@@ -458,6 +458,11 @@ describe("TunnelService", () => {
         expect(tunnelClient.unexposePort).toHaveBeenCalledWith(8080);
         expect(tunnelClient.unexposePort).not.toHaveBeenCalledWith(9090);
 
+        // Idempotent: the daemon's worker-exit hook and the relay's later
+        // session_ended both invoke cleanup — the second call is a no-op.
+        service.handleSessionEnded("sess-a");
+        expect(tunnelClient.unexposePort).toHaveBeenCalledTimes(1);
+
         // sess-b's tunnel is still listable by sess-b.
         socket.emitted.length = 0;
         getServiceMessageHandler(socket)({

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -175,6 +175,7 @@ describe("session-spawner child", () => {
             const restartRestartingSessions = new Set<string>();
             const restartKilledSessions = new Set<string>();
             const onRestartRequested = mock(() => {});
+            const onSessionExitRestart = mock((_sessionId: string) => {});
             spawnSession(
                 "sess-restart",
                 "api-key",
@@ -184,6 +185,7 @@ describe("session-spawner child", () => {
                 restartRestartingSessions,
                 restartKilledSessions,
                 onRestartRequested,
+                { onSessionExit: onSessionExitRestart },
             );
             latestChild!.exitCode = 43;
             latestChild!.emit("exit", 43, null);
@@ -193,16 +195,26 @@ describe("session-spawner child", () => {
             expect(restartRunningSessions.has("sess-restart")).toBe(false);
             expect(untrackSessionCwd).toHaveBeenCalledWith("sess-restart", tempCwd);
             expect(cleanupSessionAttachments).not.toHaveBeenCalled();
+            // Restart-in-place is NOT a session end — service cleanup must not run.
+            expect(onSessionExitRestart).not.toHaveBeenCalled();
 
             const normalRunningSessions = new Map();
             const normalRestartingSessions = new Set<string>();
             const normalKilledSessions = new Set<string>();
-            spawnSession("sess-exit", "api-key", "https://relay.example", tempCwd, normalRunningSessions, normalRestartingSessions, normalKilledSessions);
+            // Daemon-owned worker-exit cleanup: fires on true termination even
+            // with no relay session_ended, and a throwing hook never crashes the
+            // exit handler.
+            const onSessionExit = mock((_sessionId: string) => {
+                throw new Error("cleanup boom");
+            });
+            spawnSession("sess-exit", "api-key", "https://relay.example", tempCwd, normalRunningSessions, normalRestartingSessions, normalKilledSessions, undefined, { onSessionExit });
             latestChild!.exitCode = 0;
             latestChild!.emit("exit", 0, null);
             await Promise.resolve();
             expect(normalRunningSessions.has("sess-exit")).toBe(false);
             expect(cleanupSessionAttachments).toHaveBeenCalledWith("sess-exit");
+            expect(onSessionExit).toHaveBeenCalledWith("sess-exit");
+            expect(onSessionExit).toHaveBeenCalledTimes(1);
 
             allowCwd = false;
             expect(() =>

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -121,6 +121,14 @@ export function spawnSession(
         parentSessionId?: string;
         resumePath?: string;
         autoClose?: boolean;
+        /**
+         * Daemon-owned cleanup hook invoked when the worker process truly exits
+         * (not a restart-in-place). Lets the daemon run session-scoped service
+         * cleanup (tunnels, git watchers, …) even when the relay is down and
+         * its `session_ended` event never arrives. Must be idempotent — the
+         * relay event may still fire later and re-run the same cleanup.
+         */
+        onSessionExit?: (sessionId: string) => void;
     },
 ): void {
     logInfo(`spawning headless worker for session ${sessionId}…`);
@@ -311,6 +319,11 @@ export function spawnSession(
             }
             removeSessionProcFile(sessionId);
             void cleanupSessionAttachments(sessionId).catch(() => {});
+            try {
+                options?.onSessionExit?.(sessionId);
+            } catch (err) {
+                logInfo(`session ${sessionId} onSessionExit cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
         }
     });
 

--- a/packages/cli/src/skills/extension-sdk-reference/SKILL.md
+++ b/packages/cli/src/skills/extension-sdk-reference/SKILL.md
@@ -701,7 +701,7 @@ pi.on("message_end", (event, ctx) => {
 });
 ```
 
-The host stamps `sessionId` and a unique `id` onto the payload for dedupe. The message is fire-and-forget — no response expected.
+The host stamps a unique top-level `id` for dedupe (`env.id`), and the relay stamps the top-level `sessionId` from the authenticated socket. The message is fire-and-forget — no response expected.
 
 Use case: Discord bridge, Slack connector, email notifications, webhook integrations.
 

--- a/packages/extension-sdk/src/host.ts
+++ b/packages/extension-sdk/src/host.ts
@@ -43,8 +43,9 @@ export function detectPizzaPiHost(pi: PizzaPiHostAPI): PizzaPiHostInfo | undefin
  * in-process events, so the package ships an extension that observes them and
  * forwards what it needs over this channel.
  *
- * The host stamps `sessionId` and a unique `id` (for at-least-once dedupe)
- * onto the payload. No-op when there is no PizzaPi host, or when the relay
+ * The host stamps a unique top-level `id` (for at-least-once dedupe, `env.id`)
+ * and the relay stamps the top-level `sessionId` from the authenticated
+ * socket. No-op when there is no PizzaPi host, or when the relay
  * socket is mid-reconnect — a dropped message must never block a turn.
  */
 export function sendServiceMessage(

--- a/packages/extension-sdk/src/service.ts
+++ b/packages/extension-sdk/src/service.ts
@@ -87,6 +87,8 @@ export interface ServiceInitOptions {
 export interface ServiceEnvelope {
   serviceId: string;
   type: string;
+  /** Host-stamped unique id for at-least-once delivery dedupe (`env.id`). */
+  id?: string;
   requestId?: string;
   /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
   sessionId?: string;

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -122,6 +122,8 @@ export interface Attachment {
 export interface ServiceEnvelope {
   serviceId: string;
   type: string;
+  /** Host-stamped unique id for at-least-once delivery dedupe (`env.id`). */
+  id?: string;
   requestId?: string;
   /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
   sessionId?: string;


### PR DESCRIPTION
Fixes runner-service state-management defects from the 2026-08-20 state audit (section 1 "Runner Services"). The snapshot/delta trigger-cache race is intentionally excluded (handled in a separate branch).

## Fixes

- **P1 — envelope dedup id in wrong field**: `service-message-bridge.ts` now stamps a unique `id` at the **top level** of `ServiceEnvelope` (matching SDK guidance to dedupe on `env.id`); the relay remains sole owner of the top-level `sessionId` (stamped from the authenticated socket in `relay/service-message.ts`). Payload copies of `id`/`sessionId` are kept for services written against the old payload-stamped shape. Type updated in `packages/protocol/src/shared.ts` and `packages/extension-sdk/src/service.ts`; `host.ts` docs and the extension-sdk-reference skill corrected.
- **P1 — session-scoped responses broadcast runner-wide (cross-session data leak)**: `MemoryService` and `ProcessService` now thread the trusted incoming envelope's top-level `sessionId` through every response emit (results *and* errors), so `runner.ts` routes them to the requesting session's viewers instead of broadcasting to every session on the runner. Audit of remaining services: git and tunnel already scoped correctly.
- **P1 — worker-crash cleanup depends on relay `session_ended`**: `spawnSession` gained a daemon-owned `onSessionExit` hook invoked in the true-termination branch of `child.on("exit")` (skipped on restart-in-place, exception-guarded). The daemon passes `cleanupSessionServices`, so session-owned service state (tunnel ownership, git watchers) is cleaned even when the relay is down. Cleanup is idempotent — the relay's later `session_ended` re-running it is a no-op.
- **P2 — time service timer drift + fragile state file**: one-shot timers now persist their **absolute `fireAt`** (keyed `timer:<subscriptionId>` in the existing state file, with the duration param for invalidation) and reuse it on daemon restart instead of rebuilding as `now + duration`. Persisted entries are dropped on fire/unsubscribe/stale reconcile, and snapshot reconcile prunes entries for subscriptions that vanished while the daemon was down. State writes use temp-file + rename (atomic), and corrupt state JSON is quarantined to `time-service-state.json.corrupt-<ts>` instead of silently reset.
- **P2 — `reconfigure_services` unserialized**: reconfigure runs are serialized via a promise chain, so overlapping calls can no longer interleave async package discovery with registry/panel/port mutation. Each queued run re-reads config fresh when it starts, so queueing (not coalescing) is correct; serialization also makes stale discovery results impossible without a generation token.

## Tests

- New: `memory-service.test.ts` (response session-scoping incl. errors), `time-service.persistence.test.ts` (6 tests: deadline reuse across restart, duration-change invalidation, drop/prune, corrupt-file quarantine, atomic writes).
- Updated: process-service test (leak regression assertions), session-spawner test (`onSessionExit` fires once on true exit, not on restart, tolerates a throwing hook), tunnel-service test (double-cleanup idempotency), bridge test (top-level `id`, asserts no top-level `sessionId` stamped session-side).

Results:
- `bun run typecheck` — clean
- `bun test packages/cli/src` — 2990 pass / 0 fail
- `bun scripts/test-isolated.ts packages/server/src` — 80 pass / 0 fail (one flaky first-run failure in `runner-recent-folders.test.ts` passed standalone and on rerun; unrelated)

## Follow-ups

- **terminal / file-explorer service_message responses carry no session context**: their dual-emit `service_message` envelopes have no `sessionId`, so the relay would broadcast them runner-wide — but their *requests* arrive via HTTP-correlated named events with no sessionId either, so scoping them needs a protocol change. Nothing in the UI consumes those channels today. Deferred.
- **pizzapi-discord `env.id` dedupe now works as documented**: the external Discord service dedupes on `env.id` per the runner-services skill; with `id` now at the top level, that code path functions as written — no change needed in that repo.
