### PR TITLE
fix: adopted-session process cleanup on session end (A1-012)

### DIFF
--- a/packages/cli/src/runner/daemon.test.ts
+++ b/packages/cli/src/runner/daemon.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { initServiceHandlers } from "./daemon.js";
 import type { ServiceHandler, ServiceInitOptions } from "./service-handler.js";
 import type { Socket } from "socket.io-client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 function makeSocket(): Socket {
     return {} as Socket;
@@ -86,5 +90,71 @@ describe("initServiceHandlers", () => {
         const result = initServiceHandlers(handlers, makeSocket(), makeOpts, initialized);
         expect(result.initialized).toEqual([]);
         expect(called).toBe(false);
+    });
+});
+
+describe("reapSessionGroups (adopted-session cleanup regression)", () => {
+    test("reaps recorded groups and removes proc file for the target session; leaves other sessions untouched", () => {
+        const tmpHome = mkdtempSync(join(tmpdir(), "reap-session-test-"));
+        const childTestPath = join(
+            import.meta.dir,
+            `.reap-session-child-${Date.now()}-${Math.random().toString(16).slice(2)}.test.ts`,
+        );
+        const cliDir = join(import.meta.dir, "../../..");
+
+        try {
+            writeFileSync(
+                childTestPath,
+                `
+import { describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+describe("reapSessionGroups", () => {
+    test("reaps target session proc groups and removes proc file; other session untouched", async () => {
+        const HOME = process.env.TEST_HOME!;
+        const procDir = join(HOME, ".pizzapi", "session-procs");
+        mkdirSync(procDir, { recursive: true });
+
+        // Target session proc file with two recorded group PIDs.
+        writeFileSync(join(procDir, "target-session.pids"), "11111\\n22222\\n");
+        // Another session whose proc file must NOT be removed.
+        writeFileSync(join(procDir, "other-session.pids"), "33333\\n");
+
+        const killCalls: number[] = [];
+        mock.module("./session-spawner.js", () => ({
+            killSessionProcessGroup: (pid: number) => { killCalls.push(pid); return true; },
+            spawnSession: () => {},
+            notifyWorkersOfRestart: async () => {},
+        }));
+
+        const { reapSessionGroups } = await import("./daemon.js");
+        reapSessionGroups("target-session");
+
+        // Both recorded group PIDs reaped for the target session.
+        expect(killCalls.sort((a, b) => a - b)).toEqual([11111, 22222]);
+
+        // Target proc file removed.
+        expect(existsSync(join(procDir, "target-session.pids"))).toBe(false);
+
+        // Other session's proc file untouched.
+        expect(existsSync(join(procDir, "other-session.pids"))).toBe(true);
+    });
+});
+`,
+            );
+
+            execFileSync(process.execPath, ["test", childTestPath], {
+                cwd: cliDir,
+                encoding: "utf-8",
+                env: { ...process.env, HOME: tmpHome, TEST_HOME: tmpHome },
+                stdio: ["ignore", "pipe", "pipe"],
+            });
+
+            expect(true).toBe(true); // child exited 0
+        } finally {
+            rmSync(childTestPath, { force: true });
+            rmSync(tmpHome, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -48,6 +48,20 @@ import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./run
 import { getWorkspaceRoots } from "./workspace.js";
 import { type RunnerSession, spawnSession, killSessionProcessGroup, notifyWorkersOfRestart } from "./session-spawner.js";
 import { pruneSessionCloseMetadata, type SessionCloseMetadata } from "./session-close-metadata.js";
+import { removeSessionProcFile, readRecordedGroupPids, sessionProcFilePath } from "./session-procs.js";
+
+/**
+ * Reap background command process groups recorded for a session and remove the
+ * session's pid file.  Safe to call multiple times — removeSessionProcFile uses
+ * force:true.  Called from session_ended for adopted sessions (only cleanup
+ * path) and idempotently for spawned sessions (child.on("exit") already ran).
+ */
+export function reapSessionGroups(sessionId: string): void {
+    for (const groupPid of readRecordedGroupPids(sessionProcFilePath(sessionId))) {
+        killSessionProcessGroup(groupPid);
+    }
+    removeSessionProcFile(sessionId);
+}
 
 import { scanGlobalSkills } from "../skills.js";
 import { scanGlobalAgents, readAgentContent } from "../agents.js";
@@ -1948,6 +1962,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // already ran cleanup, so this is a no-op (idempotent).  For adopted sessions
             // (child: null) this is the only cleanup path.
             void cleanupSessionAttachments(sessionId).catch(() => {});
+
+            // Reap background command process groups and remove the proc file.
+            // For spawned sessions, child.on("exit") already did this (idempotent).
+            // For adopted sessions there is no child handle — this is the only cleanup path.
+            reapSessionGroups(sessionId);
         });
 
         socket.on("list_sessions", () => {

--- a/packages/cli/src/runner/session-spawner-detach.test.ts
+++ b/packages/cli/src/runner/session-spawner-detach.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn, mock } from "bun:test";
 import type { ChildProcess } from "node:child_process";
-import { notifyWorkersOfRestart, type RunnerSession } from "./session-spawner.js";
+import { notifyWorkersOfRestart, killSessionProcessGroup, type RunnerSession } from "./session-spawner.js";
 
 function session(id: string, child: { connected: boolean; send: (...args: any[]) => boolean } | null): RunnerSession {
     return { sessionId: id, child: child as unknown as ChildProcess | null, startedAt: 0 };
@@ -39,5 +39,31 @@ describe("notifyWorkersOfRestart", () => {
             ["a", session("a", { connected: true, send: () => { throw new Error("EPIPE"); } })],
         ]);
         await notifyWorkersOfRestart(map, 50);
+    });
+});
+
+describe("killSessionProcessGroup — pid validation", () => {
+    test("rejects invalid pids without calling process.kill", () => {
+        const spy = spyOn(process, "kill").mockImplementation(() => true);
+        try {
+            for (const bad of [0, -1, -999, NaN, Infinity, -Infinity, 1.5, undefined]) {
+                const result = killSessionProcessGroup(bad as unknown as number);
+                expect(result).toBe(false);
+            }
+            expect(spy).not.toHaveBeenCalled();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    test("calls process.kill(-pid) for a valid positive integer pid", () => {
+        const spy = spyOn(process, "kill").mockImplementation(() => true);
+        try {
+            const result = killSessionProcessGroup(12345, "SIGTERM");
+            expect(result).toBe(true);
+            expect(spy).toHaveBeenCalledWith(-12345, "SIGTERM");
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -38,7 +38,7 @@ export interface RunnerSession {
  * platform without process groups).
  */
 export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): boolean {
-    if (!pid) return false;
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false; // ponytail: strict guard — rejects undefined, negative, zero, NaN, Infinity, non-integer
     try {
         process.kill(-pid, signal);
         return true;


### PR DESCRIPTION
Night Shift dish A1-012

## Problem
In `session_ended`, adopted sessions (no child process handle) never called `removeSessionProcFile` or reaped recorded command process groups. These groups (detached bash commands run during the session) survived the session and daemon restarts.

## Fix
- Added `reapSessionGroups(sessionId)` exported helper in `daemon.ts` that reads the session's recorded group PIDs, kills each via `killSessionProcessGroup`, and removes the proc file.
- Called `reapSessionGroups` at the end of the `session_ended` handler — idempotent for spawned sessions (child.on("exit") already ran it), mandatory for adopted sessions.
- Imported `removeSessionProcFile`, `readRecordedGroupPids`, `sessionProcFilePath` from `session-procs.ts`.

## Regression test
`daemon.test.ts` → *reapSessionGroups (adopted-session cleanup regression)*: writes real proc files for a target session (PIDs 11111, 22222) and another session (33333), mocks `killSessionProcessGroup`, calls `reapSessionGroups`, and asserts: both target PIDs reaped, target proc file removed, other session's proc file untouched.

## Verification
```
bun test src/runner   # 571 pass, 0 fail
bun run typecheck     # exit 0
```