### PR TITLE
fix: protect replacement sessions from stale cross-node disconnects (A2-017)

### DIFF
--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ack.test.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ack.test.ts
@@ -27,6 +27,8 @@ mock.module("../../sio-registry.js", () => ({
 }));
 
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     removeChildSession: async (parentId: string, childId: string) => {
         childSets.get(parentId)?.delete(childId);
     },

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -95,7 +95,11 @@ mock.module("@pizzapi/protocol", () => ({
 
 afterAll(() => mock.restore());
 
-const { registerEventHandler } = await import("./event-pipeline.js");
+const { registerEventHandler, sessionEventQueues } = await import("./event-pipeline.js");
+
+async function drainPipeline(sessionId: string): Promise<void> {
+    await sessionEventQueues.get(sessionId);
+}
 
 function makeSocket(sessionId: string, token: string) {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
@@ -134,8 +138,9 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         await fireA("event", {
             token: "token-node-a",
             seq: 1,
-            event: { type: "heartbeat", active: true },
+            event: { type: "session_active", state: { sessionFile: "stale.json" } },
         });
+        await drainPipeline("sess-1");
 
         expect(stateUpdates).toHaveLength(0);
         expect(broadcasts).toHaveLength(0);
@@ -149,15 +154,12 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         await fireB("event", {
             token: "token-node-b",
             seq: 2,
-            event: { type: "heartbeat", active: true },
+            event: { type: "session_active", state: { sessionFile: "current.json" } },
         });
+        await drainPipeline("sess-1");
 
-        // heartbeat calls updateSessionHeartbeat (not stateUpdates/broadcasts)
-        // but the key assertion is the event was NOT rejected early.
-        // Since heartbeat doesn't call updateSessionState/broadcastSessionEventToViewers,
-        // we just confirm no errors thrown and token guard didn't block it.
-        // The absence of any throw is the assertion here.
-        expect(true).toBe(true);
+        expect(stateUpdates).toEqual(["sess-1"]);
+        expect(broadcasts).toEqual(["sess-1"]);
     });
 
     it("Redis read throws → fail-open: event is accepted (not dropped)", async () => {
@@ -169,10 +171,15 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         tokenReadShouldThrow = true; // Redis throws on next read
 
         // Must not reject — event proceeds through the pipeline.
-        await expect(
-            fireA("event", { token: "token-node-a", seq: 1, event: { type: "heartbeat", active: true } }),
-        ).resolves.toBeUndefined();
-        // No unhandled throw means the event was not dropped via a rejection.
+        await fireA("event", {
+            token: "token-node-a",
+            seq: 1,
+            event: { type: "session_active", state: { sessionFile: "redis-error.json" } },
+        });
+        await drainPipeline("sess-1");
+
+        expect(stateUpdates).toEqual(["sess-1"]);
+        expect(broadcasts).toEqual(["sess-1"]);
     });
 
     it("accepts events when Redis has no session yet (sharedOwnerToken === null)", async () => {
@@ -186,6 +193,7 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
             seq: 1,
             event: { type: "heartbeat", active: false },
         });
+        await drainPipeline("sess-1");
 
         expect(stateUpdates).toHaveLength(0); // heartbeat doesn't write state
     });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -1,0 +1,170 @@
+// ============================================================================
+// event-pipeline.cross-node.test.ts — Regression: A2-017
+//
+// Verifies that stale events arriving on a superseded cross-node socket are
+// silently dropped (no state updates, no viewer broadcasts) when the shared
+// Redis owner token has been bumped by a replacement session on another node.
+// ============================================================================
+
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Shared spy state ─────────────────────────────────────────────────────────
+const stateUpdates: string[] = [];
+const broadcasts: string[] = [];
+let redisOwnerToken: string | null = "token-node-a";
+
+mock.module("../../sio-registry.js", () => ({
+    getSessionOwnerToken: async (_sessionId: string) => redisOwnerToken,
+    updateSessionState: async (sessionId: string) => { stateUpdates.push(sessionId); },
+    patchSessionSnapshotState: async () => {},
+    touchSessionActivity: async () => {},
+    updateSessionHeartbeat: async () => {},
+    getSharedSession: async () => null,
+    getSharedSessionSummary: async () => null,
+    broadcastSessionEventToViewers: async (sessionId: string) => { broadcasts.push(sessionId); },
+    publishSessionEvent: async (sessionId: string) => { broadcasts.push(sessionId); return 0; },
+    consumePendingRecovery: () => false,
+    updateSessionMetaState: async () => 0,
+    broadcastToSessionMeta: async () => {},
+    getSessionMetaState: async () => null,
+}));
+
+mock.module("../../../sessions/redis.js", () => ({
+    appendRelayEventToCache: async () => {},
+}));
+
+mock.module("./viewer-gate.js", () => ({
+    isDeltaEvent: () => false,
+    shouldPublishDelta: () => true,
+    forgetViewerGate: () => {},
+}));
+
+mock.module("../../sio-registry/meta.js", () => ({
+    updateSessionMetaState: async () => 0,
+    broadcastToSessionMeta: async () => {},
+    getSessionMetaState: async () => null,
+    buildSnapshotPatchFromMetadata: () => ({}),
+    buildSnapshotPatchFromCapabilities: () => ({}),
+}));
+
+mock.module("../../sio-registry/snapshot-state.js", () => ({
+    buildSnapshotPatchFromCapabilities: () => ({}),
+    buildSnapshotPatchFromMetadata: () => ({}),
+}));
+
+mock.module("../../strip-images.js", () => ({
+    storeAndReplaceImagesInEvent: async (_e: unknown) => _e,
+    stripImagesFromPipelineEvent: async (_e: unknown) => _e,
+}));
+
+mock.module("./thinking-tracker.js", () => ({
+    trackThinkingDeltas: () => {},
+    augmentMessageThinkingDurations: (_e: unknown) => _e,
+    clearThinkingMaps: () => {},
+    thinkingDurations: new Map(),
+}));
+
+mock.module("./ack-tracker.js", () => ({
+    socketAckedSeqs: new Map(),
+    sendCumulativeEventAck: () => {},
+}));
+
+mock.module("./push-tracker.js", () => ({
+    trackPushPendingState: async () => {},
+    checkPushNotifications: async () => {},
+}));
+
+mock.module("../../../sessions/store.js", () => ({
+    updateRelaySessionName: async () => {},
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    updateSessionFields: async () => {},
+}));
+
+mock.module("@pizzapi/protocol", () => ({
+    isMetaRelayEvent: () => false,
+    metaEventToPatch: () => ({}),
+}));
+
+afterAll(() => mock.restore());
+
+const { registerEventHandler } = await import("./event-pipeline.js");
+
+function makeSocket(sessionId: string, token: string) {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    return {
+        socket: {
+            id: "sock-x",
+            data: { sessionId, token },
+            on(event: string, cb: (...args: unknown[]) => unknown) {
+                handlers.set(event, cb);
+            },
+            emit: () => {},
+        } as never,
+        fire: async (event: string, data?: unknown) => {
+            const h = handlers.get(event);
+            if (h) await h(data);
+        },
+    };
+}
+
+describe("A2-017: event pipeline stale cross-node socket rejection", () => {
+    beforeEach(() => {
+        stateUpdates.length = 0;
+        broadcasts.length = 0;
+        redisOwnerToken = "token-node-a";
+    });
+
+    it("rejects a stale event (token mismatch) — no state update or broadcast", async () => {
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        registerEventHandler(socketA);
+
+        // Replacement registers on node-B — bumps shared token.
+        redisOwnerToken = "token-node-b";
+
+        // Stale event arrives on node-A socket with old token.
+        await fireA("event", {
+            token: "token-node-a",
+            seq: 1,
+            event: { type: "heartbeat", active: true },
+        });
+
+        expect(stateUpdates).toHaveLength(0);
+        expect(broadcasts).toHaveLength(0);
+    });
+
+    it("accepts a valid event from the current owner socket", async () => {
+        redisOwnerToken = "token-node-b";
+        const { socket: socketB, fire: fireB } = makeSocket("sess-1", "token-node-b");
+        registerEventHandler(socketB);
+
+        await fireB("event", {
+            token: "token-node-b",
+            seq: 2,
+            event: { type: "heartbeat", active: true },
+        });
+
+        // heartbeat calls updateSessionHeartbeat (not stateUpdates/broadcasts)
+        // but the key assertion is the event was NOT rejected early.
+        // Since heartbeat doesn't call updateSessionState/broadcastSessionEventToViewers,
+        // we just confirm no errors thrown and token guard didn't block it.
+        // The absence of any throw is the assertion here.
+        expect(true).toBe(true);
+    });
+
+    it("accepts events when Redis has no session yet (sharedOwnerToken === null)", async () => {
+        redisOwnerToken = null; // session deleted or not yet written
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        registerEventHandler(socketA);
+
+        // Should NOT reject — null means session doesn't exist yet.
+        await fireA("event", {
+            token: "token-node-a",
+            seq: 1,
+            event: { type: "heartbeat", active: false },
+        });
+
+        expect(stateUpdates).toHaveLength(0); // heartbeat doesn't write state
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -85,6 +85,8 @@ mock.module("../../../sessions/store.js", () => ({
 }));
 
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     updateSessionFields: async () => {},
 }));
 
@@ -162,15 +164,14 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         expect(broadcasts).toEqual(["sess-1"]);
     });
 
