### PR TITLE
fix: clear redeemed setup-claim API keys (B-016)

### DIFF
--- a/packages/server/src/setup-claims.test.ts
+++ b/packages/server/src/setup-claims.test.ts
@@ -56,6 +56,66 @@ describe("setup-claims store", () => {
         });
     });
 
+    // B-016: redemption must clear the plaintext key from the row in the same
+    // atomic UPDATE that marks it redeemed — no redeemed-but-key-still-present
+    // window for DB backups/readers.
+    test("redemption clears the stored apiKey column while still serving the caller", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492");
+            const approve = await approveSetupClaim(token, "user-clear", "Clear");
+            expect(approve).not.toBeNull();
+
+            const { getKysely } = await import("./auth.js");
+            const before = await getKysely()
+                .selectFrom("setup_claim")
+                .select(["apiKey", "status"])
+                .where("id", "=", token)
+                .executeTakeFirstOrThrow();
+            expect(before.status).toBe("approved");
+            expect(before.apiKey).toBe(approve!.apiKey);
+
+            // Legitimate poller still receives the key.
+            const first = await pollSetupClaim(token);
+            expect(first!.status).toBe("approved");
+            expect(first!.apiKey).toBe(approve!.apiKey);
+
+            // But the row no longer holds it — cleared atomically with the redeem.
+            const after = await getKysely()
+                .selectFrom("setup_claim")
+                .select(["apiKey", "status", "redeemedAt"])
+                .where("id", "=", token)
+                .executeTakeFirstOrThrow();
+            expect(after.status).toBe("redeemed");
+            expect(after.apiKey).toBeNull();
+            expect(after.redeemedAt).not.toBeNull();
+
+            // Second poll reports redeemed and never re-serves the key.
+            const second = await pollSetupClaim(token);
+            expect(second!.status).toBe("redeemed");
+            expect(second!.apiKey).toBeUndefined();
+        });
+    });
+
+    test("concurrent polls serve the key exactly once", async () => {
+        await runWithAuthContext(authContext, async () => {
+            const { token } = await createSetupClaim("http://localhost:7492");
+            const approve = await approveSetupClaim(token, "user-race", "Race");
+            expect(approve).not.toBeNull();
+
+            const results = await Promise.all([
+                pollSetupClaim(token),
+                pollSetupClaim(token),
+                pollSetupClaim(token),
+            ]);
+            const served = results.filter((r) => r!.apiKey === approve!.apiKey);
+            expect(served.length).toBe(1);
+            for (const r of results.filter((r) => r!.apiKey !== approve!.apiKey)) {
+                expect(r!.apiKey).toBeUndefined();
+                expect(r!.status).toBe("redeemed");
+            }
+        });
+    });
+
     test("unknown token returns null", async () => {
         await runWithAuthContext(authContext, async () => {
             const status = await pollSetupClaim("definitely-not-a-token");

--- a/packages/server/src/setup-claims.ts
+++ b/packages/server/src/setup-claims.ts
@@ -9,8 +9,8 @@
  * Security notes:
  * - Tokens are 32-byte random hex strings, single-use, and expire after 10 min.
  * - The plain API key is stored only while the claim is in `approved` status.
- *   Once the CLI redeems it, the claim moves to `redeemed` and no longer
- *   exposes the key.
+ *   Redemption clears the `apiKey` column atomically in the same UPDATE that
+ *   marks the claim `redeemed`, so the key never persists after one-shot use.
  * - Approval requires a valid better-auth session.
  */
 
@@ -135,11 +135,26 @@ export async function pollSetupClaim(token: string): Promise<SetupClaimStatus | 
     }
 
     if (row.status === "approved" && row.apiKey) {
-        await getKysely()
+        // One-shot redeem: flip status AND clear the stored key in the same
+        // atomic UPDATE, guarded on the still-approved status so a concurrent
+        // second poll loses the race instead of re-serving the key.
+        const result = await getKysely()
             .updateTable("setup_claim")
-            .set({ status: "redeemed", redeemedAt: new Date().toISOString() })
+            .set({ status: "redeemed", redeemedAt: new Date().toISOString(), apiKey: null })
             .where("id", "=", token)
+            .where("status", "=", "approved")
             .execute();
+        if (Number(result[0]?.numUpdatedRows ?? 0) === 0) {
+            // Lost the race (or claim expired mid-flight): re-read and report
+            // the current status — never serve the key twice.
+            const current = await getKysely()
+                .selectFrom("setup_claim")
+                .select(["status", "relayUrl", "label"])
+                .where("id", "=", token)
+                .executeTakeFirst();
+            if (!current) return null;
+            return { status: current.status, relayUrl: current.relayUrl, label: current.label ?? undefined };
+        }
         return { status: "approved", relayUrl: row.relayUrl, apiKey: row.apiKey, label: row.label ?? undefined };
     }
 


### PR DESCRIPTION
Night Shift dish B-016

## Problem
`pollSetupClaim` was marking a claim redeemed but leaving the plaintext API key in `setup_claim.apiKey` until hourly cleanup — a bearer credential persisting in the DB/backups beyond one-shot redemption.

## Fix
Redeeming now clears `apiKey` (set NULL) in the **same atomic UPDATE** that flips `status → redeemed`, with an additional `.where("status", "=", "approved")` guard so a concurrent second poll loses the CAS race and never re-serves the key. The caller still receives the key in the response (read from the pre-clear row select).

## Tests added (18 pass)
- **Atomic clear assertion**: after `pollSetupClaim` redeems, caller got the key AND `setup_claim.apiKey IS NULL` in the DB; `redeemedAt` set.
- **Second poll safety**: second poll returns `status: redeemed` with no `apiKey`.
- **Concurrent poll**: 3 simultaneous polls, exactly one serves the key, rest get redeemed status without key.

## Artifact cleanup
Reverted stray `packages/ui/dev-dist/sw.js` build artifact from previous cook's session — not included in this PR.