### PR TITLE
fix(usage): live token cache keying, scanner replay/truncation correctness, event dedup schema v2, quota refresh guard

### DIFF
--- a/packages/cli/src/extensions/remote-heartbeat.test.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test";
+import { buildTokenUsage } from "./remote-heartbeat.js";
+
+function entry(input: number, output: number) {
+  return {
+    type: "message",
+    message: {
+      role: "assistant",
+      usage: { input, output, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+    },
+  };
+}
+
+function makeRctx(entries: any[], leafId: string, contextTokens: number) {
+  const manager = {
+    getEntries: () => entries,
+    getLeafId: () => leafId,
+  };
+  const rctx: any = {
+    latestCtx: {
+      sessionManager: manager,
+      getContextUsage: () => ({ tokens: contextTokens }),
+    },
+  };
+  return rctx;
+}
+
+describe("buildTokenUsage", () => {
+  test("two sessions with identical entry count and leafId do not share totals", () => {
+    const a = makeRctx([entry(100, 50)], "leaf-1", 1000);
+    const b = makeRctx([entry(999, 999)], "leaf-1", 2000);
+
+    // Prime a's cache, then read b — b must NOT get a's totals.
+    expect(buildTokenUsage(a).input).toBe(100);
+    expect(buildTokenUsage(b).input).toBe(999);
+    // And a is still correct afterwards.
+    expect(buildTokenUsage(a).input).toBe(100);
+  });
+
+  test("session switch (new manager, same entry count/leafId) recomputes totals", () => {
+    const rctx = makeRctx([entry(100, 50)], "leaf-1", 1000);
+    expect(buildTokenUsage(rctx).input).toBe(100);
+
+    // Swap the session manager under the same rctx (e.g. /new) — same entry
+    // count and leafId, different data.
+    rctx.latestCtx.sessionManager = {
+      getEntries: () => [entry(7, 3)],
+      getLeafId: () => "leaf-1",
+    };
+    expect(buildTokenUsage(rctx).input).toBe(7);
+  });
+
+  test("compaction with unchanged entry count/leafId still refreshes contextTokens", () => {
+    let tokens = 50_000;
+    const rctx = makeRctx([entry(100, 50)], "leaf-1", 0);
+    rctx.latestCtx.getContextUsage = () => ({ tokens });
+
+    expect(buildTokenUsage(rctx).contextTokens).toBe(50_000);
+    // Compaction shrinks context without changing the cache key.
+    tokens = 5_000;
+    expect(buildTokenUsage(rctx).contextTokens).toBe(5_000);
+  });
+
+  test("returns zeros with no latestCtx", () => {
+    const result = buildTokenUsage({ latestCtx: null } as any);
+    expect(result).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: null });
+  });
+});

--- a/packages/cli/src/extensions/remote-heartbeat.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.ts
@@ -5,19 +5,30 @@
 import type { RelayContext } from "./remote-types.js";
 import { emitSessionMetadataUpdate, readQueuedFollowUps } from "./remote/chunked-delivery.js";
 
-let tokenUsageCache: { key: string; value: ReturnType<typeof buildTokenUsage> } | null = null;
+interface TokenTotals { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number }
+
+// Per-relay-context cache of cumulative totals, additionally pinned to the
+// session manager instance so a session switch (or two sessions sharing the
+// process) with an identical entry count/leafId can never serve another
+// session's totals. contextTokens is deliberately NOT cached: compaction can
+// change context size without changing the entry-count/leaf cache key.
+const tokenUsageCaches = new WeakMap<object, { manager: unknown; key: string; value: TokenTotals }>();
 
 export function buildTokenUsage(rctx: RelayContext): { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number; contextTokens: number | null } {
     if (!rctx.latestCtx) {
-        tokenUsageCache = null;
+        tokenUsageCaches.delete(rctx);
         return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: null };
     }
-    const entries = rctx.latestCtx.sessionManager.getEntries();
-    const leafId = rctx.latestCtx.sessionManager.getLeafId?.() ?? null;
+    const manager = rctx.latestCtx.sessionManager;
+    const entries = manager.getEntries();
+    const leafId = manager.getLeafId?.() ?? null;
     const cacheKey = `${entries.length}:${leafId ?? "null"}`;
 
-    if (tokenUsageCache?.key === cacheKey) {
-        return tokenUsageCache.value;
+    const contextTokens = rctx.latestCtx.getContextUsage?.()?.tokens ?? null;
+
+    const cached = tokenUsageCaches.get(rctx);
+    if (cached && cached.manager === manager && cached.key === cacheKey) {
+        return { ...cached.value, contextTokens };
     }
 
     let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
@@ -30,10 +41,9 @@ export function buildTokenUsage(rctx: RelayContext): { input: number; output: nu
             cost += Math.max(0, entry.message.usage.cost.total);
         }
     }
-    const contextUsage = rctx.latestCtx.getContextUsage?.();
-    const result = { input, output, cacheRead, cacheWrite, cost, contextTokens: contextUsage?.tokens ?? null };
-    tokenUsageCache = { key: cacheKey, value: result };
-    return result;
+    const totals: TokenTotals = { input, output, cacheRead, cacheWrite, cost };
+    tokenUsageCaches.set(rctx, { manager, key: cacheKey, value: totals });
+    return { ...totals, contextTokens };
 }
 
 export function buildHeartbeat(rctx: RelayContext) {

--- a/packages/cli/src/runner/runner-usage-cache.test.ts
+++ b/packages/cli/src/runner/runner-usage-cache.test.ts
@@ -154,3 +154,43 @@ describe("runner-usage-cache child", () => {
         }
     });
 });
