### PR TITLE
fix: verify runner ownership before offline wake (B-008)

### DIFF
--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -2222,6 +2222,32 @@ describe("POST /api/sessions/:id/trigger — wakeSession", () => {
         expect(mockEmitToRunnerCalls[0][2].resumeId).toBe("sess-wake");
     });
 
+    // SECURITY regression: cross-user runner ownership check on the wake path.
+    // A session points to runner-A, but runner-A was reclaimed by user-2 after
+    // the session ended. The wake must be REFUSED — user-1's resume must never
+    // be sent to user-2's runner (cross-user command injection).
+    test("CROSS-USER: refuses wake when the session's runner was reclaimed by another user", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(offlineSession()));
+        mockGetLocalRunnerSocket.mockReturnValue(null);
+        // runner-A now belongs to user-2, not user-1
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A" } as any));
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-wake/trigger", {
+            type: "time:cron",
+            payload: {},
+            wakeSession: true,
+        });
+        const res = await handleTriggersRoute(req, url);
+        // Fail-closed: refuse with 404, not 503/waking
+        expect(res!.status).toBe(404);
+        const body = await res!.json() as { waking?: boolean };
+        expect(body.waking).toBeUndefined();
+
+        await new Promise((r) => setTimeout(r, 20));
+        // Zero emissions to user-2's runner
+        expect(mockEmitToRunnerCalls).toHaveLength(0);
+    });
+
     // The orphan sweep deletes the live record ~2 min after a worker dies, so
     // this — not the live-but-disconnected case — is what a schedule normally
     // meets when it fires. It must still return to the session that created it.
@@ -2300,6 +2326,34 @@ describe("POST /api/sessions/:id/trigger — wakeSession", () => {
             await new Promise((r) => setTimeout(r, 20));
             expect(mockEmitToRunnerCalls).toHaveLength(0);
         });
+
+        // SECURITY regression: cross-user runner ownership check when the session
+        // record was swept. The persisted row says runnerId=runner-A (user-1's old
+        // runner), but runner-A has since been reclaimed and now belongs to user-2.
+        // The wake must be REFUSED — never emit a resume command to user-2's runner.
+        test("CROSS-USER: refuses wake when persisted runnerId was reclaimed by another user", async () => {
+            // Persisted record: user-1's session, stored runnerId = runner-A
+            mockGetPersistedRelaySessionOwner.mockReturnValue(
+                Promise.resolve({ userId: "user-1", runnerId: "runner-A", cwd: "/tmp/proj" }),
+            );
+            mockGetLocalRunnerSocket.mockReturnValue(null);
+            // runner-A was reclaimed — now belongs to user-2
+            mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A" } as any));
+
+            const [req, url] = makeReq("POST", "/api/sessions/sess-swept/trigger", {
+                type: "time:cron",
+                payload: {},
+                wakeSession: true,
+            });
+            const res = await handleTriggersRoute(req, url);
+            // Fail-closed: refuse, never emit to user-2's runner
+            expect(res!.status).toBe(404);
+            const body = await res!.json() as { waking?: boolean };
+            expect(body.waking).toBeUndefined();
+
+            await new Promise((r) => setTimeout(r, 20));
+            expect(mockEmitToRunnerCalls).toHaveLength(0);
+        });
     });
 });
 
