### PR TITLE
fix(ui): robust action sigil parsing and inline pill layout

### DIFF
--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -330,7 +330,7 @@ function SpanOrSigil(props: any) {
   if (props["data-sigil-type"]) return <SigilInline {...props} />;
   if (props["data-sigil-group"]) {
     return (
-      <span className="inline-flex items-center gap-0.5 align-baseline">
+      <span className="flex flex-wrap items-center gap-1 align-baseline">
         {props.children}
       </span>
     );

--- a/packages/ui/src/components/ai-elements/sigil-rendering.test.tsx
+++ b/packages/ui/src/components/ai-elements/sigil-rendering.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+(win as unknown as { SyntaxError?: typeof SyntaxError }).SyntaxError = SyntaxError;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).SyntaxError = win.SyntaxError;
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+(globalThis as any).IntersectionObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import { MessageResponse } from "./message";
+
+afterEach(() => {
+  cleanup();
+  win.document.body.innerHTML = "";
+});
+
+function renderSigilMarkdown(text: string) {
+  return render(
+    <MessageResponse mode="static" sigilCanInteract={true} sigilMessageComplete={true}>
+      {text}
+    </MessageResponse>,
+  );
+}
+
+describe("sigil rendering pipeline", () => {
+  test("action sigil with quoted params containing em-dashes/commas/pipes renders as buttons", async () => {
+    const text =
+      'Is the complaint the pill rendering itself (UI bug worth capturing — e.g. inline sigils breaking sentence flow/punctuation), or just my formatting? [[action:choose id=badwhat options="UI rendering bug — capture it|Just your formatting, fixed now|Something else"]]';
+    renderSigilMarkdown(text);
+    await waitFor(
+      () => {
+        expect(document.body.querySelector("button")).not.toBeNull();
+        expect(document.body.textContent).toContain("UI rendering bug — capture it");
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  test("simple confirm action sigil with label renders as button", async () => {
+    renderSigilMarkdown("Pick one [[action:confirm id=x label=Yes]]");
+    await waitFor(
+      () => {
+        expect(document.body.querySelector("button")).not.toBeNull();
+        expect(document.body.textContent).toContain("Yes");
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  test("adjacent action sigils coalesce into a wrapping flex row", async () => {
+    renderSigilMarkdown(
+      "[[action:choose id=a options=Yes|No]] [[action:choose id=b options=Maybe|Later]]",
+    );
+    await waitFor(
+      () => {
+        expect(document.body.innerHTML).toContain("flex flex-wrap");
+        const buttons = document.body.querySelectorAll("button");
+        expect(buttons.length).toBeGreaterThanOrEqual(4);
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  test("sigil pills use a generous max-width truncation class", async () => {
+    renderSigilMarkdown('[[pr:123 label="fix(triggers): typed subscription handling"]]');
+    await waitFor(
+      () => {
+        expect(document.body.innerHTML).toContain("max-w-[40ch]");
+      },
+      { timeout: 10000 },
+    );
+  });
+});

--- a/packages/ui/src/components/sigils/ActionSigil.tsx
+++ b/packages/ui/src/components/sigils/ActionSigil.tsx
@@ -24,6 +24,8 @@ export function ActionSigil({ variant, params, raw }: ActionSigilProps) {
   }
 
   const action = parsed.action;
+  const confirmLabel = params.label?.trim() || "Confirm";
+  const cancelLabel = params.cancelLabel?.trim() || "Cancel";
 
   if (!runtime.canInteract && runtime.isMessageComplete) {
     return <RawActionSigil raw={raw} />;
@@ -54,14 +56,16 @@ export function ActionSigil({ variant, params, raw }: ActionSigilProps) {
         )}
         data-sigil={raw}
       >
-        <span className="font-medium text-muted-foreground">{action.question}</span>
+        {action.question && (
+          <span className="font-medium text-muted-foreground">{action.question}</span>
+        )}
         {action.kind === "confirm" && (
           <>
             <Button size="sm" type="button" disabled={disabled} onClick={() => void submit("confirm")}>
-              Confirm
+              {confirmLabel}
             </Button>
             <Button size="sm" type="button" variant="outline" disabled={disabled} onClick={() => void submit("cancel")}>
-              Cancel
+              {cancelLabel}
             </Button>
           </>
         )}
@@ -85,7 +89,7 @@ export function ActionSigil({ variant, params, raw }: ActionSigilProps) {
               placeholder={action.placeholder}
               disabled={disabled}
               className="h-8 w-40"
-              aria-label={action.question}
+              aria-label={action.question || action.placeholder || "Input"}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   e.preventDefault();

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -113,7 +113,7 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const pillInner = (
     <>
       <SigilIcon name={config.icon ?? "hash"} className="size-3 shrink-0 opacity-80" />
-      <span className="truncate max-w-[24ch]">{displayText}</span>
+      <span className="truncate max-w-[40ch]">{displayText}</span>
       {statusParam && (
         <span className={cn(
           "rounded-full px-1 py-px text-[9px] font-bold uppercase tracking-wider",

--- a/packages/ui/src/lib/sigils/actions.test.ts
+++ b/packages/ui/src/lib/sigils/actions.test.ts
@@ -2,20 +2,40 @@ import { describe, expect, test } from "bun:test";
 import { buildActionResponse, parseActionOptions, parseActionSigil } from "./actions";
 
 describe("parseActionSigil", () => {
-  test("parses confirm with required question", () => {
+  test("parses confirm with question", () => {
     expect(parseActionSigil("confirm", { question: "Deploy to production?" })).toEqual({
       ok: true,
       action: { kind: "confirm", question: "Deploy to production?" },
     });
   });
 
-  test("parses choose options", () => {
+  test("parses confirm without question, using label for button text", () => {
+    expect(parseActionSigil("confirm", { id: "x", label: "Yes" })).toEqual({
+      ok: true,
+      action: { kind: "confirm" },
+    });
+  });
+
+  test("parses comma-separated choose options", () => {
     expect(parseActionSigil("choose", {
       question: "Merge strategy?",
       options: "merge,rebase,squash",
     })).toEqual({
       ok: true,
       action: { kind: "choose", question: "Merge strategy?", options: ["merge", "rebase", "squash"] },
+    });
+  });
+
+  test("parses pipe-separated choose options and allows missing question", () => {
+    expect(parseActionSigil("choose", {
+      id: "badwhat",
+      options: "UI rendering bug — capture it|Just your formatting, fixed now|Something else",
+    })).toEqual({
+      ok: true,
+      action: {
+        kind: "choose",
+        options: ["UI rendering bug — capture it", "Just your formatting, fixed now", "Something else"],
+      },
     });
   });
 
@@ -41,8 +61,11 @@ describe("parseActionSigil", () => {
     expect(parseActionSigil("wat", { question: "Hi?" })).toEqual({ ok: false, error: "unknown_variant" });
   });
 
-  test("rejects missing question", () => {
-    expect(parseActionSigil("confirm", {})).toEqual({ ok: false, error: "missing_question" });
+  test("rejects choose without options", () => {
+    expect(parseActionSigil("choose", { question: "Merge strategy?" })).toEqual({
+      ok: false,
+      error: "missing_options",
+    });
   });
 
   test("formats confirm and cancel responses", () => {

--- a/packages/ui/src/lib/sigils/actions.ts
+++ b/packages/ui/src/lib/sigils/actions.ts
@@ -1,7 +1,7 @@
 export type ParsedActionSigil =
-  | { kind: "confirm"; question: string }
-  | { kind: "choose"; question: string; options: string[] }
-  | { kind: "input"; question: string; placeholder?: string };
+  | { kind: "confirm"; question?: string }
+  | { kind: "choose"; question?: string; options: string[] }
+  | { kind: "input"; question?: string; placeholder?: string };
 
 export type ActionParseResult =
   | { ok: true; action: ParsedActionSigil }
@@ -11,8 +11,7 @@ export function parseActionSigil(
   variant: string,
   params: Record<string, string>,
 ): ActionParseResult {
-  const question = params.question?.trim();
-  if (!question) return { ok: false, error: "missing_question" };
+  const question = params.question?.trim() || undefined;
 
   switch (variant) {
     case "confirm":
@@ -36,8 +35,12 @@ export function parseActionSigil(
 
 export function parseActionOptions(raw?: string): string[] {
   if (!raw) return [];
+  // Support both comma-separated and pipe-separated option lists so LLM-generated
+  // sigils like options="a|b|c" render correctly alongside the documented
+  // comma form.
+  const separator = raw.includes("|") ? "|" : ",";
   return raw
-    .split(",")
+    .split(separator)
     .map((option) => option.trim())
     .filter(Boolean);
 }
@@ -46,7 +49,7 @@ export function buildActionResponse(action: ParsedActionSigil, value: string): s
   return [
     "Action sigil response",
     `variant=${action.kind}`,
-    `question=${action.question}`,
+    `question=${action.question ?? ""}`,
     `value=${value}`,
   ].join("\n");
 }


### PR DESCRIPTION
Fixes two sigil rendering issues in the PizzaPi web UI.

## Bug 1 — action sigil rendered as raw text

**Before:** `[[action:choose id=badwhat options="UI rendering bug — capture it|Just your formatting, fixed now|Something else"]]` rendered as a muted `<code>` block instead of interactive buttons.

**Root cause:** `parseActionSigil` rejected any action sigil without a `question` param and only split `choose` options on commas. The reported assistant message has no `question` and uses pipe-separated options.

**After:**
- `question` is optional for all action variants; the surrounding prose can serve as the prompt.
- `choose` options support both comma- and pipe-separated lists (pipe used when present).
- Confirm buttons use the `label` param as button text when no question is provided.

## Bug 2 — inline sigil pills were hard to read in prose

**Before:** multiple inline `[[pr:…]]` pills were forced onto a single line with `max-w-[24ch]` truncation, leaving truncated titles and dangling punctuation.

**After:**
- `SigilPill` truncation widened to `max-w-[40ch]` so PR/issue titles are readable.
- Coalesced sigil groups render as `flex flex-wrap` rows so they wrap cleanly instead of jamming into the sentence baseline.

## Verification

- `cd packages/ui && bun test src` — 1496 pass, 0 fail.
- `bun run typecheck` — clean.

Added regression tests:
- The exact previously failing quoted action sigil renders as buttons.
- A simple confirm sigil with a `label` renders as a button.
- Adjacent action sigils coalesce into a wrapping flex row.
- Sigil pills render with the more generous `max-w-[40ch]` truncation class.