+
+import { singleFlight } from "./runner-usage-cache.js";
+
+describe("singleFlight", () => {
+  test("concurrent calls coalesce into one in-flight execution", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fn = singleFlight(async () => {
+      calls++;
+      await gate;
+    });
+
+    const p1 = fn();
+    const p2 = fn();
+    const p3 = fn();
+    expect(p2).toBe(p1);
+    expect(p3).toBe(p1);
+    expect(calls).toBe(1);
+
+    release();
+    await p1;
+
+    // After completion a new call runs again
+    await fn();
+    expect(calls).toBe(2);
+  });
+
+  test("a rejected in-flight run clears the guard", async () => {
+    let calls = 0;
+    const fn = singleFlight(async () => {
+      calls++;
+      if (calls === 1) throw new Error("boom");
+    });
+
+    await expect(fn()).rejects.toThrow("boom");
+    await fn(); // must not stay stuck on the failed promise
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -220,7 +220,25 @@ async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
  * cache file so every worker on this runner node can read it without making
  * their own API calls.
  */
-async function refreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean } = {}): Promise<void> {
+/**
+ * Coalesce concurrent invocations of an async fn into one in-flight promise.
+ * Prevents an interval tick from overlapping a slow previous fetch and
+ * publishing results out of order (older data overwriting newer).
+ */
+export function singleFlight<A extends unknown[]>(fn: (...args: A) => Promise<void>): (...args: A) => Promise<void> {
+    let inflight: Promise<void> | null = null;
+    return (...args: A) => {
+        if (inflight) return inflight;
+        inflight = fn(...args).finally(() => {
+            inflight = null;
+        });
+        return inflight;
+    };
+}
+
+const refreshAndWriteRunnerUsageCache = singleFlight(doRefreshAndWriteRunnerUsageCache);
+
+async function doRefreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean } = {}): Promise<void> {
     const [anthropicResult, codexResult] = await Promise.allSettled([
         getRunnerAnthropicUsageData({ force: opts.forceAnthropic === true }),
         fetchCodexUsageData(),

--- a/packages/cli/src/usage/scanner.test.ts
+++ b/packages/cli/src/usage/scanner.test.ts
@@ -1,35 +1,55 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { writeFileSync, statSync } from "node:fs";
+import { mkdtempSync, writeFileSync, statSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { openUsageDb } from "./schema.js";
 import { processFile, parseSessionHeader, extractSessionName } from "./scanner.js";
 
+function makeDb(tmpDir: string): Database {
+  return openUsageDb(join(tmpDir, "test.db"));
+}
+
+function usageMsg(id: string, timestamp: string, input: number, output: number, cost = 0.001) {
+  return {
+    type: "message",
+    id,
+    timestamp,
+    message: {
+      role: "assistant",
+      provider: "anthropic",
+      model: "claude-opus",
+      usage: {
+        input,
+        output,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: input + output,
+        cost: { total: cost, input: cost / 2, output: cost / 2, cacheRead: 0, cacheWrite: 0 },
+      },
+    },
+  };
+}
+
+const header = (id: string) =>
+  ({
+    type: "session",
+    version: 1,
+    id,
+    timestamp: "2026-03-23T12:00:00Z",
+    cwd: "/project/test",
+  }) as const;
+
 describe("Scanner", () => {
   test("parseSessionHeader parses valid session header", () => {
-    const line = JSON.stringify({
-      type: "session",
-      version: 1,
-      id: "session-123",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/home/user/projects/pizzapi",
-    });
-
+    const line = JSON.stringify(header("session-123"));
     const result = parseSessionHeader(line);
     expect(result).toBeTruthy();
     expect(result?.id).toBe("session-123");
-    expect(result?.cwd).toBe("/home/user/projects/pizzapi");
+    expect(result?.cwd).toBe("/project/test");
   });
 
   test("parseSessionHeader returns null for non-session lines", () => {
-    const line = JSON.stringify({
-      type: "message",
-      id: "msg-123",
-    });
-
-    const result = parseSessionHeader(line);
-    expect(result).toBeNull();
+    expect(parseSessionHeader(JSON.stringify({ type: "message", id: "msg-123" }))).toBeNull();
   });
 
   test("extractSessionName finds set_session_name in tool calls", () => {
@@ -41,130 +61,32 @@ describe("Scanner", () => {
         provider: "anthropic",
         model: "claude-opus",
         tool_calls: [
-          {
-            tool_call_id: "call-123",
-            name: "set_session_name",
-            arguments: JSON.stringify({
-              name: "My Test Session",
-            }),
-          },
+          { tool_call_id: "call-123", name: "set_session_name", arguments: JSON.stringify({ name: "My Test Session" }) },
         ],
       },
     });
-
-    const result = extractSessionName(line);
-    expect(result).toBe("My Test Session");
+    expect(extractSessionName(line)).toBe("My Test Session");
   });
 
   test("extractSessionName returns null when no session name found", () => {
     const line = JSON.stringify({
       type: "message",
       timestamp: "2026-03-23T12:00:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-      },
+      message: { role: "assistant", provider: "anthropic", model: "claude-opus" },
     });
-
-    const result = extractSessionName(line);
-    expect(result).toBeNull();
+    expect(extractSessionName(line)).toBeNull();
   });
 
   test("processFile correctly parses JSONL with usage data", () => {
-    // Create temp directory
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-001");
+    const msg = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50);
+    writeFileSync(filePath, `${JSON.stringify(h)}\n${JSON.stringify(msg)}\n`);
 
-    // Create JSONL file
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-001",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h);
 
-    const usageMessage = {
-      type: "message",
-      id: "msg-001",
-      timestamp: "2026-03-23T12:05:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 100,
-          output: 50,
-          cacheRead: 10,
-          cacheWrite: 5,
-          totalTokens: 165,
-          cost: {
-            total: 0.001,
-            input: 0.0005,
-            output: 0.0004,
-            cacheRead: 0.00005,
-            cacheWrite: 0.000001,
-          },
-        },
-      },
-    };
-
-    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n`;
-    writeFileSync(filePath, content);
-
-    // Process the file
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
-
-    processFile(db, filePath, "session.jsonl", sessionHeader);
-
-    // Verify usage_events was inserted
     const events = db.query<any, []>("SELECT * FROM usage_events").all();
     expect(events.length).toBe(1);
     expect(events[0].session_id).toBe("session-001");
@@ -173,52 +95,22 @@ describe("Scanner", () => {
     expect(events[0].input_tokens).toBe(100);
     expect(events[0].output_tokens).toBe(50);
     expect(events[0].cost_usd).toBeCloseTo(0.001, 6);
+    expect(events[0].event_uid).toBeTruthy();
 
-    // Verify sessions was upserted
     const sessions = db.query<any, []>("SELECT * FROM sessions").all();
     expect(sessions.length).toBe(1);
     expect(sessions[0].id).toBe("session-001");
     expect(sessions[0].message_count).toBe(1);
     expect(sessions[0].total_input).toBe(100);
-
+    expect(sessions[0].primary_model).toBe("claude-opus");
     db.close();
   });
 
   test("processFile includes /goal evaluator spend (goal_evaluator_usage custom entries) in usage totals", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
-
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-goal",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
-
-    const usageMessage = {
-      type: "message",
-      id: "msg-001",
-      timestamp: "2026-03-23T12:05:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 100,
-          output: 50,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 150,
-          cost: { total: 0.01, input: 0.006, output: 0.004, cacheRead: 0, cacheWrite: 0 },
-        },
-      },
-    };
-
-    // The /goal LLM evaluator makes a separate API call outside the normal
-    // turn pipeline; its spend is persisted as a goal_evaluator_usage custom
-    // entry (see extensions/goal/state.ts) rather than an assistant message.
+    const h = header("session-goal");
+    const msg = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.01);
     const evaluatorUsage = {
       type: "custom",
       id: "entry-001",
@@ -232,58 +124,11 @@ describe("Scanner", () => {
         timestamp: new Date("2026-03-23T12:06:00Z").getTime(),
       },
     };
-
-    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n${JSON.stringify(evaluatorUsage)}\n`;
+    const content = `${JSON.stringify(h)}\n${JSON.stringify(msg)}\n${JSON.stringify(evaluatorUsage)}\n`;
     writeFileSync(filePath, content);
 
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
-
-    processFile(db, filePath, "session.jsonl", sessionHeader, content);
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
 
     const events = db.query<any, []>("SELECT * FROM usage_events ORDER BY timestamp").all();
     expect(events.length).toBe(2);
@@ -293,102 +138,28 @@ describe("Scanner", () => {
 
     const sessions = db.query<any, []>("SELECT * FROM sessions").all();
     expect(sessions.length).toBe(1);
-    // Evaluator spend must be folded into the session total, not silently
-    // dropped — this is the whole point of the fix.
     expect(sessions[0].total_cost).toBeCloseTo(0.01 + 0.0002, 6);
     expect(sessions[0].total_output).toBe(50 + 60);
-
     db.close();
   });
 
   test("processFile skips malformed JSON lines without crashing", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-002");
+    writeFileSync(filePath, `${JSON.stringify(h)}\nmalformed json line\n`);
 
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-002",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
-
-    // Content with a malformed JSON line
-    const content = `${JSON.stringify(sessionHeader)}\nmalformed json line\n`;
-    writeFileSync(filePath, content);
-
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
-
-    // Should not throw
-    processFile(db, filePath, "session.jsonl", sessionHeader);
-
-    // Should have no events (malformed line was skipped)
-    const events = db.query<any, []>("SELECT * FROM usage_events").all();
-    expect(events.length).toBe(0);
-
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h);
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(0);
     db.close();
   });
 
   test("processFile handles sessions with no cost data", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
-
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-003",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
-
-    const usageMessage = {
+    const h = header("session-003");
+    const msg = {
       type: "message",
       id: "msg-001",
       timestamp: "2026-03-23T12:05:00Z",
@@ -396,375 +167,209 @@ describe("Scanner", () => {
         role: "assistant",
         provider: "anthropic",
         model: "claude-opus",
-        usage: {
-          input: 100,
-          output: 50,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 150,
-          // No cost field
-        },
+        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, totalTokens: 150 },
       },
     };
+    writeFileSync(filePath, `${JSON.stringify(h)}\n${JSON.stringify(msg)}\n`);
 
-    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n`;
-    writeFileSync(filePath, content);
-
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
-
-    processFile(db, filePath, "session.jsonl", sessionHeader);
-
-    // Verify event was inserted with NULL cost
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h);
     const events = db.query<any, []>("SELECT * FROM usage_events").all();
     expect(events.length).toBe(1);
     expect(events[0].cost_usd).toBeNull();
-
     db.close();
   });
 
   test("processFile handles incremental processing correctly", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
-
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-004",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
-
-    const usageMessage1 = {
-      type: "message",
-      id: "msg-001",
-      timestamp: "2026-03-23T12:05:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 100,
-          output: 50,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 150,
-          cost: {
-            total: 0.001,
-            input: 0.0005,
-            output: 0.0004,
-            cacheRead: 0.00005,
-            cacheWrite: 0.000001,
-          },
-        },
-      },
-    };
-
-    // Write initial file with header + one message
-    let content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n`;
+    const h = header("session-004");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    let content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n`;
     writeFileSync(filePath, content);
 
-    // Set up database
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
 
-    // First scan: process initial file
-    processFile(db, filePath, "session.jsonl", sessionHeader, content);
-
-    // Verify first message was processed
-    let events = db.query<any, []>("SELECT * FROM usage_events").all();
-    expect(events.length).toBe(1);
     let sessions = db.query<any, []>("SELECT * FROM sessions").all();
-    expect(sessions.length).toBe(1);
     expect(sessions[0].message_count).toBe(1);
     expect(sessions[0].total_input).toBe(100);
 
-    // Get the stored offset
-    const state = db
+    const firstScanOffset = db
       .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
-      .get();
-    expect(state).toBeTruthy();
-    const firstScanOffset = state!.last_offset;
+      .get()!.last_offset;
 
-    // Append a second message
-    const usageMessage2 = {
-      type: "message",
-      id: "msg-002",
-      timestamp: "2026-03-23T12:10:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 200,
-          output: 100,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 300,
-          cost: {
-            total: 0.002,
-            input: 0.001,
-            output: 0.0008,
-            cacheRead: 0.0001,
-            cacheWrite: 0.000002,
-          },
-        },
-      },
-    };
-
-    content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${JSON.stringify(usageMessage2)}\n`;
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:10:00Z", 200, 100, 0.002);
+    content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${JSON.stringify(msg2)}\n`;
     writeFileSync(filePath, content);
+    processFile(db, filePath, "session.jsonl", h, content, firstScanOffset);
 
-    // Second scan: incremental processing with lastOffset
-    processFile(db, filePath, "session.jsonl", sessionHeader, content, firstScanOffset);
-
-    // Verify both messages are now in the database
-    events = db.query<any, []>("SELECT * FROM usage_events").all();
-    expect(events.length).toBe(2);
-
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(2);
     sessions = db.query<any, []>("SELECT * FROM sessions").all();
-    expect(sessions.length).toBe(1);
     expect(sessions[0].message_count).toBe(2);
-    expect(sessions[0].total_input).toBe(300); // 100 + 200
-    expect(sessions[0].total_output).toBe(150); // 50 + 100
-
+    expect(sessions[0].total_input).toBe(300);
+    expect(sessions[0].total_output).toBe(150);
     db.close();
   });
 
   test("processFile handles partial lines correctly", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
-    const dbPath = join(tmpDir, "test.db");
     const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-005");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:10:00Z", 200, 100, 0.002);
 
-    const sessionHeader = {
-      type: "session",
-      version: 1,
-      id: "session-005",
-      timestamp: "2026-03-23T12:00:00Z",
-      cwd: "/project/test",
-    } as const;
-
-    const usageMessage1 = {
-      type: "message",
-      id: "msg-001",
-      timestamp: "2026-03-23T12:05:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 100,
-          output: 50,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 150,
-          cost: {
-            total: 0.001,
-            input: 0.0005,
-            output: 0.0004,
-            cacheRead: 0.00005,
-            cacheWrite: 0.000001,
-          },
-        },
-      },
-    };
-
-    const usageMessage2 = {
-      type: "message",
-      id: "msg-002",
-      timestamp: "2026-03-23T12:10:00Z",
-      message: {
-        role: "assistant",
-        provider: "anthropic",
-        model: "claude-opus",
-        usage: {
-          input: 200,
-          output: 100,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 300,
-          cost: {
-            total: 0.002,
-            input: 0.001,
-            output: 0.0008,
-            cacheRead: 0.0001,
-            cacheWrite: 0.000002,
-          },
-        },
-      },
-    };
-
-    // Write file with one complete message and a partial line (cut mid-JSON)
-    const completeMsg = JSON.stringify(usageMessage2);
-    const partialLine = completeMsg.slice(0, 50); // Cut the message mid-way, no newline
-    let content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${partialLine}`;
+    // File with one complete message and a partial line (cut mid-JSON, no newline)
+    const partialLine = JSON.stringify(msg2).slice(0, 50);
+    let content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${partialLine}`;
     writeFileSync(filePath, content);
 
-    // Set up database
-    const db = new Database(dbPath);
-    db.run("PRAGMA journal_mode=WAL");
-    db.run(`
-      CREATE TABLE usage_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        input_tokens INTEGER DEFAULT 0,
-        output_tokens INTEGER DEFAULT 0,
-        cache_read_tokens INTEGER DEFAULT 0,
-        cache_write_tokens INTEGER DEFAULT 0,
-        cost_usd REAL,
-        cost_input REAL,
-        cost_output REAL,
-        cost_cache_read REAL,
-        cost_cache_write REAL,
-        UNIQUE(session_id, timestamp, model)
-      )
-    `);
-    db.run(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        project TEXT NOT NULL,
-        session_name TEXT,
-        started_at INTEGER NOT NULL,
-        ended_at INTEGER,
-        message_count INTEGER DEFAULT 0,
-        total_input INTEGER DEFAULT 0,
-        total_output INTEGER DEFAULT 0,
-        total_cache_read INTEGER DEFAULT 0,
-        total_cache_write INTEGER DEFAULT 0,
-        total_cost REAL,
-        primary_model TEXT,
-        primary_provider TEXT
-      )
-    `);
-    db.run(`
-      CREATE TABLE processing_state (
-        file_path TEXT PRIMARY KEY,
-        last_offset INTEGER DEFAULT 0,
-        last_modified INTEGER
-      )
-    `);
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
 
-    // First scan: should process complete message but skip partial line (no trailing newline)
-    processFile(db, filePath, "session.jsonl", sessionHeader, content);
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(1);
+    expect(db.query<any, []>("SELECT * FROM sessions").all()[0].message_count).toBe(1);
 
-    // Verify only the complete message was processed (not the partial line)
-    let events = db.query<any, []>("SELECT * FROM usage_events").all();
-    expect(events.length).toBe(1); // Only message1 should be processed
-    let sessions = db.query<any, []>("SELECT * FROM sessions").all();
-    expect(sessions[0].message_count).toBe(1);
-
-    // Get the stored offset (should be after the first complete message's newline)
-    const state = db
+    const firstScanOffset = db
       .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
-      .get();
-    const firstScanOffset = state!.last_offset;
+      .get()!.last_offset;
+    // Offset must point exactly at the start of the partial line — i.e. the
+    // partial bytes were NOT consumed.
+    expect(firstScanOffset).toBe(
+      Buffer.byteLength(`${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n`, "utf-8"),
+    );
 
-    // Now complete the partial line and add a new complete line
-    content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${JSON.stringify(usageMessage2)}\n`;
+    // Complete the partial line
+    content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${JSON.stringify(msg2)}\n`;
+    writeFileSync(filePath, content);
+    processFile(db, filePath, "session.jsonl", h, content, firstScanOffset);
+
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(2);
+    expect(db.query<any, []>("SELECT * FROM sessions").all()[0].message_count).toBe(2);
+    db.close();
+  });
+
+  test("replaying the same file does not double-count summaries", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-replay");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:10:00Z", 200, 100, 0.002);
+    const content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${JSON.stringify(msg2)}\n`;
     writeFileSync(filePath, content);
 
-    // Second scan: should process message2 (which completes the partial line)
-    processFile(db, filePath, "session.jsonl", sessionHeader, content, firstScanOffset);
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
+    // Replay from offset 0 (e.g. lost processing_state row) — events are
+    // deduped by event_uid, and summaries must not inflate.
+    processFile(db, filePath, "session.jsonl", h, content);
+    processFile(db, filePath, "session.jsonl", h, content);
 
-    // Verify message2 was processed
-    events = db.query<any, []>("SELECT * FROM usage_events").all();
-    expect(events.length).toBe(2); // message1 from first scan + message2 from second scan
-    sessions = db.query<any, []>("SELECT * FROM sessions").all();
-    expect(sessions[0].message_count).toBe(2);
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(2);
+    const s = db.query<any, []>("SELECT * FROM sessions").all()[0];
+    expect(s.message_count).toBe(2);
+    expect(s.total_input).toBe(300);
+    expect(s.total_output).toBe(150);
+    expect(s.total_cost).toBeCloseTo(0.003, 6);
+    db.close();
+  });
 
+  test("distinct events with identical (session, timestamp, model) are both recorded", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-samets");
+    // Two distinct API calls in the same millisecond with the same model —
+    // the old UNIQUE(session_id, timestamp, model) key silently dropped one.
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:05:00Z", 200, 100, 0.002);
+    const content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${JSON.stringify(msg2)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
+
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(2);
+    const s = db.query<any, []>("SELECT * FROM sessions").all()[0];
+    expect(s.total_input).toBe(300);
+    db.close();
+  });
+
+  test("malformed complete line stops processing and records its exact byte start", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-badline");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:10:00Z", 200, 100, 0.002);
+    const prefix = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n`;
+    const content = `${prefix}{not json}\n${JSON.stringify(msg2)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
+
+    // Only the message before the malformed line was processed; the offset
+    // points at the malformed line's byte start, not past msg2.
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(1);
+    const offset = db
+      .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
+      .get()!.last_offset;
+    expect(offset).toBe(Buffer.byteLength(prefix, "utf-8"));
+    db.close();
+  });
+
+  test("rebuild replaces obsolete accounting for a truncated/rewritten file", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-truncate");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const msg2 = usageMsg("msg-002", "2026-03-23T12:10:00Z", 200, 100, 0.002);
+    let content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n${JSON.stringify(msg2)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = makeDb(tmpDir);
+    processFile(db, filePath, "session.jsonl", h, content);
+    expect(db.query<any, []>("SELECT * FROM sessions").all()[0].total_input).toBe(300);
+
+    // File rewritten shorter (e.g. trimmed history): only msg1 remains.
+    content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n`;
+    writeFileSync(filePath, content);
+    processFile(db, filePath, "session.jsonl", h, content, undefined, { rebuild: true });
+
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(1);
+    const s = db.query<any, []>("SELECT * FROM sessions").all()[0];
+    expect(s.total_input).toBe(100);
+    expect(s.total_output).toBe(50);
+    expect(s.message_count).toBe(1);
+    // Offset state reflects the rebuilt (shorter) file
+    const offset = db
+      .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
+      .get()!.last_offset;
+    expect(offset).toBe(Buffer.byteLength(content, "utf-8"));
+    db.close();
+  });
+
+  test("rebuild also purges legacy NULL-uid rows for the session", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const filePath = join(tmpDir, "session.jsonl");
+    const h = header("session-legacy");
+    const msg1 = usageMsg("msg-001", "2026-03-23T12:05:00Z", 100, 50, 0.001);
+    const content = `${JSON.stringify(h)}\n${JSON.stringify(msg1)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = makeDb(tmpDir);
+    // Simulate a pre-migration row (event_uid NULL) for the same session
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model, input_tokens, output_tokens)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ["session-legacy", "/project/test", 111, "anthropic", "claude-opus", 999, 999],
+    );
+
+    processFile(db, filePath, "session.jsonl", h, content, undefined, { rebuild: true });
+
+    const events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(1);
+    expect(events[0].input_tokens).toBe(100);
+    expect(db.query<any, []>("SELECT * FROM sessions").all()[0].total_input).toBe(100);
     db.close();
   });
 });

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -72,43 +72,31 @@ export function processFile(
   sessionHeader: SessionHeader,
   fullContent?: string,
   lastOffset?: number,
+  opts?: { rebuild?: boolean },
 ): void {
   const sessionId = sessionHeader.id;
   const project = sessionHeader.cwd;
   const startedAtMs = new Date(sessionHeader.timestamp).getTime();
+  const rebuild = opts?.rebuild === true;
 
   // Read the full file if content wasn't provided
   if (!fullContent) {
     fullContent = readFileSync(filePath, "utf-8");
   }
 
-  // Handle incremental processing: if we have a lastOffset, process only new lines
-  let linesToProcess: string[];
-  if (lastOffset !== undefined && lastOffset > 0) {
-    // lastOffset is a UTF-8 byte count. We must use Buffer-based slicing so
-    // that multi-byte Unicode characters in cwd/session names don't cause
-    // offset drift (JS string .slice() counts UTF-16 code units, not bytes).
-    const fullBuf = Buffer.from(fullContent, "utf-8");
-    if (lastOffset >= fullBuf.length) {
-      linesToProcess = [];
-    } else {
-      // Start from lastOffset (byte position)
-      // If there's a newline byte at lastOffset (shouldn't happen), skip it
-      let startPos = lastOffset;
-      if (startPos < fullBuf.length && fullBuf[startPos] === 0x0a /* '\n' */) {
-        startPos++;
-      }
-      // Slice by bytes then decode — correctly handles multi-byte characters
-      const newContent = fullBuf.slice(startPos).toString("utf-8");
-      linesToProcess = newContent.split("\n");
-    }
-  } else {
-    // First scan: process all lines (skip the header in the processing loop)
-    linesToProcess = fullContent.split("\n");
+  // All offsets are UTF-8 byte offsets; operate on a Buffer so multi-byte
+  // characters can never cause offset drift.
+  const fullBuf = Buffer.from(fullContent, "utf-8");
+  let pos = lastOffset !== undefined && lastOffset > 0 && !rebuild ? lastOffset : 0;
+  if (pos > fullBuf.length) pos = fullBuf.length;
+  // If there's a newline byte at pos (shouldn't happen), skip it
+  if (pos > 0 && pos < fullBuf.length && fullBuf[pos] === 0x0a /* '\n' */) {
+    pos++;
   }
 
   // Track usage data
   interface UsageEvent {
+    event_uid: string;
     timestamp: number;
     provider: string;
     model: string;
@@ -125,173 +113,127 @@ export function processFile(
 
   const events: UsageEvent[] = [];
   let sessionName: string | null = null;
-  let lastMessageTimestamp = startedAtMs;
-  let messageCount = 0;
 
-  // Model usage tracking (by count)
-  const modelUsage = new Map<string, number>();
+  // Byte offset just past the last successfully processed, newline-terminated
+  // line. A trailing line with no newline (still being written) or the first
+  // malformed line stops processing — the offset records its exact byte start
+  // so the next scan retries from there instead of desyncing.
+  let lastCompleteLineOffset = pos;
 
-  // For incremental scans, we need to get existing session data to merge with
-  let existingSession: any = null;
-  if (lastOffset !== undefined && lastOffset > 0) {
-    existingSession = db
-      .query<any, [string]>("SELECT * FROM sessions WHERE id = ?")
-      .get(sessionId);
-  }
+  while (pos < fullBuf.length) {
+    const nl = fullBuf.indexOf(0x0a, pos);
+    if (nl === -1) break; // incomplete final line — don't consume it
+    const lineStart = pos;
+    const line = fullBuf.slice(pos, nl).toString("utf-8");
+    pos = nl + 1;
 
-  // Track the byte position of the last complete line we process
-  let lastCompleteLineOffset = lastOffset ?? 0;
+    if (!line.trim()) {
+      lastCompleteLineOffset = pos;
+      continue;
+    }
 
-  // Process each line
-  for (let i = 0; i < linesToProcess.length; i++) {
-    const line = linesToProcess[i];
-    if (!line.trim()) continue;
-
+    let obj: any;
     try {
-      const obj = JSON.parse(line);
-
-      // Skip the session header (already have it)
-      if (obj.type === "session") {
-        // Mark this line as successfully processed
-        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
-        continue;
-      }
-
-      // Check for session name
-      if (obj.type === "message" && !sessionName) {
-        const name = extractSessionName(line);
-        if (name) sessionName = name;
-      }
-
-      // Extract usage from assistant messages
-      if (
-        obj.type === "message" &&
-        obj.message &&
-        obj.message.role === "assistant" &&
-        obj.message.usage
-      ) {
-        const msg = obj.message as any;
-        const usage = msg.usage;
-        const timestamp = new Date(obj.timestamp).getTime();
-
-        lastMessageTimestamp = Math.max(lastMessageTimestamp, timestamp);
-        messageCount++;
-
-        const provider = msg.provider || "unknown";
-        const model = msg.model || "unknown";
-
-        // Track model usage
-        modelUsage.set(model, (modelUsage.get(model) || 0) + 1);
-
-        const event: UsageEvent = {
-          timestamp,
-          provider,
-          model,
-          input_tokens: usage.input || 0,
-          output_tokens: usage.output || 0,
-          cache_read_tokens: usage.cacheRead || 0,
-          cache_write_tokens: usage.cacheWrite || 0,
-          cost_usd: usage.cost?.total ?? null,
-          cost_input: usage.cost?.input ?? null,
-          cost_output: usage.cost?.output ?? null,
-          cost_cache_read: usage.cost?.cacheRead ?? null,
-          cost_cache_write: usage.cost?.cacheWrite ?? null,
-        };
-
-        events.push(event);
-
-        // Mark this line as successfully processed
-        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
-      } else if (obj.type === "custom" && obj.customType === GOAL_EVALUATOR_USAGE_CUSTOM_TYPE) {
-        // /goal LLM evaluator calls are separate API requests outside the
-        // normal turn — surface their spend here so it isn't invisible to
-        // the Usage dashboard. Written as a per-call delta (see state.ts),
-        // so it's safe to add directly without cumulative double-counting.
-        const data = obj.data as { provider?: string; model?: string; tokens?: number; cost?: number; timestamp?: number };
-        const timestamp = data.timestamp ?? new Date(obj.timestamp).getTime();
-
-        modelUsage.set(data.model || "unknown", (modelUsage.get(data.model || "unknown") || 0) + 1);
-
-        events.push({
-          timestamp,
-          provider: data.provider || "unknown",
-          model: data.model || "unknown",
-          input_tokens: 0,
-          output_tokens: data.tokens || 0,
-          cache_read_tokens: 0,
-          cache_write_tokens: 0,
-          cost_usd: data.cost ?? null,
-          cost_input: null,
-          cost_output: data.cost ?? null,
-          cost_cache_read: null,
-          cost_cache_write: null,
-        });
-
-        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
-      } else {
-        // For other valid JSON types (like message without usage), still mark as processed
-        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
-      }
+      obj = JSON.parse(line);
     } catch {
-      // Skip malformed lines — don't update lastCompleteLineOffset for malformed lines
+      // Malformed complete line: stop here and record its byte start so the
+      // offset stays in sync with what was actually accounted.
+      lastCompleteLineOffset = lineStart;
+      break;
     }
-  }
 
-  // Determine primary model (most used by count)
-  let primaryModel = "unknown";
-  let primaryProvider = "unknown";
-  if (modelUsage.size > 0) {
-    primaryModel = [...modelUsage.entries()].sort((a, b) => b[1] - a[1])[0][0];
-    // Extract provider from first matching event
-    const firstEvent = events.find((e) => e.model === primaryModel);
-    if (firstEvent) {
-      primaryProvider = firstEvent.provider;
+    // Skip the session header (already have it)
+    if (obj.type === "session") {
+      lastCompleteLineOffset = pos;
+      continue;
     }
-  }
 
-  // Aggregate totals
-  let totalInput = 0;
-  let totalOutput = 0;
-  let totalCacheRead = 0;
-  let totalCacheWrite = 0;
-  let totalCost: number | null = null;
-
-  for (const event of events) {
-    totalInput += event.input_tokens;
-    totalOutput += event.output_tokens;
-    totalCacheRead += event.cache_read_tokens;
-    totalCacheWrite += event.cache_write_tokens;
-
-    // Sum cost (skip null values)
-    if (event.cost_usd !== null) {
-      totalCost = (totalCost ?? 0) + event.cost_usd;
+    // Check for session name
+    if (obj.type === "message" && !sessionName) {
+      const name = extractSessionName(line);
+      if (name) sessionName = name;
     }
-  }
 
-  // For incremental scans, merge with existing data. Guard on events.length
-  // (not messageCount) — goal_evaluator_usage entries add events without
-  // being an assistant message, and would otherwise be dropped from history.
-  if (existingSession && events.length > 0) {
-    totalInput += existingSession.total_input || 0;
-    totalOutput += existingSession.total_output || 0;
-    totalCacheRead += existingSession.total_cache_read || 0;
-    totalCacheWrite += existingSession.total_cache_write || 0;
-    if (existingSession.total_cost !== null) {
-      totalCost = (totalCost ?? 0) + existingSession.total_cost;
+    // Stable per-line event ID: file identity + absolute byte start of the
+    // line. Deterministic across replays, unique across distinct API calls.
+    const eventUid = `${relativePath}:${lineStart}`;
+
+    // Extract usage from assistant messages
+    if (
+      obj.type === "message" &&
+      obj.message &&
+      obj.message.role === "assistant" &&
+      obj.message.usage
+    ) {
+      const msg = obj.message as any;
+      const usage = msg.usage;
+      const timestamp = new Date(obj.timestamp).getTime();
+
+      events.push({
+        event_uid: eventUid,
+        timestamp,
+        provider: msg.provider || "unknown",
+        model: msg.model || "unknown",
+        input_tokens: usage.input || 0,
+        output_tokens: usage.output || 0,
+        cache_read_tokens: usage.cacheRead || 0,
+        cache_write_tokens: usage.cacheWrite || 0,
+        cost_usd: usage.cost?.total ?? null,
+        cost_input: usage.cost?.input ?? null,
+        cost_output: usage.cost?.output ?? null,
+        cost_cache_read: usage.cost?.cacheRead ?? null,
+        cost_cache_write: usage.cost?.cacheWrite ?? null,
+      });
+    } else if (obj.type === "custom" && obj.customType === GOAL_EVALUATOR_USAGE_CUSTOM_TYPE) {
+      // /goal LLM evaluator calls are separate API requests outside the
+      // normal turn — surface their spend here so it isn't invisible to
+      // the Usage dashboard. Written as a per-call delta (see state.ts),
+      // so it's safe to add directly without cumulative double-counting.
+      const data = obj.data as { provider?: string; model?: string; tokens?: number; cost?: number; timestamp?: number };
+      const timestamp = data.timestamp ?? new Date(obj.timestamp).getTime();
+
+      events.push({
+        event_uid: eventUid,
+        timestamp,
+        provider: data.provider || "unknown",
+        model: data.model || "unknown",
+        input_tokens: 0,
+        output_tokens: data.tokens || 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost_usd: data.cost ?? null,
+        cost_input: null,
+        cost_output: data.cost ?? null,
+        cost_cache_read: null,
+        cost_cache_write: null,
+      });
     }
-    messageCount += existingSession.message_count || 0;
+    lastCompleteLineOffset = pos;
   }
 
   // Use transaction for atomicity
   db.transaction(() => {
-    // Insert usage events
+    if (rebuild) {
+      // File was truncated or replaced — drop this file's previous accounting
+      // before re-inserting. Also drops legacy (pre-event_uid) rows for this
+      // session so they can't double-count against the replay.
+      // ponytail: legacy NULL-uid delete is session-wide; fine because a
+      // session's usage lives in one jsonl file in practice.
+      const likePrefix = `${relativePath.replace(/([%_\\])/g, "\\$1")}:%`;
+      db.run(
+        "DELETE FROM usage_events WHERE event_uid LIKE ? ESCAPE '\\' OR (session_id = ? AND event_uid IS NULL)",
+        [likePrefix, sessionId],
+      );
+    }
+
+    // Insert usage events — OR IGNORE on event_uid makes replays no-ops.
     for (const event of events) {
       db.run(
         `INSERT OR IGNORE INTO usage_events 
          (session_id, project, timestamp, provider, model, 
           input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-          cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write, event_uid)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           sessionId,
           project,
@@ -307,15 +249,34 @@ export function processFile(
           event.cost_output,
           event.cost_cache_read,
           event.cost_cache_write,
+          event.event_uid,
         ],
       );
     }
 
