### PR TITLE
feat: separate tunnel-token signing from auth (B-005)

### DIFF
--- a/packages/docs/src/content/docs/features/tunnels.mdx
+++ b/packages/docs/src/content/docs/features/tunnels.mdx
@@ -253,6 +253,9 @@ Close an active tunnel and stop proxying traffic to the local port.
 The relay enforces several security measures:
 
 - **Auth-only access** — every tunnel request requires a valid session cookie or API key, or a short-lived signed path token minted by the runner/session owner for mobile/cross-origin iframe access.
+- **Dedicated signing secret** — tunnel tokens are signed with `PIZZAPI_TUNNEL_TOKEN_SECRET` (distinct from the Better Auth session secret). When unset, the relay falls back to `BETTER_AUTH_SECRET` so unconfigured deployments keep working. Set it to allow independent rotation: rotating the tunnel secret does not invalidate existing auth sessions.
+  - **Key rotation** — set `PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS` to the old secret; tokens signed by it are still accepted until their natural 1-hour TTL expires, then the env var can be removed.
+- **Token claims** — every token carries `aud` (`pizzapi:tunnel`), `iat` (issued-at), `kid` (key identifier derived from the active secret), and `exp`. On verify: `aud`, `kid`, and `exp` are all enforced. A token whose `kid` does not match the active key (or the previous key, if configured) is rejected outright.
 - **Owner verification** — the caller's user ID must match the session/runner owner.
 - **Header stripping** — `Cookie`, `Authorization`, `X-API-Key`, and `Referer` headers are never forwarded to the local service, preventing auth-leakage to tunneled apps.
 - **Query param sanitization** — `apiKey` and `tunnelToken` query parameters are stripped before forwarding.

