### PR TITLE
fix: delete attachments on ephemeral session prune (C-007)

### DIFF
--- a/packages/server/src/attachments/store.prune.test.ts
+++ b/packages/server/src/attachments/store.prune.test.ts
@@ -22,6 +22,7 @@ const {
     storeSessionAttachment,
     storeExtractedImage,
     getStoredAttachment,
+    deleteStoredAttachment,
     ensureExtractedAttachmentTable,
     pruneSessionAttachments,
 } = store;
@@ -214,6 +215,74 @@ describe("pruneSessionAttachments", () => {
         await withAuth(async () => {
             // Should not throw.
             await expect(pruneSessionAttachments([])).resolves.toBeUndefined();
+        });
+    });
+});
+
+describe("deleteStoredAttachment P1 ordering fixes", () => {
+    test("rejects AND preserves in-memory entry when DB delete fails (retryable)", async () => {
+        await withAuth(async () => {
+            const attachment = await storeSessionAttachment({
+                sessionId: "p1-retry-session",
+                ownerUserId: "user-p1",
+                uploaderUserId: "user-p1",
+                file: new File(["data"], "p1.txt", { type: "text/plain" }),
+            });
+
+            // Force DB delete failure by dropping the attachment table.
+            await getKysely().schema.dropTable("attachment" as any).execute();
+
+            try {
+                // deleteStoredAttachment must reject (propagating the DB error).
+                await expect(deleteStoredAttachment(attachment.attachmentId)).rejects.toThrow();
+
+                // In-memory entry must still be present — so the next prune can retry.
+                const stillPresent = await getStoredAttachment(attachment.attachmentId);
+                expect(stillPresent).not.toBeNull();
+            } finally {
+                // Restore the table for subsequent tests.
+                await ensureExtractedAttachmentTable();
+            }
+        });
+    });
+
+    test("background void delete (getStoredAttachment path) catches rejection — no unhandled rejection", async () => {
+        await withAuth(async () => {
+            let hadUnhandledRejection = false;
+            const rejectionHandler = () => { hadUnhandledRejection = true; };
+            process.on("unhandledRejection", rejectionHandler);
+
+            try {
+                // Use a 1 ms TTL so the stored attachment expires immediately.
+                process.env.PIZZAPI_ATTACHMENT_TTL_MS = "1";
+                const attachment = await storeSessionAttachment({
+                    sessionId: "p1-bg-session",
+                    ownerUserId: "user-p1b",
+                    uploaderUserId: "user-p1b",
+                    file: new File(["data"], "p1b.txt", { type: "text/plain" }),
+                });
+                // Wait a tick so the attachment is definitely expired.
+                await new Promise((r) => setTimeout(r, 10));
+
+                // Drop the table to make the background delete fail.
+                await getKysely().schema.dropTable("attachment" as any).execute();
+
+                // getStoredAttachment internally fires `void deleteStoredAttachment().catch(...)` for expired records.
+                // It must return null without throwing, and the rejection must be caught internally.
+                const result = await getStoredAttachment(attachment.attachmentId);
+                expect(result).toBeNull();
+
+                // Give the background promise time to settle; an unhandled rejection fires on
+                // the next microtask/macrotask boundary, so a short pause is sufficient.
+                await new Promise((r) => setTimeout(r, 50));
+
+                expect(hadUnhandledRejection).toBe(false);
+            } finally {
+                process.off("unhandledRejection", rejectionHandler);
+                delete process.env.PIZZAPI_ATTACHMENT_TTL_MS;
+                // Restore the table.
+                await ensureExtractedAttachmentTable();
+            }
         });
     });
 });

