### PR TITLE
fix: abort resync hydration when viewer switches sessions (A2-016)

### DIFF
--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -78,6 +78,7 @@ function emitSnapshotWithTrailingDeltas(
     cached: LatestCachedSnapshot,
     generation: number | undefined,
     snapshotOverlay?: string | null,
+    sessionId?: string,
 ): void {
     // The cached session_active predates any later metadata-only updates (queue,
     // model, todo list), which are carried by the overlay rather than re-cached.
@@ -86,10 +87,10 @@ function emitSnapshotWithTrailingDeltas(
     if (snapshotOverlay && event.type === "session_active") {
         event = { ...event, state: applySnapshotOverlayToState(event.state, snapshotOverlay) };
     }
-    socket.emit("event", { event, replay: true, generation });
+    socket.emit("event", { event, replay: true, generation, ...(sessionId !== undefined ? { sessionId } : {}) });
     // Replay deltas cached after the snapshot so the viewer isn't left stale
     // between the snapshot and the seq advertised in "connected".
-    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
+    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation, sessionId);
 }
 
 export async function sendLatestSnapshotFromCache(
@@ -102,7 +103,7 @@ export async function sendLatestSnapshotFromCache(
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return false;
 
-    emitSnapshotWithTrailingDeltas(socket, cached, generation, snapshotOverlay);
+    emitSnapshotWithTrailingDeltas(socket, cached, generation, snapshotOverlay, sessionId);
     return true;
 }
 
@@ -110,6 +111,7 @@ export function sendCachedDeltaReplayEvents(
     socket: ViewerEventEmitter,
     cachedEvents: CachedRelayEvent[],
     generation?: number,
+    sessionId?: string,
 ): boolean {
     let sentAny = false;
 
@@ -124,6 +126,7 @@ export function sendCachedDeltaReplayEvents(
             replay: true,
             deltaReplay: true,
             generation,
+            ...(sessionId !== undefined ? { sessionId } : {}),
         });
     }
 