--- a/packages/server/src/routes/tunnel-token.test.ts
+++ b/packages/server/src/routes/tunnel-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test, beforeEach, afterEach } from "bun:test";
 import { createTestAuthContext, runWithAuthContext } from "../auth.js";
 
 const mockGetActiveRelaySessionUserId = mock(
@@ -23,10 +23,29 @@ const {
     getAuthTunnelBasePath,
     verifyTunnelToken,
     assertTunnelTokenStillValid,
+    TUNNEL_TOKEN_AUD,
 } = await import("./tunnel-token.js");
 
-describe("tunnel token", () => {
-    test("creates scoped signed path tokens", () => {
+// Helpers to manipulate env vars during a test
+function withEnv(vars: Record<string, string | undefined>, fn: () => void): void {
+    const saved: Record<string, string | undefined> = {};
+    for (const [k, v] of Object.entries(vars)) {
+        saved[k] = process.env[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    try {
+        fn();
+    } finally {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+    }
+}
+
+describe("tunnel token — basic sign/verify", () => {
+    test("creates scoped signed path tokens with v2 claims", () => {
         const ctx = createTestAuthContext({ dbPath: ":memory:" });
         runWithAuthContext(ctx, () => {
             const { token, expiresAt } = createTunnelToken(
@@ -44,11 +63,14 @@ describe("tunnel token", () => {
                 userId: "u-1",
                 sessionId: "s-1",
                 port: 3000,
+                aud: TUNNEL_TOKEN_AUD,
             });
+            expect(typeof payload?.iat).toBe("number");
+            expect(typeof payload?.kid).toBe("string");
         });
     });
 
-    test("rejects tampered and expired tokens", () => {
+    test("rejects tampered tokens", () => {
         const ctx = createTestAuthContext({ dbPath: ":memory:" });
         runWithAuthContext(ctx, () => {
             const { token } = createTunnelToken(
@@ -56,7 +78,151 @@ describe("tunnel token", () => {
                 1_000,
             );
             expect(verifyTunnelToken(`${token}x`, 1_000)).toBeNull();
+        });
+    });
+
+    test("rejects expired tokens", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            const { token } = createTunnelToken(
+                { userId: "u-1", sessionId: "s-1", port: 3000 },
+                1_000,
+            );
             expect(verifyTunnelToken(token, 3_601_000)).toBeNull();
+        });
+    });
+});
+
+describe("tunnel token — dedicated secret", () => {
+    test("signs with PIZZAPI_TUNNEL_TOKEN_SECRET when set", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-aaaaaaaaaaaaaaaaaaaaaa" });
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: "tunnel-secret-bbbbbbbbbbbbbbbbbbbb" }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+                // Verifies with tunnel secret
+                expect(verifyTunnelToken(token, 1_000)).not.toBeNull();
+            });
+        });
+    });
+
+    test("falls back to auth secret when PIZZAPI_TUNNEL_TOKEN_SECRET is unset", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-fallback-aaaaaaaaaaaaa" });
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: undefined }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+                expect(verifyTunnelToken(token, 1_000)).not.toBeNull();
+            });
+        });
+    });
+
+    test("token minted with auth secret is rejected when a different dedicated secret is active", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-cccccccccccccccccccc" });
+
+        // Mint with auth secret (no dedicated secret)
+        let mintedToken: string;
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: undefined, PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+                mintedToken = token;
+            });
+        });
+
+        // Verify with a completely different dedicated secret (no previous set)
+        withEnv({
+            PIZZAPI_TUNNEL_TOKEN_SECRET: "dedicated-secret-dddddddddddddddddddd",
+            PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined,
+        }, () => {
+            runWithAuthContext(ctx, () => {
+                // The auth-secret-minted token has no kid, so it goes through the
+                // legacy path and is verified against the current dedicated secret —
+                // which differs from auth secret. It should be rejected.
+                expect(verifyTunnelToken(mintedToken!, 1_000)).toBeNull();
+            });
+        });
+    });
+});
+
+describe("tunnel token — aud validation", () => {
+    test("rejects token with wrong aud", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:" });
+        runWithAuthContext(ctx, () => {
+            // Manually construct a token with a bad aud
+            const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+            // Decode, tamper aud, re-sign with same secret
+            const [encoded] = token.split(".");
+            const payload = JSON.parse(Buffer.from(encoded!, "base64url").toString("utf8"));
+            payload.aud = "evil:audience";
+            const tamperedEncoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+            // Signature will not match tamperedEncoded — so this tests both paths
+            const tamperedToken = `${tamperedEncoded}.${token.split(".")[1]}`;
+            expect(verifyTunnelToken(tamperedToken, 1_000)).toBeNull();
+        });
+    });
+});
+
+describe("tunnel token — kid validation", () => {
+    test("rejects token with mismatched kid when no previous secret", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-aaaaaaaaaaaaaaaaaaaaaa" });
+        withEnv({
+            PIZZAPI_TUNNEL_TOKEN_SECRET: "secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined,
+        }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+
+                // Now switch to a different active secret (no previous)
+                withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: "secret-B-bbbbbbbbbbbbbbbbbbbbbbbbbbb" }, () => {
+                    // kid won't match either current or previous → rejected
+                    expect(verifyTunnelToken(token, 1_000)).toBeNull();
+                });
+            });
+        });
+    });
+});
+
+describe("tunnel token — rotation (previous secret)", () => {
+    test("accepts token signed by previous secret during rotation window", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-aaaaaaaaaaaaaaaaaaaaaa" });
+
+        const oldSecret = "old-secret-cccccccccccccccccccccccccccc";
+        const newSecret = "new-secret-dddddddddddddddddddddddddddd";
+
+        // Mint with old secret
+        let oldToken: string;
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: oldSecret, PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+                oldToken = token;
+            });
+        });
+
+        // Verify with new secret + old as previous → accepted
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: newSecret, PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: oldSecret }, () => {
+            runWithAuthContext(ctx, () => {
+                expect(verifyTunnelToken(oldToken!, 1_000)).not.toBeNull();
+            });
+        });
+    });
+
+    test("rejects previous-key token once previous secret is removed", () => {
+        const ctx = createTestAuthContext({ dbPath: ":memory:", secret: "auth-secret-aaaaaaaaaaaaaaaaaaaaaa" });
+
+        const oldSecret = "old-secret-eeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        const newSecret = "new-secret-ffffffffffffffffffffffffffff";
+
+        let oldToken: string;
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: oldSecret, PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined }, () => {
+            runWithAuthContext(ctx, () => {
+                const { token } = createTunnelToken({ userId: "u-1", sessionId: "s-1", port: 3000 }, 1_000);
+                oldToken = token;
+            });
+        });
+
+        // Verify with new secret only (no previous) → kid mismatch → rejected
+        withEnv({ PIZZAPI_TUNNEL_TOKEN_SECRET: newSecret, PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS: undefined }, () => {
+            runWithAuthContext(ctx, () => {
+                expect(verifyTunnelToken(oldToken!, 1_000)).toBeNull();
+            });
         });
     });
 });