-    // Only upsert session summary when we have new usage events to write.
-    // Skipping when events.length === 0 prevents an incremental rescan from
-    // zeroing out existing aggregates (message_count, totals, primary_model)
-    // on files that contain no new assistant-usage entries.
-    if (events.length > 0) {
+    // Derive the session summary from persisted events — the single source of
+    // truth. Replayed (ignored) inserts therefore can never inflate summaries,
+    // and rebuilds are automatically consistent.
+    if (events.length > 0 || rebuild) {
+      const agg = db
+        .query<any, [string]>(
+          `SELECT COUNT(*) AS n,
+                  COALESCE(SUM(input_tokens), 0) AS total_input,
+                  COALESCE(SUM(output_tokens), 0) AS total_output,
+                  COALESCE(SUM(cache_read_tokens), 0) AS total_cache_read,
+                  COALESCE(SUM(cache_write_tokens), 0) AS total_cache_write,
+                  SUM(cost_usd) AS total_cost,
+                  MAX(timestamp) AS last_ts
+           FROM usage_events WHERE session_id = ?`,
+        )
+        .get(sessionId);
+      const primary = db
+        .query<{ model: string; provider: string }, [string]>(
+          `SELECT model, provider FROM usage_events WHERE session_id = ?
+           GROUP BY model, provider ORDER BY COUNT(*) DESC LIMIT 1`,
+        )
+        .get(sessionId);
+
       db.run(
         `INSERT INTO sessions 
          (id, project, session_name, started_at, ended_at, message_count,
@@ -324,7 +285,7 @@ export function processFile(
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
          session_name = COALESCE(excluded.session_name, session_name),
-         ended_at = CASE WHEN excluded.ended_at IS NULL THEN ended_at ELSE MAX(ended_at, excluded.ended_at) END,
+         ended_at = excluded.ended_at,
          message_count = excluded.message_count,
          total_input = excluded.total_input,
          total_output = excluded.total_output,
@@ -338,15 +299,15 @@ export function processFile(
           project,
           sessionName,
           startedAtMs,
-          messageCount > 0 ? lastMessageTimestamp : null,
-          messageCount,
-          totalInput,
-          totalOutput,
-          totalCacheRead,
-          totalCacheWrite,
-          totalCost,
-          primaryModel,
-          primaryProvider,
+          agg?.last_ts ?? null,
+          agg?.n ?? 0,
+          agg?.total_input ?? 0,
+          agg?.total_output ?? 0,
+          agg?.total_cache_read ?? 0,
+          agg?.total_cache_write ?? 0,
+          agg?.total_cost ?? null,
+          primary?.model ?? "unknown",
+          primary?.provider ?? "unknown",
         ],
       );
     }
@@ -354,12 +315,13 @@ export function processFile(
     // Update processing state with byte offset (only for the lines we actually processed)
     const fileStats = statSync(filePath);
     db.run(
-      `INSERT INTO processing_state (file_path, last_offset, last_modified)
-       VALUES (?, ?, ?)
+      `INSERT INTO processing_state (file_path, last_offset, last_modified, ino)
+       VALUES (?, ?, ?, ?)
        ON CONFLICT(file_path) DO UPDATE SET
        last_offset = excluded.last_offset,
-       last_modified = excluded.last_modified`,
-      [relativePath, lastCompleteLineOffset, fileStats.mtimeMs],
+       last_modified = excluded.last_modified,
+       ino = excluded.ino`,
+      [relativePath, lastCompleteLineOffset, fileStats.mtimeMs, fileStats.ino ?? null],
     );
   })();
 }
@@ -414,8 +376,8 @@ export async function scanSessions(db: Database): Promise<void> {
 
         // Check if we need to process this file
         const state = db
-          .query<{ last_offset: number; last_modified: number }, [string]>(
-            "SELECT last_offset, last_modified FROM processing_state WHERE file_path = ?",
+          .query<{ last_offset: number; last_modified: number; ino: number | null }, [string]>(
+            "SELECT last_offset, last_modified, ino FROM processing_state WHERE file_path = ?",
           )
           .get(relativePath);
 
@@ -442,10 +404,19 @@ export async function scanSessions(db: Database): Promise<void> {
           continue;
         }
 
+        // Truncated (size < recorded offset) or replaced (inode changed) file:
+        // the recorded accounting no longer matches the bytes on disk — rebuild
+        // this file's accounting from scratch instead of silently keeping it.
+        const rebuild =
+          state !== null &&
+          state !== undefined &&
+          (fileStats.size < state.last_offset ||
+            (state.ino !== null && state.ino !== undefined && Number(state.ino) !== Number(fileStats.ino)));
+
         // Process the file, passing content to avoid double read
         // and passing lastOffset for incremental processing
         try {
-          processFile(db, filePath, relativePath, sessionHeader, content, state?.last_offset);
+          processFile(db, filePath, relativePath, sessionHeader, content, rebuild ? undefined : state?.last_offset, { rebuild });
         } catch (e) {
           log.error(`Error processing ${filePath}:`, e);
         }

--- a/packages/cli/src/usage/schema-migration.test.ts
+++ b/packages/cli/src/usage/schema-migration.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { openUsageDb } from "./schema.js";
+
+function createV1Db(path: string): void {
+  const db = new Database(path);
+  db.run(`
+    CREATE TABLE usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0,
+      cache_write_tokens INTEGER DEFAULT 0,
+      cost_usd REAL,
+      cost_input REAL,
+      cost_output REAL,
+      cost_cache_read REAL,
+      cost_cache_write REAL,
+      UNIQUE(session_id, timestamp, model)
+    )
+  `);
+  db.run(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, project TEXT NOT NULL, session_name TEXT,
+      started_at INTEGER NOT NULL, ended_at INTEGER, message_count INTEGER DEFAULT 0,
+      total_input INTEGER DEFAULT 0, total_output INTEGER DEFAULT 0,
+      total_cache_read INTEGER DEFAULT 0, total_cache_write INTEGER DEFAULT 0,
+      total_cost REAL, primary_model TEXT, primary_provider TEXT
+    )
+  `);
+  db.run(`
+    CREATE TABLE processing_state (
+      file_path TEXT PRIMARY KEY, last_offset INTEGER DEFAULT 0, last_modified INTEGER
+    )
+  `);
+  db.run(
+    `INSERT INTO usage_events (session_id, project, timestamp, provider, model, input_tokens)
+     VALUES ('s1', '/p', 100, 'anthropic', 'claude-opus', 42)`,
+  );
+  db.run(`INSERT INTO processing_state (file_path, last_offset, last_modified) VALUES ('a/b.jsonl', 10, 1)`);
+  db.run("PRAGMA user_version = 1");
+  db.close();
+}
+
+describe("usage.db v1 → v2 migration", () => {
+  test("preserves rows, adds event_uid, drops the (session, timestamp, model) uniqueness", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-migration-test-");
+    const dbPath = join(tmpDir, "usage.db");
+    createV1Db(dbPath);
+
+    const db = openUsageDb(dbPath);
+    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()!.user_version).toBe(2);
+
+    // Existing row preserved with NULL uid
+    const rows = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(rows.length).toBe(1);
+    expect(rows[0].input_tokens).toBe(42);
+    expect(rows[0].event_uid).toBeNull();
+
+    // Distinct calls sharing (session, timestamp, model) both insert now
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model, input_tokens, event_uid)
+       VALUES ('s1', '/p', 100, 'anthropic', 'claude-opus', 1, 'f:10')`,
+    );
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model, input_tokens, event_uid)
+       VALUES ('s1', '/p', 100, 'anthropic', 'claude-opus', 2, 'f:20')`,
+    );
+    expect(db.query<any, []>("SELECT * FROM usage_events").all().length).toBe(3);
+
+    // Same event_uid is rejected (dedup key)
+    const before = db.query<any, []>("SELECT COUNT(*) c FROM usage_events").get()!.c;
+    db.run(
+      `INSERT OR IGNORE INTO usage_events (session_id, project, timestamp, provider, model, input_tokens, event_uid)
+       VALUES ('s1', '/p', 999, 'anthropic', 'claude-opus', 3, 'f:10')`,
+    );
+    expect(db.query<any, []>("SELECT COUNT(*) c FROM usage_events").get()!.c).toBe(before);
+
+    // processing_state gained the ino column and kept its row
+    const st = db.query<any, []>("SELECT * FROM processing_state").get();
+    expect(st.last_offset).toBe(10);
+    expect(st.ino).toBeNull();
+    db.close();
+  });
+
+  test("fresh database is created directly at v2", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-migration-test-");
+    const db = openUsageDb(join(tmpDir, "usage.db"));
+    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()!.user_version).toBe(2);
+    const cols = db.query<{ name: string }, []>("PRAGMA table_info(usage_events)").all().map((c) => c.name);
+    expect(cols).toContain("event_uid");
+    db.close();
+  });
+});

