### PR TITLE
feat: HMAC-signed attachment tokens (B-001)

### DIFF
--- a/packages/server/src/routes/attachment-token.test.ts
+++ b/packages/server/src/routes/attachment-token.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { createTestAuthContext, runWithAuthContext } from "../auth.js";
+import { createAttachmentToken, verifyAttachmentToken, ATTACHMENT_TOKEN_TTL_MS } from "./attachment-token.js";
+
+describe("attachment token", () => {
+    test("creates signed token with correct payload and expiry", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            const { token, expiresAt } = createAttachmentToken(
+                { userId: "u-1", attachmentId: "att-1" },
+                1_000,
+            );
+            expect(expiresAt).toBe(new Date(1_000 + ATTACHMENT_TOKEN_TTL_MS).toISOString());
+
+            const payload = verifyAttachmentToken(token, 1_000);
+            expect(payload).toMatchObject({
+                v: 1,
+                userId: "u-1",
+                attachmentId: "att-1",
+            });
+            expect(payload!.exp).toBe(Math.floor((1_000 + ATTACHMENT_TOKEN_TTL_MS) / 1000));
+        });
+    });
+
+    test("rejects expired tokens", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            const { token } = createAttachmentToken(
+                { userId: "u-1", attachmentId: "att-1" },
+                1_000,
+            );
+            // Verify at time after expiry
+            expect(verifyAttachmentToken(token, 1_000 + ATTACHMENT_TOKEN_TTL_MS + 1_000)).toBeNull();
+        });
+    });
+
+    test("rejects tampered tokens", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            const { token } = createAttachmentToken(
+                { userId: "u-1", attachmentId: "att-1" },
+                1_000,
+            );
+            expect(verifyAttachmentToken(`${token}x`, 1_000)).toBeNull();
+            expect(verifyAttachmentToken(token.slice(0, -1), 1_000)).toBeNull();
+            // Tamper the payload portion
+            const [payload, sig] = token.split(".");
+            const tamperedPayload = Buffer.from(JSON.stringify({ v: 1, userId: "u-evil", attachmentId: "att-1", exp: 9999999 })).toString("base64url");
+            expect(verifyAttachmentToken(`${tamperedPayload}.${sig}`, 1_000)).toBeNull();
+        });
+    });
+
+    test("rejects tokens with wrong number of segments", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            expect(verifyAttachmentToken("onlyone", 1_000)).toBeNull();
+            expect(verifyAttachmentToken("a.b.c", 1_000)).toBeNull();
+        });
+    });
+
+    test("rejects tokens with wrong version", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            const { token } = createAttachmentToken(
+                { userId: "u-1", attachmentId: "att-1" },
+                1_000,
+            );
+            // Mutate v field manually — tamper detection should catch it
+            const [encodedPayload] = token.split(".");
+            const raw = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+            raw.v = 2;
+            const newEncoded = Buffer.from(JSON.stringify(raw)).toString("base64url");
+            // Signature won't match — should be rejected
+            expect(verifyAttachmentToken(`${newEncoded}.invalidsig`, 1_000)).toBeNull();
+        });
+    });
+});