-    it("Redis read throws → fail-open: event is accepted (not dropped)", async () => {
-        // When the Redis hGet call throws, getSessionOwnerToken returns null.
-        // null → fail-open: the guard must NOT drop the event.
+    it("Redis read throws → fail-closed: event is dropped", async () => {
+        // Unknown ownership must never authorize processing a sensitive event.
         const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
         registerEventHandler(socketA);
 
         tokenReadShouldThrow = true; // Redis throws on next read
 
-        // Must not reject — event proceeds through the pipeline.
+        // The socket-level acknowledgement is harmless, but processing is dropped.
         await fireA("event", {
             token: "token-node-a",
             seq: 1,
@@ -178,23 +179,23 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         });
         await drainPipeline("sess-1");
 
-        expect(stateUpdates).toEqual(["sess-1"]);
-        expect(broadcasts).toEqual(["sess-1"]);
+        expect(stateUpdates).toHaveLength(0);
+        expect(broadcasts).toHaveLength(0);
     });
 
-    it("accepts events when Redis has no session yet (sharedOwnerToken === null)", async () => {
+    it("drops events when Redis has no session owner token", async () => {
         redisOwnerToken = null; // session deleted or not yet written
         const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
         registerEventHandler(socketA);
 
-        // Should NOT reject — null means session doesn't exist yet.
         await fireA("event", {
             token: "token-node-a",
             seq: 1,
-            event: { type: "heartbeat", active: false },
+            event: { type: "session_active", state: { sessionFile: "missing.json" } },
         });
         await drainPipeline("sess-1");
 
-        expect(stateUpdates).toHaveLength(0); // heartbeat doesn't write state
+        expect(stateUpdates).toHaveLength(0);
+        expect(broadcasts).toHaveLength(0);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -12,9 +12,15 @@ import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
 const stateUpdates: string[] = [];
 const broadcasts: string[] = [];
 let redisOwnerToken: string | null = "token-node-a";
+let tokenReadShouldThrow = false;
 
 mock.module("../../sio-registry.js", () => ({
-    getSessionOwnerToken: async (_sessionId: string) => redisOwnerToken,
+    // After the A2-017 expo fix, getSessionOwnerToken catches Redis errors and
+    // returns null (fail-open).  Simulate that: return null when shouldThrow.
+    getSessionOwnerToken: async (_sessionId: string) => {
+        if (tokenReadShouldThrow) return null;
+        return redisOwnerToken;
+    },
     updateSessionState: async (sessionId: string) => { stateUpdates.push(sessionId); },
     patchSessionSnapshotState: async () => {},
     touchSessionActivity: async () => {},
@@ -114,6 +120,7 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         stateUpdates.length = 0;
         broadcasts.length = 0;
         redisOwnerToken = "token-node-a";
+        tokenReadShouldThrow = false;
     });
 
     it("rejects a stale event (token mismatch) — no state update or broadcast", async () => {
@@ -151,6 +158,21 @@ describe("A2-017: event pipeline stale cross-node socket rejection", () => {
         // we just confirm no errors thrown and token guard didn't block it.
         // The absence of any throw is the assertion here.
         expect(true).toBe(true);
+    });
+
+    it("Redis read throws → fail-open: event is accepted (not dropped)", async () => {
+        // When the Redis hGet call throws, getSessionOwnerToken returns null.
+        // null → fail-open: the guard must NOT drop the event.
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        registerEventHandler(socketA);
+
+        tokenReadShouldThrow = true; // Redis throws on next read
+
+        // Must not reject — event proceeds through the pipeline.
+        await expect(
+            fireA("event", { token: "token-node-a", seq: 1, event: { type: "heartbeat", active: true } }),
+        ).resolves.toBeUndefined();
+        // No unhandled throw means the event was not dropped via a rejection.
     });
 
     it("accepts events when Redis has no session yet (sharedOwnerToken === null)", async () => {

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -13,6 +13,7 @@ import {
     broadcastSessionEventToViewers,
     publishSessionEvent,
     consumePendingRecovery,
+    getSessionOwnerToken,
 } from "../../sio-registry.js";
 import { appendRelayEventToCache } from "../../../sessions/redis.js";
 import { isDeltaEvent, shouldPublishDelta } from "./viewer-gate.js";
@@ -270,6 +271,17 @@ export function registerEventHandler(socket: RelaySocket): void {
 
         // Serialize async processing per session to guarantee chunk order.
         enqueueSessionEvent(sessionId, async () => {
+
+        // ── Cross-node stale socket guard ────────────────────────────────
+        // A replacement session may have registered on a different relay node.
+        // Compare this socket's captured token against the current shared
+        // (Redis) owner token.  If they differ, this socket is stale and
+        // superseded — reject the event silently (do not update any state or
+        // broadcast to viewers).
+        const _sharedOwnerToken = await getSessionOwnerToken(sessionId);
+        if (_sharedOwnerToken !== null && _sharedOwnerToken !== socket.data.token) {
+            return; // ponytail: stale cross-node event, replacement session owns sessionId
+        }
 
         // ── Single-pass image stripping ──────────────────────────────────
         // Strip inline base64 images ONCE at ingestion so all downstream

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -278,9 +278,15 @@ export function registerEventHandler(socket: RelaySocket): void {
         // (Redis) owner token.  If they differ, this socket is stale and
         // superseded — reject the event silently (do not update any state or
         // broadcast to viewers).
-        const _sharedOwnerToken = await getSessionOwnerToken(sessionId);
-        if (_sharedOwnerToken !== null && _sharedOwnerToken !== socket.data.token) {
-            return; // ponytail: stale cross-node event, replacement session owns sessionId
+        let sharedOwnerToken: string | null;
+        try {
+            sharedOwnerToken = await getSessionOwnerToken(sessionId);
+        } catch {
+            console.warn(`[sio/relay] Redis ownership lookup failed for ${sessionId}; dropping event`);
+            return;
+        }
+        if (sharedOwnerToken !== socket.data.token) {
+            return; // stale or unknown owner; never process sensitive events
         }
 
         // ── Single-pass image stripping ──────────────────────────────────

--- a/packages/server/src/ws/namespaces/relay/messaging.test.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.test.ts
@@ -19,6 +19,8 @@ mock.module("../../sio-registry.js", () => ({
 }));
 
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     isChildOfParent: mockIsChildOfParent,
     isPendingParentDelinkChild: mockIsPendingParentDelinkChild,
     refreshChildSessionsTTL: mockRefreshChildSessionsTTL,

--- a/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
+++ b/packages/server/src/ws/namespaces/relay/push-tracker.test.ts
@@ -12,6 +12,8 @@ mock.module("../../../push.js", () => ({
     notifyAgentError: () => {},
 }));
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     setPushPendingQuestion: async () => {},
     clearPushPendingQuestion: async () => {},
     isLinkedChildForSuppression: async () => false,

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
@@ -18,6 +18,10 @@ const endedSessions: Array<{ sessionId: string; reason?: string; opts?: unknown 
 let redisOwnerToken: string | null = "token-node-a";
 // Set to true to simulate a Redis read error (fix returns null, not throws).
 let tokenReadShouldThrow = false;
+let getSessionOwnerTokenForTest = async (_sessionId: string) => {
+    if (tokenReadShouldThrow) return null;
+    return redisOwnerToken;
+};
 
 mock.module("../../sio-registry.js", () => ({
     registerTuiSession: async (_socket: unknown, _cwd: string, opts: { sessionId?: string }) => ({
@@ -34,16 +38,16 @@ mock.module("../../sio-registry.js", () => ({
         return localSocketMap.get(sessionId);
     },
     broadcastToViewers: () => {},
-    endSharedSession: async (sessionId: string, reason?: string, opts?: unknown) => {
+    endSharedSession: async (sessionId: string, reason?: string, opts?: { expectedOwnerToken?: string }) => {
+        // Model the atomic delete guard: a replacement that rotates the token
+        // after the lifecycle check must still prevent deletion.
+        if (opts?.expectedOwnerToken && redisOwnerToken !== opts.expectedOwnerToken) return;
         endedSessions.push({ sessionId, reason, opts });
     },
     // Returns the CURRENT shared (Redis) owner token — bumped by node-B's register.
     // After the A2-017 expo fix, getSessionOwnerToken catches Redis errors and
     // returns null (fail-open).  Simulate that: return null when shouldThrow.
-    getSessionOwnerToken: async (_sessionId: string) => {
-        if (tokenReadShouldThrow) return null;
-        return redisOwnerToken;
-    },
+    getSessionOwnerToken: (sessionId: string) => getSessionOwnerTokenForTest(sessionId),
 }));
 
 mock.module("../../sio-state/index.js", () => ({
@@ -97,6 +101,10 @@ describe("A2-017: cross-node stale socket protection", () => {
         endedSessions.length = 0;
         redisOwnerToken = "token-node-a";
         tokenReadShouldThrow = false;
+        getSessionOwnerTokenForTest = async (_sessionId: string) => {
+            if (tokenReadShouldThrow) return null;
+            return redisOwnerToken;
+        };
         localSocketMap.clear();
     });
 
@@ -144,6 +152,23 @@ describe("A2-017: cross-node stale socket protection", () => {
         });
 
         // Session must not have been ended.
+        expect(endedSessions).toHaveLength(0);
+    });
+
+    it("token rotation between ownership check and teardown does NOT end replacement", async () => {
+        const { socket, fire } = makeSocket("sess-1", "token-node-a");
+        localSocketMap.set("sess-1", socket);
+        registerSessionLifecycleHandlers(socket);
+
+        // The check returns the old owner, then a replacement wins before
+        // endSharedSession receives the expected token.
+        const original = getSessionOwnerTokenForTest;
+        getSessionOwnerTokenForTest = async () => {
+            getSessionOwnerTokenForTest = original;
+            redisOwnerToken = "token-node-b";
+            return "token-node-a";
+        };
+        await fire("disconnect", "transport close");
         expect(endedSessions).toHaveLength(0);
     });
 

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
@@ -16,6 +16,8 @@ const endedSessions: Array<{ sessionId: string; reason?: string; opts?: unknown 
 
 // Current Redis owner token — bumped when the replacement registers.
 let redisOwnerToken: string | null = "token-node-a";
+// Set to true to simulate a Redis read error (fix returns null, not throws).
+let tokenReadShouldThrow = false;
 
 mock.module("../../sio-registry.js", () => ({
     registerTuiSession: async (_socket: unknown, _cwd: string, opts: { sessionId?: string }) => ({
@@ -36,7 +38,12 @@ mock.module("../../sio-registry.js", () => ({
         endedSessions.push({ sessionId, reason, opts });
     },
     // Returns the CURRENT shared (Redis) owner token — bumped by node-B's register.
-    getSessionOwnerToken: async (_sessionId: string) => redisOwnerToken,
+    // After the A2-017 expo fix, getSessionOwnerToken catches Redis errors and
+    // returns null (fail-open).  Simulate that: return null when shouldThrow.
+    getSessionOwnerToken: async (_sessionId: string) => {
+        if (tokenReadShouldThrow) return null;
+        return redisOwnerToken;
+    },
 }));
 
 mock.module("../../sio-state/index.js", () => ({
@@ -89,6 +96,7 @@ describe("A2-017: cross-node stale socket protection", () => {
     beforeEach(() => {
         endedSessions.length = 0;
         redisOwnerToken = "token-node-a";
+        tokenReadShouldThrow = false;
         localSocketMap.clear();
     });
 
@@ -149,6 +157,22 @@ describe("A2-017: cross-node stale socket protection", () => {
 
         await fireB("disconnect", "transport close");
 
+        expect(endedSessions).toHaveLength(1);
+        expect(endedSessions[0].sessionId).toBe("sess-1");
+    });
+
+    it("Redis read throws on disconnect → fail-open: teardown proceeds as current owner", async () => {
+        // Simulate a Redis error during the owner-token read in the disconnect guard.
+        // The guard must treat unknown-owner (null) as fail-open → endSharedSession IS called.
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        localSocketMap.set("sess-1", socketA);
+        registerSessionLifecycleHandlers(socketA);
+
+        tokenReadShouldThrow = true; // Redis will throw on next hGet
+
+        await fireA("disconnect", "transport close");
+
+        // Fail-open: teardown must NOT be blocked — treat as matching (unknown) owner.
         expect(endedSessions).toHaveLength(1);
         expect(endedSessions[0].sessionId).toBe("sess-1");
     });

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
@@ -1,0 +1,170 @@
+// ============================================================================
+// session-lifecycle.cross-node.test.ts — Regression: A2-017
+//
+// Scenario: node-A socket registers a session, then node-B registers a
+// REPLACEMENT for the same session (bumping the Redis owner token).  When
+// node-A's socket later disconnects, endSharedSession must NOT be called
+// (the replacement session on node-B survives).  Stale events arriving on
+// node-A's socket are also rejected.  Only the replacement (current-token)
+// socket's disconnect may end the session.
+// ============================================================================
+
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Shared test state ────────────────────────────────────────────────────────
+const endedSessions: Array<{ sessionId: string; reason?: string; opts?: unknown }> = [];
+
+// Current Redis owner token — bumped when the replacement registers.
+let redisOwnerToken: string | null = "token-node-a";
+
+mock.module("../../sio-registry.js", () => ({
+    registerTuiSession: async (_socket: unknown, _cwd: string, opts: { sessionId?: string }) => ({
+        sessionId: opts.sessionId ?? "sess-1",
+        token: redisOwnerToken ?? "token-node-a",
+        shareUrl: "",
+        parentSessionId: null,
+        wasDelinked: false,
+    }),
+    // Node-local socket map — simulate node-A not having node-B's socket.
+    getLocalTuiSocket: (sessionId: string) => {
+        // On node-A the local socket map has the stale socketA; after node-B
+        // registers it is NOT updated (maps are node-local).
+        return localSocketMap.get(sessionId);
+    },
+    broadcastToViewers: () => {},
+    endSharedSession: async (sessionId: string, reason?: string, opts?: unknown) => {
+        endedSessions.push({ sessionId, reason, opts });
+    },
+    // Returns the CURRENT shared (Redis) owner token — bumped by node-B's register.
+    getSessionOwnerToken: async (_sessionId: string) => redisOwnerToken,
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    clearPushPendingQuestion: async () => {},
+    deleteRunnerAssociation: async () => {},
+}));
+
+mock.module("./event-pipeline.js", () => ({
+    pendingChunkedStates: new Map(),
+    enqueueSessionEvent: async (_id: string, fn: () => Promise<void>) => fn(),
+}));
+
+mock.module("./ack-tracker.js", () => ({ socketAckedSeqs: new Map() }));
+mock.module("./thinking-tracker.js", () => ({ clearThinkingMaps: () => {} }));
+mock.module("./viewer-gate.js", () => ({ forgetViewerGate: () => {} }));
+mock.module("../../../health.js", () => ({ shouldPreserveOnSocketDisconnect: () => false }));
+mock.module("../../../user-preferences.js", () => ({
+    getUserPreference: async () => null,
+    PREF_SUBAGENT_MODEL: "subagent_model",
+}));
+
+afterAll(() => mock.restore());
+
+const { registerSessionLifecycleHandlers } = await import("./session-lifecycle.js");
+
+// Node-A local socket map — simulates localTuiSockets on node A.
+// Node B's register does NOT touch this map (different process/node).
+const localSocketMap = new Map<string, object>();
+
+function makeSocket(sessionId: string, token: string, socketId = "sock-a") {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const socket = {
+        id: socketId,
+        data: { sessionId, token },
+        on(event: string, cb: (...args: unknown[]) => unknown) {
+            handlers.set(event, cb);
+        },
+        emit: () => {},
+    } as never;
+    return {
+        socket,
+        fire: async (event: string, data?: unknown) => {
+            const h = handlers.get(event);
+            if (h) await h(data);
+        },
+    };
+}
+
+describe("A2-017: cross-node stale socket protection", () => {
+    beforeEach(() => {
+        endedSessions.length = 0;
+        redisOwnerToken = "token-node-a";
+        localSocketMap.clear();
+    });
+
+    it("node-A stale disconnect does NOT end the replacement session", async () => {
+        // 1. Node-A socket registers — local map points to socketA.
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        localSocketMap.set("sess-1", socketA);
+        registerSessionLifecycleHandlers(socketA);
+
+        // 2. Node-B registers a replacement — bumps the shared Redis token.
+        //    Node-A's localSocketMap is NOT updated (node-local).
+        redisOwnerToken = "token-node-b";
+
+        // 3. Node-A socket disconnects — must NOT call endSharedSession.
+        await fireA("disconnect", "transport close");
+
+        expect(endedSessions).toHaveLength(0);
+    });
+
+    it("stale event from node-A socket is rejected after replacement registers", async () => {
+        // Spy on the event pipeline enqueue to check if processing runs.
+        const processedEvents: string[] = [];
+        const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
+        localSocketMap.set("sess-1", socketA);
+
+        // Override enqueueSessionEvent to track whether the pipeline ran.
+        // We re-mock after original import to capture the spy.
+        // Instead: verify endSharedSession is NOT called and that the
+        // session is not modified (event-pipeline mock swallows all async work).
+        // The token guard is inside enqueueSessionEvent — just verify no error
+        // is thrown and the session is not harmed.
+        registerSessionLifecycleHandlers(socketA);
+
+        // Replacement registers on node-B.
+        redisOwnerToken = "token-node-b";
+
+        // Fire a stale event with old token — should be silently dropped.
+        // (No assertion on processedEvents since the pipeline is mocked;
+        //  the key assertion is that endSharedSession was never called and
+        //  no uncaught error is thrown.)
+        await fireA("event", {
+            token: "token-node-a",
+            seq: 1,
+            event: { type: "heartbeat", active: true },
+        });
+
+        // Session must not have been ended.
+        expect(endedSessions).toHaveLength(0);
+    });
+
+    it("replacement (current-token) socket disconnect DOES end the session", async () => {
+        // Node-B's socket has the new token matching the Redis owner token.
+        const { socket: socketB, fire: fireB } = makeSocket("sess-1", "token-node-b", "sock-b");
+        // On node-B the local map holds socketB.
+        localSocketMap.set("sess-1", socketB);
+        redisOwnerToken = "token-node-b";
+        registerSessionLifecycleHandlers(socketB);
+
+        await fireB("disconnect", "transport close");
+
+        expect(endedSessions).toHaveLength(1);
+        expect(endedSessions[0].sessionId).toBe("sess-1");
+    });
+
+    it("single-node reconnect still works (same-token re-register does not block teardown)", async () => {
+        // Simulate a same-node reconnect where the token is refreshed but we
+        // are testing the old socket. The old socket was cleared (data.sessionId
+        // set to undefined by registerTuiSession on same node).
+        const { socket: socketOld, fire: fireOld } = makeSocket("sess-1", "token-v1");
+        registerSessionLifecycleHandlers(socketOld);
+
+        // Same-node reconnect: registerTuiSession clears old socket's sessionId.
+        (socketOld as { data: { sessionId: string | undefined } }).data.sessionId = undefined;
+
+        // Old socket disconnects with no sessionId → early return, no endSharedSession.
+        await fireOld("disconnect", "transport close");
+        expect(endedSessions).toHaveLength(0);
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts
@@ -51,6 +51,8 @@ mock.module("../../sio-registry.js", () => ({
 }));
 
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     clearPushPendingQuestion: async () => {},
     deleteRunnerAssociation: async () => {},
 }));
@@ -186,9 +188,9 @@ describe("A2-017: cross-node stale socket protection", () => {
         expect(endedSessions[0].sessionId).toBe("sess-1");
     });
 
-    it("Redis read throws on disconnect → fail-open: teardown proceeds as current owner", async () => {
+    it("Redis read throws on disconnect → fail-closed: teardown is skipped", async () => {
         // Simulate a Redis error during the owner-token read in the disconnect guard.
-        // The guard must treat unknown-owner (null) as fail-open → endSharedSession IS called.
+        // Unknown ownership must never authorize destructive teardown.
         const { socket: socketA, fire: fireA } = makeSocket("sess-1", "token-node-a");
         localSocketMap.set("sess-1", socketA);
         registerSessionLifecycleHandlers(socketA);
@@ -197,9 +199,7 @@ describe("A2-017: cross-node stale socket protection", () => {
 
         await fireA("disconnect", "transport close");
 
-        // Fail-open: teardown must NOT be blocked — treat as matching (unknown) owner.
-        expect(endedSessions).toHaveLength(1);
-        expect(endedSessions[0].sessionId).toBe("sess-1");
+        expect(endedSessions).toHaveLength(0);
     });
 
     it("single-node reconnect still works (same-token re-register does not block teardown)", async () => {

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
@@ -16,6 +16,9 @@ mock.module("../../sio-registry.js", () => ({
     endSharedSession: async (sessionId: string, reason?: string, opts?: unknown) => {
         endedSessions.push({ sessionId, reason, opts });
     },
+    // A2-017: cross-node owner token guard — return matching token so
+    // the existing disconnect tests are not blocked by the stale-socket guard.
+    getSessionOwnerToken: async () => "tok",
 }));
 
 mock.module("../../sio-state/index.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
@@ -8,6 +8,7 @@
 import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
 
 const endedSessions: Array<{ sessionId: string; reason?: string; opts?: unknown }> = [];
+let sharedOwnerToken = "tok";
 
 mock.module("../../sio-registry.js", () => ({
     registerTuiSession: async () => ({ sessionId: "s", token: "t", shareUrl: "", parentSessionId: null, wasDelinked: false }),
@@ -18,7 +19,7 @@ mock.module("../../sio-registry.js", () => ({
     },
     // A2-017: cross-node owner token guard — return matching token so
     // the existing disconnect tests are not blocked by the stale-socket guard.
-    getSessionOwnerToken: async () => "tok",
+    getSessionOwnerToken: async () => sharedOwnerToken,
 }));
 
 mock.module("../../sio-state/index.js", () => ({
@@ -62,6 +63,7 @@ function makeSocket(sessionId: string, token = "tok") {
 describe("session_end handler", () => {
     beforeEach(() => {
         endedSessions.length = 0;
+        sharedOwnerToken = "tok";
     });
 
     it("ends the session with confirmedTerminal so parent membership is removed", async () => {
@@ -71,8 +73,18 @@ describe("session_end handler", () => {
         await fire("session_end", { token: "tok" });
 
         expect(endedSessions).toEqual([
-            { sessionId: "child-mirror", reason: "Session ended", opts: { confirmedTerminal: true } },
+            { sessionId: "child-mirror", reason: "Session ended", opts: { confirmedTerminal: true, expectedOwnerToken: "tok" } },
         ]);
+    });
+
+    it("stale cross-node session_end cannot end the replacement", async () => {
+        const { socket, fire } = makeSocket("child-mirror", "old-token");
+        sharedOwnerToken = "new-token";
+        registerSessionLifecycleHandlers(socket);
+
+        await fire("session_end", { token: "old-token" });
+
+        expect(endedSessions).toHaveLength(0);
     });
 
     it("plain disconnect does NOT mark the end as confirmed terminal", async () => {
@@ -83,6 +95,6 @@ describe("session_end handler", () => {
 
         expect(endedSessions.length).toBe(1);
         expect(endedSessions[0].sessionId).toBe("child-mirror");
-        expect(endedSessions[0].opts).toBeUndefined();
+        expect(endedSessions[0].opts).toEqual({ expectedOwnerToken: "tok" });
     });
 });

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts
@@ -23,6 +23,8 @@ mock.module("../../sio-registry.js", () => ({
 }));
 
 mock.module("../../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
     clearPushPendingQuestion: async () => {},
     deleteRunnerAssociation: async () => {},
 }));

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -85,6 +85,11 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             socket.emit("error", { message: "Invalid token" });
             return;
         }
+        const sharedOwnerToken = await getSessionOwnerToken(sessionId);
+        if (sharedOwnerToken !== null && sharedOwnerToken !== socket.data.token) {
+            log.info(`session_end for ${socket.id} — stale cross-node socket, skipping teardown`);
+            return;
+        }
 
         clearThinkingMaps(sessionId);
         forgetViewerGate(sessionId);
@@ -102,7 +107,10 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         await deleteRunnerAssociation(sessionId);
         // Graceful session_end is a confirmed terminal end — remove this child
         // from its parent's membership set (fixes subagent-mirror leak).
-        await endSharedSession(sessionId, "Session ended", { confirmedTerminal: true });
+        await endSharedSession(sessionId, "Session ended", {
+            confirmedTerminal: true,
+            expectedOwnerToken: socket.data.token,
+        });
         socket.data.sessionId = undefined;
         socketAckedSeqs.delete(socket.id);
     });
@@ -174,7 +182,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             // to the parent's new conversation.  Leaving the membership in
             // place is harmless — delink_children will clean it up, and
             // stale entries are pruned when the session key expires.
-            await endSharedSession(sessionId);
+            await endSharedSession(sessionId, "Session ended", { expectedOwnerToken: socket.data.token });
         }
         socketAckedSeqs.delete(socket.id);
     });

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -8,6 +8,7 @@ import {
     getLocalTuiSocket,
     broadcastToViewers,
     endSharedSession,
+    getSessionOwnerToken,
 } from "../../sio-registry.js";
 import {
     clearPushPendingQuestion,
@@ -118,13 +119,30 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         log.info(`disconnected: ${socket.id} (${reason})`);
         const sessionId = socket.data.sessionId;
         if (sessionId) {
-            // If a newer socket already re-registered this session (reconnect),
-            // don't tear down the new session.  registerTuiSession clears our
-            // sessionId as a primary guard, but this check is defense-in-depth
-            // for any remaining race windows.
+            // Guard 1 (single-node): if a newer socket already re-registered
+            // this session on THIS node, don't tear down the new session.
+            // registerTuiSession clears our sessionId as a primary guard, but
+            // this check is defense-in-depth for any remaining race windows.
             const currentSocket = getLocalTuiSocket(sessionId);
             if (currentSocket && currentSocket !== socket) {
                 log.info(`disconnect for ${socket.id} — session ${sessionId} already owned by ${currentSocket.id}, skipping teardown`);
+                socketAckedSeqs.delete(socket.id);
+                return;
+            }
+
+            // Guard 2 (cross-node): a replacement session may have registered
+            // on a DIFFERENT node (multi-node relay).  The local socket map
+            // cannot see cross-node sockets, so guard 1 is blind to them.
+            // Fetch the current connection-owner token from shared (Redis)
+            // state: if it differs from this socket's captured token, this
+            // socket is stale/superseded — the replacement session owns the
+            // session ID now.  Only the matching token may end the session.
+            const sharedOwnerToken = await getSessionOwnerToken(sessionId);
+            if (sharedOwnerToken !== null && sharedOwnerToken !== socket.data.token) {
+                log.info(
+                    `disconnect for ${socket.id} — stale cross-node socket for session ${sessionId}` +
+                    ` (token mismatch), skipping teardown to protect replacement session`,
+                );
                 socketAckedSeqs.delete(socket.id);
                 return;
             }

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -85,9 +85,15 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             socket.emit("error", { message: "Invalid token" });
             return;
         }
-        const sharedOwnerToken = await getSessionOwnerToken(sessionId);
-        if (sharedOwnerToken !== null && sharedOwnerToken !== socket.data.token) {
-            log.info(`session_end for ${socket.id} — stale cross-node socket, skipping teardown`);
+        let sharedOwnerToken: string | null;
+        try {
+            sharedOwnerToken = await getSessionOwnerToken(sessionId);
+        } catch {
+            log.warn(`session_end for ${socket.id} — Redis ownership lookup failed; skipping teardown`);
+            return;
+        }
+        if (sharedOwnerToken !== socket.data.token) {
+            log.info(`session_end for ${socket.id} — stale or unknown owner, skipping teardown`);
             return;
         }
 
@@ -145,11 +151,17 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             // state: if it differs from this socket's captured token, this
             // socket is stale/superseded — the replacement session owns the
             // session ID now.  Only the matching token may end the session.
-            const sharedOwnerToken = await getSessionOwnerToken(sessionId);
-            if (sharedOwnerToken !== null && sharedOwnerToken !== socket.data.token) {
+            let sharedOwnerToken: string | null;
+            try {
+                sharedOwnerToken = await getSessionOwnerToken(sessionId);
+            } catch {
+                log.warn(`disconnect for ${socket.id} — Redis ownership lookup failed; skipping teardown`);
+                socketAckedSeqs.delete(socket.id);
+                return;
+            }
+            if (sharedOwnerToken !== socket.data.token) {
                 log.info(
-                    `disconnect for ${socket.id} — stale cross-node socket for session ${sessionId}` +
-                    ` (token mismatch), skipping teardown to protect replacement session`,
+                    `disconnect for ${socket.id} — stale or unknown owner for session ${sessionId}, skipping teardown`,
                 );
                 socketAckedSeqs.delete(socket.id);
                 return;

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -27,6 +27,7 @@ export {
     getSessionLastHeartbeat,
     sendSnapshotToViewer,
     endSharedSession,
+    getSessionOwnerToken,
     sweepExpiredSessions,
     sweepOrphanedSessions,
     addViewer,

--- a/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
@@ -74,7 +74,7 @@ const mockRedis = {
     multi: mock(() => mockMulti()),
     on: mock(() => mockRedis),
     connect: mock(async () => {}),
-    set: mock(async (key: string, value: string, _opts?: unknown) => { store.set(key, value); }),
+    set: mock(async (key: string, value: string, _opts?: unknown) => { store.set(key, value); return "OK" as const; }),
     get: mock(async (key: string) => store.get(key) ?? null),
     del: mock(async (key: string) => {
         store.delete(key);

--- a/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
@@ -13,6 +13,9 @@ const mockRefreshRunnerAssociationTTL = mock(async () => {});
 const noopAsync = async () => {};
 
 mock.module("../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: noopAsync,
+    releaseSessionOwnershipLock: noopAsync,
+    deleteSessionIfOwner: async () => true,
     setSession: noopAsync,
     getSession: mockGetSession,
     getSessionSummary: mockGetSession,

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -1,9 +1,8 @@
 // ============================================================================
 // sessions.owner-token.test.ts — Unit tests for getSessionOwnerToken (A2-017)
 //
-// Verifies that getSessionOwnerToken is fail-open: when the underlying Redis
-// read throws, it returns null (identical to "not found") instead of
-// propagating the error.  A genuine stored token is still returned correctly.
+// Verifies that getSessionOwnerToken fails closed: Redis errors propagate so
+// sensitive lifecycle operations can skip rather than treating unknown as owner.
 // ============================================================================
 
 import { afterAll, describe, it, expect, mock } from "bun:test";
@@ -21,6 +20,9 @@ mock.module("../sio-state/index.js", () => ({
         if (fieldShouldThrow) throw new Error("Redis ECONNRESET (test)");
         return fieldValue;
     },
+    acquireSessionOwnershipLock: noopAsync,
+    releaseSessionOwnershipLock: noopAsync,
+    deleteSessionIfOwner: async () => true,
     updateSessionFields: noopAsync,
     deleteSession: noopAsync,
     getAllSessionSummaries: async () => [],
@@ -71,11 +73,10 @@ afterAll(() => mock.restore());
 
 const { getSessionOwnerToken } = await import("./sessions.js");
 
-describe("getSessionOwnerToken (A2-017 expo fix: fail-open on Redis error)", () => {
-    it("returns null when Redis read throws — does NOT propagate the error", async () => {
+describe("getSessionOwnerToken (A2-017 fail-closed ownership)", () => {
+    it("propagates Redis errors so callers skip sensitive operations", async () => {
         fieldShouldThrow = true;
-        const result = await getSessionOwnerToken("sess-1");
-        expect(result).toBeNull();
+        await expect(getSessionOwnerToken("sess-1")).rejects.toThrow("Redis ECONNRESET");
         fieldShouldThrow = false;
     });
 

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -1,0 +1,94 @@
+// ============================================================================
+// sessions.owner-token.test.ts — Unit tests for getSessionOwnerToken (A2-017)
+//
+// Verifies that getSessionOwnerToken is fail-open: when the underlying Redis
+// read throws, it returns null (identical to "not found") instead of
+// propagating the error.  A genuine stored token is still returned correctly.
+// ============================================================================
+
+import { afterAll, describe, it, expect, mock } from "bun:test";
+
+let fieldValue: string | null = null;
+let fieldShouldThrow = false;
+
+const noopAsync = async () => {};
+
+mock.module("../sio-state/index.js", () => ({
+    setSession: noopAsync,
+    getSession: async () => null,
+    getSessionSummary: async () => null,
+    getSessionField: async (_sessionId: string, _field: string) => {
+        if (fieldShouldThrow) throw new Error("Redis ECONNRESET (test)");
+        return fieldValue;
+    },
+    updateSessionFields: noopAsync,
+    deleteSession: noopAsync,
+    getAllSessionSummaries: async () => [],
+    refreshSessionTTL: noopAsync,
+    incrementSeq: async () => 0,
+    getSeq: async () => 0,
+    setPendingRunnerLink: noopAsync,
+    getPendingRunnerLink: async () => null,
+    deletePendingRunnerLink: noopAsync,
+    getRunnerAssociation: async () => null,
+    setRunnerAssociation: noopAsync,
+    refreshRunnerAssociationTTL: noopAsync,
+    scanExpiredSessions: async () => [],
+    addChildSession: noopAsync,
+    addChildSessionMembership: noopAsync,
+    removeChildSession: noopAsync,
+    isChildDelinked: async () => false,
+    clearParentSessionId: noopAsync,
+    refreshChildSessionsTTL: noopAsync,
+    removePendingParentDelinkChild: noopAsync,
+    getRunner: async () => null,
+}));
+
+mock.module("./meta.js", () => ({ extractMetaFromHeartbeat: () => ({}) }));
+mock.module("./hub.js", () => ({ broadcastToHub: noopAsync }));
+
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    getPersistedRelaySessionRunner: async () => null,
+    getRelaySessionUserId: async () => null,
+    getPersistedRelaySessionSnapshot: async () => null,
+    recordRelaySessionStart: noopAsync,
+    recordRelaySessionEnd: noopAsync,
+    recordRelaySessionState: noopAsync,
+    recordRelaySessionStateSerialized: noopAsync,
+    touchRelaySession: noopAsync,
+    updateRelaySessionName: noopAsync,
+}));
+
+mock.module("../strip-images.js", () => ({
+    storeAndReplaceImages: noopAsync,
+    storeAndReplaceImagesInEvent: async (event: unknown) => event,
+}));
+
+mock.module("../stale-parent-link.js", () => ({ severStaleParentLink: noopAsync }));
+
+afterAll(() => mock.restore());
+
+const { getSessionOwnerToken } = await import("./sessions.js");
+
+describe("getSessionOwnerToken (A2-017 expo fix: fail-open on Redis error)", () => {
+    it("returns null when Redis read throws — does NOT propagate the error", async () => {
+        fieldShouldThrow = true;
+        const result = await getSessionOwnerToken("sess-1");
+        expect(result).toBeNull();
+        fieldShouldThrow = false;
+    });
+
+    it("returns the stored token when Redis read succeeds", async () => {
+        fieldValue = "token-abc";
+        const result = await getSessionOwnerToken("sess-1");
+        expect(result).toBe("token-abc");
+        fieldValue = null;
+    });
+
+    it("returns null when field is absent (session not yet written)", async () => {
+        fieldValue = null;
+        const result = await getSessionOwnerToken("sess-1");
+        expect(result).toBeNull();
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -122,6 +122,9 @@ mock.module("../../sessions/store.js", () => ({
 }));
 
 mock.module("../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
+    deleteSessionIfOwner: async () => true,
     initStateRedis: async () => {},
     setSession: async (sessionId: string, data: Record<string, unknown>) => {
         store.set(`__hash__:pizzapi:sio:session:${sessionId}`, JSON.stringify(data));

--- a/packages/server/src/ws/sio-registry/sessions.parent-transfer.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-transfer.test.ts
@@ -35,6 +35,9 @@ const pendingDelinkKey = (p: string) => `pending-delink:${p}`;
 const sessionHashKey = (s: string) => `session:${s}`;
 
 mock.module("../sio-state/index.js", () => ({
+    acquireSessionOwnershipLock: async () => {},
+    releaseSessionOwnershipLock: async () => {},
+    deleteSessionIfOwner: async () => true,
     initStateRedis: async () => {},
     setSession: async (sessionId: string, data: Record<string, unknown>) => {
         store.set(sessionHashKey(sessionId), JSON.stringify(data));

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -18,6 +18,7 @@ import {
     getSessionField,
     updateSessionFields,
     deleteSession,
+    deleteSessionIfOwner,
     getAllSessionSummaries,
     refreshSessionTTL,
     incrementSeq,
@@ -918,7 +919,7 @@ function viewerDisconnectPayload(reason: string): { reason: string; code?: "sess
 export async function endSharedSession(
     sessionId: string,
     reason: string = "Session ended",
-    opts: { confirmedTerminal?: boolean } = {},
+    opts: { confirmedTerminal?: boolean; expectedOwnerToken?: string } = {},
 ): Promise<void> {
     const io = getIo();
     await deletePendingRunnerLink(sessionId);
@@ -1021,8 +1022,18 @@ export async function endSharedSession(
         );
     }
 
-    // Delete from Redis
-    await deleteSession(sessionId);
+    // Delete atomically with the owner check so a replacement cannot win
+    // between the disconnect check and teardown. Redis errors remain fail-open.
+    if (opts.expectedOwnerToken) {
+        try {
+            if (!(await deleteSessionIfOwner(sessionId, opts.expectedOwnerToken))) return;
+        } catch (err) {
+            log.warn("endSharedSession: owner-guard Redis error, failing open", err);
+            await deleteSession(sessionId);
+        }
+    } else {
+        await deleteSession(sessionId);
+    }
     lastRelaySessionStateWriteTimes.delete(sessionId);
 
     // Persist end in SQLite

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -850,6 +850,20 @@ export async function updateSessionHeartbeat(
     }
 }
 
+/**
+ * Fetch the current connection owner token from shared (Redis) state.
+ *
+ * This is regenerated every time `registerTuiSession` is called, so if a
+ * replacement session registers on a DIFFERENT node (cross-node reconnect),
+ * the Redis token will differ from the stale socket's `socket.data.token`.
+ *
+ * Only the socket whose token MATCHES the current shared token may end/delete
+ * the session or emit accepted events.  All others are stale/superseded.
+ */
+export async function getSessionOwnerToken(sessionId: string): Promise<string | null> {
+    return getSessionField(sessionId, "token");
+}
+
 /** Get the current seq counter for a session. */
 export async function getSessionSeq(sessionId: string): Promise<number> {
     return getSeq(sessionId);

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -19,6 +19,8 @@ import {
     updateSessionFields,
     deleteSession,
     deleteSessionIfOwner,
+    acquireSessionOwnershipLock,
+    releaseSessionOwnershipLock,
     getAllSessionSummaries,
     refreshSessionTTL,
     incrementSeq,
@@ -155,6 +157,28 @@ export async function registerTuiSession(
     opts: RegisterTuiSessionOpts = {},
 ): Promise<{ sessionId: string; token: string; shareUrl: string; parentSessionId: string | null; wasDelinked: boolean }> {
     const requestedSessionId = typeof opts.sessionId === "string" ? opts.sessionId.trim() : "";
+    const lockSessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
+    const lockOwner = randomUUID();
+    await acquireSessionOwnershipLock(lockSessionId, lockOwner);
+    try {
+        return await registerTuiSessionUnlocked(
+            socket,
+            cwd,
+            { ...opts, sessionId: requestedSessionId || lockSessionId },
+            requestedSessionId.length === 0,
+        );
+    } finally {
+        await releaseSessionOwnershipLock(lockSessionId, lockOwner);
+    }
+}
+
+async function registerTuiSessionUnlocked(
+    socket: Socket,
+    cwd: string = "",
+    opts: RegisterTuiSessionOpts = {},
+    generatedSessionId = false,
+): Promise<{ sessionId: string; token: string; shareUrl: string; parentSessionId: string | null; wasDelinked: boolean }> {
+    const requestedSessionId = typeof opts.sessionId === "string" ? opts.sessionId.trim() : "";
     let sessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
     const token = randomBytes(32).toString("hex");
     let shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
@@ -195,7 +219,7 @@ export async function registerTuiSession(
             if (oldSocket && oldSocket !== socket) {
                 oldSocket.data.sessionId = undefined;
             }
-            await endSharedSession(sessionId, "Session reconnected");
+            await endSharedSessionUnlocked(sessionId, "Session reconnected");
         }
     }
 
@@ -206,7 +230,7 @@ export async function registerTuiSession(
     // bypassed because `existing` is null, but the persisted row still has the
     // original owner.  Generate a fresh session ID so this user gets their own
     // slot without touching the other owner's persisted data.
-    if (!existing && requestedSessionId.length > 0 && sessionId === requestedSessionId) {
+    if (!existing && !generatedSessionId && requestedSessionId.length > 0 && sessionId === requestedSessionId) {
         const persistedUserId = await getRelaySessionUserId(sessionId);
         if (persistedUserId !== null && persistedUserId !== userId) {
             log.warn(
@@ -865,9 +889,8 @@ export async function getSessionOwnerToken(sessionId: string): Promise<string | 
     try {
         return await getSessionField(sessionId, "token");
     } catch (err) {
-        // ponytail: fail-open on Redis read error — treat as unknown owner (same as null)
-        log.warn("getSessionOwnerToken: Redis read error, treating as unknown owner (fail-open)", err);
-        return null;
+        log.warn("getSessionOwnerToken: Redis read error; ownership is unknown", err);
+        throw err;
     }
 }
 
@@ -921,7 +944,28 @@ export async function endSharedSession(
     reason: string = "Session ended",
     opts: { confirmedTerminal?: boolean; expectedOwnerToken?: string } = {},
 ): Promise<void> {
+    const lockOwner = randomUUID();
+    await acquireSessionOwnershipLock(sessionId, lockOwner);
+    try {
+        await endSharedSessionUnlocked(sessionId, reason, opts);
+    } finally {
+        await releaseSessionOwnershipLock(sessionId, lockOwner);
+    }
+}
+
+async function endSharedSessionUnlocked(
+    sessionId: string,
+    reason: string = "Session ended",
+    opts: { confirmedTerminal?: boolean; expectedOwnerToken?: string } = {},
+): Promise<void> {
     const io = getIo();
+    if (opts.expectedOwnerToken !== undefined) {
+        const currentOwnerToken = await getSessionOwnerToken(sessionId);
+        if (currentOwnerToken !== opts.expectedOwnerToken) {
+            log.info(`endSharedSession: owner changed for ${sessionId}; skipping teardown`);
+            return;
+        }
+    }
     await deletePendingRunnerLink(sessionId);
 
     const session = await getSession(sessionId);
@@ -1022,15 +1066,10 @@ export async function endSharedSession(
         );
     }
 
-    // Delete atomically with the owner check so a replacement cannot win
-    // between the disconnect check and teardown. Redis errors remain fail-open.
-    if (opts.expectedOwnerToken) {
-        try {
-            if (!(await deleteSessionIfOwner(sessionId, opts.expectedOwnerToken))) return;
-        } catch (err) {
-            log.warn("endSharedSession: owner-guard Redis error, failing open", err);
-            await deleteSession(sessionId);
-        }
+    // The lock and this atomic delete are defense in depth: ownership was
+    // checked before teardown, and the delete still requires an exact token.
+    if (opts.expectedOwnerToken !== undefined) {
+        if (!(await deleteSessionIfOwner(sessionId, opts.expectedOwnerToken))) return;
     } else {
         await deleteSession(sessionId);
     }

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -861,7 +861,13 @@ export async function updateSessionHeartbeat(
  * the session or emit accepted events.  All others are stale/superseded.
  */
 export async function getSessionOwnerToken(sessionId: string): Promise<string | null> {
-    return getSessionField(sessionId, "token");
+    try {
+        return await getSessionField(sessionId, "token");
+    } catch (err) {
+        // ponytail: fail-open on Redis read error — treat as unknown owner (same as null)
+        log.warn("getSessionOwnerToken: Redis read error, treating as unknown owner (fail-open)", err);
+        return null;
+    }
 }
 
 /** Get the current seq counter for a session. */

--- a/packages/server/src/ws/sio-state.session-lock.test.ts
+++ b/packages/server/src/ws/sio-state.session-lock.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { closeStateRedis, initStateRedis, acquireSessionOwnershipLock, releaseSessionOwnershipLock } from "./sio-state.js";
+
+const owners = new Map<string, string>();
+const redis = {
+    isOpen: true,
+    set: async (key: string, value: string, opts: { NX?: boolean }) => {
+        if (opts.NX && owners.has(key)) return null;
+        owners.set(key, value);
+        return "OK";
+    },
+    quit: async () => {},
+    eval: async (_script: string, args: { keys: string[]; arguments: string[] }) => {
+        const key = args.keys[0];
+        if (owners.get(key) !== args.arguments[0]) return 0;
+        owners.delete(key);
+        return 1;
+    },
+} as never;
+
+afterEach(async () => {
+    owners.clear();
+    await closeStateRedis();
+});
+
+describe("session ownership lock", () => {
+    it("serializes observable teardown and registration side effects", async () => {
+        await initStateRedis(redis);
+        const effects: string[] = [];
+        let releaseFirst!: () => void;
+        const firstHeld = new Promise<void>((resolve) => (releaseFirst = resolve));
+
+        const first = (async () => {
+            await acquireSessionOwnershipLock("session-1", "teardown");
+            effects.push("teardown-start");
+            await firstHeld;
+            effects.push("teardown-end");
+            await releaseSessionOwnershipLock("session-1", "teardown");
+        })();
+        const second = (async () => {
+            await acquireSessionOwnershipLock("session-1", "registration");
+            effects.push("registration");
+            await releaseSessionOwnershipLock("session-1", "registration");
+        })();
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(effects).toEqual(["teardown-start"]);
+        releaseFirst();
+        await Promise.all([first, second]);
+        expect(effects).toEqual(["teardown-start", "teardown-end", "registration"]);
+    });
+});

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -541,6 +541,27 @@ export async function deleteSession(sessionId: string): Promise<void> {
     await multi.exec();
 }
 
+/** Delete only if the session still belongs to expectedToken (one Redis op). */
+export async function deleteSessionIfOwner(sessionId: string, expectedToken: string): Promise<boolean> {
+    const r = requireRedis();
+    const result = await r.eval(`
+        if redis.call('HGET', KEYS[1], 'token') ~= ARGV[1] then
+            return 0
+        end
+        local userId = redis.call('HGET', KEYS[1], 'userId')
+        redis.call('DEL', KEYS[1], KEYS[2])
+        redis.call('SREM', KEYS[3], ARGV[2])
+        if userId and userId ~= '' then
+            redis.call('SREM', ARGV[3] .. userId, ARGV[2])
+        end
+        return 1
+    `, {
+        keys: [sessionKey(sessionId), seqKey(sessionId), allSessionsKey()],
+        arguments: [expectedToken, sessionId, `${KEY_PREFIX}:user-sessions:`],
+    });
+    return result === 1;
+}
+
 export async function getAllSessionSummaries(filterUserId?: string): Promise<RedisSessionSummaryData[]> {
     const r = requireRedis();
 

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -113,6 +113,33 @@ function userSessionsKey(userId: string): string {
     return `${KEY_PREFIX}:user-sessions:${userId}`;
 }
 
+const SESSION_OWNERSHIP_LOCK_TTL_MS = 30_000;
+function sessionOwnershipLockKey(sessionId: string): string {
+    return `${KEY_PREFIX}:session-lock:${sessionId}`;
+}
+
+/** Serialize registration and destructive teardown for one session ID. */
+export async function acquireSessionOwnershipLock(sessionId: string, owner: string): Promise<void> {
+    const r = requireRedis();
+    const key = sessionOwnershipLockKey(sessionId);
+    for (;;) {
+        const acquired = await r.set(key, owner, { NX: true, PX: SESSION_OWNERSHIP_LOCK_TTL_MS });
+        if (acquired === "OK") return;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+}
+
+/** Release only the lock still owned by this caller. */
+export async function releaseSessionOwnershipLock(sessionId: string, owner: string): Promise<void> {
+    const r = requireRedis();
+    await r.eval(`
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        end
+        return 0
+    `, { keys: [sessionOwnershipLockKey(sessionId)], arguments: [owner] });
+}
+
 /** Global set of all active session IDs. */
 function allSessionsKey(): string {
     return `${KEY_PREFIX}:all-sessions`;


### PR DESCRIPTION
Night Shift dish A2-017

## Problem

On node B, registering a REPLACEMENT session cannot clear node A's LOCAL socket (socket maps are node-local). The stale node-A relay socket stays "valid"; when it LATER disconnects, its handler calls endSharedSession and ENDS/DELETES node B's replacement session. Stale events from the node-A socket are also still accepted (routed by socket token).

## Fix

**Shared connection-owner token** — the existing `token` field in Redis session state (already regenerated on every `registerTuiSession`) is used as the connection-generation owner token.

- **Disconnect handler** (`session-lifecycle.ts`): After the single-node local-socket guard, a new cross-node guard fetches `getSessionOwnerToken(sessionId)` from Redis. If the shared token differs from `socket.data.token`, this socket is stale/superseded — `endSharedSession` is **not** called.
- **Event pipeline** (`event-pipeline.ts`): Inside `enqueueSessionEvent`, the same token comparison runs before any state update or viewer broadcast. Stale events are silently dropped.

## Files Changed

- `packages/server/src/ws/sio-registry/sessions.ts` — `getSessionOwnerToken` helper (wraps single-field hGet)
- `packages/server/src/ws/sio-registry/index.ts` — export new helper
- `packages/server/src/ws/namespaces/relay/session-lifecycle.ts` — cross-node guard in disconnect handler
- `packages/server/src/ws/namespaces/relay/event-pipeline.ts` — cross-node guard in event enqueue
- `packages/server/src/ws/namespaces/relay/session-lifecycle.cross-node.test.ts` — two-node reconnect regression tests (4 cases)
- `packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts` — event pipeline stale rejection tests (3 cases)
- `packages/server/src/ws/namespaces/relay/session-lifecycle.session-end.test.ts` — added missing mock for new export

## Verification

```
bun run typecheck && bun scripts/test-isolated.ts packages/server/src/ws
```

✅ Typecheck clean, 38/38 test files pass (0 failures)