--- a/packages/server/src/routes/tunnel-token.ts
+++ b/packages/server/src/routes/tunnel-token.ts
@@ -1,9 +1,12 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { getAuthContext } from "../auth.js";
 import { getActiveRelaySessionUserId } from "../sessions/store.js";
 import { getRunnerData } from "../ws/sio-registry.js";
 
 export const TUNNEL_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+/** Stable audience claim for all tunnel tokens. */
+export const TUNNEL_TOKEN_AUD = "pizzapi:tunnel";
 
 export interface TunnelTokenPayload {
     v: 1;
@@ -11,6 +14,10 @@ export interface TunnelTokenPayload {
     sessionId: string;
     port: number;
     exp: number;
+    // v2 claims — absent on legacy tokens signed before this change
+    aud?: string;
+    iat?: number;
+    kid?: string;
 }
 
 function base64url(input: string): string {
@@ -25,26 +32,67 @@ function unbase64url(input: string): string | null {
     }
 }
 
-function sign(encodedPayload: string): string {
-    return createHmac("sha256", getAuthContext().config.secret).update(encodedPayload).digest("base64url");
+/**
+ * Derive a short key-id from a secret so callers can route to the right key
+ * without transmitting the secret. Uses first 8 hex chars of SHA256.
+ */
+function deriveKid(secret: string): string {
+    return createHash("sha256").update(secret, "utf8").digest("hex").slice(0, 8);
 }
 
-export function createTunnelToken(input: { userId: string; sessionId: string; port: number }, nowMs = Date.now()): { token: string; expiresAt: string } {
+/**
+ * Dedicated tunnel-token signing secret.
+ * Set PIZZAPI_TUNNEL_TOKEN_SECRET to isolate tunnel tokens from Better Auth
+ * session secrets. Falls back to the Better Auth secret when unset so
+ * unconfigured deploys keep working without code changes.
+ *
+ * Rotation: set PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS to the old secret;
+ * tokens signed with it are still accepted until they expire (up to 1 h).
+ */
+function getTunnelSecret(): string {
+    return process.env.PIZZAPI_TUNNEL_TOKEN_SECRET ?? getAuthContext().config.secret;
+}
+
+function getPreviousSecret(): string | null {
+    return process.env.PIZZAPI_TUNNEL_TOKEN_SECRET_PREVIOUS ?? null;
+}
+
+function signPayload(encodedPayload: string, secret: string): string {
+    return createHmac("sha256", secret).update(encodedPayload).digest("base64url");
+}
+
+function signaturesMatch(actual: string, expected: string): boolean {
+    const a = Buffer.from(actual);
+    const e = Buffer.from(expected);
+    return a.length === e.length && timingSafeEqual(a, e);
+}
+
+export function createTunnelToken(
+    input: { userId: string; sessionId: string; port: number },
+    nowMs = Date.now(),
+): { token: string; expiresAt: string } {
+    const secret = getTunnelSecret();
     const exp = Math.floor((nowMs + TUNNEL_TOKEN_TTL_MS) / 1000);
-    const payload: TunnelTokenPayload = { v: 1, userId: input.userId, sessionId: input.sessionId, port: input.port, exp };
+    const iat = Math.floor(nowMs / 1000);
+    const kid = deriveKid(secret);
+    const payload: TunnelTokenPayload = {
+        v: 1,
+        userId: input.userId,
+        sessionId: input.sessionId,
+        port: input.port,
+        exp,
+        aud: TUNNEL_TOKEN_AUD,
+        iat,
+        kid,
+    };
     const encodedPayload = base64url(JSON.stringify(payload));
-    const signature = sign(encodedPayload);
+    const signature = signPayload(encodedPayload, secret);
     return { token: `${encodedPayload}.${signature}`, expiresAt: new Date(exp * 1000).toISOString() };
 }
 
 export function verifyTunnelToken(token: string, nowMs = Date.now()): TunnelTokenPayload | null {
     const [encodedPayload, signature, extra] = token.split(".");
     if (!encodedPayload || !signature || extra !== undefined) return null;
-
-    const expected = sign(encodedPayload);
-    const actualBuf = Buffer.from(signature);
-    const expectedBuf = Buffer.from(expected);
-    if (actualBuf.length !== expectedBuf.length || !timingSafeEqual(actualBuf, expectedBuf)) return null;
 
     const rawPayload = unbase64url(encodedPayload);
     if (!rawPayload) return null;
@@ -54,6 +102,41 @@ export function verifyTunnelToken(token: string, nowMs = Date.now()): TunnelToke
         payload = JSON.parse(rawPayload) as TunnelTokenPayload;
     } catch {
         return null;
+    }
+
+    const secret = getTunnelSecret();
+    const prevSecret = getPreviousSecret();
+
+    let verified = false;
+
+    if (payload.kid) {
+        // v2 path: match by kid, then verify signature with the matching key.
+        const currentKid = deriveKid(secret);
+        if (payload.kid === currentKid) {
+            verified = signaturesMatch(signature, signPayload(encodedPayload, secret));
+        } else if (prevSecret) {
+            const prevKid = deriveKid(prevSecret);
+            if (payload.kid === prevKid) {
+                // ponytail: previous-key window; tokens accepted until their own exp
+                verified = signaturesMatch(signature, signPayload(encodedPayload, prevSecret));
+            }
+        }
+        if (!verified) return null;
+        if (payload.aud !== TUNNEL_TOKEN_AUD) return null;
+    } else {
+        // Legacy path: tokens pre-dating aud/iat/kid claims. Verify signature
+        // against current secret (or previous if set) and accept during the
+        // natural 1-h TTL window. Log a deprecation warning.
+        //
+        // Policy: legacy tokens are accepted until they expire. After the 1-h
+        // window they are gone; no permanent compat shim is needed.
+        verified = signaturesMatch(signature, signPayload(encodedPayload, secret));
+        if (!verified && prevSecret) {
+            verified = signaturesMatch(signature, signPayload(encodedPayload, prevSecret));
+        }
+        if (!verified) return null;
+        // ponytail: legacy token accepted; log once, no metric infra needed yet
+        console.warn("[tunnel-token] deprecated: token missing aud/kid — re-mint to get v2 claims");
     }
 
     if (payload.v !== 1) return null;


### PR DESCRIPTION
Night Shift dish B-005

## What
- Dedicated  env var for tunnel token signing, isolated from Better Auth session secret
- Falls back to  when unset (zero-change deploy compat)
- Key rotation via  — old-key tokens accepted until their natural 1-hour TTL expires
- New v2 token claims: `aud` (pizzapi:tunnel), `iat` (issued-at), `kid` (SHA256-derived key identifier)
- Legacy tokens (no kid/aud) accepted during transition window with deprecation log; rejected after their TTL

## Files changed
- `packages/server/src/routes/tunnel-token.ts` — core implementation
- `packages/server/src/routes/tunnel-token.test.ts` — 13 tests covering all paths
- `packages/docs/src/content/docs/features/tunnels.mdx` — security docs updated

## Verification
```
bun test packages/server/src/routes/tunnel-token.test.ts  # 13 pass, 0 fail
bun run typecheck                                           # exit 0
```