### PR TITLE
fix: prevent resync cursor rewind (A2-007)

### DIFF
--- a/packages/ui/src/App.resync.test.ts
+++ b/packages/ui/src/App.resync.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for the live-gap/resync cursor-rewind bug (A2-007).
+ *
+ * Problem: When a live sequence gap was detected the UI emitted a "resync"
+ * request, which caused the server to replay cached deltas starting from
+ * the last stored cursor. But the replay path in App.tsx unconditionally
+ * assigned `lastSeqRef.current = seq`, so any replayed delta with a seq
+ * older than the cursor (which had already advanced to accommodate the
+ * live gap event) rewound the cursor and re-applied stale state.
+ *
+ * Fix: The replay path now routes through `analyzeReplaySeq`, which only
+ * accepts deltas with seq strictly greater than the current cursor.
+ *
+ * These tests verify the pure guard logic that App.tsx delegates to.
+ * The React component integration is covered by the guard itself — if
+ * analyzeReplaySeq returns accept:false, App.tsx returns early without
+ * calling handleRelayEvent or advancing lastSeqRef.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { analyzeIncomingSeq, analyzeReplaySeq } from "./lib/session-seq";
+
+describe("resync replay cursor-rewind regression (A2-007)", () => {
+  test("live gap advances cursor; subsequent stale replay deltas are dropped", () => {
+    let cursor: number | null = null;
+
+    // ── Normal live delivery ──────────────────────────────────────────────
+    for (const seq of [1, 2, 3]) {
+      const d = analyzeIncomingSeq(cursor, seq);
+      expect(d.accept).toBe(true);
+      cursor = d.nextSeq;
+    }
+    expect(cursor).toBe(3);
+
+    // ── Live gap: seq 5 arrives (4 was missing) ──────────────────────────
+    const gap = analyzeIncomingSeq(cursor, 5);
+    expect(gap.gap).toBe(true);    // gap detected → UI would request resync
+    expect(gap.accept).toBe(true);
+    cursor = gap.nextSeq;
+    expect(cursor).toBe(5);        // cursor now at 5
+
+    // ── Resync: server replays cached deltas from an earlier position ─────
+    // Deltas seq 3, 4, 5 are "older" than our current cursor (5).
+    // Before the fix: these would each unconditionally set cursor = seq,
+    //   causing cursor to rewind from 5 → 3, then 4, then 5.
+    // After the fix: all three are dropped; cursor stays at 5.
+    for (const staleSeq of [3, 4, 5]) {
+      const r = analyzeReplaySeq(cursor, staleSeq);
+      expect(r.accept).toBe(false);  // stale — must be dropped
+      cursor = r.nextSeq;            // cursor unchanged
+    }
+    expect(cursor).toBe(5);          // ← was 3 before the fix
+
+    // ── First genuinely new replay delta ─────────────────────────────────
+    const fresh = analyzeReplaySeq(cursor, 6);
+    expect(fresh.accept).toBe(true);
+    cursor = fresh.nextSeq;
+    expect(cursor).toBe(6);
+  });
+
+  test("replay drops duplicate seq (equal to cursor)", () => {
+    // cursor already at 10; replay sends seq 10 again — must be dropped
+    const r = analyzeReplaySeq(10, 10);
+    expect(r.accept).toBe(false);
+    expect(r.nextSeq).toBe(10);
+  });
+
+  test("normal contiguous replay still advances cursor", () => {
+    // Fresh connection: no cursor yet; replay delivers 1, 2, 3 in order
+    let cursor: number | null = null;
+    for (const seq of [1, 2, 3]) {
+      const r = analyzeReplaySeq(cursor, seq);
+      expect(r.accept).toBe(true);
+      cursor = r.nextSeq;
+    }
+    expect(cursor).toBe(3);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -142,6 +142,7 @@ import { createWizardSpawnHandler } from "@/lib/wizard-spawn-handler";
 import { sessionLifecycleActions as lifecycleActions } from "@/lib/session-lifecycle";
 import {
   analyzeIncomingSeq,
+  analyzeReplaySeq,
   canFinalizeChunkHydration,
   mergeConnectedSeq,
   registerChunkIndex,
@@ -3579,7 +3580,14 @@ export function App() {
         const seq = envelopeSeq ?? null;
         if (seq !== null) {
           if (deltaReplay === true) {
-            lastSeqRef.current = seq;
+            // Only advance the cursor when the replayed seq is strictly newer.
+            // Stale cached deltas emitted by the resync endpoint (seq <= cursor)
+            // are dropped so they cannot rewind the cursor or reapply old state.
+            const replayDecision = analyzeReplaySeq(lastSeqRef.current, seq);
+            if (!replayDecision.accept) {
+              return;
+            }
+            lastSeqRef.current = replayDecision.nextSeq;
           } else {
             const allowOutOfOrderHydrationSnapshot = shouldAllowOutOfOrderSnapshotDuringHydration(
               eventType,

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   analyzeIncomingSeq,
+  analyzeReplaySeq,
   canFinalizeChunkHydration,
   mergeConnectedSeq,
   registerChunkIndex,
@@ -143,6 +144,75 @@ describe("shouldAllowOutOfOrderSnapshotDuringHydration", () => {
     expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", false, 11, 10)).toBe(false);
     expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", true, null, 10)).toBe(false);
     expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", true, 10, 11)).toBe(false);
+  });
+});
+
+describe("analyzeReplaySeq", () => {
+  test("accepts first replay delta when no cursor exists", () => {
+    expect(analyzeReplaySeq(null, 5)).toEqual({ accept: true, nextSeq: 5 });
+  });
+
+  test("advances cursor for strictly newer replay delta", () => {
+    expect(analyzeReplaySeq(5, 6)).toEqual({ accept: true, nextSeq: 6 });
+    expect(analyzeReplaySeq(5, 10)).toEqual({ accept: true, nextSeq: 10 });
+  });
+
+  test("drops replay delta with same seq as cursor (duplicate)", () => {
+    expect(analyzeReplaySeq(5, 5)).toEqual({ accept: false, nextSeq: 5 });
+  });
+
+  test("drops stale replay delta (seq < cursor) — live-gap/resync regression", () => {
+    // Scenario: live gap advanced cursor to 10. Resync endpoint replays cached
+    // deltas starting from an earlier position (e.g. seq 8). These must be
+    // dropped, not applied, so the cursor stays at 10.
+    expect(analyzeReplaySeq(10, 8)).toEqual({ accept: false, nextSeq: 10 });
+    expect(analyzeReplaySeq(10, 9)).toEqual({ accept: false, nextSeq: 10 });
+  });
+
+  test("drops non-finite seq", () => {
+    expect(analyzeReplaySeq(5, NaN)).toEqual({ accept: false, nextSeq: 5 });
+    expect(analyzeReplaySeq(null, NaN)).toEqual({ accept: false, nextSeq: null });
+  });
+
+  test("live-gap then replay: cursor never rewinds", () => {
+    // Simulate the full scenario:
+    // 1. Live events advance cursor 1 → 2 → 3
+    // 2. Seq 5 arrives (gap: 4 missing) — cursor jumps to 5
+    // 3. Resync is requested. Server replays from seq 3:
+    //    replay seq 3 → stale, drop
+    //    replay seq 4 → stale, drop
+    //    replay seq 5 → stale (already at 5), drop
+    //    replay seq 6 → fresh, accept
+    let cursor: number | null = null;
+
+    // Live path (use analyzeIncomingSeq for live)
+    for (const seq of [1, 2, 3]) {
+      const d = analyzeIncomingSeq(cursor, seq);
+      expect(d.accept).toBe(true);
+      cursor = d.nextSeq;
+    }
+    expect(cursor).toBe(3);
+
+    // Gap: seq 5 arrives (4 missing)
+    const gapDecision = analyzeIncomingSeq(cursor, 5);
+    expect(gapDecision.gap).toBe(true);
+    expect(gapDecision.accept).toBe(true);
+    cursor = gapDecision.nextSeq;
+    expect(cursor).toBe(5);
+
+    // Replay of cached deltas — must not rewind
+    for (const staleSeq of [3, 4, 5]) {
+      const r = analyzeReplaySeq(cursor, staleSeq);
+      expect(r.accept).toBe(false);
+      cursor = r.nextSeq; // cursor stays at 5
+    }
+    expect(cursor).toBe(5);
+
+    // First genuinely new replay delta
+    const freshReplay = analyzeReplaySeq(cursor, 6);
+    expect(freshReplay.accept).toBe(true);
+    cursor = freshReplay.nextSeq;
+    expect(cursor).toBe(6);
   });
 });
 

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -91,6 +91,31 @@ export function canFinalizeChunkHydration(
   return true;
 }
 
+/**
+ * Decide whether a replayed delta may advance the cursor.
+ *
+ * Unlike the live path, replay events must be strictly monotonic — they must
+ * never rewind the cursor. A stale replayed delta (seq <= current) is dropped
+ * so cached deltas emitted by the resync endpoint after a live gap cannot
+ * reapply stale state or move the cursor backward.
+ */
+export function analyzeReplaySeq(
+  currentSeq: number | null,
+  incomingSeq: number,
+): { accept: boolean; nextSeq: number | null } {
+  if (!Number.isFinite(incomingSeq)) {
+    return { accept: false, nextSeq: currentSeq };
+  }
+  if (currentSeq === null) {
+    return { accept: true, nextSeq: incomingSeq };
+  }
+  // ponytail: strict monotonic — only advance, never rewind
+  if (incomingSeq <= currentSeq) {
+    return { accept: false, nextSeq: currentSeq };
+  }
+  return { accept: true, nextSeq: incomingSeq };
+}
+
 export function analyzeIncomingSeq(
   currentSeq: number | null,
   incomingSeq: number,


### PR DESCRIPTION
Night Shift dish A2-007

## Problem
When a live sequence gap was detected, the UI emitted a `resync` request. The server then replayed cached deltas starting from an earlier cursor position. The replay path in `App.tsx` unconditionally assigned `lastSeqRef.current = seq`, so any replayed delta older than the current cursor rewound the cursor and reapplied stale state.

## Fix
- Added `analyzeReplaySeq(currentSeq, incomingSeq)` to `session-seq.ts`: only advances the cursor when `incomingSeq > currentSeq`, otherwise returns `accept: false`
- Updated `App.tsx` replay path to use this guard: returns early (drops the event) when `accept` is false
- No change to the live path or normal (contiguous) replay

## Files Changed
- `packages/ui/src/lib/session-seq.ts` — new `analyzeReplaySeq` export
- `packages/ui/src/App.tsx` — replay path uses `analyzeReplaySeq` instead of unconditional assign
- `packages/ui/src/lib/session-seq.test.ts` — 6 new tests for `analyzeReplaySeq`
- `packages/ui/src/App.resync.test.ts` — regression tests for the full live-gap/replay scenario

## Verification
```
bun test src/App.resync.test.ts src/lib/session-seq.test.ts  → 31 pass, 0 fail
bun test src                                                  → 1099 pass, 66 pre-existing fail (JSX/native, not my files)
bunx tsc --noEmit                                             → no errors in session-seq.ts or App.tsx
```