### PR TITLE
fix(git-service): state-management defects from 2026-08 audit §3

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -782,6 +782,18 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         } else {
             registry.register(new GitService({
                 generateCommitMessage: makeCommitMessageGenerator(resolveConfiguredAgentDir()).generate,
+                // Runner-owned session cwd authority — sessionCloseMetadata is
+                // populated at spawn/adopt time and outlives worker restarts.
+                // (Declared below; closures run only after daemon init completes.)
+                getSessionCwd: (sessionId) => sessionCloseMetadata.get(sessionId)?.cwd ?? null,
+                getActiveSessionCwds: () => {
+                    const cwds: string[] = [];
+                    for (const id of runningSessions.keys()) {
+                        const cwd = sessionCloseMetadata.get(id)?.cwd;
+                        if (cwd) cwds.push(cwd);
+                    }
+                    return cwds;
+                },
             }));
         }
         if (isServiceDisabled("process")) {

--- a/packages/cli/src/runner/services/git-service.state.test.ts
+++ b/packages/cli/src/runner/services/git-service.state.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Regression tests for git-service state-management fixes (2026-08 audit §3):
+ *  1. caller-controlled cwd is authorized against runner-owned session cwd
+ *  2. shared mutations lock by --git-common-dir (linked worktrees serialize)
+ *  3. metadata changes broadcast versioned git_repo_changed to all repo subscribers
+ *  4. in-use worktree removal is rejected unless explicitly overridden
+ *  5. metadata watchers are rebuilt after checkout (external checkout is seen)
+ *  6. stage/unstage serialize per worktree with a retryable busy result
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ServiceEnvelope } from "../service-handler.js";
+import { GitService } from "./git-service.js";
+
+function createMockSocket() {
+    const emitted: ServiceEnvelope[] = [];
+    const listeners = new Map<string, Function[]>();
+    return {
+        emitted,
+        listeners,
+        emit: (event: string, envelope: ServiceEnvelope) => {
+            if (event === "service_message") emitted.push(envelope);
+        },
+        on: (event: string, handler: Function) => {
+            listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+        },
+        off: (event: string, handler: Function) => {
+            listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+        },
+    };
+}
+
+function dispatch(socket: ReturnType<typeof createMockSocket>, envelope: ServiceEnvelope): void {
+    for (const handler of socket.listeners.get("service_message") ?? []) handler(envelope);
+}
+
+async function waitForResult(
+    socket: ReturnType<typeof createMockSocket>,
+    requestId: string,
+    type: string,
+    timeoutMs = 5_000,
+): Promise<ServiceEnvelope> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const hit = socket.emitted.find((e) => e.requestId === requestId && e.type === type);
+        if (hit) return hit;
+        await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error(`Timed out waiting for ${type} (${requestId})`);
+}
+
+async function waitForEnvelope(
+    socket: ReturnType<typeof createMockSocket>,
+    matcher: (e: ServiceEnvelope & { sessionId?: string }) => boolean,
+    timeoutMs = 5_000,
+): Promise<ServiceEnvelope> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const hit = socket.emitted.find(matcher as (e: ServiceEnvelope) => boolean);
+        if (hit) return hit;
+        await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error("Timed out waiting for matching envelope");
+}
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+/** Create a real repo with one commit; returns its path. */
+function makeRepo(root: string, name: string): string {
+    const repo = join(root, name);
+    execFileSync("git", ["init", "-b", "main", repo], { encoding: "utf8" });
+    git(repo, "config", "user.email", "t@t.test");
+    git(repo, "config", "user.name", "t");
+    writeFileSync(join(repo, "a.txt"), "a\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-m", "init");
+    return repo;
+}
+
+let root: string;
+let repoA: string;
+let repoB: string;
+let worktreeA2: string;
+
+beforeAll(() => {
+    // realpath: on macOS tmpdir() is a /var → /private/var symlink, but git
+    // reports realpaths — known-worktree and watcher path comparisons need them.
+    root = realpathSync(mkdtempSync(join(tmpdir(), "git-state-test-")));
+    repoA = makeRepo(root, "repoA");
+    repoB = makeRepo(root, "repoB");
+    worktreeA2 = join(root, "repoA-wt2");
+    git(repoA, "worktree", "add", "-b", "wt2", worktreeA2);
+});
+
+afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+});
+
+describe("cwd authority (fix 1)", () => {
+    test("a session cannot mutate a repo outside its own repository family", async () => {
+        // Two sessions on the same runner: session-a lives in repoA, session-b in repoB.
+        const service = new GitService({
+            getSessionCwd: (id) => (id === "session-a" ? repoA : id === "session-b" ? repoB : null),
+        });
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        // session-b tries to stage in repoA (a path under globally allowed roots).
+        dispatch(socket, {
+            serviceId: "git", type: "git_stage", requestId: "x1",
+            sessionId: "session-b", payload: { cwd: repoA, all: true },
+        });
+        const denied = await waitForResult(socket, "x1", "git_stage_result");
+        expect((denied.payload as any).ok).toBe(false);
+        expect((denied.payload as any).message).toContain("session's repository");
+
+        // session-a in its own repo is fine.
+        writeFileSync(join(repoA, "b.txt"), "b\n");
+        dispatch(socket, {
+            serviceId: "git", type: "git_stage", requestId: "x2",
+            sessionId: "session-a", payload: { cwd: repoA, all: true },
+        });
+        const ok = await waitForResult(socket, "x2", "git_stage_result");
+        expect((ok.payload as any).ok).toBe(true);
+        git(repoA, "restore", "--staged", ":/");
+
+        service.dispose();
+    });
+
+    test("a linked worktree of the session's repo is authorized (same common dir)", async () => {
+        const service = new GitService({
+            getSessionCwd: () => repoA,
+        });
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatch(socket, {
+            serviceId: "git", type: "git_status", requestId: "x3",
+            sessionId: "session-a", payload: { cwd: worktreeA2 },
+        });
+        const res = await waitForResult(socket, "x3", "git_status_result");
+        expect((res.payload as any).ok).toBe(true);
+        expect((res.payload as any).branch).toBe("wt2");
+
+        service.dispose();
+    });
+
+    test("sessions without runner cwd metadata fall back to allowed-roots validation", async () => {
+        const service = new GitService({ getSessionCwd: () => null });
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatch(socket, {
+            serviceId: "git", type: "git_status", requestId: "x4",
+            sessionId: "session-unknown", payload: { cwd: repoB },
+        });
+        const res = await waitForResult(socket, "x4", "git_status_result");
+        expect((res.payload as any).ok).toBe(true);
+
+        service.dispose();
+    });
+});
+
+describe("common-dir mutation locking (fix 2)", () => {
+    test("shared mutations in two linked worktrees of one repo serialize on one lock", async () => {
+        // Fake exec: both worktrees report the SAME --git-common-dir; the first
+        // checkout blocks on a gate, the second must not start until released.
+        let release: () => void = () => {};
+        const gate = new Promise<void>((r) => { release = r; });
+        const checkoutStarts: string[] = [];
+
+        const service = new GitService({
+            execGit: async (args, { cwd }) => {
+                if (args[0] === "rev-parse" && args.includes("--git-common-dir")) {
+                    return { stdout: "/repo/.git\n", stderr: "" };
+                }
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+                    return { stdout: `${cwd}\n`, stderr: "" };
+                }
+                if (args[0] === "rev-parse") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "checkout") {
+                    checkoutStarts.push(cwd);
+                    await gate;
+                    return { stdout: "", stderr: "" };
+                }
+                return { stdout: "", stderr: "" };
+            },
+        });
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatch(socket, {
+            serviceId: "git", type: "git_checkout", requestId: "c1",
+            sessionId: "s1", payload: { cwd: "/repo/wt1", branch: "feature-1" },
+        });
+        dispatch(socket, {
+            serviceId: "git", type: "git_checkout", requestId: "c2",
+            sessionId: "s2", payload: { cwd: "/repo/wt2", branch: "feature-2" },
+        });
+
+        // First checkout starts; second must be held behind the shared repo lock.
+        const start = Date.now();
+        while (checkoutStarts.length === 0 && Date.now() - start < 2000) {
+            await new Promise((r) => setTimeout(r, 5));
+        }
+        expect(checkoutStarts.length).toBe(1);
+        await new Promise((r) => setTimeout(r, 150));
+        expect(checkoutStarts.length).toBe(1);
+
+        release();
+        await waitForResult(socket, "c1", "git_checkout_result");
+        const second = await waitForResult(socket, "c2", "git_checkout_result");
+        expect((second.payload as any).ok).toBe(true);
+        expect(checkoutStarts.length).toBe(2);
+
+        service.dispose();
+    });
+});
+
+describe("repo-change broadcast (fix 3) + watcher rebuild (fix 5)", () => {
+    test("external checkout pushes git_repo_changed and fresh status to subscribers", async () => {
+        const service = new GitService({});
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        // Subscribe a session to repoB.
+        dispatch(socket, {
+            serviceId: "git", type: "git_status", requestId: "s1",
+            sessionId: "viewer-1", payload: { cwd: repoB },
+        });
+        await waitForResult(socket, "s1", "git_status_result");
+        // Watcher registration is async — give fs.watch handles time to attach
+        // before making the external change they are supposed to observe.
+        await new Promise((r) => setTimeout(r, 500));
+
+        // External change: checkout a new branch outside the service.
+        git(repoB, "checkout", "-b", "external-branch");
+
+        // Every subscriber gets the versioned invalidation broadcast...
+        const changed = await waitForEnvelope(
+            socket,
+            (e) => e.type === "git_repo_changed" && (e.payload as any).cwd === repoB,
+        );
+        expect(typeof (changed.payload as any).version).toBe("number");
+        expect((changed as any).sessionId).toBe("viewer-1");
+
+        // ...and the proactive status push reflects the NEW branch, which proves
+        // the metadata watchers survived/rebuilt across the HEAD change.
+        await waitForEnvelope(
+            socket,
+            (e) => e.type === "git_status_result" && !e.requestId && (e.payload as any).branch === "external-branch",
+        );
+
+        // Watchers must still be live for the new branch ref: a second external
+        // change (commit moves the new branch ref) is detected too.
+        // (Watcher rebuild is async — let the new fs.watch handles attach.)
+        await new Promise((r) => setTimeout(r, 500));
+        socket.emitted.length = 0;
+        writeFileSync(join(repoB, "c.txt"), "c\n");
+        git(repoB, "add", "-A");
+        git(repoB, "commit", "-m", "external commit");
+        await waitForEnvelope(socket, (e) => e.type === "git_repo_changed");
+
+        git(repoB, "checkout", "main");
+        service.dispose();
+    }, 20_000);
+
+    test("a mutation by one session broadcasts git_repo_changed to a subscriber in a linked worktree", async () => {
+        const service = new GitService({});
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        // viewer-wt subscribes in the linked worktree, viewer-main in the main checkout.
+        dispatch(socket, {
+            serviceId: "git", type: "git_status", requestId: "m1",
+            sessionId: "viewer-main", payload: { cwd: repoA },
+        });
+        await waitForResult(socket, "m1", "git_status_result");
+        dispatch(socket, {
+            serviceId: "git", type: "git_status", requestId: "m2",
+            sessionId: "viewer-wt", payload: { cwd: worktreeA2 },
+        });
+        await waitForResult(socket, "m2", "git_status_result");
+
+        // viewer-main stages a file via the service → the linked-worktree
+        // subscriber must receive the family-wide invalidation broadcast.
+        writeFileSync(join(repoA, "d.txt"), "d\n");
+        dispatch(socket, {
+            serviceId: "git", type: "git_stage", requestId: "m3",
+            sessionId: "viewer-main", payload: { cwd: repoA, all: true },
+        });
+        await waitForResult(socket, "m3", "git_stage_result");
+
+        const wtBroadcast = await waitForEnvelope(
+            socket,
+            (e) => e.type === "git_repo_changed"
+                && (e.payload as any).cwd === worktreeA2
+                && (e as any).sessionId === "viewer-wt",
+        );
+        expect((wtBroadcast.payload as any).version).toBeGreaterThan(0);
+
+        git(repoA, "restore", "--staged", ":/");
+        rmSync(join(repoA, "d.txt"), { force: true });
+        service.dispose();
+    });
+});
+
+describe("in-use worktree removal (fix 4)", () => {
+    test("removal of a live session's worktree is rejected, even with force", async () => {
+        const wt = join(root, "repoA-wt-inuse");
+        git(repoA, "worktree", "add", "-b", "wt-inuse", wt);
+        try {
+            const service = new GitService({
+                getActiveSessionCwds: () => [join(wt, "sub", "dir")], // session cwd inside the worktree
+            });
+            const socket = createMockSocket();
+            service.init(socket as any, { isShuttingDown: () => false });
+
+            dispatch(socket, {
+                serviceId: "git", type: "git_worktree_remove", requestId: "w1",
+                sessionId: "s1", payload: { cwd: repoA, path: wt, force: true },
+            });
+            const denied = await waitForResult(socket, "w1", "git_worktree_remove_result");
+            expect((denied.payload as any).ok).toBe(false);
+            expect((denied.payload as any).reason).toBe("in_use");
+
+            // Explicit override goes through.
+            dispatch(socket, {
+                serviceId: "git", type: "git_worktree_remove", requestId: "w2",
+                sessionId: "s1", payload: { cwd: repoA, path: wt, force: true, overrideInUse: true },
+            });
+            const removed = await waitForResult(socket, "w2", "git_worktree_remove_result");
+            expect((removed.payload as any).ok).toBe(true);
+
+            service.dispose();
+        } finally {
+            rmSync(wt, { recursive: true, force: true });
+            try { git(repoA, "worktree", "prune"); } catch { /* already gone */ }
+        }
+    });
+});
+
+describe("index mutation serialization (fix 6)", () => {
+    test("a stage that cannot acquire the worktree lock returns a retryable busy result", async () => {
+        // Immediate-callback timers + a fast-forwarding clock make the busy
+        // deadline trip without real sleeps.
+        let now = 0;
+        let release: () => void = () => {};
+        const gate = new Promise<void>((r) => { release = r; });
+
+        const service = new GitService({
+            now: () => now,
+            setTimeoutFn: (cb) => { now += 1000; queueMicrotask(cb); return 0 as unknown as ReturnType<typeof setTimeout>; },
+            clearTimeoutFn: () => {},
+            execGit: async (args, { cwd }) => {
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return { stdout: "/repo\n", stderr: "" };
+                if (args[0] === "rev-parse") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "add") { await gate; return { stdout: "", stderr: "" }; }
+                return { stdout: "", stderr: "" };
+            },
+        });
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatch(socket, {
+            serviceId: "git", type: "git_stage", requestId: "b1",
+            sessionId: "s1", payload: { cwd: "/repo", all: true },
+        });
+        dispatch(socket, {
+            serviceId: "git", type: "git_stage", requestId: "b2",
+            sessionId: "s2", payload: { cwd: "/repo", all: true },
+        });
+
+        const busy = await waitForResult(socket, "b2", "git_stage_result");
+        expect((busy.payload as any).ok).toBe(false);
+        expect((busy.payload as any).reason).toBe("busy");
+        expect((busy.payload as any).retryable).toBe(true);
+
+        release();
+        const first = await waitForResult(socket, "b1", "git_stage_result");
+        expect((first.payload as any).ok).toBe(true);
+
+        service.dispose();
+    });
+});

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -183,6 +183,8 @@ describe("GitService status caching", () => {
             payload: { cwd: "/repo" },
         });
 