@@ -138,7 +141,7 @@ async function sendDeltaReplayFromCache(
     deps: ViewerCacheDeps,
 ): Promise<boolean> {
     const cachedEvents = await deps.getCachedRelayEventsAfterSeq(sessionId, afterSeq);
-    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation);
+    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation, sessionId);
 }
 
 /**
@@ -180,7 +183,7 @@ export async function hydrateViewerFromCache(
             // reach is decidable. Refusing outright left resyncing viewers blank.
             const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
             if (cached && snapshotCoversCursor(cached, opts.lastSeq)) {
-                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation, opts.snapshotOverlay);
+                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation, opts.snapshotOverlay, sessionId);
                 return true;
             }
 

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -371,6 +371,34 @@ describe("checkServiceMessageRateLimit", () => {
     });
 });
 
+// ── sendCachedDeltaReplayEvents — sessionId stamp (A2-016) ──────────────────
+
+describe("sendCachedDeltaReplayEvents — sessionId stamp", () => {
+    test("stamps replay envelopes with sessionId when provided", () => {
+        const calls: unknown[][] = [];
+        const socket = { emit: (...args: unknown[]) => { calls.push(args); return true; } } as any;
+
+        sendCachedDeltaReplayEvents(socket, [
+            { seq: 1, event: { type: "text_delta" } },
+        ], 3, "session-A");
+
+        expect(calls.length).toBe(1);
+        expect((calls[0][1] as Record<string, unknown>).sessionId).toBe("session-A");
+    });
+
+    test("omits sessionId when not provided (backward-compat)", () => {
+        const calls: unknown[][] = [];
+        const socket = { emit: (...args: unknown[]) => { calls.push(args); return true; } } as any;
+
+        sendCachedDeltaReplayEvents(socket, [
+            { seq: 1, event: { type: "text_delta" } },
+        ], 3);
+
+        expect(calls.length).toBe(1);
+        expect((calls[0][1] as Record<string, unknown>).sessionId).toBeUndefined();
+    });
+});
+
 describe("runnerLooksLive", () => {
     test("live: isActive with a fresh heartbeat", () => {
         expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: new Date().toISOString() })).toBe(true);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -716,6 +716,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("resync", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
+            // Capture generation BEFORE any await so we can detect a viewer
+            // switch that happens while Redis reads are in flight. If the
+            // viewer switches from A→B during the await, getCurrentGeneration()
+            // returns B's generation — replaying A's cache with B's generation
+            // passes the client's matchesHydrationGeneration check and corrupts
+            // B's state. Capturing here lets us abort the continuation.
+            const resyncGeneration = getCurrentGeneration();
             // Never answer an in-flight chunk resync with lastState: it is the
             // previous completed checkpoint until server assembly finishes.
             // The client keeps the last good transcript visible and retries on
@@ -735,15 +742,21 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     getSharedSession(currentSessionId),
                     getSessionSeq(currentSessionId),
                 ]);
+                // Viewer switched sessions while we were awaiting Redis — abort.
+                // Emitting A's cache replay under B's (post-switch) generation
+                // would pass the client's generation guard and corrupt B's state.
+                // The client-side matchesViewerSession guard provides a second
+                // layer of defence via the sessionId stamp on replay envelopes.
+                if (getCurrentGeneration() !== resyncGeneration) return;
                 const cacheHydrated = await hydrateViewerFromCache(socket, currentSessionId, {
                     lastSeq: requestedLastSeq,
-                    generation: getCurrentGeneration(),
+                    generation: resyncGeneration,
                     snapshotOverlay: resyncSession?.snapshotOverlay,
                     latestSessionSeq: resyncSeq,
                 });
                 if (cacheHydrated) {
                     if (resyncStaleStream) {
-                        forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                        forwardRecoverySignalOrNotify(currentSessionId, socket, resyncGeneration);
                     }
                     return;
                 }
@@ -754,7 +767,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 // Reaching here means only unsequenced state is left, which
                 // cannot safely fill the gap — ask the runner for a fresh one.
                 if (requestedLastSeq !== undefined && !resyncChunkedPending) {
-                    forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                    forwardRecoverySignalOrNotify(currentSessionId, socket, resyncGeneration);
                 }
                 return;
             }

--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -1,0 +1,58 @@
+// ============================================================================
+// App.test.tsx — Switch-race resync hydration guard tests (A2-016)
+//
+// Verifies that replay envelopes stamped with a session ID are dropped by the
+// client when the active viewer session has switched, preventing cross-session
+// state corruption.
+// ============================================================================
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { matchesViewerSession } from "@/lib/viewer-switch";
+
+// ── matchesViewerSession — client-side replay filter ─────────────────────────
+
+describe("matchesViewerSession — resync switch-race guard", () => {
+  test("drops replay stamped with wrong session (cross-session bleed)", () => {
+    // Viewer switched from A to B. A replay envelope arrives stamped for A.
+    expect(matchesViewerSession("session-B", "session-A")).toBe(false);
+  });
+
+  test("accepts replay stamped with the current session", () => {
+    expect(matchesViewerSession("session-A", "session-A")).toBe(true);
+  });
+
+  test("accepts unstamped replay envelope (older server, no sessionId)", () => {
+    // Older servers don't stamp envelopes — accept and let generation guard apply.
+    expect(matchesViewerSession("session-B", undefined)).toBe(true);
+  });
+
+  test("accepts replay when active session is null but envelope is also null/undefined", () => {
+    expect(matchesViewerSession(null, undefined)).toBe(true);
+  });
+
+  test("drops when active session is null but envelope has a specific sessionId", () => {
+    // No active session yet; a stale replay for an old session must be dropped.
+    expect(matchesViewerSession(null, "session-A")).toBe(false);
+  });
+});
+
+// ── App.tsx structural wiring ─────────────────────────────────────────────────
+
+describe("App.tsx wiring — matchesViewerSession applied to resync replay path", () => {
+  const src = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
+
+  test("imports matchesViewerSession from viewer-switch", () => {
+    expect(src).toMatch(/matchesViewerSession/);
+  });
+
+  test("reads sessionId from the viewer event envelope", () => {
+    // The envelope destructuring must extract sessionId.
+    expect(src).toMatch(/sessionId.*envelopeSessionId|envelopeSessionId.*sessionId/);
+  });
+
+  test("calls matchesViewerSession before processing envelope events", () => {
+    // Guard is called in the hot path before any state mutations.
+    expect(src).toMatch(/matchesViewerSession\(.*activeSessionId.*envelopeSessionId/s);
+  });
+});


### PR DESCRIPTION
Night Shift dish A2-016

## Problem
The `resync` handler captured `sessionId` then awaited Redis reads. If the viewer switched from session A→B during the await, the continuation emitted A's replay cache using the post-switch generation (now B's), with no `sessionId` stamp. The client accepted it — A's state corrupted B's viewer.

## Fix (two-sided)

### Server (`packages/server/src/ws/namespaces/viewer.ts`, `viewer-cache.ts`)
- **Generation capture**: Capture `resyncGeneration = getCurrentGeneration()` before any async operations. After the Redis await, abort if generation changed (`getCurrentGeneration() !== resyncGeneration`).
- **SessionId stamp**: `sendCachedDeltaReplayEvents` and `emitSnapshotWithTrailingDeltas` now accept an optional `sessionId` and include it in each emitted `event` envelope. `hydrateViewerFromCache` threads the `sessionId` through.

### Client (`packages/ui/src/App.tsx`)
The existing `matchesViewerSession` guard (already in place for live-event bleed) now automatically drops resync replay envelopes stamped for session A when the active session is B.

## Tests
- `packages/ui/src/App.test.tsx` (new): switch-race guard unit tests — drops A-stamped replay when active is B, accepts same-session replay, accepts unstamped replay (backward compat with older servers).
- `packages/server/src/ws/namespaces/viewer.test.ts`: two new tests verifying `sendCachedDeltaReplayEvents` stamps `sessionId` when provided and omits it when not.

## Verification
```
cd packages/ui && bun test src/App.test.tsx  # 8/8 pass
```
No new TS errors (baseline 264 lines, after-patch 264 lines).