--- a/packages/server/src/routes/attachment-token.ts
+++ b/packages/server/src/routes/attachment-token.ts
@@ -1,0 +1,64 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getAuthContext } from "../auth.js";
+
+/** Maximum lifetime for an attachment download token (5 minutes). */
+export const ATTACHMENT_TOKEN_TTL_MS = 5 * 60 * 1000;
+
+export interface AttachmentTokenPayload {
+    v: 1;
+    userId: string;
+    attachmentId: string;
+    exp: number;
+}
+
+function base64url(input: string): string {
+    return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function unbase64url(input: string): string | null {
+    try {
+        return Buffer.from(input, "base64url").toString("utf8");
+    } catch {
+        return null;
+    }
+}
+
+function sign(encodedPayload: string): string {
+    return createHmac("sha256", getAuthContext().config.secret).update(encodedPayload).digest("base64url");
+}
+
+export function createAttachmentToken(
+    input: { userId: string; attachmentId: string },
+    nowMs = Date.now(),
+): { token: string; expiresAt: string } {
+    const exp = Math.floor((nowMs + ATTACHMENT_TOKEN_TTL_MS) / 1000);
+    const payload: AttachmentTokenPayload = { v: 1, userId: input.userId, attachmentId: input.attachmentId, exp };
+    const encodedPayload = base64url(JSON.stringify(payload));
+    const signature = sign(encodedPayload);
+    return { token: `${encodedPayload}.${signature}`, expiresAt: new Date(exp * 1000).toISOString() };
+}
+
+export function verifyAttachmentToken(token: string, nowMs = Date.now()): AttachmentTokenPayload | null {
+    const [encodedPayload, signature, extra] = token.split(".");
+    if (!encodedPayload || !signature || extra !== undefined) return null;
+
+    const expected = sign(encodedPayload);
+    const actualBuf = Buffer.from(signature);
+    const expectedBuf = Buffer.from(expected);
+    if (actualBuf.length !== expectedBuf.length || !timingSafeEqual(actualBuf, expectedBuf)) return null;
+
+    const rawPayload = unbase64url(encodedPayload);
+    if (!rawPayload) return null;
+
+    let payload: AttachmentTokenPayload;
+    try {
+        payload = JSON.parse(rawPayload) as AttachmentTokenPayload;
+    } catch {
+        return null;
+    }
+
+    if (payload.v !== 1) return null;
+    if (!payload.userId || !payload.attachmentId) return null;
+    if (!Number.isFinite(payload.exp) || payload.exp <= Math.floor(nowMs / 1000)) return null;
+    return payload;
+}

--- a/packages/server/src/routes/attachments-token.test.ts
+++ b/packages/server/src/routes/attachments-token.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for HMAC token-based attachment auth:
+ *   POST /api/attachments/:id/token  — mint a short-lived token
+ *   GET  /api/attachments/:id?token= — download with token
+ *
+ * Also covers deprecation warning on ?apiKey= path and ownership mismatch.
+ *
+ * Key wiring: createAttachmentToken / verifyAttachmentToken both call
+ * getAuthContext() so every call to handleAttachmentsRoute is wrapped in
+ * runWithAuthContext(authCtx, ...) to supply the HMAC secret.
+ */
+
+import { mock, describe, test, expect, beforeAll, beforeEach, afterAll } from "bun:test";
+import { createTestAuthContext, runWithAuthContext } from "../auth.js";
+import { createAttachmentToken, verifyAttachmentToken } from "./attachment-token.js";
+
+// ── Test auth context ─────────────────────────────────────────────────────────
+const authCtx = createTestAuthContext({ dbPath: ":memory:" });
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+let requireSessionUserId: string | null = "u-1";
+const requireSessionCalls: number[] = [];
+
+const storedAttachments: Map<string, {
+    attachmentId: string;
+    ownerUserId: string;
+    filename: string;
+    mimeType: string;
+    size: number;
+    filePath: string;
+    expiresAt: string;
+}> = new Map();
+
+const warnLogs: string[] = [];
+
+// ── Module mocks (must be BEFORE dynamic import) ──────────────────────────────
+
+mock.module("../middleware.js", () => ({
+    validateApiKey: async (_req: Request, _key?: string) => ({ userId: "u-1", userName: "test" }),
+    requireSession: async (_req: Request) => {
+        requireSessionCalls.push(1);
+        if (!requireSessionUserId) return Response.json({ error: "Unauthorized" }, { status: 401 });
+        return { userId: requireSessionUserId, userName: "test" };
+    },
+}));
+
+mock.module("../ws/sio-registry.js", () => ({
+    emitToRunner: mock(() => {}),
+    getSharedSession: async (_id: string) => null,
+}));
+
+mock.module("../attachments/store.js", () => ({
+    attachmentMaxFileSizeBytes: () => 50 * 1024 * 1024,
+    getStoredAttachment: async (id: string) => storedAttachments.get(id) ?? null,
+    storeSessionAttachment: async () => ({}),
+}));
+
+mock.module("@pizzapi/tools", () => ({
+    createLogger: (_name: string) => ({
+        warn: (msg: string) => { warnLogs.push(msg); },
+        info: () => {},
+        error: () => {},
+        debug: () => {},
+    }),
+}));
+
+// ── Dynamic import (after mocks) ──────────────────────────────────────────────
+type RouteHandler = (req: Request, url: URL) => Promise<Response | undefined>;
+let handleAttachmentsRoute: RouteHandler;
+
+/** Calls the route handler inside the test auth context (HMAC secret required). */
+async function callRoute(req: Request): Promise<Response | undefined> {
+    return runWithAuthContext(authCtx, () => handleAttachmentsRoute(req, new URL(req.url)));
+}
+
+beforeAll(async () => {
+    const mod = await import("./attachments.js") as { handleAttachmentsRoute: RouteHandler };
+    handleAttachmentsRoute = mod.handleAttachmentsRoute;
+
+    storedAttachments.set("att-1", {
+        attachmentId: "att-1",
+        ownerUserId: "u-1",
+        filename: "test.png",
+        mimeType: "image/png",
+        size: 100,
+        filePath: "/dev/null",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+});
+
+beforeEach(() => {
+    requireSessionCalls.length = 0;
+    warnLogs.length = 0;
+    requireSessionUserId = "u-1";
+});
+
+afterAll(() => mock.restore());
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mintToken(userId: string, attachmentId: string, nowMs = Date.now()): string {
+    return runWithAuthContext(authCtx, () => createAttachmentToken({ userId, attachmentId }, nowMs).token);
+}
+
+// ── Token mint: POST /api/attachments/:id/token ───────────────────────────────
+
+describe("POST /api/attachments/:id/token", () => {
+    test("returns 401 when session is not authenticated", async () => {
+        requireSessionUserId = null;
+        const res = await callRoute(new Request("http://localhost/api/attachments/att-1/token", { method: "POST" }));
+        expect(res?.status).toBe(401);
+        expect(requireSessionCalls.length).toBe(1);
+    });
+
+    test("returns 404 when attachment does not exist", async () => {
+        const res = await callRoute(new Request("http://localhost/api/attachments/no-such/token", { method: "POST" }));
+        expect(res?.status).toBe(404);
+    });
+
+    test("returns 403 when requester doesn't own the attachment", async () => {
+        requireSessionUserId = "u-other";
+        const res = await callRoute(new Request("http://localhost/api/attachments/att-1/token", { method: "POST" }));
+        expect(res?.status).toBe(403);
+    });
+
+    test("returns token + expiresAt JSON for the owner", async () => {
+        const res = await callRoute(new Request("http://localhost/api/attachments/att-1/token", { method: "POST" }));
+        expect(res?.status).toBe(200);
+        const body = await res!.json() as { token: string; expiresAt: string };
+        expect(typeof body.token).toBe("string");
+        // Two base64url segments joined by "."
+        expect(body.token.split(".")).toHaveLength(2);
+        expect(typeof body.expiresAt).toBe("string");
+        // expiresAt should be in the future
+        expect(new Date(body.expiresAt).getTime()).toBeGreaterThan(Date.now());
+        // Token should be valid
+        const payload = runWithAuthContext(authCtx, () => verifyAttachmentToken(body.token));
+        expect(payload?.userId).toBe("u-1");
+        expect(payload?.attachmentId).toBe("att-1");
+    });
+});
+
+// ── Token download: GET /api/attachments/:id?token= ──────────────────────────
+
+describe("GET /api/attachments/:id?token=", () => {
+    test("returns 401 for a syntactically invalid token", async () => {
+        const res = await callRoute(new Request("http://localhost/api/attachments/att-1?token=bad"));
+        expect(res?.status).toBe(401);
+        expect(requireSessionCalls.length).toBe(0);
+    });
+
+    test("returns 401 for an expired token", async () => {
+        const token = mintToken("u-1", "att-1", 1); // minted at epoch+1ms → expired
+        const res = await callRoute(new Request(`http://localhost/api/attachments/att-1?token=${encodeURIComponent(token)}`));
+        expect(res?.status).toBe(401);
+    });
+
+    test("returns 403 when token attachment ID mismatches URL", async () => {
+        // Token scoped to att-1 but URL has att-2
+        storedAttachments.set("att-2", { ...storedAttachments.get("att-1")!, attachmentId: "att-2" });
+        const token = mintToken("u-1", "att-1");
+        const res = await callRoute(new Request(`http://localhost/api/attachments/att-2?token=${encodeURIComponent(token)}`));
+        expect(res?.status).toBe(403);
+        storedAttachments.delete("att-2");
+    });
+
+    test("returns 403 on ownership mismatch (token owner ≠ attachment owner)", async () => {
+        const token = mintToken("u-evil", "att-1");
+        const res = await callRoute(new Request(`http://localhost/api/attachments/att-1?token=${encodeURIComponent(token)}`));
+        expect(res?.status).toBe(403);
+    });
+
+    test("serves attachment (200) for a valid token", async () => {
+        const token = mintToken("u-1", "att-1");
+        const res = await callRoute(new Request(`http://localhost/api/attachments/att-1?token=${encodeURIComponent(token)}`));
+        expect(res?.status).toBe(200);
+        expect(res?.headers.get("x-attachment-id")).toBe("att-1");
+    });
+});
+
+// ── Deprecation warning on ?apiKey= ──────────────────────────────────────────
+
+describe("GET /api/attachments/:id?apiKey= (deprecated)", () => {
+    test("logs a deprecation warning when ?apiKey= is used", async () => {
+        await callRoute(new Request("http://localhost/api/attachments/att-1?apiKey=my-key"));
+        expect(warnLogs.some((m) => m.includes("deprecated") || m.includes("apiKey"))).toBe(true);
+    });
+
+    test("does not log a deprecation warning for x-api-key header", async () => {
+        await callRoute(new Request("http://localhost/api/attachments/att-1", {
+            headers: { "x-api-key": "my-key" },
+        }));
+        expect(warnLogs.some((m) => m.includes("deprecated"))).toBe(false);
+    });
+
+    test("still serves attachment when ?apiKey= used (backward compat)", async () => {
+        const res = await callRoute(new Request("http://localhost/api/attachments/att-1?apiKey=my-key"));
+        expect(res?.status).not.toBe(401);
+        expect(res?.status).not.toBe(403);
+    });
+});

--- a/packages/server/src/routes/attachments.ts
+++ b/packages/server/src/routes/attachments.ts
@@ -2,6 +2,7 @@
  * Attachments router — file upload and download for sessions.
  */
 
+import { createLogger } from "@pizzapi/tools";
 import { requireSession, validateApiKey } from "../middleware.js";
 import { getSharedSession } from "../ws/sio-registry.js";
 import {
@@ -9,7 +10,10 @@ import {
     getStoredAttachment,
     storeSessionAttachment,
 } from "../attachments/store.js";
+import { createAttachmentToken, verifyAttachmentToken } from "./attachment-token.js";
 import type { RouteHandler } from "./types.js";
+
+const log = createLogger("attachments");
 
 /**
  * MIME types safe to serve inline — rendered by the browser without any
@@ -181,6 +185,35 @@ export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
         });
     }
 
+    // ── Mint token: POST /api/attachments/:id/token ─────────────────────
+    if (
+        url.pathname.startsWith("/api/attachments/") &&
+        url.pathname.endsWith("/token") &&
+        req.method === "POST"
+    ) {
+        const attachmentId = decodeURIComponent(
+            url.pathname.slice("/api/attachments/".length, -"/token".length),
+        );
+        if (!attachmentId) {
+            return Response.json({ error: "Missing attachment ID" }, { status: 400 });
+        }
+
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const attachment = await getStoredAttachment(attachmentId);
+        if (!attachment) {
+            return Response.json({ error: "Attachment not found" }, { status: 404 });
+        }
+
+        if (attachment.ownerUserId !== identity.userId) {
+            return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
+
+        const { token, expiresAt } = createAttachmentToken({ userId: identity.userId, attachmentId });
+        return Response.json({ token, expiresAt });
+    }
+
     // ── Download: GET /api/attachments/:id ──────────────────────────────
     if (url.pathname.startsWith("/api/attachments/") && req.method === "GET") {
         const attachmentId = decodeURIComponent(url.pathname.slice("/api/attachments/".length));
@@ -188,13 +221,48 @@ export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Missing attachment ID" }, { status: 400 });
         }
 
-        // Support both header-based and query-parameter API key auth for
-        // backward compatibility.  Clients that embed the key in the URL
-        // (e.g. direct download links, documented ?apiKey= pattern) must
-        // continue to work alongside the preferred x-api-key header form.
+        // ── Token auth (preferred) ──
+        const queryToken = url.searchParams.get("token") || undefined;
+        if (queryToken) {
+            const payload = verifyAttachmentToken(queryToken);
+            if (!payload) {
+                return Response.json({ error: "Invalid or expired token" }, { status: 401 });
+            }
+            if (payload.attachmentId !== attachmentId) {
+                return Response.json({ error: "Token/attachment mismatch" }, { status: 403 });
+            }
+
+            const attachment = await getStoredAttachment(attachmentId);
+            if (!attachment) {
+                return Response.json({ error: "Attachment not found" }, { status: 404 });
+            }
+            // Re-check ownership against DB — never trust token fields alone.
+            if (attachment.ownerUserId !== payload.userId) {
+                return Response.json({ error: "Forbidden" }, { status: 403 });
+            }
+
+            const { contentType: servedMimeType, disposition: dispositionMode } =
+                resolveServedContentType(attachment.mimeType);
+            return new Response(Bun.file(attachment.filePath), {
+                headers: {
+                    "content-type": servedMimeType,
+                    "x-content-type-options": "nosniff",
+                    "content-length": String(attachment.size),
+                    "content-disposition": buildContentDisposition(attachment.filename, dispositionMode),
+                    "x-attachment-id": attachment.attachmentId,
+                    "x-attachment-filename": encodeHeaderFilename(attachment.filename),
+                },
+            });
+        }
+
+        // ── Legacy API-key auth (deprecated — logs warning) ──
         const headerApiKey = req.headers.get("x-api-key") || undefined;
         const queryApiKey = url.searchParams.get("apiKey") || undefined;
         const providedApiKey = headerApiKey ?? queryApiKey;
+        if (queryApiKey) {
+            // ponytail: one-cycle deprecation shim; remove after mobile clients migrate
+            log.warn("[deprecated] ?apiKey= on attachment download; use POST /api/attachments/:id/token instead");
+        }
         const identity = providedApiKey
             ? await validateApiKey(req, providedApiKey)
             : await requireSession(req);

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -67,7 +67,14 @@ export { tryRenderServerToolBlock } from "@/components/session-viewer/server-too
 
 import { CommandResultCard, type CommandResultData } from "@/components/session-viewer/cards/CommandResultCard";
 import { TriggerCard } from "@/components/session-viewer/cards/TriggerCard";
-import { resolveMobileMediaUrl } from "@/lib/mobile-runtime";
+import { resolveMobileMediaUrlAsync } from "@/lib/mobile-runtime";
+
+/** Resolves a mobile attachment URL asynchronously (mints a short-lived token). */
+function MobileMediaImg({ url, alt, className, loading }: { url: string; alt: string; className?: string; loading?: "lazy" | "eager" }) {
+  const [src, setSrc] = React.useState(url);
+  React.useEffect(() => { resolveMobileMediaUrlAsync(url).then(setSrc); }, [url]);
+  return <img src={src} alt={alt} className={className} loading={loading} />;
+}
 import { tryRenderServerToolBlock } from "@/components/session-viewer/server-tools";
 
 /** Type guard: is the content a structured command result? */
@@ -341,9 +348,9 @@ export function renderContent(
               }
               if (isSafeUrl) {
                 return (
-                  <img
+                  <MobileMediaImg
                     key={i}
-                    src={resolveMobileMediaUrl(url)}
+                    url={url}
                     alt="Message attachment"
                     className="max-h-80 max-w-full rounded border border-border object-contain"
                     loading="lazy"

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -57,7 +57,14 @@ import { CopyableCodeBlock } from "@/components/session-viewer/cards/InterAgentC
 import { WriteFileCard } from "@/components/session-viewer/cards/WriteFileCard";
 import { TodoCard } from "@/components/session-viewer/cards/TodoCard";
 import type { TodoItem } from "@/lib/types";
-import { resolveMobileMediaUrl } from "@/lib/mobile-runtime";
+import { resolveMobileMediaUrlAsync } from "@/lib/mobile-runtime";
+
+/** Resolves a mobile attachment URL asynchronously (mints a short-lived token). */
+function MobileMediaImg({ url, alt, className, loading }: { url: string; alt: string; className?: string; loading?: "lazy" | "eager" }) {
+  const [src, setSrc] = React.useState(url);
+  React.useEffect(() => { resolveMobileMediaUrlAsync(url).then(setSrc); }, [url]);
+  return <img src={src} alt={alt} className={className} loading={loading} />;
+}
 import { SessionNameCard } from "@/components/session-viewer/cards/SessionNameCard";
 import {
   truncateSessionId,
@@ -285,12 +292,9 @@ export function renderReadToolResult(
               : null}
             {mtime ? metadataBadge("mtime", mtime) : null}
           </div>
-          <img
-            src={data ? `data:${imgMime};base64,${data}` : resolveMobileMediaUrl(url!)}
-            alt={title}
-            className="max-w-full rounded border border-border/70 bg-background object-contain"
-            loading="lazy"
-          />
+          {data
+            ? <img src={`data:${imgMime};base64,${data}`} alt={title} className="max-w-full rounded border border-border/70 bg-background object-contain" loading="lazy" />
+            : <MobileMediaImg url={url!} alt={title} className="max-w-full rounded border border-border/70 bg-background object-contain" loading="lazy" />}
         </div>
       </FileTypeCard>
     );

--- a/packages/ui/src/lib/mobile-runtime.test.ts
+++ b/packages/ui/src/lib/mobile-runtime.test.ts
@@ -12,6 +12,7 @@ import {
     clearMobileApiKey,
     initMobileRuntime,
     resolveMobileMediaUrl,
+    resolveMobileMediaUrlAsync,
     _resetMobileRuntimeCache,
     _setMobileRuntimeCache,
 } from "./mobile-runtime";
@@ -116,5 +117,86 @@ describe("resolveMobileMediaUrl (mobile-bundled path)", () => {
         expect(resolveMobileMediaUrl("https://cdn.example.com/x.png")).toBe(
             "https://cdn.example.com/x.png",
         );
+    });
+});
+
+describe("resolveMobileMediaUrlAsync (web no-op path)", () => {
+    beforeEach(() => {
+        _resetMobileRuntimeCache();
+        Object.defineProperty(globalThis, "localStorage", {
+            value: makeLocalStorage(null),
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        _resetMobileRuntimeCache();
+        (globalThis as any).localStorage = origLocalStorage;
+    });
+
+    test("returns path unchanged on web", async () => {
+        expect(await resolveMobileMediaUrlAsync("/api/attachments/abc")).toBe("/api/attachments/abc");
+    });
+
+    test("returns absolute URL unchanged on web", async () => {
+        expect(await resolveMobileMediaUrlAsync("https://cdn.example.com/x.png")).toBe(
+            "https://cdn.example.com/x.png",
+        );
+    });
+});
+
+describe("resolveMobileMediaUrlAsync (mobile-bundled path)", () => {
+    const origFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        _resetMobileRuntimeCache();
+        _setMobileRuntimeCache("secret-key");
+        Object.defineProperty(globalThis, "localStorage", {
+            value: makeLocalStorage("https://relay.example.com"),
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        _resetMobileRuntimeCache();
+        (globalThis as any).localStorage = origLocalStorage;
+        globalThis.fetch = origFetch;
+    });
+
+    test("mints a token and appends ?token= for attachment URLs", async () => {
+        (globalThis as any).fetch = async (_url: string, _opts?: RequestInit) =>
+            new Response(JSON.stringify({ token: "tok-123" }), { status: 200 });
+
+        const result = await resolveMobileMediaUrlAsync("/api/attachments/abc");
+        expect(result).toContain("?token=tok-123");
+        expect(result).toContain("https://relay.example.com");
+    });
+
+    test("falls back to deprecated ?apiKey= URL when token fetch fails", async () => {
+        (globalThis as any).fetch = async () => { throw new Error("network error"); };
+
+        const result = await resolveMobileMediaUrlAsync("/api/attachments/abc");
+        // Fallback to resolveMobileMediaUrl which uses ?apiKey=
+        expect(result).toContain("?apiKey=secret-key");
+    });
+
+    test("falls back when fetch returns non-OK status", async () => {
+        (globalThis as any).fetch = async () => new Response("Unauthorized", { status: 401 });
+
+        const result = await resolveMobileMediaUrlAsync("/api/attachments/abc");
+        expect(result).toContain("?apiKey=secret-key");
+    });
+
+    test("returns non-attachment relative paths via deprecated path", async () => {
+        // Non-attachment paths don't hit the token endpoint
+        const fetchCalls: string[] = [];
+        (globalThis as any).fetch = async (url: string) => { fetchCalls.push(url); throw new Error("should not be called"); };
+
+        const result = await resolveMobileMediaUrlAsync("/api/sessions/x");
+        // No attachment match → falls through to resolveMobileMediaUrl
+        expect(result).toContain("https://relay.example.com/api/sessions/x");
+        expect(fetchCalls.length).toBe(0);
     });
 });

--- a/packages/ui/src/lib/mobile-runtime.ts
+++ b/packages/ui/src/lib/mobile-runtime.ts
@@ -81,11 +81,48 @@ export function resolveMobileUrl(path: string): string {
 }
 
 /**
- * Resolve a relative media path (e.g. /api/attachments/…) for use as an
- * <img>/<video> src in the bundled mobile app. Unlike resolveMobileUrl, this
- * also appends the API key as a query param: element loads can't carry the
- * x-api-key header the fetch patch injects, and the download endpoint accepts
- * ?apiKey= for exactly this case. No-op on web (relative src stays same-origin).
+ * Resolve a relative attachment path for use as an <img>/<video> src in the
+ * bundled mobile app by minting a short-lived HMAC token via
+ * POST /api/attachments/:id/token. Falls back to the raw path on web.
+ *
+ * Callers should use this inside a useEffect / async context and update state.
+ */
+export async function resolveMobileMediaUrlAsync(path: string): Promise<string> {
+    if (!path.startsWith("/")) return path;
+    const { serverUrl, isMobileBundled } = getMobileRuntimeConfig();
+    if (!isMobileBundled || !serverUrl) return path;
+
+    // Extract attachment ID from /api/attachments/:id paths.
+    const match = path.match(/^\/api\/attachments\/([^/?#]+)/);
+    if (match) {
+        const attachmentId = match[1];
+        try {
+            const base = serverUrl.replace(/\/+$/, "");
+            const res = await fetch(`${base}/api/attachments/${encodeURIComponent(attachmentId)}/token`, {
+                method: "POST",
+                // mobile fetch patch injects x-api-key header automatically
+            });
+            if (res.ok) {
+                const { token } = (await res.json()) as { token: string };
+                const url = new URL(`${base}${path}`);
+                url.searchParams.set("token", token);
+                return url.toString();
+            }
+        } catch {
+            // fall through to deprecated path
+        }
+    }
+
+    // ponytail: deprecated fallback; remove after mobile clients fully migrate
+    return resolveMobileMediaUrl(path);
+}
+
+/**
+ * @deprecated Use resolveMobileMediaUrlAsync. This leaks the durable API key
+ * into URLs, logs, and proxies. Kept for one transition cycle.
+ *
+ * Resolve a relative media path for use as an <img>/<video> src in the bundled
+ * mobile app by appending ?apiKey= to the URL. No-op on web.
  */
 export function resolveMobileMediaUrl(path: string): string {
     if (!path.startsWith("/")) return path;


### PR DESCRIPTION
Night Shift dish B-001

## Summary

Replaces durable  attachment download URLs with short-lived (5-minute) HMAC-signed tokens, mirroring the existing tunnel-token pattern.

## Changes

### Server
- **New** `packages/server/src/routes/attachment-token.ts`: `createAttachmentToken()` / `verifyAttachmentToken()` — HMAC-SHA256, constant-time compare, same pattern as `tunnel-token.ts`
- **Updated** `packages/server/src/routes/attachments.ts`:
  - `POST /api/attachments/:id/token` — authenticated endpoint to mint a 5-min scoped token (verifies ownership)
  - `GET /api/attachments/:id?token=` — verifies token + re-checks ownership in DB, serves file
  - `?apiKey=` path still works but logs a deprecation warning

### UI
- **Updated** `packages/ui/src/lib/mobile-runtime.ts`:
  - New `resolveMobileMediaUrlAsync(path)` — calls POST token endpoint, appends `?token=`; falls back to deprecated `?apiKey=` on error
  - `resolveMobileMediaUrl()` kept as deprecated sync fallback
- **Updated** `packages/ui/src/components/session-viewer/rendering.tsx`: added `MobileMediaImg` component using the async resolver
- **Updated** `packages/ui/src/components/session-viewer/tool-rendering.tsx`: same pattern

### Tests
- `attachment-token.test.ts`: mint, verify, expiry, tamper, wrong version (5 tests)
- `attachments-token.test.ts`: token mint (4 scenarios), token download (5 scenarios), deprecation warning (3 scenarios) (12 tests)
- `mobile-runtime.test.ts`: 6 new async resolver tests (14 total, all pass)
- `attachments-apikey.test.ts`: existing 5 tests still pass (no regressions)

### Docs
- `.pizzapi/skills/pizzapi-serving-files-to-user/SKILL.md`: documents token path, deprecation, mobile wiring

## Verification

```
bun run typecheck                                          ✓ exit 0
bun test packages/server/src/routes/attachments-apikey.test.ts  ✓ 5/5 pass
cd packages/ui && bun test src/lib/mobile-runtime.test.ts ✓ 14/14 pass
```

Additional tests run and passed:
- `attachment-token.test.ts`: 5/5 pass
- `attachments-token.test.ts`: 12/12 pass

**Redis-dependent tests** (`tunnel-token.test.ts`, integration tests) require a running Redis server and were not run in this environment — same pre-existing limitation as the rest of the server test suite.