### PR TITLE
fix: drop stale exec_result on session switch (A2-011)

### DIFF
--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -52,6 +52,8 @@ export interface ViewerServerToClientEvents {
     command: string;
     result?: unknown;
     error?: string;
+    /** Session that produced this result — stamped by the relay for stale-drop guards. */
+    sessionId?: string;
   }) => void;
 
   /** Generic service message from runner → relay → viewer.

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -1,0 +1,109 @@
+// ============================================================================
+// session-lifecycle.exec-result.test.ts
+// Regression: exec_result forwarded to viewers must be stamped with the
+// originating sessionId so viewers can drop stale results after a switch.
+// ============================================================================
+
+import { afterAll, describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Captures ──────────────────────────────────────────────────────────────────
+
+const broadcasts: Array<{ sessionId: string; event: string; data: unknown }> = [];
+
+const mockBroadcastToViewers = mock(
+    (sessionId: string, event: string, data: unknown) => {
+        broadcasts.push({ sessionId, event, data });
+    },
+);
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+mock.module("../../sio-registry.js", () => ({
+    registerTuiSession: async () => ({
+        sessionId: "sess-A",
+        token: "tok",
+        shareUrl: "",
+        parentSessionId: null,
+        wasDelinked: false,
+    }),
+    getLocalTuiSocket: () => undefined,
+    broadcastToViewers: mockBroadcastToViewers,
+    endSharedSession: async () => {},
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    clearPushPendingQuestion: async () => {},
+    deleteRunnerAssociation: async () => {},
+}));
+
+mock.module("./event-pipeline.js", () => ({
+    pendingChunkedStates: new Map(),
+    enqueueSessionEvent: async (_id: string, fn: () => Promise<void>) => fn(),
+}));
+
+mock.module("./ack-tracker.js", () => ({ socketAckedSeqs: new Map() }));
+mock.module("./thinking-tracker.js", () => ({ clearThinkingMaps: () => {} }));
+mock.module("./viewer-gate.js", () => ({ forgetViewerGate: () => {} }));
+mock.module("../../../health.js", () => ({ shouldPreserveOnSocketDisconnect: () => false }));
+mock.module("../../../user-preferences.js", () => ({
+    getUserPreference: async () => null,
+    PREF_SUBAGENT_MODEL: "subagent_model",
+}));
+
+afterAll(() => mock.restore());
+
+const { registerSessionLifecycleHandlers } = await import("./session-lifecycle.js");
+
+function makeSocket(sessionId: string, token = "tok") {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const socket = {
+        id: "sock-1",
+        data: { sessionId, token } as Record<string, unknown>,
+        on(event: string, cb: (...args: unknown[]) => unknown) {
+            handlers.set(event, cb);
+        },
+        emit: () => {},
+    } as never;
+    const fire = (event: string, data?: unknown) => handlers.get(event)!(data);
+    return { socket, fire };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("exec_result forwarding", () => {
+    beforeEach(() => {
+        broadcasts.length = 0;
+        mockBroadcastToViewers.mockClear();
+    });
+
+    it("stamps sessionId onto the broadcast payload", async () => {
+        const { socket, fire } = makeSocket("sess-A");
+        registerSessionLifecycleHandlers(socket, {} as never);
+
+        // Register the session so socket.data.sessionId is populated
+        await fire("register", { sessionId: "sess-A", token: "tok", cwd: "/", shareUrl: "" });
+
+        const payload = { id: "req-1", ok: true, command: "list_resume_sessions", result: [] };
+        fire("exec_result", payload);
+
+        expect(mockBroadcastToViewers).toHaveBeenCalledTimes(1);
+        const [broadcastedSessionId, event, data] = mockBroadcastToViewers.mock.calls[0] as [string, string, unknown];
+        expect(broadcastedSessionId).toBe("sess-A");
+        expect(event).toBe("exec_result");
+        // sessionId must be stamped
+        expect((data as Record<string, unknown>).sessionId).toBe("sess-A");
+        // original fields preserved
+        expect((data as Record<string, unknown>).id).toBe("req-1");
+        expect((data as Record<string, unknown>).command).toBe("list_resume_sessions");
+    });
+
+    it("does not forward if socket has no sessionId", () => {
+        const { socket, fire } = makeSocket("sess-B");
+        socket.data.sessionId = undefined; // simulate unregistered
+        registerSessionLifecycleHandlers(socket, {} as never);
+
+        fire("exec_result", { id: "req-2", ok: false, command: "get_fork_messages", error: "no" });
+
+        expect(mockBroadcastToViewers).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -5,6 +5,7 @@
 // ============================================================================
 
 import { afterAll, describe, it, expect, mock, beforeEach } from "bun:test";
+import type { RelaySocket } from "./types.js";
 
 // ── Captures ──────────────────────────────────────────────────────────────────
 
@@ -54,16 +55,16 @@ afterAll(() => mock.restore());
 
 const { registerSessionLifecycleHandlers } = await import("./session-lifecycle.js");
 
-function makeSocket(sessionId: string, token = "tok") {
+function makeSocket(sessionId: string | undefined, token = "tok") {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const socket = {
         id: "sock-1",
-        data: { sessionId, token } as Record<string, unknown>,
+        data: { sessionId, token },
         on(event: string, cb: (...args: unknown[]) => unknown) {
             handlers.set(event, cb);
         },
         emit: () => {},
-    } as never;
+    } as unknown as RelaySocket;
     const fire = (event: string, data?: unknown) => handlers.get(event)!(data);
     return { socket, fire };
 }
@@ -78,7 +79,7 @@ describe("exec_result forwarding", () => {
 
     it("stamps sessionId onto the broadcast payload", async () => {
         const { socket, fire } = makeSocket("sess-A");
-        registerSessionLifecycleHandlers(socket, {} as never);
+        registerSessionLifecycleHandlers(socket);
 
         // Register the session so socket.data.sessionId is populated
         await fire("register", { sessionId: "sess-A", token: "tok", cwd: "/", shareUrl: "" });
@@ -98,9 +99,8 @@ describe("exec_result forwarding", () => {
     });
 
     it("does not forward if socket has no sessionId", () => {
-        const { socket, fire } = makeSocket("sess-B");
-        socket.data.sessionId = undefined; // simulate unregistered
-        registerSessionLifecycleHandlers(socket, {} as never);
+        const { socket, fire } = makeSocket(undefined);
+        registerSessionLifecycleHandlers(socket);
 
         fire("exec_result", { id: "req-2", ok: false, command: "get_fork_messages", error: "no" });
 

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -110,7 +110,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
     socket.on("exec_result", (data) => {
         const sessionId = socket.data.sessionId;
         if (!sessionId) return;
-        broadcastToViewers(sessionId, "exec_result", data);
+        broadcastToViewers(sessionId, "exec_result", { ...data, sessionId });
     });
 
     // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/ui/src/App.stale-exec-result.test.ts
+++ b/packages/ui/src/App.stale-exec-result.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guard: exec_result events from a previous session must be dropped when
+ * the viewer has already switched to a new session.
+ *
+ * The relay stamps exec_result with the originating sessionId; App.tsx must
+ * reject any event whose sessionId != the currently-active session.
+ */
+describe("App stale exec_result session guard", () => {
+  const src = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
+
+  // Find the exec_result socket handler block.
+  const execResultBlock = (() => {
+    const start = src.indexOf('nextSocket.on("exec_result"');
+    const end = src.indexOf("});", start) + 3;
+    return src.slice(start, end);
+  })();
+
+  test("handler rejects exec_result when sessionId mismatches active session", () => {
+    // The guard must compare data.sessionId against the active session ref.
+    expect(execResultBlock).toMatch(/data\.sessionId.*!==.*activeSessionId/);
+  });
+
+  test("handler allows exec_result without sessionId (old relay compat)", () => {
+    // The guard must be conditional so legacy payloads (no sessionId) still pass.
+    // Pattern: `if (data.sessionId && data.sessionId !== ...)` — short-circuits on falsy.
+    expect(execResultBlock).toMatch(/data\.sessionId &&/);
+  });
+
+  test("handler still guards on awaitingSnapshot", () => {
+    expect(execResultBlock).toMatch(/awaitingSnapshot/);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3623,13 +3623,12 @@ export function App() {
       });
 
       nextSocket.on("exec_result", (data) => {
-        // Important: check generation to prevent exec_result events from old sessions
-        // being processed after a session switch. Unlike other events, exec_result doesn't
-        // always include generation data, so we also guard with a recent-switch check.
+        // Drop stale results from a previous session. The relay stamps every
+        // forwarded exec_result with the originating sessionId; if it doesn't
+        // match the active session, the event arrived late and must be ignored.
         if (!lifecycleRefs.activeSessionId.current) return;
-        // If we're in the initial phase of a session switch (awaiting snapshot), reject
-        // any exec_results that might be from the old session. We'll start accepting them
-        // once the "connected" event confirms we're synchronized with the new session.
+        if (data.sessionId && data.sessionId !== lifecycleRefs.activeSessionId.current) return;
+        // Also reject during snapshot acquisition — viewer isn't yet in sync.
         if (lifecycleRefs.awaitingSnapshot.current) return;
         lastViewerEventAtRef.current = Date.now();
         handleRelayEvent({ type: "exec_result", ...data });


### PR DESCRIPTION
Night Shift dish A2-011

## Problem
The relay broadcast `exec_result` without a `sessionId`. After a viewer switches from session A to B and B finishes hydration, a late `exec_result` from A could pass the `awaitingSnapshot` guard and mutate B's state.

## Fix
- **Protocol** (`packages/protocol/src/viewer.ts`): added optional `sessionId?: string` to `exec_result` viewer event
- **Relay** (`packages/server/src/ws/namespaces/relay/session-lifecycle.ts`): stamp `sessionId` into every `exec_result` envelope before broadcasting to viewers (`{ ...data, sessionId }`)
- **UI** (`packages/ui/src/App.tsx`): added guard `if (data.sessionId && data.sessionId !== activeSessionId.current) return` — drops events from a mismatched session; legacy payloads without `sessionId` pass through for backward compatibility

## Tests
- `packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts` — verifies stamp is applied and unregistered sockets don't broadcast
- `packages/ui/src/App.stale-exec-result.test.ts` — source-scan guards verify the sessionId check and backward-compat short-circuit are present

All 5 new tests pass. Typecheck errors are pre-existing (missing `redis`, `qrcode`, JSX types in root tsconfig).