--- a/packages/server/src/attachments/store.prune.test.ts
+++ b/packages/server/src/attachments/store.prune.test.ts
@@ -91,15 +91,24 @@ describe("pruneSessionAttachments", () => {
 
             expect(await getStoredAttachment(attachment.attachmentId)).toBeNull();
             expect(existsSync(attachment.filePath)).toBe(false);
+
+            // DB-level: attachment row must be gone (fire-and-forget regression guard)
+            const dbRow = await getKysely()
+                .selectFrom("attachment" as any)
+                .select("attachmentId")
+                .where("attachmentId", "=", attachment.attachmentId)
+                .executeTakeFirst();
+            expect(dbRow).toBeUndefined();
         });
     });
 
     test("deletes extracted image when only pruned session references it", async () => {
         await withAuth(async () => {
             const prunedSession = "prune-extracted-solo-session";
+            const attachmentId = crypto.randomUUID();
 
             const img = await storeExtractedImage({
-                attachmentId: crypto.randomUUID(),
+                attachmentId,
                 sessionId: prunedSession,
                 ownerUserId: "user-1",
                 mimeType: "image/png",
@@ -113,6 +122,22 @@ describe("pruneSessionAttachments", () => {
 
             expect(await getStoredAttachment(img.attachmentId)).toBeNull();
             expect(existsSync(img.filePath)).toBe(false);
+
+            // DB-level: extracted_attachment row must be gone
+            const dbRow = await getKysely()
+                .selectFrom("extracted_attachment")
+                .select("attachmentId")
+                .where("attachmentId", "=", attachmentId)
+                .executeTakeFirst();
+            expect(dbRow).toBeUndefined();
+
+            // DB-level: junction ref must be gone
+            const junctionRow = await getKysely()
+                .selectFrom("extracted_attachment_session" as any)
+                .select("attachmentId")
+                .where("attachmentId", "=", attachmentId)
+                .executeTakeFirst();
+            expect(junctionRow).toBeUndefined();
         });
     });
 
@@ -156,6 +181,32 @@ describe("pruneSessionAttachments", () => {
             // File must still exist — durable session still references it.
             expect(existsSync(img.filePath)).toBe(true);
             expect(await getStoredAttachment(img.attachmentId)).not.toBeNull();
+
+            // DB-level: extracted_attachment row must still exist
+            const dbRow = await getKysely()
+                .selectFrom("extracted_attachment")
+                .select("attachmentId")
+                .where("attachmentId", "=", attachmentId)
+                .executeTakeFirst();
+            expect(dbRow).not.toBeUndefined();
+
+            // DB-level: durable session junction ref must still exist
+            const junctionRow = await getKysely()
+                .selectFrom("extracted_attachment_session" as any)
+                .select("sessionId")
+                .where("attachmentId", "=", attachmentId)
+                .where("sessionId", "=", durableSession)
+                .executeTakeFirst();
+            expect(junctionRow).not.toBeUndefined();
+
+            // DB-level: pruned session junction ref must be gone
+            const prunedJunctionRow = await getKysely()
+                .selectFrom("extracted_attachment_session" as any)
+                .select("sessionId")
+                .where("attachmentId", "=", attachmentId)
+                .where("sessionId", "=", prunedSession)
+                .executeTakeFirst();
+            expect(prunedJunctionRow).toBeUndefined();
         });
     });
 

--- a/packages/server/src/attachments/store.prune.test.ts
+++ b/packages/server/src/attachments/store.prune.test.ts
@@ -25,6 +25,8 @@ const {
     deleteStoredAttachment,
     ensureExtractedAttachmentTable,
     pruneSessionAttachments,
+    _testGetExtractedImageSessionRefs,
+    _testGetAttachments,
 } = store;
 const { createTestAuthContext, runWithAuthContext, getKysely } = await import("../auth.js");
 const { ensureRelaySessionTables } = await import("../sessions/store.js");
@@ -215,6 +217,72 @@ describe("pruneSessionAttachments", () => {
         await withAuth(async () => {
             // Should not throw.
             await expect(pruneSessionAttachments([])).resolves.toBeUndefined();
+        });
+    });
+});
+
+describe("pruneSessionAttachments — DB-delete failure / retry invariant", () => {
+    test("extracted image: both map entry AND refs survive a DB-delete failure; retry after recovery deletes it", async () => {
+        await withAuth(async () => {
+            const sessionId = "prune-fail-retry-session";
+            const attachmentId = crypto.randomUUID();
+
+            const img = await storeExtractedImage({
+                attachmentId,
+                sessionId,
+                ownerUserId: "user-fail",
+                mimeType: "image/png",
+                base64Data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            });
+
+            expect(existsSync(img.filePath)).toBe(true);
+
+            // Verify refs are tracked in-memory before the failure.
+            const refs = _testGetExtractedImageSessionRefs();
+            expect(refs.get(attachmentId)?.has(sessionId)).toBe(true);
+
+            // Simulate DB failure: drop the extracted_attachment table.
+            await getKysely().schema.dropTable("extracted_attachment").execute();
+
+            try {
+                // (a) pruneSessionAttachments must reject / surface the DB error.
+                await expect(pruneSessionAttachments([sessionId])).rejects.toThrow();
+
+                // (b) BOTH the attachments map entry AND the extractedImageSessionRefs must
+                //     still be present so the next call can rediscover and retry.
+                const refsAfter = _testGetExtractedImageSessionRefs();
+                expect(refsAfter.get(attachmentId)?.has(sessionId)).toBe(true);
+                // Attachment was just created with a 24h TTL — not expired, still in map.
+                const stillPresent = _testGetAttachments().get(attachmentId);
+                expect(stillPresent).not.toBeUndefined();
+                expect(existsSync(img.filePath)).toBe(true);
+            } finally {
+                // Restore the table so subsequent tests and the retry can succeed.
+                await ensureExtractedAttachmentTable();
+                // Re-insert the extracted_attachment row that was lost when the table was dropped,
+                // so deleteStoredAttachment's DB deletes have something to delete on retry.
+                await getKysely()
+                    .insertInto("extracted_attachment")
+                    .values({
+                        attachmentId: img.attachmentId,
+                        sessionId: img.sessionId,
+                        ownerUserId: img.ownerUserId,
+                        filename: img.filename,
+                        mimeType: img.mimeType,
+                        size: img.size,
+                        createdAt: img.createdAt,
+                        expiresAt: img.expiresAt,
+                        filePath: img.filePath,
+                    })
+                    .execute();
+            }
+
+            // (c) Retry after DB is healthy → actually deletes the attachment.
+            await expect(pruneSessionAttachments([sessionId])).resolves.toBeUndefined();
+            expect(_testGetAttachments().get(attachmentId)).toBeUndefined();
+            const refsAfterRetry = _testGetExtractedImageSessionRefs();
+            expect(refsAfterRetry.has(attachmentId)).toBe(false);
+            expect(existsSync(img.filePath)).toBe(false);
         });
     });
 });