+        // cwd authorization is async now — wait for the (single) status exec to start.
+        await waitForCondition(() => statusCalls === 1);
         expect(statusCalls).toBe(1);
 
         releaseStatus();

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -232,15 +232,26 @@ export class GitService implements ServiceHandler {
     private readonly _sessionCwd = new Map<string, string>();
     private readonly _repoWatchers = new Map<string, RepoWatchState>();
     /**
-     * Mutation lock map: repoRoot → mutation token.
+     * Mutation lock map: lock key → mutation token.
      *
-     * Only used for operations that genuinely conflict with each other
-     * (checkout, commit, push, pull, merge, rebase, set-upstream).
-     * Stage/unstage are NOT locked here — git's own index lock serializes
-     * concurrent `git add`/`git restore --staged` safely, and the UI
-     * already disables buttons while an operation is in-flight.
+     * Two lock granularities share this map (keys are prefixed so they never
+     * collide):
+     *   - `repo:<git-common-dir>` — shared repo state (refs, config, stash).
+     *     Linked worktrees of one repository resolve to the SAME common dir,
+     *     so ref/config/stash mutations across worktrees serialize correctly.
+     *   - `wt:<toplevel>` — per-worktree index state (stage/unstage).
+     * Shared-scope mutations acquire BOTH keys (they touch the index too);
+     * index-scope mutations acquire only their worktree key.
      */
     private readonly _activeRepoMutations = new Map<string, string>();
+    /** cwd → canonical `git rev-parse --git-common-dir` (identifies the repo across linked worktrees). */
+    private readonly _cwdCommonDir = new Map<string, string>();
+    /** commonDir → monotonically increasing repo-change version for git_repo_changed broadcasts. */
+    private readonly _repoVersion = new Map<string, number>();
+    /** Runner-owned session cwd lookup — the authority for what repo a session may mutate. */
+    private readonly _getSessionCwd: ((sessionId: string) => string | null) | null;
+    /** cwds of live sessions — used to refuse removing an in-use worktree. */
+    private readonly _getActiveSessionCwds: (() => string[]) | null;
 
     constructor(options?: {
         execGit?: GitExec;
@@ -250,7 +261,11 @@ export class GitService implements ServiceHandler {
         now?: () => number;
         rm?: GitRm;
         generateCommitMessage?: (diff: string) => Promise<{ subject: string; body: string } | null>;
+        getSessionCwd?: (sessionId: string) => string | null;
+        getActiveSessionCwds?: () => string[];
     }) {
+        this._getSessionCwd = options?.getSessionCwd ?? null;
+        this._getActiveSessionCwds = options?.getActiveSessionCwds ?? null;
         this._execGit = options?.execGit ?? ((args, execOptions) => execFileAsync("git", args, execOptions));
         this._watchFs = options?.watchFs ?? ((path, listener) => watch(path, { persistent: false }, listener));
         this._setTimeout = options?.setTimeoutFn ?? ((callback, delayMs) => setTimeout(callback, delayMs));
@@ -382,6 +397,8 @@ export class GitService implements ServiceHandler {
         this._cwdSubscribers.clear();
         this._sessionCwd.clear();
         this._cwdRepoRoot.clear();
+        this._cwdCommonDir.clear();
+        this._repoVersion.clear();
         this._statusCache.clear();
         this._statusGeneration.clear();
         this._statusInFlight.clear();
@@ -418,26 +435,51 @@ export class GitService implements ServiceHandler {
      * be released instead of immediately rejecting. This eliminates the
      * "Another git operation is already running" error for brief overlaps.
      */
+    private async resolveCommonDir(cwd: string): Promise<string> {
+        const cached = this._cwdCommonDir.get(cwd);
+        if (cached) return cached;
+        try {
+            const { stdout } = await this._execGit(
+                ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+                { cwd, timeout: 5000 },
+            );
+            const dir = stdout.trim();
+            const key = dir ? resolve(dir) : cwd;
+            this._cwdCommonDir.set(cwd, key);
+            return key;
+        } catch {
+            return cwd;
+        }
+    }
+
+    private async lockKeysFor(cwd: string, scope: "shared" | "index"): Promise<string[]> {
+        const toplevel = this._cwdRepoRoot.get(cwd) ?? await this.resolveRepoRoot(cwd);
+        if (!this._cwdRepoRoot.has(cwd)) this._cwdRepoRoot.set(cwd, toplevel);
+        if (scope === "index") return [`wt:${toplevel}`];
+        const commonDir = await this.resolveCommonDir(cwd);
+        return [`repo:${commonDir}`, `wt:${toplevel}`];
+    }
+
     private async beginRepoMutation(
         cwd: string,
         type: string,
         mutationName: string,
         requestId?: string,
         sessionId?: string,
-        { waitMs = 5000 }: { waitMs?: number } = {},
-    ): Promise<{ key: string; token: string } | null> {
-        const key = this._cwdRepoRoot.get(cwd) ?? await this.resolveRepoRoot(cwd);
-        // Cache for future calls
-        if (!this._cwdRepoRoot.has(cwd)) this._cwdRepoRoot.set(cwd, key);
+        { waitMs = 5000, scope = "shared" }: { waitMs?: number; scope?: "shared" | "index" } = {},
+    ): Promise<{ keys: string[]; token: string } | null> {
+        const keys = await this.lockKeysFor(cwd, scope);
 
-        // Wait for existing mutation to complete (with timeout)
+        // Wait for existing mutations on any required key to complete (with timeout)
         const deadline = this._now() + waitMs;
-        while (this._activeRepoMutations.has(key)) {
+        while (keys.some((key) => this._activeRepoMutations.has(key))) {
             if (this._now() >= deadline) {
-                const activeMutation = this._activeRepoMutations.get(key) ?? "unknown";
+                const busyKey = keys.find((key) => this._activeRepoMutations.has(key));
+                const activeMutation = (busyKey && this._activeRepoMutations.get(busyKey)) ?? "unknown";
                 this.emit(type, {
                     ok: false,
                     reason: "busy",
+                    retryable: true,
                     message: `Another git operation (${activeMutation}) is still running after ${waitMs / 1000}s. Try again.`,
                 }, requestId, sessionId);
                 return null;
@@ -446,14 +488,16 @@ export class GitService implements ServiceHandler {
         }
 
         const token = `${mutationName}:${requestId ?? `${Date.now()}`}`;
-        this._activeRepoMutations.set(key, token);
-        return { key, token };
+        for (const key of keys) this._activeRepoMutations.set(key, token);
+        return { keys, token };
     }
 
-    private endRepoMutation(mutation: { key: string; token: string } | null): void {
+    private endRepoMutation(mutation: { keys: string[]; token: string } | null): void {
         if (!mutation) return;
-        if (this._activeRepoMutations.get(mutation.key) === mutation.token) {
-            this._activeRepoMutations.delete(mutation.key);
+        for (const key of mutation.keys) {
+            if (this._activeRepoMutations.get(key) === mutation.token) {
+                this._activeRepoMutations.delete(key);
+            }
         }
     }
 
@@ -466,6 +510,41 @@ export class GitService implements ServiceHandler {
         }
         if (!isCwdAllowed(cwd)) {
             this.emitError(responseType, "Path outside allowed roots", requestId, sessionId);
+            return null;
+        }
+        return cwd;
+    }
+
+    /**
+     * Validate AND authorize a caller-provided cwd against the runner-owned
+     * session cwd. A payload cwd is only accepted when it belongs to the same
+     * repository family (same `git --git-common-dir`) as the session's actual
+     * working directory — a collab viewer cannot point the git service at an
+     * arbitrary repo under the globally allowed roots.
+     *
+     * Falls back to plain allowed-roots validation when the daemon has no cwd
+     * metadata for the session (e.g. adopted sessions before re-registration).
+     */
+    private async authorizeCwd(
+        rawCwd: unknown,
+        responseType: string,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<string | null> {
+        const cwd = this.validateCwd(rawCwd, responseType, requestId, sessionId);
+        if (!cwd) return null;
+        if (!sessionId || !this._getSessionCwd) return cwd;
+        const sessionCwd = this._getSessionCwd(sessionId);
+        if (!sessionCwd) return cwd;
+        if (resolve(cwd) === resolve(sessionCwd)) return cwd;
+        const [requested, owned] = await Promise.all([
+            this.resolveCommonDir(cwd),
+            this.resolveCommonDir(sessionCwd),
+        ]);
+        // resolveCommonDir falls back to the input path outside a git repo —
+        // two non-repo paths never spuriously match unless they are equal.
+        if (requested !== owned) {
+            this.emitError(responseType, "Path outside this session's repository", requestId, sessionId);
             return null;
         }
         return cwd;
@@ -625,7 +704,7 @@ export class GitService implements ServiceHandler {
 
         watchState.refreshInFlight = true;
         try {
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             let snapshot = await this.getStatusSnapshot(cwd);
             if (snapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
                 snapshot = await this.getStatusSnapshot(cwd);
@@ -740,6 +819,39 @@ export class GitService implements ServiceHandler {
         }
     }
 
+    /**
+     * Invalidate caches for the whole repository family (all linked worktrees
+     * sharing one `--git-common-dir`), rebuild metadata watchers (HEAD/upstream
+     * refs may have changed — e.g. after a checkout), and broadcast a versioned
+     * `git_repo_changed` to EVERY subscriber of the family so non-initiating
+     * viewers refresh branches/worktrees/commits, not just status.
+     */
+    private async notifyRepoChanged(cwd: string): Promise<void> {
+        await this.invalidateStatusCacheFamily(cwd);
+        const commonDir = await this.resolveCommonDir(cwd);
+        const version = (this._repoVersion.get(commonDir) ?? 0) + 1;
+        this._repoVersion.set(commonDir, version);
+
+        for (const knownCwd of [...this._cwdSubscribers.keys()]) {
+            const knownCommon = await this.resolveCommonDir(knownCwd);
+            if (knownCommon !== commonDir) continue;
+            // Linked worktrees have different toplevels, so the toplevel-keyed
+            // family invalidation above missed them — invalidate directly.
+            this.invalidateStatusCache(knownCwd);
+            // ponytail: unconditional watcher rebuild per change — diff the
+            // resolved watch paths first if fs.watch churn ever shows up.
+            if (this._repoWatchers.has(knownCwd)) {
+                this.stopWatchingRepo(knownCwd);
+                void this.startWatchingRepo(knownCwd);
+            }
+            const subscribers = this._cwdSubscribers.get(knownCwd);
+            if (!subscribers) continue;
+            for (const sessionId of subscribers) {
+                this.emit("git_repo_changed", { cwd: knownCwd, version }, undefined, sessionId);
+            }
+        }
+    }
+
     private async getStatusSnapshot(cwd: string): Promise<GitStatusSnapshot> {
         const now = this._now();
         const generation = this._statusGeneration.get(cwd) ?? 0;
@@ -842,7 +954,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_status_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_status_result", requestId, sessionId);
         if (!cwd) return;
         this.registerSubscriber(cwd, sessionId);
 
@@ -864,7 +976,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_diff_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_diff_result", requestId, sessionId);
         if (!cwd) return;
 
         const filePath = typeof payload.path === "string" ? payload.path : "";
@@ -961,7 +1073,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_branches_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_branches_result", requestId, sessionId);
         if (!cwd) return;
         this.registerSubscriber(cwd, sessionId);
 
@@ -981,7 +1093,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_full_status_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_full_status_result", requestId, sessionId);
         if (!cwd) return;
         this.registerSubscriber(cwd, sessionId);
 
@@ -1043,7 +1155,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_checkout_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_checkout_result", requestId, sessionId);
         if (!cwd) return;
 
         const branch = typeof payload.branch === "string" ? payload.branch : "";
@@ -1084,7 +1196,7 @@ export class GitService implements ServiceHandler {
             }
 
             await this._execGit(args, { cwd, timeout: 15000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
 
             this.emit("git_checkout_result", {
                 ok: true,
@@ -1104,7 +1216,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stage_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stage_result", requestId, sessionId);
         if (!cwd) return;
 
         const all = payload.all === true;
@@ -1125,6 +1237,11 @@ export class GitService implements ServiceHandler {
             }
         }
 
+        // Serialize index mutations per worktree — a concurrent session gets a
+        // retryable "busy" result instead of racing git's index.lock.
+        const mutation = await this.beginRepoMutation(cwd, "git_stage_result", "stage", requestId, sessionId, { scope: "index", waitMs: 3000 });
+        if (!mutation) return;
+
         try {
             // Resolve repo root — paths from git status are repo-root-relative,
             // so operations must run from repo root for paths to resolve correctly.
@@ -1133,10 +1250,12 @@ export class GitService implements ServiceHandler {
 
             const args = all ? ["add", "--all"] : ["add", "--", ...paths];
             await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_stage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1147,7 +1266,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_unstage_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_unstage_result", requestId, sessionId);
         if (!cwd) return;
 
         const all = payload.all === true;
@@ -1167,6 +1286,9 @@ export class GitService implements ServiceHandler {
             }
         }
 
+        const mutation = await this.beginRepoMutation(cwd, "git_unstage_result", "unstage", requestId, sessionId, { scope: "index", waitMs: 3000 });
+        if (!mutation) return;
+
         try {
             // Resolve repo root — run from there so repo-root-relative paths work.
             // For unstage-all, use ":/" pathspec (magic "repo root") instead of "."
@@ -1178,10 +1300,12 @@ export class GitService implements ServiceHandler {
                 ? ["restore", "--staged", ":/"]
                 : ["restore", "--staged", "--", ...paths];
             await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1192,7 +1316,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_commit_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_commit_result", requestId, sessionId);
         if (!cwd) return;
 
         const message = typeof payload.message === "string" ? payload.message.trim() : "";
@@ -1211,7 +1335,7 @@ export class GitService implements ServiceHandler {
 
             // Parse the short summary (e.g. "[main abc1234] Fix thing\n 1 file changed...")
             const firstLine = stdout.split("\n")[0] ?? "";
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
 
             this.emit("git_commit_result", {
                 ok: true,
@@ -1236,7 +1360,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_commit_message_suggest_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_commit_message_suggest_result", requestId, sessionId);
         if (!cwd) return;
 
         try {
@@ -1460,7 +1584,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_worktrees_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_worktrees_result", requestId, sessionId);
         if (!cwd) return;
         this.registerSubscriber(cwd, sessionId);
 
@@ -1578,7 +1702,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_pull_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_pull_result", requestId, sessionId);
         if (!cwd) return;
         const rebase = payload.rebase !== false;
         const mutation = await this.beginRepoMutation(cwd, "git_pull_result", "pull", requestId, sessionId);
@@ -1615,7 +1739,7 @@ export class GitService implements ServiceHandler {
                 integrateResult.stderr,
             ].join("\n").trim();
 
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
 
             this.emit("git_pull_result", {
                 ok: true,
@@ -1628,7 +1752,7 @@ export class GitService implements ServiceHandler {
             const message = err instanceof Error ? err.message : String(err);
             const classified = this.classifySyncFailure(message);
             if (classified.reason === "conflict") {
-                await this.invalidateStatusCacheFamily(cwd);
+                await this.notifyRepoChanged(cwd);
             }
             this.emit("git_pull_result", {
                 ok: false,
@@ -1646,7 +1770,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_set_upstream_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_set_upstream_result", requestId, sessionId);
         if (!cwd) return;
 
         const remote = typeof payload.remote === "string" ? payload.remote.trim() : "";
@@ -1676,7 +1800,7 @@ export class GitService implements ServiceHandler {
             }
 
             await this._execGit(["branch", `--set-upstream-to=${remote}/${branch}`, localBranch], { cwd, timeout: 15000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_set_upstream_result", {
                 ok: true,
                 summary: `Branch ${localBranch} now tracks ${remote}/${branch}`,
@@ -1697,7 +1821,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_merge_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_merge_result", requestId, sessionId);
         if (!cwd) return;
 
         const branch = typeof payload.branch === "string" ? payload.branch : "";
@@ -1722,13 +1846,13 @@ export class GitService implements ServiceHandler {
             // a ref, never as a git option (guards against e.g. "--abort" injection).
             const result = await this._execGit(["merge", "--", branch], { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_merge_result", { ok: true, output }, requestId, sessionId);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const classified = this.classifySyncFailure(message);
             if (classified.reason === "conflict") {
-                await this.invalidateStatusCacheFamily(cwd);
+                await this.notifyRepoChanged(cwd);
             }
             this.emit("git_merge_result", {
                 ok: false,
@@ -1748,7 +1872,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_merge_abort_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_merge_abort_result", requestId, sessionId);
         if (!cwd) return;
 
         const mutation = await this.beginRepoMutation(cwd, "git_merge_abort_result", "merge-abort", requestId, sessionId);
@@ -1756,7 +1880,7 @@ export class GitService implements ServiceHandler {
 
         try {
             await this._execGit(["merge", "--abort"], { cwd, timeout: 30000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_merge_abort_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emit("git_merge_abort_result", {
@@ -1775,7 +1899,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_push_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_push_result", requestId, sessionId);
         if (!cwd) return;
 
         const setUpstream = payload.setUpstream === true;
@@ -1817,7 +1941,7 @@ export class GitService implements ServiceHandler {
             // git push writes to stderr (progress), use a larger timeout for network ops
             const result = await this._execGit(args, { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
 
             this.emit("git_push_result", {
                 ok: true,
@@ -1844,7 +1968,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_rebase_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_rebase_result", requestId, sessionId);
         if (!cwd) return;
 
         const branch = typeof payload.branch === "string" ? payload.branch.trim() : "";
@@ -1859,13 +1983,13 @@ export class GitService implements ServiceHandler {
         try {
             const result = await this._execGit(["rebase", "--", branch], { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_rebase_result", { ok: true, output }, requestId, sessionId);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const classified = this.classifySyncFailure(message);
             if (classified.reason === "conflict") {
-                await this.invalidateStatusCacheFamily(cwd);
+                await this.notifyRepoChanged(cwd);
             }
             this.emit("git_rebase_result", {
                 ok: false,
@@ -1883,7 +2007,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_rebase_abort_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_rebase_abort_result", requestId, sessionId);
         if (!cwd) return;
 
         const mutation = await this.beginRepoMutation(cwd, "git_rebase_abort_result", "rebase-abort", requestId, sessionId);
@@ -1892,7 +2016,7 @@ export class GitService implements ServiceHandler {
         try {
             const result = await this._execGit(["rebase", "--abort"], { cwd, timeout: 30000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_rebase_abort_result", { ok: true, output }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_rebase_abort_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -1906,7 +2030,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_rebase_continue_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_rebase_continue_result", requestId, sessionId);
         if (!cwd) return;
 
         const mutation = await this.beginRepoMutation(cwd, "git_rebase_continue_result", "rebase-continue", requestId, sessionId);
@@ -1920,13 +2044,13 @@ export class GitService implements ServiceHandler {
                 { cwd, timeout: 60000, env: { ...process.env, GIT_EDITOR: "true" } },
             );
             const output = (result.stdout + "\n" + result.stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_rebase_continue_result", { ok: true, output }, requestId, sessionId);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const classified = this.classifySyncFailure(message);
             if (classified.reason === "conflict") {
-                await this.invalidateStatusCacheFamily(cwd);
+                await this.notifyRepoChanged(cwd);
             }
             this.emit("git_rebase_continue_result", {
                 ok: false,
@@ -1946,7 +2070,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_worktree_add_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_worktree_add_result", requestId, sessionId);
         if (!cwd) return;
 
         const branch = typeof payload.branch === "string" ? payload.branch.trim() : "";
@@ -2014,7 +2138,7 @@ export class GitService implements ServiceHandler {
             }
 
             await this._execGit(args, { cwd, timeout: 30000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_worktree_add_result", {
                 ok: true,
                 branch: resultBranch,
@@ -2032,11 +2156,12 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_worktree_remove_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_worktree_remove_result", requestId, sessionId);
         if (!cwd) return;
 
         const worktreePath = typeof payload.path === "string" ? payload.path.trim() : "";
         const force = payload.force === true;
+        const overrideInUse = payload.overrideInUse === true;
 
         if (!worktreePath) {
             this.emitError("git_worktree_remove_result", "Missing worktree path", requestId, sessionId);
@@ -2068,6 +2193,24 @@ export class GitService implements ServiceHandler {
             return;
         }
 
+        // Refuse to remove a worktree that is the working directory of a live
+        // session (even with --force) unless the caller explicitly overrides.
+        if (!overrideInUse && this._getActiveSessionCwds) {
+            const wtResolved = resolve(resolvedPath);
+            const inUse = this._getActiveSessionCwds().some((sessionCwd) => {
+                const rc = resolve(sessionCwd);
+                return rc === wtResolved || rc.startsWith(wtResolved + "/");
+            });
+            if (inUse) {
+                this.emit("git_worktree_remove_result", {
+                    ok: false,
+                    reason: "in_use",
+                    message: "Worktree is the working directory of a live session. Close the session first, or retry with overrideInUse.",
+                }, requestId, sessionId);
+                return;
+            }
+        }
+
         const mutation = await this.beginRepoMutation(cwd, "git_worktree_remove_result", "worktree-remove", requestId, sessionId);
         if (!mutation) return;
 
@@ -2076,7 +2219,7 @@ export class GitService implements ServiceHandler {
                 ? ["worktree", "remove", "--force", "--", worktreePath]
                 : ["worktree", "remove", "--", worktreePath];
             await this._execGit(args, { cwd, timeout: 30000 });
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_worktree_remove_result", { ok: true, path: worktreePath }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_worktree_remove_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -2093,7 +2236,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_worktree_prune_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_worktree_prune_result", requestId, sessionId);
         if (!cwd) return;
 
         const mutation = await this.beginRepoMutation(cwd, "git_worktree_prune_result", "worktree-prune", requestId, sessionId);
@@ -2103,7 +2246,7 @@ export class GitService implements ServiceHandler {
             const { stdout, stderr } = await this._execGit(["worktree", "prune", "-v"], { cwd, timeout: 15000 });
             const lines = [(stdout + "\n" + stderr).trim()].filter(Boolean);
             lines.push(...await this.removeMergedWorktrees(cwd));
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             const output = lines.join("\n");
             this.emit("git_worktree_prune_result", { ok: true, ...(output ? { message: output } : {}) }, requestId, sessionId);
         } catch (err) {
@@ -2186,7 +2329,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stash_list_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stash_list_result", requestId, sessionId);
         if (!cwd) return;
 
         try {
@@ -2224,7 +2367,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stash_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stash_result", requestId, sessionId);
         if (!cwd) return;
 
         const message = typeof payload.message === "string" ? payload.message.trim() : "";
@@ -2239,7 +2382,7 @@ export class GitService implements ServiceHandler {
             if (message) args.push("-m", message);
             const { stdout, stderr } = await this._execGit(args, { cwd, timeout: 15000 });
             const output = (stdout + "\n" + stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, ...(output ? { message: output } : {}) },
@@ -2260,7 +2403,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stash_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stash_result", requestId, sessionId);
         if (!cwd) return;
 
         const index = typeof payload.index === "number" && payload.index >= 0 ? payload.index : 0;
@@ -2274,7 +2417,7 @@ export class GitService implements ServiceHandler {
                 { cwd, timeout: 30000 },
             );
             const output = (stdout + "\n" + stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, ...(output ? { message: output } : {}) },
@@ -2284,7 +2427,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const conflict = /CONFLICT|could not apply|unmerged|Automatic merge failed/i.test(message);
-            if (conflict) await this.invalidateStatusCacheFamily(cwd);
+            if (conflict) await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, conflict, ...(message ? { message } : {}) },
@@ -2303,7 +2446,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stash_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stash_result", requestId, sessionId);
         if (!cwd) return;
 
         const index = typeof payload.index === "number" && payload.index >= 0 ? payload.index : 0;
@@ -2318,7 +2461,7 @@ export class GitService implements ServiceHandler {
             const args = ["stash", "apply", `stash@{${index}}`];
             const { stdout, stderr } = await this._execGit(args, { cwd, timeout: 30000 });
             const output = (stdout + "\n" + stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, ...(output ? { message: output } : {}) },
@@ -2328,7 +2471,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const conflict = /CONFLICT|could not apply|unmerged|Automatic merge failed/i.test(message);
-            if (conflict) await this.invalidateStatusCacheFamily(cwd);
+            if (conflict) await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, conflict, ...(message ? { message } : {}) },
@@ -2347,7 +2490,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_stash_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_stash_result", requestId, sessionId);
         if (!cwd) return;
 
         const index = typeof payload.index === "number" && payload.index >= 0 ? payload.index : 0;
@@ -2361,7 +2504,7 @@ export class GitService implements ServiceHandler {
                 { cwd, timeout: 15000 },
             );
             const output = (stdout + "\n" + stderr).trim();
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit(
                 "git_stash_result",
                 { ok: true, ...(output ? { message: output } : {}) },
@@ -2382,7 +2525,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_log_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_log_result", requestId, sessionId);
         if (!cwd) return;
 
         let limit = typeof payload.limit === "number" ? payload.limit : 50;
@@ -2457,7 +2600,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_diff_revs_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_diff_revs_result", requestId, sessionId);
         if (!cwd) return;
 
         const base = typeof payload.base === "string" ? payload.base.trim() : "";
@@ -2501,7 +2644,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_blame_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_blame_result", requestId, sessionId);
         if (!cwd) return;
 
         const path = typeof payload.path === "string" ? payload.path : "";
@@ -2616,7 +2759,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_commit_files_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_commit_files_result", requestId, sessionId);
         if (!cwd) return;
 
         const revision = typeof payload.revision === "string" ? payload.revision.trim() : "";
@@ -2682,7 +2825,7 @@ export class GitService implements ServiceHandler {
         requestId?: string,
         sessionId?: string,
     ): Promise<void> {
-        const cwd = this.validateCwd(payload.cwd, "git_discard_result", requestId, sessionId);
+        const cwd = await this.authorizeCwd(payload.cwd, "git_discard_result", requestId, sessionId);
         if (!cwd) return;
 
         const paths = Array.isArray(payload.paths)
@@ -2732,7 +2875,7 @@ export class GitService implements ServiceHandler {
                 }
             }
 
-            await this.invalidateStatusCacheFamily(cwd);
+            await this.notifyRepoChanged(cwd);
             this.emit("git_discard_result", { ok: true, paths }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_discard_result", err instanceof Error ? err.message : String(err), requestId, sessionId);

--- a/packages/ui/src/hooks/useGitService.test.ts
+++ b/packages/ui/src/hooks/useGitService.test.ts
@@ -372,3 +372,63 @@ describe("stash actions", () => {
         expect(result.current.stashes).toEqual([]);
     });
 });
+
+describe("git_repo_changed broadcast", () => {
+    /** Settle the initial mount-time full-status request so the refresh scheduler isn't blocked by it. */
+    function settleInitialFullStatus() {
+        const initial = findSendCall("git_full_status");
+        if (initial?.requestId) {
+            emitMessage("git_full_status_result", { ok: true, status: { ok: true, branch: "main", changes: [] }, branches: [], currentBranch: "main", worktrees: [] }, initial.requestId);
+        }
+    }
+
+    test("triggers a debounced full-status refresh for the current cwd", async () => {
+        renderGitHook("/repo");
+        settleInitialFullStatus();
+        sendSpy.mockClear();
+
+        emitMessage("git_repo_changed", { cwd: "/repo", version: 1 });
+
+        await waitFor(() => {
+            expect(findSendCall("git_full_status")).toBeDefined();
+        });
+        expect(findSendCall("git_full_status")!.payload.cwd).toBe("/repo");
+    });
+
+    test("ignores broadcasts for another cwd and stale/duplicate versions", async () => {
+        renderGitHook("/repo");
+        settleInitialFullStatus();
+        sendSpy.mockClear();
+        emitMessage("git_repo_changed", { cwd: "/repo", version: 3 });
+        await waitFor(() => {
+            expect(findSendCall("git_full_status")).toBeDefined();
+        });
+        // Settle the triggered refresh so an in-flight request can't mask the
+        // version/cwd filtering being tested below.
+        settleInitialFullStatus();
+        sendSpy.mockClear();
+
+        // Other repo's broadcast — not ours.
+        emitMessage("git_repo_changed", { cwd: "/elsewhere", version: 9 });
+        // Stale/duplicate version — already handled.
+        emitMessage("git_repo_changed", { cwd: "/repo", version: 3 });
+        emitMessage("git_repo_changed", { cwd: "/repo", version: 2 });
+
+        await new Promise((r) => setTimeout(r, 250));
+        expect(findSendCall("git_full_status")).toBeUndefined();
+    });
+});
+
+describe("removeWorktree overrideInUse", () => {
+    test("passes overrideInUse only when explicitly requested", () => {
+        const { result } = renderGitHook("/repo");
+        sendSpy.mockClear();
+
+        act(() => result.current.removeWorktree("/repo/wt", true));
+        expect(lastSendCall().type).toBe("git_worktree_remove");
+        expect(lastSendCall().payload.overrideInUse).toBeUndefined();
+
+        act(() => result.current.removeWorktree("/repo/wt", true, true));
+        expect(lastSendCall().payload.overrideInUse).toBe(true);
+    });
+});

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -160,7 +160,7 @@ export interface UseGitServiceReturn {
     rebaseAbort: () => void;
     rebaseContinue: () => void;
     addWorktree: (branch: string, path: string, opts?: { base?: string; create?: boolean; isRemote?: boolean }) => void;
-    removeWorktree: (path: string, force?: boolean) => void;
+    removeWorktree: (path: string, force?: boolean, overrideInUse?: boolean) => void;
     pruneWorktrees: () => void;
     clearOperationResult: () => void;
 }
@@ -203,6 +203,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     const requestGenerationRef = useRef(new Map<string, number>());
     const lastBranchFetchRef = useRef(0);
     const conflictActiveRef = useRef(false);
+    // Highest git_repo_changed version seen — stale/duplicate broadcasts are dropped.
+    const lastRepoVersionRef = useRef(0);
 
     // Generation counter — incremented on cwd change. Responses from stale
     // generations are discarded so a slow response from the old cwd doesn't
@@ -618,6 +620,18 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     if (payload.ok || payload.conflict === true) {
                         postMutationRefreshSchedulerRef.current.schedule();
                     }
+                    break;
+                }
+                case "git_repo_changed": {
+                    // Versioned repo-wide invalidation push — the runner broadcasts
+                    // this to every subscriber after metadata changes and mutations
+                    // so non-initiating viewers refresh branches/worktrees/commits.
+                    const payloadCwd = typeof payload.cwd === "string" ? payload.cwd : null;
+                    if (!payloadCwd || payloadCwd !== cwdRef.current) break;
+                    const version = typeof payload.version === "number" ? payload.version : 0;
+                    if (version <= lastRepoVersionRef.current) break;
+                    lastRepoVersionRef.current = version;
+                    postMutationRefreshSchedulerRef.current.schedule();
                     break;
                 }
                 case "git_stage_result":
@@ -1044,13 +1058,13 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         }, requestId);
     }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
-    const removeWorktree = useCallback((path: string, force = false) => {
+    const removeWorktree = useCallback((path: string, force = false, overrideInUse = false) => {
         if (!available || !path) return;
         const requestId = makeRequestId();
         registerRequestGeneration(requestId);
         setOperationInProgress("worktree-remove");
         setLastOperationResult(null);
-        send("git_worktree_remove", { cwd, path, force }, requestId);
+        send("git_worktree_remove", { cwd, path, force, ...(overrideInUse ? { overrideInUse: true } : {}) }, requestId);
     }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const pruneWorktrees = useCallback(() => {
@@ -1087,6 +1101,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setLastOperationResult(null);
         setLastConflictType(null);
         conflictActiveRef.current = false;
+        lastRepoVersionRef.current = 0;
         clearPendingRequests("(request cancelled)");
         requestGenerationRef.current.clear();
         pendingFullStatusRequestRef.current = null;


### PR DESCRIPTION
Fixes the git-service state-management defects from the 2026-08-20 state audit (§3 "Git"): four P1s and two P2s.

## Fixes

| # | Sev | Defect | Fix |
|---|-----|--------|-----|
| 1 | P1 | Mutations trusted caller-provided `cwd` — any collab viewer could mutate any repo under globally allowed roots | New `authorizeCwd()`: payload cwd must share `git rev-parse --git-common-dir` with the runner-owned session cwd (daemon wires `getSessionCwd` from `sessionCloseMetadata`). Falls back to allowed-roots-only validation when no metadata exists (adopted sessions, tests). |
| 2 | P1 | Mutation locks keyed by `--show-toplevel` — linked worktrees of one repo got different locks for shared refs/config/stash | Locks keyed `repo:<git-common-dir>` for shared mutations (checkout/commit/push/pull/merge/rebase/stash/worktree ops, which also take the `wt:<toplevel>` key), `wt:<toplevel>` alone for index-only ops. |
| 3 | P1 | External changes broadcast only `git_status_result` — branches/currentBranch/worktrees/commits stayed stale for non-initiating viewers | `notifyRepoChanged()` broadcasts a versioned `git_repo_changed` to every subscriber of the repo family (linked worktrees included) after mutations and external metadata changes; `useGitService` drops stale/duplicate versions and schedules a debounced full-status refresh. |
| 4 | P1 | Worktrees removable (incl. `--force`) while a live session used them | `git_worktree_remove` rejects with `reason:"in_use"` — even with `force` — when any live session's cwd is inside the worktree, unless the caller passes `overrideInUse:true` (plumbed through the hook as an explicit third arg). |
| 5 | P2 | Metadata watchers not rebuilt after checkout — attached to old branch/upstream refs | Watchers rebuilt on every repo change, so HEAD/upstream ref watchers survive checkouts (external ones included). |
| 6 | P2 | Stage/unstage ran outside the service lock — concurrent sessions raced the shared index | Stage/unstage acquire the per-worktree lock (3s wait) and return a retryable `{reason:"busy", retryable:true}` result instead of relying on git's `index.lock` failure. |

## Tests

New `packages/cli/src/runner/services/git-service.state.test.ts` — 8 regression tests against real git temp repos (`realpathSync(mkdtempSync(...))`):

- cross-session repo mutation denied; same-repo and linked-worktree cwds authorized; no-metadata fallback
- shared mutations in two linked worktrees serialize on one common-dir lock
- external checkout pushes `git_repo_changed` + fresh status; a second external change proves watchers were rebuilt
- a mutation by one session broadcasts to a subscriber in a linked worktree
- in-use worktree removal rejected (incl. `force`), allowed with `overrideInUse`
- concurrent stage returns a retryable busy result

Plus 3 new `useGitService` UI tests (`git_repo_changed` refresh, stale-version/wrong-cwd filtering, `overrideInUse` plumbing). One existing test updated for a sync-timing assumption (cwd authorization is now async).

Results:

- `bun run typecheck` — clean
- `bun test packages/cli/src` — 2991 pass, 0 fail
- `cd packages/ui && bun test src` — 1493 pass, 0 fail
- new state tests stable across 3 consecutive runs

## Follow-ups (deliberately not built)

- **Working-tree file watching** — edits stay invisible until manual refresh; needs a perf design (watcher or polling while subscribed).
- **Mixed-moment full-status retry** — full-status can still combine status/branches/worktrees from slightly different repo moments; needs a HEAD/index identity check + retry.
- **Subscriber identity redesign** — one cwd per session with silent subscription reassignment remains; separating authoritative cwd from subscriptions is a larger model change.