@@ -2368,6 +2422,26 @@ describe("subscription routes — schedule whose owning session has ended", () =
         mockGetPersistedRelaySessionOwner.mockReturnValue(Promise.resolve({ userId: "someone-else", runnerId: "runner-A", cwd: null }));
         const [req, url] = makeReq("DELETE", "/api/sessions/sess-ended/trigger-subscriptions/time:cron");
         expect((await handleTriggersRoute(req, url))!.status).toBe(404);
+        expect(mockEmitDeltaCalls).toHaveLength(0);
+    });
+
+    // SECURITY regression: cross-user runner ownership check on subscription
+    // mutation paths. The persisted runnerId (runner-A) was reclaimed by user-2.
+    // DELETE must succeed (removes from Redis) but must NOT emit a delta to
+    // user-2's runner.
+    test("CROSS-USER: DELETE completes but skips delta when runner was reclaimed by another user", async () => {
+        // runner-A now belongs to user-2
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A" } as any));
+        mockUnsubscribeSessionSubscription.mockReturnValue(Promise.resolve(true));
+
+        const [req, url] = makeReq(
+            "DELETE",
+            "/api/sessions/sess-ended/trigger-subscriptions/time:cron?subscriptionId=sub-cron",
+        );
+        const res = await handleTriggersRoute(req, url);
+        // Unsubscribe from Redis succeeds
+        expect(res!.status).toBe(200);
+        // But no delta is emitted to user-2's runner
         expect(mockEmitDeltaCalls).toHaveLength(0);
     });
 });

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -2177,11 +2177,12 @@ describe("POST /api/sessions/:id/trigger — wakeSession", () => {
         expect(mockEmitToRunnerCalls).toHaveLength(0);
     });
 
