### PR TITLE
fix: gate external PresentedCard images (C-006)

### DIFF
--- a/packages/ui/src/components/session-viewer/PresentedCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/PresentedCard.test.tsx
@@ -3,7 +3,7 @@
  */
 import { afterEach, describe, test, expect } from "bun:test";
 import { Window } from "happy-dom";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 import React from "react";
 import type { PresentedCard as PresentedCardData } from "./presented-card";
 
@@ -67,5 +67,43 @@ describe("PresentedCard", () => {
     const { queryByText, getByText } = render(<PresentedCardGroup cards={[card]} />);
     expect(getByText("Bob's Handyman")).toBeDefined();
     expect(queryByText(/results$/)).toBeNull();
+  });
+});
+
+describe("PresentedCard — external image privacy gating", () => {
+  const externalImageCard: PresentedCardData = {
+    kind: "business",
+    title: "Evil Corp",
+    icon: "store",
+    image: "https://attacker.example/track.gif",
+    badges: [],
+    fields: [],
+    actions: [],
+  };
+
+  test("does NOT render <img> for external image on initial render", () => {
+    const { container } = render(<PresentedCard card={externalImageCard} />);
+    const imgs = container.querySelectorAll("img");
+    expect(imgs.length).toBe(0);
+  });
+
+  test("shows a 'Load image' button for external image", () => {
+    const { getByTitle } = render(<PresentedCard card={externalImageCard} />);
+    expect(getByTitle("Load image")).toBeDefined();
+  });
+
+  test("renders <img> with correct src after clicking Load image", () => {
+    const { getByTitle, container } = render(<PresentedCard card={externalImageCard} />);
+    fireEvent.click(getByTitle("Load image"));
+    const img = container.querySelector("img") as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://attacker.example/track.gif");
+  });
+
+  test("card without image renders kind icon, no Load image button", () => {
+    const noImageCard: PresentedCardData = { ...externalImageCard, image: undefined };
+    const { container, queryByTitle } = render(<PresentedCard card={noImageCard} />);
+    expect(container.querySelectorAll("img").length).toBe(0);
+    expect(queryByTitle("Load image")).toBeNull();
   });
 });

--- a/packages/ui/src/components/session-viewer/PresentedCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/PresentedCard.test.tsx
@@ -106,4 +106,28 @@ describe("PresentedCard — external image privacy gating", () => {
     expect(container.querySelectorAll("img").length).toBe(0);
     expect(queryByTitle("Load image")).toBeNull();
   });
+
+  test("protocol-relative image (//host/…) is gated: no <img> on initial render", () => {
+    const protoRelCard: PresentedCardData = {
+      ...externalImageCard,
+      image: "//attacker.example/track.gif",
+    };
+    const { container, getByTitle } = render(<PresentedCard card={protoRelCard} />);
+    // Must not emit an <img> that the browser would auto-fetch.
+    expect(container.querySelectorAll("img").length).toBe(0);
+    // Must show the click-to-load affordance.
+    expect(getByTitle("Load image")).toBeDefined();
+  });
+
+  test("protocol-relative image renders after clicking Load image", () => {
+    const protoRelCard: PresentedCardData = {
+      ...externalImageCard,
+      image: "//attacker.example/track.gif",
+    };
+    const { getByTitle, container } = render(<PresentedCard card={protoRelCard} />);
+    fireEvent.click(getByTitle("Load image"));
+    const img = container.querySelector("img") as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("//attacker.example/track.gif");
+  });
 });

--- a/packages/ui/src/components/session-viewer/PresentedCard.tsx
+++ b/packages/ui/src/components/session-viewer/PresentedCard.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
 import type { PresentedCard as PresentedCardData, CardRating } from "@/components/session-viewer/presented-card";
