### PR TITLE
fix: local TUI transition cleanup parity (A1-007)

### DIFF
--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -112,6 +112,126 @@ export interface LifecycleHandlerState {
     } | null;
 }
 
+/**
+ * Cleanup performed on every session transition (local-TUI non-startup
+ * session_start, or worker session_switch with reason "new"):
+ * clears stale child links, cancels pending triggers, and resets
+ * session-complete generation state.
+ *
+ * Exported so it can be called from the local-TUI session_start path and
+ * tested independently.
+ */
+export function performSessionTransitionCleanup({
+    state,
+    rctx,
+    triggerWaits,
+    delinkManager,
+    cancellationManager,
+    followUpGrace,
+}: Pick<LifecycleHandlersDeps, "state" | "rctx" | "triggerWaits" | "delinkManager" | "cancellationManager" | "followUpGrace">): void {
+    // ── Stale child / trigger cleanup ─────────────────────────────────────────
+    state.staleChildIds.clear();
+    for (const entry of receivedTriggers.values()) {
+        state.staleChildIds.add(entry.sourceSessionId);
+    }
+    for (const { childSessionId } of state.pendingCancellations) {
+        state.staleChildIds.add(childSessionId);
+    }
+
+    const { cancelled, sent, failed } = clearAndCancelPendingTriggers(
+        (confirmedTriggerId, confirmedChildSessionId) => {
+            const idx = state.pendingCancellations.findIndex(
+                (c) =>
+                    c.triggerId === confirmedTriggerId &&
+                    c.childSessionId === confirmedChildSessionId,
+            );
+            if (idx >= 0) {
+                state.pendingCancellations.splice(idx, 1);
+                log.info(
+                    `pizzapi: trigger cancellation confirmed for ${confirmedTriggerId} — removed from retry queue`,
+                );
+                if (state.pendingCancellations.length === 0) {
+                    cancellationManager.stopPendingCancellationRetryLoop();
+                }
+            }
+        },
+    );
+
+    if (cancelled > 0) {
+        log.info(
+            `pizzapi: cancelled ${cancelled} pending trigger(s) on session transition (${sent.length} sent-pending-ack, ${failed.length} deferred)`,
+        );
+    }
+
+    const allNeedingConfirmation = [...sent, ...failed];
+    if (allNeedingConfirmation.length > 0) {
+        state.pendingCancellations = [...state.pendingCancellations, ...allNeedingConfirmation];
+        for (const { childSessionId } of allNeedingConfirmation) {
+            state.staleChildIds.add(childSessionId);
+        }
+        if (rctx.relay && rctx.sioSocket?.connected) {
+            cancellationManager.startPendingCancellationRetryLoop();
+        }
+    }
+
+    // ── Unsubscribe from all active trigger subscriptions ─────────────────────
+    const sid = rctx.relaySessionId;
+    if (sid) {
+        listTriggerSubscriptions(sid)
+            .then(async (subs) => {
+                if (subs.length === 0) return;
+                log.info(`pizzapi: unsubscribing from ${subs.length} trigger subscription(s) on session transition`);
+                const results = await Promise.allSettled(
+                    subs.map((s) => unsubscribeTrigger(sid, { subscriptionId: s.subscriptionId, triggerType: s.triggerType })),
+                );
+                const failedSubs = results.filter(
+                    (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
+                );
+                if (failedSubs.length > 0) {
+                    log.info(`pizzapi: ${failedSubs.length} trigger unsubscribe(s) failed on session transition`);
+                }
+            })
+            .catch((err) => {
+                log.info(
+                    `pizzapi: trigger subscription cleanup failed on session transition: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            });
+    }
+
+    // ── Delink children ───────────────────────────────────────────────────────
+    const rawDelinkEpoch = Date.now();
+    state.pendingDelink = true;
+    state.pendingDelinkEpoch = rawDelinkEpoch;
+    delinkManager.clearPendingDelinkRetryTimer();
+    if (rctx.relay && rctx.sioSocket?.connected) {
+        delinkManager.emitDelinkChildren(rawDelinkEpoch);
+    }
+
+    if (rctx.isChildSession) {
+        const cancelledChild = triggerWaits.cancelAll("Session switched — parent link cleared.");
+        log.info(
+            `pizzapi: clearing own parent link on session transition${cancelledChild > 0 ? ` — cancelled ${cancelledChild} pending trigger wait(s)` : ""}`,
+        );
+        state.pendingDelinkOwnParent = true;
+        delinkManager.clearPendingDelinkOwnParentRetryTimer();
+        state.stalePrimaryParentId = rctx.parentSessionId;
+        if (rctx.relay && rctx.sioSocket?.connected) {
+            delinkManager.emitDelinkOwnParent();
+        }
+        rctx.parentSessionId = null;
+        rctx.isChildSession = false;
+        followUpGrace.clearFollowUpGrace();
+    }
+
+    // ── Session-complete generation state reset ───────────────────────────────
+    state.sessionCompleteFired = false;
+    state.sessionCompleteGeneration += 1;
+    state.pendingSessionCompleteDelivery = null;
+    state.pendingSessionCompleteSocket = null;
+    state.pendingSessionCompleteTransportGeneration = null;
+    state.lastSessionCompletePayload = null;
+}
+
 export interface LifecycleHandlersDeps {
     /** PiInstance (factory argument) — typed as any since the type is not publicly exported. */
     pi: any;
@@ -148,6 +268,14 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
         doDisconnect,
         clearCtx,
     } = deps;
+
+    // Local TUI (index.ts) fires session_start for /new, /resume, /fork.
+    // Worker (worker.ts) sets PIZZAPI_WORKER_CWD and emits session_switch manually.
+    // Use the env var to distinguish the two paths.
+    const localTuiTransitionCleanup = !process.env.PIZZAPI_WORKER_CWD;
+
+    // Counts session_start invocations so we skip cleanup on the first (startup).
+    let sessionStartCount = 0;
 
     // Session-local error-fired flag (not shared — only used inside agent_end/turn_start).
     let sessionErrorFired = false;
@@ -189,6 +317,14 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
     // ── Session lifecycle ─────────────────────────────────────────────────────
 
     pi.on("session_start", (_event: any, ctx: any) => {
+        sessionStartCount += 1;
+        // Local-TUI: /new, /resume, /fork fire session_start (not session_switch).
+        // Run the same transition cleanup as session_switch, but only for
+        // non-startup starts (sessionStartCount > 1). The worker path sets
+        // localTuiTransitionCleanup=false and emits session_switch itself.
+        if (localTuiTransitionCleanup && sessionStartCount > 1) {
+            performSessionTransitionCleanup({ state, rctx, triggerWaits, delinkManager, cancellationManager, followUpGrace });
+        }
         rctx.latestCtx = ctx;
         rctx.sessionStartedAt = Date.now();
         rctx.isAgentActive = false;
@@ -214,105 +350,16 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
         // ── /new cleanup: cancel pending triggers and delink children ─────────
         if (event.reason === "new") {
-            state.staleChildIds.clear();
-            for (const entry of receivedTriggers.values()) {
-                state.staleChildIds.add(entry.sourceSessionId);
-            }
-            for (const { childSessionId } of state.pendingCancellations) {
-                state.staleChildIds.add(childSessionId);
-            }
-
-            const { cancelled, sent, failed } = clearAndCancelPendingTriggers(
-                (confirmedTriggerId, confirmedChildSessionId) => {
-                    const idx = state.pendingCancellations.findIndex(
-                        (c) =>
-                            c.triggerId === confirmedTriggerId &&
-                            c.childSessionId === confirmedChildSessionId,
-                    );
-                    if (idx >= 0) {
-                        state.pendingCancellations.splice(idx, 1);
-                        log.info(
-                            `pizzapi: trigger cancellation confirmed for ${confirmedTriggerId} — removed from retry queue`,
-                        );
-                        if (state.pendingCancellations.length === 0) {
-                            cancellationManager.stopPendingCancellationRetryLoop();
-                        }
-                    }
-                },
-            );
-
-            if (cancelled > 0) {
-                log.info(
-                    `pizzapi: cancelled ${cancelled} pending trigger(s) on session switch (${sent.length} sent-pending-ack, ${failed.length} deferred)`,
-                );
-            }
-
-            const allNeedingConfirmation = [...sent, ...failed];
-            if (allNeedingConfirmation.length > 0) {
-                state.pendingCancellations = [...state.pendingCancellations, ...allNeedingConfirmation];
-                for (const { childSessionId } of allNeedingConfirmation) {
-                    state.staleChildIds.add(childSessionId);
-                }
-                if (rctx.relay && rctx.sioSocket?.connected) {
-                    cancellationManager.startPendingCancellationRetryLoop();
-                }
-            }
-
-            // ── Unsubscribe from all active trigger subscriptions ─────────────
-            const sid = rctx.relaySessionId;
-            if (sid) {
-                listTriggerSubscriptions(sid)
-                    .then(async (subs) => {
-                        if (subs.length === 0) return;
-                        log.info(`pizzapi: unsubscribing from ${subs.length} trigger subscription(s) on /new`);
-                        const results = await Promise.allSettled(
-                            subs.map((s) => unsubscribeTrigger(sid, { subscriptionId: s.subscriptionId, triggerType: s.triggerType })),
-                        );
-                        const failedSubs = results.filter(
-                            (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
-                        );
-                        if (failedSubs.length > 0) {
-                            log.info(`pizzapi: ${failedSubs.length} trigger unsubscribe(s) failed on /new`);
-                        }
-                    })
-                    .catch((err) => {
-                        log.info(
-                            `pizzapi: trigger subscription cleanup failed on /new: ${err instanceof Error ? err.message : String(err)}`,
-                        );
-                    });
-            }
-
-            const rawDelinkEpoch = Date.now();
-            state.pendingDelink = true;
-            state.pendingDelinkEpoch = rawDelinkEpoch;
-            delinkManager.clearPendingDelinkRetryTimer();
-            if (rctx.relay && rctx.sioSocket?.connected) {
-                delinkManager.emitDelinkChildren(rawDelinkEpoch);
-            }
-
-            if (rctx.isChildSession) {
-                const cancelledChild = triggerWaits.cancelAll("Session switched — parent link cleared.");
-                log.info(
-                    `pizzapi: clearing own parent link on /new${cancelledChild > 0 ? ` — cancelled ${cancelledChild} pending trigger wait(s)` : ""}`,
-                );
-                state.pendingDelinkOwnParent = true;
-                delinkManager.clearPendingDelinkOwnParentRetryTimer();
-                state.stalePrimaryParentId = rctx.parentSessionId;
-                if (rctx.relay && rctx.sioSocket?.connected) {
-                    delinkManager.emitDelinkOwnParent();
-                }
-                rctx.parentSessionId = null;
-                rctx.isChildSession = false;
-                followUpGrace.clearFollowUpGrace();
-            }
+            performSessionTransitionCleanup({ state, rctx, triggerWaits, delinkManager, cancellationManager, followUpGrace });
+        } else {
+            // For resume/fork: just reset session-complete state (no stale-child cleanup).
+            state.sessionCompleteFired = false;
+            state.sessionCompleteGeneration += 1;
+            state.pendingSessionCompleteDelivery = null;
+            state.pendingSessionCompleteSocket = null;
+            state.pendingSessionCompleteTransportGeneration = null;
+            state.lastSessionCompletePayload = null;
         }
-
-        state.sessionCompleteFired = false;
-        state.sessionCompleteGeneration += 1;
-        state.pendingSessionCompleteDelivery = null;
-        state.pendingSessionCompleteSocket = null;
-        state.pendingSessionCompleteTransportGeneration = null;
-        state.lastSessionCompletePayload = null;
 
         installFooter(rctx, ctx);
         startSessionNameSync();

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -274,9 +274,6 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
     // Use the env var to distinguish the two paths.
     const localTuiTransitionCleanup = !process.env.PIZZAPI_WORKER_CWD;
 
-    // Counts session_start invocations so we skip cleanup on the first (startup).
-    let sessionStartCount = 0;
-
     // Session-local error-fired flag (not shared — only used inside agent_end/turn_start).
     let sessionErrorFired = false;
     // Messages from the last agent_end, consumed by agent_settled. agent_end
@@ -316,13 +313,15 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     // ── Session lifecycle ─────────────────────────────────────────────────────
 
-    pi.on("session_start", (_event: any, ctx: any) => {
-        sessionStartCount += 1;
+    pi.on("session_start", (event: any, ctx: any) => {
         // Local-TUI: /new, /resume, /fork fire session_start (not session_switch).
-        // Run the same transition cleanup as session_switch, but only for
-        // non-startup starts (sessionStartCount > 1). The worker path sets
-        // localTuiTransitionCleanup=false and emits session_switch itself.
-        if (localTuiTransitionCleanup && sessionStartCount > 1) {
+        // Only run transition cleanup for real transitions — skip "startup" (first
+        // load) and "reload" (/restart, /skills reload, plugin-change reloads).
+        // Reason gate is the primary discriminator; localTuiTransitionCleanup
+        // ensures worker path (which drives transitions via session_switch) never
+        // double-cleans even if PIZZAPI_WORKER_CWD is unset.
+        const isTransitionReason = event?.reason === "new" || event?.reason === "resume" || event?.reason === "fork";
+        if (localTuiTransitionCleanup && isTransitionReason) {
             performSessionTransitionCleanup({ state, rctx, triggerWaits, delinkManager, cancellationManager, followUpGrace });
         }
         rctx.latestCtx = ctx;

--- a/packages/cli/src/extensions/remote/local-tui-lifecycle-parity.test.ts
+++ b/packages/cli/src/extensions/remote/local-tui-lifecycle-parity.test.ts
@@ -166,31 +166,30 @@ describe("local-TUI transition cleanup parity", () => {
             state.pendingCancellations.push({ triggerId: "t1", childSessionId: "child-a" });
             const genBefore = state.sessionCompleteGeneration;
 
-            sessionStart({}, minimalCtx);
+            sessionStart({ reason: "startup" }, minimalCtx);
 
             // First session_start must NOT clear stale state
             expect(state.staleChildIds.has("child-session-old")).toBe(true);
             expect(state.pendingCancellations).toHaveLength(1);
             // session-complete generation must NOT be bumped by cleanup
-            // (no cleanup ran; session_start itself doesn't bump it)
             expect(state.sessionCompleteGeneration).toBe(genBefore);
         });
 
-        test("second session_start DOES clear stale child links and reset session-complete state", () => {
+        test("session_start with reason:new DOES clear stale child links and reset session-complete state", () => {
             delete process.env.PIZZAPI_WORKER_CWD;
             const { handlers, state } = makeMinimalDeps();
             const sessionStart = handlers.get("session_start")!;
 
-            // First (startup) call
-            sessionStart({}, minimalCtx);
+            // Startup
+            sessionStart({ reason: "startup" }, minimalCtx);
 
             // Seed stale state to verify cleanup
             state.staleChildIds.add("child-stale");
             state.sessionCompleteFired = true;
             const genBefore = state.sessionCompleteGeneration;
 
-            // Second call (transition: /new, /resume, /fork)
-            sessionStart({}, minimalCtx);
+            // Transition: /new
+            sessionStart({ reason: "new" }, minimalCtx);
 
             expect(state.staleChildIds.has("child-stale")).toBe(false);
             expect(state.pendingDelink).toBe(true);
@@ -198,23 +197,68 @@ describe("local-TUI transition cleanup parity", () => {
             expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
         });
 
-        test("third session_start also cleans (every subsequent start is a transition)", () => {
+        test("session_start with reason:resume and reason:fork also clean", () => {
             delete process.env.PIZZAPI_WORKER_CWD;
             const { handlers, state } = makeMinimalDeps();
             const sessionStart = handlers.get("session_start")!;
 
-            sessionStart({}, minimalCtx); // startup
-            sessionStart({}, minimalCtx); // transition 1
+            sessionStart({ reason: "startup" }, minimalCtx);
 
-            state.staleChildIds.add("child-2");
+            state.staleChildIds.add("child-resume");
             state.sessionCompleteFired = true;
+            let genBefore = state.sessionCompleteGeneration;
+
+            sessionStart({ reason: "resume" }, minimalCtx);
+            expect(state.staleChildIds.has("child-resume")).toBe(false);
+            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+
+            state.staleChildIds.add("child-fork");
+            state.sessionCompleteFired = true;
+            genBefore = state.sessionCompleteGeneration;
+
+            sessionStart({ reason: "fork" }, minimalCtx);
+            expect(state.staleChildIds.has("child-fork")).toBe(false);
+            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+        });
+
+        test("session_start with reason:reload does NOT clean (regression guard)", () => {
+            delete process.env.PIZZAPI_WORKER_CWD;
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            sessionStart({ reason: "startup" }, minimalCtx);
+
+            // Simulate in-flight child state that must survive a /reload
+            state.staleChildIds.add("child-in-flight");
+            state.pendingCancellations.push({ triggerId: "t-reload", childSessionId: "child-in-flight" });
             const genBefore = state.sessionCompleteGeneration;
 
-            sessionStart({}, minimalCtx); // transition 2
+            // /reload fires session_start with reason:"reload"
+            sessionStart({ reason: "reload" }, minimalCtx);
 
-            expect(state.staleChildIds.has("child-2")).toBe(false);
-            expect(state.sessionCompleteFired).toBe(false);
-            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+            // Must NOT be cleaned
+            expect(state.staleChildIds.has("child-in-flight")).toBe(true);
+            expect(state.pendingCancellations).toHaveLength(1);
+            expect(state.sessionCompleteGeneration).toBe(genBefore);
+        });
+
+        test("session_start with reason:startup after a transition does NOT clean", () => {
+            delete process.env.PIZZAPI_WORKER_CWD;
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            // Startup then a real transition
+            sessionStart({ reason: "startup" }, minimalCtx);
+            sessionStart({ reason: "new" }, minimalCtx);
+
+            state.staleChildIds.add("child-should-survive");
+            const genBefore = state.sessionCompleteGeneration;
+
+            // Another startup-reason (shouldn't happen in practice, but must be safe)
+            sessionStart({ reason: "startup" }, minimalCtx);
+
+            expect(state.staleChildIds.has("child-should-survive")).toBe(true);
+            expect(state.sessionCompleteGeneration).toBe(genBefore);
         });
     });
 
@@ -224,13 +268,13 @@ describe("local-TUI transition cleanup parity", () => {
             const { handlers, state } = makeMinimalDeps();
             const sessionStart = handlers.get("session_start")!;
 
-            sessionStart({}, minimalCtx); // startup
+            sessionStart({ reason: "startup" }, minimalCtx);
 
             state.staleChildIds.add("child-stale");
             state.sessionCompleteFired = true;
             const genBefore = state.sessionCompleteGeneration;
 
-            sessionStart({}, minimalCtx); // second call — should NOT clean
+            sessionStart({ reason: "new" }, minimalCtx); // second call — should NOT clean (worker path)
 
             expect(state.staleChildIds.has("child-stale")).toBe(true);
             expect(state.sessionCompleteFired).toBe(true);
@@ -244,7 +288,7 @@ describe("local-TUI transition cleanup parity", () => {
             const sessionSwitch = handlers.get("session_switch")!;
 
             // Worker fires session_start first (pi's native event)
-            sessionStart({}, minimalCtx);
+            sessionStart({ reason: "startup" }, minimalCtx);
 
             state.staleChildIds.add("child-stale");
             state.sessionCompleteFired = true;

--- a/packages/cli/src/extensions/remote/local-tui-lifecycle-parity.test.ts
+++ b/packages/cli/src/extensions/remote/local-tui-lifecycle-parity.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for local-TUI transition cleanup parity (A1-007).
+ *
+ * Local TUI: pi fires session_start for /new, /resume, /fork.
+ * Worker: emits session_switch manually — must NOT double-clean.
+ *
+ * Verifies:
+ *  1. Startup (first) session_start does NOT clean stale child state.
+ *  2. A subsequent session_start DOES clean (stale child links / trigger
+ *     cancels cleared, session-complete state reset).
+ *  3. Worker path (localTuiTransitionCleanup=false) — session_start never
+ *     cleans; session_switch (reason:"new") still cleans exactly once.
+ */
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { LifecycleHandlerState } from "./lifecycle-handlers.js";
+import type { RelayContext } from "../remote-types.js";
+
+// ── Module mocks (must appear before any local import of the mocked modules) ──
+
+// Stub out heavy chunked-delivery internals — session_active shape is not
+// what this test verifies; we only care about state side-effects.
+mock.module("./chunked-delivery.js", () => ({
+    emitSessionActive: () => {},
+    emitSessionMetadataUpdate: () => {},
+}));
+
+mock.module("../triggers/extension.js", () => ({
+    clearAndCancelPendingTriggers: (_cb: any) => ({ cancelled: 0, sent: [], failed: [] }),
+    receivedTriggers: new Map(),
+}));
+
+mock.module("../trigger-client.js", () => ({
+    listTriggerSubscriptions: async (_sid: string) => [],
+    unsubscribeTrigger: async () => ({ ok: true }),
+}));
+
+// Mocked after module mocks are registered:
+import { registerLifecycleHandlers } from "./lifecycle-handlers.js";
+import { createFollowUpGrace } from "./followup-grace.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeState(): LifecycleHandlerState {
+    return {
+        staleChildIds: new Set(),
+        pendingDelink: false,
+        pendingDelinkEpoch: null,
+        pendingDelinkOwnParent: false,
+        stalePrimaryParentId: null,
+        pendingCancellations: [],
+        sessionCompleteFired: false,
+        sessionCompleteGeneration: 0,
+        sessionCompleteTransportGeneration: 0,
+        sessionCompleteRetryTimer: null,
+        pendingSessionCompleteDelivery: null,
+        pendingSessionCompleteSocket: null,
+        pendingSessionCompleteTransportGeneration: null,
+        lastSessionCompletePayload: null,
+    };
+}
+
+function makeRctx(overrides: Partial<RelayContext> = {}): RelayContext {
+    const pi: any = {
+        on: () => {},
+        events: { on: () => {} },
+        registerTool: () => {},
+        registerCommand: () => {},
+    };
+    return {
+        pi,
+        isChildSession: false,
+        parentSessionId: null,
+        relay: null,
+        sioSocket: null,
+        isAgentActive: false,
+        isAgentSettling: false,
+        lastRetryableError: null,
+        wasAborted: false,
+        shuttingDown: false,
+        forwardEvent: mock(() => {}),
+        buildHeartbeat: () => ({ type: "heartbeat", ts: Date.now() }),
+        buildCapabilitiesState: () => ({}),
+        setRelayStatus: () => {},
+        disconnectedStatusText: () => "Not connected",
+        emitSessionActive: () => {},
+        relaySessionId: null,
+        apiKey: () => null,
+        relayUrl: () => "",
+        pendingAskUserQuestion: null,
+        getCurrentThinkingLevel: () => null,
+        relayStatusText: "",
+        ...overrides,
+    } as unknown as RelayContext;
+}
+
+function makeMinimalDeps() {
+    const handlers = new Map<string, (event: any, ctx: any) => void>();
+    const pi: any = {
+        on: (name: string, fn: any) => handlers.set(name, fn),
+        events: { on: () => {} },
+        registerTool: () => {},
+        registerCommand: () => {},
+    };
+    const state = makeState();
+    const rctx = makeRctx();
+    const followUpGrace = createFollowUpGrace(rctx, state as any);
+
+    const delinkManager: any = {
+        clearPendingDelinkRetryTimer: () => {},
+        clearPendingDelinkOwnParentRetryTimer: () => {},
+        emitDelinkChildren: () => {},
+        emitDelinkOwnParent: () => {},
+    };
+    const cancellationManager: any = {
+        stopPendingCancellationRetryLoop: () => {},
+        startPendingCancellationRetryLoop: () => {},
+    };
+    const triggerWaits: any = { cancelAll: () => 0 };
+
+    registerLifecycleHandlers({
+        pi,
+        rctx,
+        state,
+        triggerWaits,
+        delinkManager,
+        cancellationManager,
+        followUpGrace,
+        startSessionNameSync: () => {},
+        stopSessionNameSync: () => {},
+        doConnect: () => {},
+        doDisconnect: () => {},
+        clearCtx: () => {},
+    });
+
+    return { handlers, state, rctx, pi };
+}
+
+const minimalCtx = {
+    hasPendingMessages: () => false,
+    shutdown: () => {},
+    ui: { notify: () => {}, setFooter: () => ({}) },
+    model: null,
+    sessionManager: { getSessionName: () => null },
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("local-TUI transition cleanup parity", () => {
+    const originalWorkerCwd = process.env.PIZZAPI_WORKER_CWD;
+    afterEach(() => {
+        // Restore env so worker tests don't pollute local-TUI tests and vice versa.
+        if (originalWorkerCwd === undefined) {
+            delete process.env.PIZZAPI_WORKER_CWD;
+        } else {
+            process.env.PIZZAPI_WORKER_CWD = originalWorkerCwd;
+        }
+    });
+    describe("localTuiTransitionCleanup = true (local TUI path)", () => {
+        test("startup (first) session_start does NOT clean stale state", () => {
+            delete process.env.PIZZAPI_WORKER_CWD;
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            // Pre-seed some stale child IDs and pending cancellations
+            state.staleChildIds.add("child-session-old");
+            state.pendingCancellations.push({ triggerId: "t1", childSessionId: "child-a" });
+            const genBefore = state.sessionCompleteGeneration;
+
+            sessionStart({}, minimalCtx);
+
+            // First session_start must NOT clear stale state
+            expect(state.staleChildIds.has("child-session-old")).toBe(true);
+            expect(state.pendingCancellations).toHaveLength(1);
+            // session-complete generation must NOT be bumped by cleanup
+            // (no cleanup ran; session_start itself doesn't bump it)
+            expect(state.sessionCompleteGeneration).toBe(genBefore);
+        });
+
+        test("second session_start DOES clear stale child links and reset session-complete state", () => {
+            delete process.env.PIZZAPI_WORKER_CWD;
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            // First (startup) call
+            sessionStart({}, minimalCtx);
+
+            // Seed stale state to verify cleanup
+            state.staleChildIds.add("child-stale");
+            state.sessionCompleteFired = true;
+            const genBefore = state.sessionCompleteGeneration;
+
+            // Second call (transition: /new, /resume, /fork)
+            sessionStart({}, minimalCtx);
+
+            expect(state.staleChildIds.has("child-stale")).toBe(false);
+            expect(state.pendingDelink).toBe(true);
+            expect(state.sessionCompleteFired).toBe(false);
+            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+        });
+
+        test("third session_start also cleans (every subsequent start is a transition)", () => {
+            delete process.env.PIZZAPI_WORKER_CWD;
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            sessionStart({}, minimalCtx); // startup
+            sessionStart({}, minimalCtx); // transition 1
+
+            state.staleChildIds.add("child-2");
+            state.sessionCompleteFired = true;
+            const genBefore = state.sessionCompleteGeneration;
+
+            sessionStart({}, minimalCtx); // transition 2
+
+            expect(state.staleChildIds.has("child-2")).toBe(false);
+            expect(state.sessionCompleteFired).toBe(false);
+            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+        });
+    });
+
+    describe("localTuiTransitionCleanup = false (worker path)", () => {
+        test("session_start never triggers cleanup, regardless of call count", () => {
+            process.env.PIZZAPI_WORKER_CWD = "/tmp/worker-cwd";
+            const { handlers, state } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+
+            sessionStart({}, minimalCtx); // startup
+
+            state.staleChildIds.add("child-stale");
+            state.sessionCompleteFired = true;
+            const genBefore = state.sessionCompleteGeneration;
+
+            sessionStart({}, minimalCtx); // second call — should NOT clean
+
+            expect(state.staleChildIds.has("child-stale")).toBe(true);
+            expect(state.sessionCompleteFired).toBe(true);
+            expect(state.sessionCompleteGeneration).toBe(genBefore);
+        });
+
+        test("session_switch with reason:new cleans exactly once (no double-clean)", () => {
+            process.env.PIZZAPI_WORKER_CWD = "/tmp/worker-cwd";
+            const { handlers, state, rctx } = makeMinimalDeps();
+            const sessionStart = handlers.get("session_start")!;
+            const sessionSwitch = handlers.get("session_switch")!;
+
+            // Worker fires session_start first (pi's native event)
+            sessionStart({}, minimalCtx);
+
+            state.staleChildIds.add("child-stale");
+            state.sessionCompleteFired = true;
+            const genBefore = state.sessionCompleteGeneration;
+
+            // Worker then emits session_switch manually
+            sessionSwitch({ reason: "new" }, minimalCtx);
+
+            // Cleanup ran exactly once (from session_switch)
+            expect(state.staleChildIds.has("child-stale")).toBe(false);
+            expect(state.pendingDelink).toBe(true);
+            expect(state.sessionCompleteFired).toBe(false);
+            // sessionCompleteGeneration bumped once by performSessionTransitionCleanup
+            expect(state.sessionCompleteGeneration).toBe(genBefore + 1);
+        });
+    });
+});

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -218,7 +218,8 @@ export function spawnSession(
         // command's detached group-leader PID, so the daemon can enumerate and
         // kill background processes that escaped the worker's own process group.
         PIZZAPI_SESSION_PROC_FILE: sessionProcFilePath(sessionId),
-        ...(requestedCwd ? { PIZZAPI_WORKER_CWD: requestedCwd } : {}),
+        // ponytail: always set so any worker is distinguishable from local-TUI
+        PIZZAPI_WORKER_CWD: requestedCwd || process.cwd(),
         // Initial prompt and model for the new session (set by spawn_session tool).
         ...(options?.prompt ? { PIZZAPI_WORKER_INITIAL_PROMPT: options.prompt } : {}),
         ...(options?.imageUrls && options.imageUrls.length > 0


### PR DESCRIPTION
Night Shift dish A1-007

## What changed

**:**
- Extracted the  cleanup (stale child links, pending trigger cancellations, session-complete generation reset) into a reusable exported function .
- Added local-TUI detection via  (the worker always sets this). When in local-TUI mode, a  counter tracks invocations and runs the cleanup on every non-startup  (count > 1).
- Refactored the  handler to call  for , removing duplicated code. For resume/fork, it still only resets session-complete state (no stale-child cleanup, matching existing behavior).

**** (new):
- Proves startup  does NOT clean.
- Proves subsequent  DOES clean (stale child links cleared, session-complete state reset).
- Proves worker path ( set) is unaffected by  — cleanup only via .

## No double-clean in worker path
Worker sets  →  →  is a no-op for cleanup. Worker still fires  manually as before.

## Files changed (within scope fence)
- 
- 