-    test("wakeSession with a runner that is gone entirely 503s for retry and does not claim to be waking", async () => {
+    // SECURITY: fail-closed — when getRunnerData returns null (runner gone/unknown)
+    // the wake must be REFUSED (404, zero emits) regardless of local socket state.
+    test("NULL RUNNER: refuses wake with 404 and zero emits when runner data is null", async () => {
         mockGetSharedSession.mockReturnValue(Promise.resolve(offlineSession()));
-        mockGetLocalRunnerSocket.mockReturnValue(null);
-        // Absent locally AND absent from Redis — genuinely gone, not merely
-        // attached to another relay node.
+        // Local socket present so runnerReachable would be true without the fix.
+        mockGetLocalRunnerSocket.mockReturnValue({ emit: mock(() => {}) });
         mockGetRunnerData.mockReturnValue(Promise.resolve(null as any));
 
         const [req, url] = makeReq("POST", "/api/sessions/sess-wake/trigger", {
@@ -2190,12 +2191,35 @@ describe("POST /api/sessions/:id/trigger — wakeSession", () => {
             wakeSession: true,
         });
         const res = await handleTriggersRoute(req, url);
-        expect(res!.status).toBe(503);
+        // Fail-closed: 404, not 503/waking
+        expect(res!.status).toBe(404);
         const body = await res!.json() as { waking?: boolean };
-        // Not "waking" — the runner is down, not the session. The caller retries
-        // rather than spawning a replacement on a runner that is coming back.
         expect(body.waking).toBeUndefined();
         await new Promise((r) => setTimeout(r, 20));
+        // Zero emissions — the guard fired before wakeOfflineSession was called
+        expect(mockEmitToRunnerCalls).toHaveLength(0);
+    });
+
+    test("wakeSession with a runner that is gone entirely 503s for retry and does not claim to be waking", async () => {
+        mockGetSharedSession.mockReturnValue(Promise.resolve(offlineSession()));
+        mockGetLocalRunnerSocket.mockReturnValue(null);
+        // Absent locally AND absent from Redis — genuinely gone, not merely
+        // attached to another relay node. With fail-closed guard, null runner
+        // data now returns 404 immediately (before reachability check).
+        mockGetRunnerData.mockReturnValue(Promise.resolve(null as any));
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-wake/trigger", {
+            type: "time:timer_fired",
+            payload: {},
+            wakeSession: true,
+        });
+        const res = await handleTriggersRoute(req, url);
+        // Fail-closed: returns 404 (unknown runner — refuse)
+        expect(res!.status).toBe(404);
+        const body = await res!.json() as { waking?: boolean };
+        expect(body.waking).toBeUndefined();
+        await new Promise((r) => setTimeout(r, 20));
+        expect(mockEmitToRunnerCalls).toHaveLength(0);
     });
 
     test("wakes a runner attached to another relay node (no local socket)", async () => {
@@ -2440,6 +2464,60 @@ describe("subscription routes — schedule whose owning session has ended", () =
         );
         const res = await handleTriggersRoute(req, url);
         // Unsubscribe from Redis succeeds
+        expect(res!.status).toBe(200);
+        // But no delta is emitted to user-2's runner
+        expect(mockEmitDeltaCalls).toHaveLength(0);
+    });
+
+    // SECURITY: fail-closed — NULL runner data must SKIP the delta (same as
+    // reclaimed). The Redis unsubscribe still completes (200).
+    test("NULL RUNNER: DELETE completes but skips delta when getRunnerData returns null", async () => {
+        mockGetRunnerData.mockReturnValue(Promise.resolve(null as any));
+        mockUnsubscribeSessionSubscription.mockReturnValue(Promise.resolve(true));
+
+        const [req, url] = makeReq(
+            "DELETE",
+            "/api/sessions/sess-ended/trigger-subscriptions/time:cron?subscriptionId=sub-cron",
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        // Zero emits — guard fired before emitTriggerSubscriptionDelta
+        expect(mockEmitDeltaCalls).toHaveLength(0);
+    });
+
+    // SECURITY: fail-closed — NULL runner data must SKIP the PUT delta.
+    // The Redis update still completes (200).
+    test("NULL RUNNER: PUT completes but skips delta when getRunnerData returns null", async () => {
+        mockGetRunnerData.mockReturnValue(Promise.resolve(null as any));
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({ serviceIds: [], triggerDefs: [] }));
+        mockUpdateSessionSubscription.mockReturnValue(Promise.resolve({ updated: true, runnerId: "runner-A" }));
+
+        const [req, url] = makeReq(
+            "PUT",
+            "/api/sessions/sess-ended/trigger-subscriptions/time:cron?subscriptionId=sub-cron",
+            { params: { cron: "0 10 * * *" } },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        // Zero emits — guard fired before emitTriggerSubscriptionDelta
+        expect(mockEmitDeltaCalls).toHaveLength(0);
+    });
+
+    // SECURITY regression: cross-user runner ownership check on PUT subscription
+    // path. The persisted runnerId (runner-A) was reclaimed by user-2.
+    // PUT must succeed (updates Redis) but must NOT emit a delta to user-2's runner.
+    test("CROSS-USER: PUT completes but skips delta when runner was reclaimed by another user", async () => {
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A" } as any));
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({ serviceIds: [], triggerDefs: [] }));
+        mockUpdateSessionSubscription.mockReturnValue(Promise.resolve({ updated: true, runnerId: "runner-A" }));
+
+        const [req, url] = makeReq(
+            "PUT",
+            "/api/sessions/sess-ended/trigger-subscriptions/time:cron?subscriptionId=sub-cron",
+            { params: { cron: "0 10 * * *" } },
+        );
+        const res = await handleTriggersRoute(req, url);
+        // Update to Redis succeeds
         expect(res!.status).toBe(200);
         // But no delta is emitted to user-2's runner
         expect(mockEmitDeltaCalls).toHaveLength(0);

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -821,8 +821,15 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // Redis-backed, so a runner attached to another relay node counts as
             // reachable — a local-socket check would report a perfectly healthy
             // multi-node deployment as "runner down".
-            const runnerReachable = !!getLocalRunnerSocket(target.runnerId)
-                || !!(await getRunnerData(target.runnerId).catch(() => null));
+            const wakeRunnerData = await getRunnerData(target.runnerId).catch(() => null);
+            // SECURITY: fail-closed — if the runner was reclaimed by another user
+            // after the session ended, refuse the wake. Never emit a resume
+            // command to another user's runner (cross-user command injection).
+            if (wakeRunnerData && wakeRunnerData.userId !== identity.userId) {
+                log.warn(`wake: runner ${target.runnerId} is owned by a different user — refusing cross-user wake for session ${sessionId}`);
+                return Response.json({ error: "Session not found or not connected" }, { status: 404 });
+            }
+            const runnerReachable = !!getLocalRunnerSocket(target.runnerId) || !!wakeRunnerData;
             if (runnerReachable) {
                 log.info(`External trigger ${triggerId}: session ${sessionId} offline — starting wake`);
                 void wakeOfflineSession(sessionId, target).catch((err) => {
@@ -1304,15 +1311,23 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "unsubscribe" });
 
         if (owner.runnerId) {
-            void emitTriggerSubscriptionDelta(owner.runnerId, {
-                action: "unsubscribe",
-                subscription: {
-                    subscriptionId: subscriptionId ?? `legacy:all:${triggerType}`,
-                    sessionId,
-                    triggerType,
-                    runnerId: owner.runnerId,
-                },
-            });
+            // SECURITY: verify the persisted runner still belongs to the caller before
+            // emitting a delta — a reclaimed runner must not receive cross-user subscription
+            // mutation events.
+            const unsubRunnerData = await getRunnerData(owner.runnerId).catch(() => null);
+            if (!unsubRunnerData || unsubRunnerData.userId === identity.userId) {
+                void emitTriggerSubscriptionDelta(owner.runnerId, {
+                    action: "unsubscribe",
+                    subscription: {
+                        subscriptionId: subscriptionId ?? `legacy:all:${triggerType}`,
+                        sessionId,
+                        triggerType,
+                        runnerId: owner.runnerId,
+                    },
+                });
+            } else {
+                log.warn(`subscription delete: runner ${owner.runnerId} belongs to a different user — skipping delta for session ${sessionId}`);
+            }
         }
 
         return Response.json({ ok: true, ...(subscriptionId ? { subscriptionId } : {}), triggerType, removed });
@@ -1469,18 +1484,26 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         // authoritative path — the legacy subscription_params_changed event
         // has been removed to prevent double-apply.
         if (owner.runnerId) {
-            void emitTriggerSubscriptionDelta(owner.runnerId, {
-                action: "update",
-                subscription: {
-                    subscriptionId: subscriptionId ?? `legacy:all:${triggerType}`,
-                    sessionId,
-                    triggerType,
-                    runnerId: owner.runnerId,
-                    ...(subParams ? { params: subParams } : {}),
-                    ...(subFilters ? { filters: subFilters } : {}),
-                    ...(subFilterMode ? { filterMode: subFilterMode } : {}),
-                },
-            });
+            // SECURITY: verify the persisted runner still belongs to the caller before
+            // emitting a delta — a reclaimed runner must not receive cross-user subscription
+            // mutation events.
+            const updateRunnerData = await getRunnerData(owner.runnerId).catch(() => null);
+            if (!updateRunnerData || updateRunnerData.userId === identity.userId) {
+                void emitTriggerSubscriptionDelta(owner.runnerId, {
+                    action: "update",
+                    subscription: {
+                        subscriptionId: subscriptionId ?? `legacy:all:${triggerType}`,
+                        sessionId,
+                        triggerType,
+                        runnerId: owner.runnerId,
+                        ...(subParams ? { params: subParams } : {}),
+                        ...(subFilters ? { filters: subFilters } : {}),
+                        ...(subFilterMode ? { filterMode: subFilterMode } : {}),
+                    },
+                });
+            } else {
+                log.warn(`subscription update: runner ${owner.runnerId} belongs to a different user — skipping delta for session ${sessionId}`);
+            }
         }
 
         return Response.json({

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -822,11 +822,11 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // reachable — a local-socket check would report a perfectly healthy
             // multi-node deployment as "runner down".
             const wakeRunnerData = await getRunnerData(target.runnerId).catch(() => null);
-            // SECURITY: fail-closed — if the runner was reclaimed by another user
-            // after the session ended, refuse the wake. Never emit a resume
-            // command to another user's runner (cross-user command injection).
-            if (wakeRunnerData && wakeRunnerData.userId !== identity.userId) {
-                log.warn(`wake: runner ${target.runnerId} is owned by a different user — refusing cross-user wake for session ${sessionId}`);
+            // SECURITY: fail-closed — refuse if runner data is missing/unknown OR
+            // the runner was reclaimed by another user. Never emit a resume command
+            // to an unknown or foreign runner (cross-user command injection).
+            if (!wakeRunnerData || wakeRunnerData.userId !== identity.userId) {
+                log.warn(`wake: runner ${target.runnerId} is missing or owned by a different user — refusing wake for session ${sessionId}`);
                 return Response.json({ error: "Session not found or not connected" }, { status: 404 });
             }
             const runnerReachable = !!getLocalRunnerSocket(target.runnerId) || !!wakeRunnerData;
@@ -1315,7 +1315,9 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // emitting a delta — a reclaimed runner must not receive cross-user subscription
             // mutation events.
             const unsubRunnerData = await getRunnerData(owner.runnerId).catch(() => null);
-            if (!unsubRunnerData || unsubRunnerData.userId === identity.userId) {
+            // SECURITY: fail-closed — only emit the delta when runner data is PRESENT
+            // AND owned by the caller. Missing/unknown runner data must skip the emit.
+            if (unsubRunnerData && unsubRunnerData.userId === identity.userId) {
                 void emitTriggerSubscriptionDelta(owner.runnerId, {
                     action: "unsubscribe",
                     subscription: {
@@ -1326,7 +1328,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     },
                 });
             } else {
-                log.warn(`subscription delete: runner ${owner.runnerId} belongs to a different user — skipping delta for session ${sessionId}`);
+                log.warn(`subscription delete: runner ${owner.runnerId} is missing or belongs to a different user — skipping delta for session ${sessionId}`);
             }
         }
 
@@ -1488,7 +1490,9 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // emitting a delta — a reclaimed runner must not receive cross-user subscription
             // mutation events.
             const updateRunnerData = await getRunnerData(owner.runnerId).catch(() => null);
-            if (!updateRunnerData || updateRunnerData.userId === identity.userId) {
+            // SECURITY: fail-closed — only emit the delta when runner data is PRESENT
+            // AND owned by the caller. Missing/unknown runner data must skip the emit.
+            if (updateRunnerData && updateRunnerData.userId === identity.userId) {
                 void emitTriggerSubscriptionDelta(owner.runnerId, {
                     action: "update",
                     subscription: {
@@ -1502,7 +1506,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     },
                 });
             } else {
-                log.warn(`subscription update: runner ${owner.runnerId} belongs to a different user — skipping delta for session ${sessionId}`);
+                log.warn(`subscription update: runner ${owner.runnerId} is missing or belongs to a different user — skipping delta for session ${sessionId}`);
             }
         }
 


### PR DESCRIPTION
Night Shift dish B-008 — cross-user runner command leak

## Vulnerability
Offline session wake in `triggers.ts` validated the session owner but trusted the stored `runnerId` without checking that the runner still belongs to the caller. A stale/reclaimed runner association could send user A's resume/wake command to user B's runner (cross-user command injection).

## Fix
Added runner ownership verification at every place that resolves a persisted `runnerId` and then acts on it:

**Site 1 — Wake path** (`wakeOfflineSession`):
Before calling `wakeOfflineSession`, verify `runnerData.userId === identity.userId`. If the runner was reclaimed by another user → return 404 (fail-closed), never emit `new_session` to the foreign runner.

**Site 2 — DELETE subscription delta**:
Before emitting `emitTriggerSubscriptionDelta` on the unsubscribe path, verify the persisted runner still belongs to the caller. If not → skip the delta (log a warning), the Redis unsubscribe still completes.

**Site 3 — PUT subscription delta**:
Same guard as DELETE on the update path.

## Tests added (3 regression tests)
- `CROSS-USER: refuses wake when the session's runner was reclaimed by another user` — live session, runner-A now owned by user-2 → 404, zero `emitToRunner` calls
- `CROSS-USER: refuses wake when persisted runnerId was reclaimed by another user` — swept session (live record gone), runner-A now owned by user-2 → 404, zero `emitToRunner` calls  
- `CROSS-USER: DELETE completes but skips delta when runner was reclaimed by another user` — unsubscribe Redis op succeeds, but no delta emitted to foreign runner

All 111 tests pass.