+import { isExternalImage } from "@/components/session-viewer/presented-card";
 
 /**
  * A read-only entity the model presented — a person, business, place, event,
@@ -43,16 +44,30 @@ export function PresentedCardGroup({ cards }: { cards: PresentedCardData[] }) {
 }
 
 function PresentedCardBody({ card }: { card: PresentedCardData }) {
+  // ponytail: only gate http/https images; data:/relative would render directly
+  const [imageApproved, setImageApproved] = React.useState(false);
+  const isExternal = !!card.image && isExternalImage(card.image);
+  const showImg = !!card.image && (!isExternal || imageApproved);
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
       <div className="flex items-start gap-3 border-b border-border bg-muted/40 px-3 py-2.5">
-        {card.image ? (
+        {showImg ? (
           <img
             src={card.image}
             alt=""
             referrerPolicy="no-referrer"
             className={cn("size-10 shrink-0 object-cover", card.kind === "person" ? "rounded-full" : "rounded-md")}
           />
+        ) : isExternal ? (
+          // External image: show kind icon + click affordance (no auto-fetch)
+          <button
+            type="button"
+            title="Load image"
+            onClick={() => setImageApproved(true)}
+            className="flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-md bg-muted hover:bg-muted/70"
+          >
+            <DynamicLucideIcon name={card.icon} className="size-5 text-muted-foreground" />
+          </button>
         ) : (
           <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-muted">
             <DynamicLucideIcon name={card.icon} className="size-5 text-muted-foreground" />

--- a/packages/ui/src/components/session-viewer/presented-card.test.ts
+++ b/packages/ui/src/components/session-viewer/presented-card.test.ts
@@ -1,7 +1,20 @@
 import { describe, test, expect } from "bun:test";
-import { detectPresentedCard, detectPresentedCards, isSafeActionHref, schemaKind, formatAddress } from "./presented-card";
+import { detectPresentedCard, detectPresentedCards, isSafeActionHref, schemaKind, formatAddress, isExternalImage } from "./presented-card";
 
 const present = (entity: unknown) => detectPresentedCard("present_card", { entity });
+
+describe("isExternalImage", () => {
+  test("returns true for http and https URLs", () => {
+    expect(isExternalImage("https://example.com/img.jpg")).toBe(true);
+    expect(isExternalImage("http://attacker.com/track.gif")).toBe(true);
+  });
+  test("returns false for non-http schemes and invalid input", () => {
+    expect(isExternalImage("data:image/png;base64,abc")).toBe(false);
+    expect(isExternalImage("/relative/path.jpg")).toBe(false);
+    expect(isExternalImage("")).toBe(false);
+    expect(isExternalImage("javascript:alert(1)")).toBe(false);
+  });
+});
 
 describe("isSafeActionHref", () => {
   test("allows tel/mailto/sms/geo/http(s)", () => {

--- a/packages/ui/src/components/session-viewer/presented-card.test.ts
+++ b/packages/ui/src/components/session-viewer/presented-card.test.ts
@@ -14,6 +14,21 @@ describe("isExternalImage", () => {
     expect(isExternalImage("")).toBe(false);
     expect(isExternalImage("javascript:alert(1)")).toBe(false);
   });
+  test("treats protocol-relative URLs as external (C-006 bypass fix)", () => {
+    expect(isExternalImage("//attacker.example/track.gif")).toBe(true);
+    expect(isExternalImage("//host/x")).toBe(true);
+  });
+  test("treats uppercase schemes as external", () => {
+    expect(isExternalImage("HTTP://host/img.jpg")).toBe(true);
+    expect(isExternalImage("HTTPS://host/img.jpg")).toBe(true);
+  });
+  test("same-origin relative paths are not external", () => {
+    expect(isExternalImage("/assets/img.png")).toBe(false);
+    expect(isExternalImage("./img.png")).toBe(false);
+  });
+  test("data: URLs (with any case) are not external", () => {
+    expect(isExternalImage("DATA:image/png;base64,abc")).toBe(false);
+  });
 });
 
 describe("isSafeActionHref", () => {

--- a/packages/ui/src/components/session-viewer/presented-card.ts
+++ b/packages/ui/src/components/session-viewer/presented-card.ts
@@ -116,6 +116,19 @@ export function isSafeActionHref(href: string): boolean {
   }
 }
 
+/**
+ * Returns true for http/https URLs that will cause an outbound network request.
+ * These must be gated behind an explicit user action before being loaded.
+ */
+export function isExternalImage(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function httpImage(value: unknown): string | undefined {
   const raw = Array.isArray(value) ? value[0] : value;
   const url = typeof raw === "string" ? raw.trim() : str(raw);

--- a/packages/ui/src/components/session-viewer/presented-card.ts
+++ b/packages/ui/src/components/session-viewer/presented-card.ts
@@ -117,14 +117,28 @@ export function isSafeActionHref(href: string): boolean {
 }
 
 /**
- * Returns true for http/https URLs that will cause an outbound network request.
- * These must be gated behind an explicit user action before being loaded.
+ * Returns true for any image URL that will (or could) cause an outbound
+ * network request. These must be gated behind an explicit user action.
+ *
+ * Fail-closed: when in doubt, classify as external. A false-positive is a
+ * click-to-load prompt (harmless); a false-negative is a privacy leak.
+ *
+ * Safe (non-external): data: URLs and relative paths that don't start with //.
+ * External: http:, https:, protocol-relative (//host/…), any absolute URL
+ *   with a remote host, and uppercase variants thereof.
  */
 export function isExternalImage(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  // Protocol-relative: browser resolves to https://host/… — always external.
+  if (trimmed.startsWith("//")) return true;
+  // data: URLs are self-contained — not external.
+  if (/^data:/i.test(trimmed)) return false;
   try {
-    const { protocol } = new URL(url);
+    const { protocol } = new URL(trimmed);
     return protocol === "http:" || protocol === "https:";
   } catch {
+    // Relative paths (/foo, ./foo) — not external.
     return false;
   }
 }


### PR DESCRIPTION
Night Shift dish C-006

## Problem
Model-provided schema.org image URLs in PresentedCard were rendered directly as `<img src=externalUrl>`, causing the viewer's browser to contact arbitrary attacker-controlled hosts on render — leaking IP, User-Agent, and timing.

## Fix
- External http(s) image URLs are now gated behind an explicit user click (click-to-load)
- Default render shows the kind icon (existing fallback) + a `title="Load image"` button
- Only after the user clicks does `<img src>` get set — no auto-fetch on render
- Non-external images (data:, relative) would render normally (currently httpImage only admits http/https, so all card.image values are gated)

## Changes
- `presented-card.ts`: Export `isExternalImage(url)` — returns true for http/https URLs
- `PresentedCard.tsx`: Add `imageApproved` state; external images default to kind icon + click button
- `presented-card.test.ts`: Unit tests for `isExternalImage`
- `PresentedCard.test.tsx`: Render tests — no `<img>` on initial render, `<img>` appears after click

## Verification
```
387 pass, 0 fail (bun test src/components/session-viewer)
tsc --noEmit: clean
```