--- a/packages/cli/src/usage/schema.test.ts
+++ b/packages/cli/src/usage/schema.test.ts
@@ -55,9 +55,9 @@ test("openUsageDb initializes a new database with correct schema", () => {
   expect(indexNames).toContain("idx_sessions_started");
   expect(indexNames).toContain("idx_sessions_project");
 
-  // Check schema version is 1
+  // Check schema version is 2
   const versionInfo = db.query("PRAGMA user_version").get() as any;
-  expect(versionInfo.user_version).toBe(1);
+  expect(versionInfo.user_version).toBe(2);
 
   // Check journal mode is WAL
   const journalModeInfo = db.query("PRAGMA journal_mode").get() as any;
@@ -79,9 +79,9 @@ test("openUsageDb opens an existing database successfully without recreation", (
   expect(record).toBeDefined();
   expect(record.last_offset).toBe(100);
 
-  // Schema version should still be 1
+  // Schema version should still be 2
   const versionInfo = db2.query("PRAGMA user_version").get() as any;
-  expect(versionInfo.user_version).toBe(1);
+  expect(versionInfo.user_version).toBe(2);
 
   db2.close();
 });

--- a/packages/cli/src/usage/schema.ts
+++ b/packages/cli/src/usage/schema.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { mkdirSync } from "node:fs";
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 export function getUsageDbPath(): string {
   return join(homedir(), ".pizzapi", "usage.db");
@@ -14,8 +14,7 @@ export function getSessionsDir(): string {
   return join(homedir(), ".pizzapi", "sessions");
 }
 
-export function openUsageDb(): Database {
-  const dbPath = getUsageDbPath();
+export function openUsageDb(dbPath: string = getUsageDbPath()): Database {
   mkdirSync(join(dbPath, ".."), { recursive: true });
 
   const db = new Database(dbPath);
@@ -82,6 +81,53 @@ export function openUsageDb(): Database {
         db.run("CREATE INDEX IF NOT EXISTS idx_events_model ON usage_events(model)");
         db.run("CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at)");
         db.run("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project)");
+      }
+
+      if (currentVersion < 2) {
+        // v2: replace the UNIQUE(session_id, timestamp, model) constraint —
+        // which collides distinct API calls sharing a timestamp — with a
+        // file-offset-derived event_uid. Existing rows keep event_uid = NULL
+        // (SQLite unique indexes permit multiple NULLs).
+        db.run(`
+          CREATE TABLE usage_events_v2 (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            project TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            model TEXT NOT NULL,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            cost_usd REAL,
+            cost_input REAL,
+            cost_output REAL,
+            cost_cache_read REAL,
+            cost_cache_write REAL,
+            event_uid TEXT
+          )
+        `);
+        db.run(`
+          INSERT INTO usage_events_v2
+            (id, session_id, project, timestamp, provider, model,
+             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+             cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write, event_uid)
+          SELECT id, session_id, project, timestamp, provider, model,
+             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+             cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write, NULL
+          FROM usage_events
+        `);
+        db.run("DROP TABLE usage_events");
+        db.run("ALTER TABLE usage_events_v2 RENAME TO usage_events");
+        db.run("CREATE UNIQUE INDEX IF NOT EXISTS idx_events_uid ON usage_events(event_uid)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_timestamp ON usage_events(timestamp)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_project ON usage_events(project)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_model ON usage_events(model)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_session ON usage_events(session_id)");
+        // Track file identity so a rewritten (replaced-inode) session file
+        // triggers a rebuild of that file's accounting.
+        db.run("ALTER TABLE processing_state ADD COLUMN ino INTEGER");
       }
 
       db.run(`PRAGMA user_version = ${SCHEMA_VERSION}`);


### PR DESCRIPTION
Fixes the usage/accounting state-management defects from the 2026-08-20 state audit (section 2 "Usage") — 4 P1s, 3 P2s.

## Fixes

1. **P1 — Live token cache cross-session bleed** (`remote-heartbeat.ts`): the module-global cache keyed only by `(entryCount, leafId)` could serve one session's totals to another. Now a `WeakMap` keyed by RelayContext, additionally pinned to the `sessionManager` instance so a `/new` session switch (or two sessions in one process) with identical entry count/leafId always recomputes.
2. **P1 — Stale `contextTokens` after compaction**: `contextTokens` is no longer cached at all — only cumulative totals are. Compaction changes context size immediately, regardless of whether the cache key changed.
3. **P1 — Historical scanner double-count** (`usage/scanner.ts`): session summaries were incremented unconditionally while `usage_events` used `INSERT OR IGNORE`, so replays diverged summary vs detail. Summaries are now derived from persisted `usage_events` via SQL aggregate inside the same transaction — replayed (ignored) inserts can never inflate them. Bonus: `primary_model` is now cumulative across the whole session instead of latest-batch-only.
4. **P1 — Truncated/rewritten files kept obsolete usage forever**: `scanSessions` now detects `size < last_offset` or an inode change (`processing_state.ino`) and transactionally rebuilds that file's accounting — deletes its events (including legacy NULL-uid rows for that session), reprocesses from byte 0, re-derives the summary.
5. **P2 — Malformed JSONL corrupted offsets**: replaced the split-and-guess line loop with a buffer-based walk that stops at the first malformed or newline-unterminated line and records its exact absolute byte start. Partial lines still being written are never consumed.
6. **P2 — Event uniqueness collided distinct calls**: `UNIQUE(session_id, timestamp, model)` silently dropped distinct API calls sharing a millisecond. Replaced with `event_uid = <relativePath>:<lineByteOffset>` — deterministic across replays, unique across calls.
7. **P2 — Runner quota refresh overlap** (`runner-usage-cache.ts`): the interval-driven refresh had no in-flight guard, so a slow old fetch could overwrite newer data. Wrapped in an exported `singleFlight()` that coalesces concurrent invocations.

## Schema v2 migration (`~/.pizzapi/usage.db`)

`openUsageDb()` migrates v1 → v2 in one transaction:
- `usage_events` table rebuild (SQLite can't drop a constraint in place): drops the old UNIQUE key, adds `event_uid TEXT` with a unique index. Existing rows are preserved with `event_uid = NULL` (SQLite unique indexes allow multiple NULLs); they are only purged when their file is rebuilt.
- `processing_state` gains an `ino INTEGER` column for file-identity change detection.
- Fresh installs land directly at v2.

## Semantic note

`sessions.message_count` now equals the count of persisted usage events for the session (derived from `usage_events`), which includes `/goal` evaluator spend events — previously it counted only assistant messages. Dashboard-only field; slight upward shift on sessions that used `/goal`.

## Tests

Regression tests per fix: two-session bleed with identical entry count/leafId, session switch with unchanged key, compaction with unchanged key, triple file replay, same-timestamp distinct calls, malformed-line exact-offset stop, partial-final-line non-consumption, truncation rebuild, legacy NULL-uid purge, v1→v2 migration (row preservation, dedup, fresh-at-v2), `singleFlight` coalescing + rejection recovery.

- `bun run typecheck` — clean
- `bun test packages/cli/src` — 2998 pass / 0 fail / 2 skip (Windows-only)

Out of scope (per audit ticket): multi-instance Redis metaState atomicity, forced-refresh fan-out redesign, dashboard range semantics.
