### PR TITLE
fix: atomic mobile-link redemption (B-017)

### DIFF
--- a/packages/server/src/mobile-links.test.ts
+++ b/packages/server/src/mobile-links.test.ts
@@ -96,6 +96,25 @@ describe("mobile-links store", () => {
         });
     });
 
+    test("redemption is atomic: concurrent redeems yield exactly one winner", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const pending = await createMobileLink("http://localhost:7492", "user-race", "Race");
+            await scanMobileLink(pending.id, { verificationToken: "RACE42", deviceName: "Phone" });
+            const approved = await approveMobileLink(pending.id, "user-race", "RACE42");
+            expect(approved!.status).toBe("approved");
+
+            const [a, b] = await Promise.all([redeemMobileLink(pending.id), redeemMobileLink(pending.id)]);
+            const keys = [a, b].map((r) => r?.apiKey).filter(Boolean);
+            expect(keys).toHaveLength(1);
+            expect(keys[0]).toMatch(/^[a-f0-9]{64}$/);
+
+            // A subsequent redemption also returns nothing.
+            const third = await redeemMobileLink(pending.id);
+            expect(third!.status).toBe("approved");
+            expect(third!.apiKey).toBeUndefined();
+        });
+    });
+
     test("sweep deletes expired mobile links", async () => {
         await runWithAuthContext(authContext, async () => {
             const link = await createMobileLink("http://localhost:7492", "user-sweep", "Sweep");

--- a/packages/server/src/mobile-links.ts
+++ b/packages/server/src/mobile-links.ts
@@ -187,21 +187,25 @@ export async function redeemMobileLink(id: string): Promise<MobileLinkStatus | n
     if (current.status !== "approved") {
         return toStatus(current);
     }
+    if (!current.apiKey) return toStatus(current);
 
-    const status: MobileLinkStatus = {
-        ...toStatus(current),
-        apiKey: current.apiKey ?? undefined,
-    };
-
-    if (current.apiKey) {
-        await getKysely()
-            .updateTable("mobile_link")
-            .set({ apiKey: null })
-            .where("id", "=", id)
-            .execute();
+    // Atomic compare-and-clear: gate the UPDATE on the key value we read.
+    // Concurrent redeemers read the same key, but exactly one UPDATE matches
+    // (apiKey is cleared by the winner before the losers' statements run);
+    // losers see numUpdatedRows=0 and get nothing. SQLite serializes writers,
+    // so no transaction wrapper is needed. (Can't use RETURNING here: SQLite
+    // RETURNING yields post-update values, i.e. the NULL we just wrote.)
+    const cleared = await getKysely()
+        .updateTable("mobile_link")
+        .set({ apiKey: null })
+        .where("id", "=", id)
+        .where("apiKey", "=", current.apiKey)
+        .executeTakeFirst();
+    if (Number(cleared.numUpdatedRows ?? 0) === 0) {
+        return toStatus(current);
     }
 
-    return status;
+    return { ...toStatus(current), apiKey: current.apiKey };
 }
 
 /** Delete expired mobile links. Safe to call periodically. */


### PR DESCRIPTION
Night Shift dish B-017<br /><br />`redeemMobileLink` read the approved API key, returned it, then cleared it in a separate UPDATE — concurrent requests both received the same one-shot bearer key.<br /><br />Fix: value-gated compare-and-clear — `UPDATE ... SET apiKey=NULL WHERE id=? AND apiKey=<read-value>`, winner decided by `numUpdatedRows`. Exactly one concurrent redeemer gets the key; losers and later polls get none.<br /><br />Why not RETURNING: SQLite's `RETURNING` yields post-update values (the NULL just written) — no OLD qualifier like PG18. `numUpdatedRows` is the correct primitive here; SQLite serializes writers so no transaction wrapper needed.<br /><br />Tests: concurrent `Promise.all` race test — exactly one winner, subsequent redemption returns nothing. Verified the test fails against pre-fix code (stash check). Typecheck exit 0, server tests 5/5.