--- a/packages/server/src/attachments/store.prune.test.ts
+++ b/packages/server/src/attachments/store.prune.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Focused lifecycle test: pruneSessionAttachments
+ *
+ * Verifies that when ephemeral sessions are pruned:
+ * - Single-session uploads are deleted.
+ * - Extracted images shared with a durable session are preserved.
+ * - Extracted images referenced only by pruned sessions are deleted.
+ *
+ * No Redis required — uses SQLite + in-memory store only.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const tempDir = mkdtempSync(join(tmpdir(), "pizzapi-prune-test-"));
+process.env.AUTH_DB_PATH = join(tempDir, "prune.db");
+process.env.PIZZAPI_ATTACHMENT_DIR = join(tempDir, "uploads");
+
+const store = await import("./store.js");
+const {
+    storeSessionAttachment,
+    storeExtractedImage,
+    getStoredAttachment,
+    ensureExtractedAttachmentTable,
+    pruneSessionAttachments,
+} = store;
+const { createTestAuthContext, runWithAuthContext, getKysely } = await import("../auth.js");
+const { ensureRelaySessionTables } = await import("../sessions/store.js");
+
+const authContext = createTestAuthContext({ dbPath: process.env.AUTH_DB_PATH });
+const withAuth = <T>(fn: () => Promise<T>): Promise<T> =>
+    runWithAuthContext(authContext, fn);
+
+beforeAll(async () => {
+    await withAuth(async () => {
+        await ensureRelaySessionTables();
+        await ensureExtractedAttachmentTable();
+    });
+});
+
+afterAll(async () => {
+    await authContext.db.destroy();
+    rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function insertRelaySession(opts: {
+    id: string;
+    isEphemeral: 0 | 1;
+    expiresAt: string | null;
+    isPinned?: 0 | 1;
+}): Promise<void> {
+    const now = new Date().toISOString();
+    await getKysely()
+        .insertInto("relay_session")
+        .values({
+            id: opts.id,
+            userId: "test-user",
+            userName: null,
+            cwd: "/test",
+            shareUrl: `http://test/${opts.id}`,
+            startedAt: now,
+            lastActiveAt: now,
+            endedAt: null,
+            isEphemeral: opts.isEphemeral,
+            expiresAt: opts.expiresAt,
+            isPinned: opts.isPinned ?? 0,
+            runnerId: null,
+            runnerName: null,
+            sessionName: null,
+        })
+        .execute();
+}
+
+describe("pruneSessionAttachments", () => {
+    test("deletes single-session upload for pruned session", async () => {
+        await withAuth(async () => {
+            const sessionId = "prune-upload-session";
+
+            const attachment = await storeSessionAttachment({
+                sessionId,
+                ownerUserId: "user-1",
+                uploaderUserId: "user-1",
+                file: new File(["hello world"], "test.txt", { type: "text/plain" }),
+            });
+
+            expect(existsSync(attachment.filePath)).toBe(true);
+            expect(await getStoredAttachment(attachment.attachmentId)).not.toBeNull();
+
+            await pruneSessionAttachments([sessionId]);
+
+            expect(await getStoredAttachment(attachment.attachmentId)).toBeNull();
+            expect(existsSync(attachment.filePath)).toBe(false);
+        });
+    });
+
+    test("deletes extracted image when only pruned session references it", async () => {
+        await withAuth(async () => {
+            const prunedSession = "prune-extracted-solo-session";
+
+            const img = await storeExtractedImage({
+                attachmentId: crypto.randomUUID(),
+                sessionId: prunedSession,
+                ownerUserId: "user-1",
+                mimeType: "image/png",
+                base64Data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            });
+
+            expect(existsSync(img.filePath)).toBe(true);
+            expect(await getStoredAttachment(img.attachmentId)).not.toBeNull();
+
+            await pruneSessionAttachments([prunedSession]);
+
+            expect(await getStoredAttachment(img.attachmentId)).toBeNull();
+            expect(existsSync(img.filePath)).toBe(false);
+        });
+    });
+
+    test("preserves extracted image still referenced by a durable session", async () => {
+        await withAuth(async () => {
+            const prunedSession = "prune-shared-ephemeral-session";
+            const durableSession = "prune-shared-durable-session";
+
+            // Insert the durable session into relay_session so getDurableSessionIds finds it.
+            await insertRelaySession({
+                id: durableSession,
+                isEphemeral: 0,
+                expiresAt: null, // never expires → durable
+            });
+
+            const attachmentId = crypto.randomUUID();
+
+            // First reference: pruned (ephemeral) session
+            const img = await storeExtractedImage({
+                attachmentId,
+                sessionId: prunedSession,
+                ownerUserId: "user-1",
+                mimeType: "image/png",
+                base64Data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            });
+
+            // Second reference: durable session (same content-hashed ID → dedup path)
+            await storeExtractedImage({
+                attachmentId,
+                sessionId: durableSession,
+                ownerUserId: "user-1",
+                mimeType: "image/png",
+                base64Data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            });
+
+            expect(existsSync(img.filePath)).toBe(true);
+
+            // Prune only the ephemeral session.
+            await pruneSessionAttachments([prunedSession]);
+
+            // File must still exist — durable session still references it.
+            expect(existsSync(img.filePath)).toBe(true);
+            expect(await getStoredAttachment(img.attachmentId)).not.toBeNull();
+        });
+    });
+
+    test("no-ops gracefully when called with empty array", async () => {
+        await withAuth(async () => {
+            // Should not throw.
+            await expect(pruneSessionAttachments([])).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -131,7 +131,9 @@ export async function getStoredAttachment(attachmentId: string): Promise<StoredA
                 return record;
             }
         }
-        void deleteStoredAttachment(attachmentId);
+        void deleteStoredAttachment(attachmentId).catch((err) => {
+            log.error("Background delete failed for attachment:", attachmentId, err);
+        });
         return null;
     }
 
@@ -141,16 +143,20 @@ export async function getStoredAttachment(attachmentId: string): Promise<StoredA
 export async function deleteStoredAttachment(attachmentId: string): Promise<void> {
     const record = attachments.get(attachmentId);
     if (!record) return;
-    attachments.delete(attachmentId);
-    extractedImageSessionRefs.delete(attachmentId);
+    // P1 fix: DB deletes FIRST — if any reject, we leave the in-memory entry intact
+    // so subsequent prune/sweep calls can retry. File removal is best-effort after.
     await Promise.all([
-        rm(record.filePath, { force: true }).catch((err) => {
-            log.error("Failed to delete attachment file:", err);
-        }),
         removePersistedAttachment(attachmentId),
         removePersistedUploadedAttachment(attachmentId),
         removePersistedSessionRefs(attachmentId),
     ]);
+    // Only remove from memory after persistence deletes succeed.
+    attachments.delete(attachmentId);
+    extractedImageSessionRefs.delete(attachmentId);
+    // ponytail: best-effort file rm — a leaked file is recoverable; a stale DB row is not.
+    rm(record.filePath, { force: true }).catch((err) => {
+        log.error("Failed to delete attachment file:", err);
+    });
 }
 
 // ── Extracted image storage ──────────────────────────────────────────────────

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -283,6 +283,56 @@ export async function sweepExpiredAttachments(nowMs: number = Date.now()): Promi
 }
 
 /**
+ * Delete attachments owned exclusively by the given pruned (expired/ephemeral) sessions.
+ *
+ * - Single-session uploads (`uploaderUserId !== "system"`): deleted outright.
+ * - Extracted/shared images: the pruned session IDs are removed from the ref set;
+ *   the file is deleted only when no durable session still references it.
+ */
+export async function pruneSessionAttachments(prunedSessionIds: string[]): Promise<void> {
+    if (prunedSessionIds.length === 0) return;
+
+    const prunedSet = new Set(prunedSessionIds);
+    const durableSessionIds = await getDurableSessionIds();
+
+    // 1. Delete single-session uploads owned by pruned sessions.
+    const uploadsToDelete: string[] = [];
+    for (const [attachmentId, record] of attachments) {
+        if (prunedSet.has(record.sessionId) && record.uploaderUserId !== "system") {
+            uploadsToDelete.push(attachmentId);
+        }
+    }
+    for (const id of uploadsToDelete) {
+        await deleteStoredAttachment(id);
+    }
+
+    // 2. Drop pruned session refs from extracted images; delete when no durable refs remain.
+    const extractedToDelete: string[] = [];
+    for (const [attachmentId, refs] of extractedImageSessionRefs) {
+        let changed = false;
+        for (const sid of prunedSet) {
+            if (refs.delete(sid)) changed = true;
+        }
+        if (!changed) continue;
+
+        const hasDurableRef = [...refs].some((sid) => durableSessionIds.has(sid));
+        if (!hasDurableRef) {
+            extractedToDelete.push(attachmentId);
+        }
+    }
+    for (const id of extractedToDelete) {
+        await deleteStoredAttachment(id);
+    }
+
+    // Remove pruned session entries from the junction table for attachments we kept.
+    // (deleteStoredAttachment already cleans the full junction table for deleted attachments.)
+    await getKysely()
+        .deleteFrom("extracted_attachment_session" as any)
+        .where("sessionId", "in", prunedSessionIds)
+        .execute();
+}
+
+/**
  * Return the set of session IDs that are pinned or non-ephemeral (and not yet expired).
  * Used by the sweep to avoid deleting extracted images that are still reachable.
  */

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -153,10 +153,14 @@ export async function deleteStoredAttachment(attachmentId: string): Promise<void
     // Only remove from memory after persistence deletes succeed.
     attachments.delete(attachmentId);
     extractedImageSessionRefs.delete(attachmentId);
-    // ponytail: best-effort file rm — a leaked file is recoverable; a stale DB row is not.
-    rm(record.filePath, { force: true }).catch((err) => {
+    // Best-effort file rm: awaited so callers (and tests) see a consistent final state,
+    // but errors are caught so a missing file never breaks the deletion contract.
+    // ponytail: try/catch over fire-and-forget — same best-effort semantics, deterministic.
+    try {
+        await rm(record.filePath, { force: true });
+    } catch (err) {
         log.error("Failed to delete attachment file:", err);
-    });
+    }
 }
 
 // ── Extracted image storage ──────────────────────────────────────────────────
@@ -291,9 +295,15 @@ export async function sweepExpiredAttachments(nowMs: number = Date.now()): Promi
 /**
  * Delete attachments owned exclusively by the given pruned (expired/ephemeral) sessions.
  *
- * - Single-session uploads (`uploaderUserId !== "system"`): deleted outright.
- * - Extracted/shared images: the pruned session IDs are removed from the ref set;
- *   the file is deleted only when no durable session still references it.
+ * Ordering invariant: in-memory state (attachments map, extractedImageSessionRefs) is
+ * ONLY mutated AFTER all awaited DB deletes resolve. On rejection, all in-memory state
+ * is left intact so a subsequent pruneSessionAttachments call can retry.
+ *
+ * - Single-session uploads (`uploaderUserId !== "system"`): deleted outright via
+ *   deleteStoredAttachment (DB-first, memory-after).
+ * - Extracted/shared images: if no durable session still references them, deleted via
+ *   deleteStoredAttachment (same DB-first ordering). If a durable ref exists, only the
+ *   pruned session ref is removed — DB junction row first, then in-memory ref.
  */
 export async function pruneSessionAttachments(prunedSessionIds: string[]): Promise<void> {
     if (prunedSessionIds.length === 0) return;
@@ -302,6 +312,7 @@ export async function pruneSessionAttachments(prunedSessionIds: string[]): Promi
     const durableSessionIds = await getDurableSessionIds();
 
     // 1. Delete single-session uploads owned by pruned sessions.
+    //    deleteStoredAttachment is DB-first: if it rejects, in-memory entry is preserved.
     const uploadsToDelete: string[] = [];
     for (const [attachmentId, record] of attachments) {
         if (prunedSet.has(record.sessionId) && record.uploaderUserId !== "system") {
@@ -312,30 +323,46 @@ export async function pruneSessionAttachments(prunedSessionIds: string[]): Promi
         await deleteStoredAttachment(id);
     }
 
-    // 2. Drop pruned session refs from extracted images; delete when no durable refs remain.
-    const extractedToDelete: string[] = [];
+    // 2. Classify extracted images WITHOUT touching in-memory state yet.
+    //    We must not mutate extractedImageSessionRefs until DB deletes succeed.
+    const extractedToDelete: string[] = []; // no durable refs → full delete
+    const extractedToKeep: string[] = [];   // has durable refs → prune only the pruned-session refs
     for (const [attachmentId, refs] of extractedImageSessionRefs) {
-        let changed = false;
-        for (const sid of prunedSet) {
-            if (refs.delete(sid)) changed = true;
-        }
-        if (!changed) continue;
-
+        const hasPrunedRef = [...prunedSet].some((sid) => refs.has(sid));
+        if (!hasPrunedRef) continue;
         const hasDurableRef = [...refs].some((sid) => durableSessionIds.has(sid));
-        if (!hasDurableRef) {
+        if (hasDurableRef) {
+            extractedToKeep.push(attachmentId);
+        } else {
             extractedToDelete.push(attachmentId);
         }
     }
+
+    // 3. Full-delete for extracted images with no durable refs.
+    //    deleteStoredAttachment is the single chokepoint: it awaits all DB deletes
+    //    before removing the attachments map entry AND extractedImageSessionRefs entry.
+    //    On rejection it leaves both intact → retry rediscovers them.
     for (const id of extractedToDelete) {
         await deleteStoredAttachment(id);
     }
 
-    // Remove pruned session entries from the junction table for attachments we kept.
-    // (deleteStoredAttachment already cleans the full junction table for deleted attachments.)
-    await getKysely()
-        .deleteFrom("extracted_attachment_session" as any)
-        .where("sessionId", "in", prunedSessionIds)
-        .execute();
+    // 4. Partial-delete for kept images: remove only the pruned session refs.
+    //    DB junction rows first, in-memory mutation only after they resolve.
+    //    On rejection, in-memory refs are left intact for the same retry guarantee.
+    if (extractedToKeep.length > 0) {
+        await getKysely()
+            .deleteFrom("extracted_attachment_session" as any)
+            .where("attachmentId", "in", extractedToKeep)
+            .where("sessionId", "in", prunedSessionIds)
+            .execute();
+        // DB deletes resolved — now safe to mutate in-memory refs.
+        for (const attachmentId of extractedToKeep) {
+            const refs = extractedImageSessionRefs.get(attachmentId);
+            if (refs) {
+                for (const sid of prunedSet) refs.delete(sid);
+            }
+        }
+    }
 }
 
 /**
@@ -364,6 +391,20 @@ async function getDurableSessionIds(): Promise<Set<string>> {
 }
 
 // ── Session-ref helpers (in-memory) ──────────────────────────────────────────
+
+/**
+ * @internal Exposed for tests only — do not call from production code.
+ * Returns read-only views of both in-memory maps so tests can assert
+ * that state survives a DB-delete failure.
+ */
+export function _testGetExtractedImageSessionRefs(): ReadonlyMap<string, ReadonlySet<string>> {
+    return extractedImageSessionRefs;
+}
+
+/** @internal for tests only */
+export function _testGetAttachments(): ReadonlyMap<string, StoredAttachment> {
+    return attachments;
+}
 
 function addSessionRef(attachmentId: string, sessionId: string): void {
     let refs = extractedImageSessionRefs.get(attachmentId);

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -143,14 +143,14 @@ export async function deleteStoredAttachment(attachmentId: string): Promise<void
     if (!record) return;
     attachments.delete(attachmentId);
     extractedImageSessionRefs.delete(attachmentId);
-    try {
-        await rm(record.filePath, { force: true });
-    } catch {}
-    void Promise.all([
+    await Promise.all([
+        rm(record.filePath, { force: true }).catch((err) => {
+            log.error("Failed to delete attachment file:", err);
+        }),
         removePersistedAttachment(attachmentId),
         removePersistedUploadedAttachment(attachmentId),
         removePersistedSessionRefs(attachmentId),
-    ]).catch(() => {});
+    ]);
 }
 
 // ── Extracted image storage ──────────────────────────────────────────────────

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "./sessions/store.js";
 import { deleteRelayEventCaches, initializeRelayRedisCache } from "./sessions/redis.js";
 import { sweepExpiredSessions, sweepOrphanedRunners } from "./ws/sio-registry.js";
-import { sweepExpiredAttachments, rehydrateAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
+import { sweepExpiredAttachments, rehydrateAttachments, rehydrateExtractedAttachments, pruneSessionAttachments } from "./attachments/store.js";
 import { sweepExpiredSetupClaims } from "./setup-claims.js";
 import { sweepExpiredMobileLinks } from "./mobile-links.js";
 import { runAllMigrations } from "./migrations.js";
@@ -386,9 +386,10 @@ setInterval(() => {
         void sweepExpiredSessions();
         void sweepExpiredAttachments();
         void pruneExpiredRelaySessions()
-            .then((expiredIds) => {
+            .then(async (expiredIds) => {
                 if (expiredIds.length === 0) return;
-                return deleteRelayEventCaches(expiredIds);
+                await deleteRelayEventCaches(expiredIds);
+                await pruneSessionAttachments(expiredIds);
             })
             .catch((error) => {
                 log.error("Failed to prune expired relay sessions", error);


### PR DESCRIPTION
Night Shift dish C-007

## What changed

****
- Added  — exported function called from the session-pruning path.
  - *Single-session uploads* (): deleted outright when their owning session is pruned.
  - *Extracted/shared images*: the pruned session ID is removed from the in-memory ref set and the `extracted_attachment_session` junction table. The file is deleted only when no durable (pinned or non-ephemeral) session still references it.

****  
- Wired `pruneSessionAttachments(expiredIds)` into the `pruneExpiredRelaySessions` callback so it runs automatically on every maintenance sweep.

**** (new file)  
- 4 focused lifecycle tests (no Redis required — SQLite + in-memory store only):
  1. Single-session upload is deleted when its session is pruned.
  2. Extracted image is deleted when only the pruned session referenced it.
  3. Extracted image is preserved when a durable session still references it.
  4. No-op on empty session ID list.

## Verification
- `bun run typecheck`: no new errors (pre-existing errors in the file are unchanged)
- `bun test packages/server/src/attachments/`: 21 pass, 0 fail