### PR TITLE
fix: scope tunnel service messages across viewer switches (A2-015) [rebase]

### DIFF
--- a/packages/server/src/ws/namespaces/runner.test.ts
+++ b/packages/server/src/ws/namespaces/runner.test.ts
@@ -5,6 +5,7 @@ import {
     cancelRunnerFileRead,
     isPendingRequestCapReached,
     pendingSocketMatches,
+    stampServiceMessageSession,
 } from "./runner.js";
 
 // NOTE: These tests deliberately import ONLY the pure helpers and do NOT use
@@ -13,6 +14,23 @@ import {
 // those modules for every other test file in the same run (see TODO(ltl2EKmU)),
 // breaking runners.broadcast/terminals suites. Testing the extracted predicates
 // covers the same security-relevant behaviour with zero cross-file bleed.
+
+describe("runner service-message fanout", () => {
+    test("stamps unscoped envelopes for each target viewer session", () => {
+        const envelope = { serviceId: "tunnel", type: "tunnel_registered", payload: {} };
+
+        expect(stampServiceMessageSession(envelope, "session-y")).toEqual({
+            ...envelope,
+            sessionId: "session-y",
+        });
+    });
+
+    test("preserves a runner-provided target session", () => {
+        const envelope = { serviceId: "tunnel", type: "tunnel_registered", sessionId: "session-x", payload: {} };
+
+        expect(stampServiceMessageSession(envelope, "session-y")).toBe(envelope);
+    });
+});
 
 describe("runner namespace pending-request hardening", () => {
     test("request IDs are crypto-random UUID v4", () => {

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -55,7 +55,12 @@ import { listRunnerTriggerListeners } from "../../sessions/runner-trigger-listen
 // Using local aliases avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
-type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; sessionId?: string; payload: unknown };
+
+/** Stamp runner-wide messages separately for each session fanout. */
+export function stampServiceMessageSession(envelope: ServiceEnvelope, sessionId: string): ServiceEnvelope {
+    return envelope.sessionId ? envelope : { ...envelope, sessionId };
+}
 
 // ── Trigger subscription reconciliation ──────────────────────────────────────
 // Revision counter is now Redis-backed (globally monotonic across all server
@@ -1168,16 +1173,18 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
                     log.warn(`service_message rejected: session ${targetSessionId} not owned by runner ${runnerId}`);
                     return;
                 }
-                broadcastToSessionViewers(targetSessionId, "service_message", envelope);
+                const scopedEnvelope = stampServiceMessageSession(envelope, targetSessionId);
+                broadcastToSessionViewers(targetSessionId, "service_message", scopedEnvelope);
                 // Also route to the session's relay socket (TUI worker) so
                 // agent-initiated service_message requests get their responses.
-                emitToRelaySession(targetSessionId, "service_message", envelope);
+                emitToRelaySession(targetSessionId, "service_message", scopedEnvelope);
             } else {
                 const sessionIds = runnerSessionIds.get(runnerId);
                 if (!sessionIds || sessionIds.size === 0) return;
                 for (const sid of sessionIds) {
-                    broadcastToSessionViewers(sid, "service_message", envelope);
-                    emitToRelaySession(sid, "service_message", envelope);
+                    const scopedEnvelope = stampServiceMessageSession(envelope, sid);
+                    broadcastToSessionViewers(sid, "service_message", scopedEnvelope);
+                    emitToRelaySession(sid, "service_message", scopedEnvelope);
                 }
             }
         });

--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("Tunnel service-message viewer switch guard", () => {
+  const source = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
+
+  test("drops stale tunnel registrations after switching viewers and accepts the active viewer", () => {
+    const handler = source.match(/const handler = \(envelope:[\s\S]*?viewerSocket\.on\("service_message", handler\);/)?.[0] ?? "";
+
+    expect(handler).toMatch(/matchesViewerSession\(lifecycleRefs\.activeSessionId\.current, envelope\.sessionId\)/);
+    expect(handler).toMatch(/matchesViewerGeneration\(lifecycleRefs\.generation\.current, envelope\.generation\)/);
+  });
+});

--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -9,5 +9,6 @@ describe("Tunnel service-message viewer switch guard", () => {
 
     expect(handler).toMatch(/matchesViewerSession\(lifecycleRefs\.activeSessionId\.current, envelope\.sessionId\)/);
     expect(handler).toMatch(/matchesViewerGeneration\(lifecycleRefs\.generation\.current, envelope\.generation\)/);
+    expect(handler).not.toMatch(/typeof envelope\.sessionId !== "string"/);
   });
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4853,8 +4853,13 @@ export function App() {
   // Auto-open Tunnel panel when a non-pinned tunnel is registered.
   React.useEffect(() => {
     if (!viewerSocket) return;
-    const handler = (envelope: { serviceId: string; type: string; payload: unknown }) => {
+    const handler = (envelope: { serviceId: string; type: string; sessionId?: string; generation?: number; payload: unknown }) => {
       if (envelope.serviceId !== "tunnel" || envelope.type !== "tunnel_registered") return;
+      if (
+        typeof envelope.sessionId !== "string" ||
+        !matchesViewerSession(lifecycleRefs.activeSessionId.current, envelope.sessionId) ||
+        !matchesViewerGeneration(lifecycleRefs.generation.current, envelope.generation)
+      ) return;
       const info = envelope.payload as { pinned?: boolean } | undefined;
       if (info?.pinned) return; // Don't auto-open for daemon-pinned panel ports
       // Open the Tunnel panel if not already open

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4856,7 +4856,6 @@ export function App() {
     const handler = (envelope: { serviceId: string; type: string; sessionId?: string; generation?: number; payload: unknown }) => {
       if (envelope.serviceId !== "tunnel" || envelope.type !== "tunnel_registered") return;
       if (
-        typeof envelope.sessionId !== "string" ||
         !matchesViewerSession(lifecycleRefs.activeSessionId.current, envelope.sessionId) ||
         !matchesViewerGeneration(lifecycleRefs.generation.current, envelope.generation)
       ) return;


### PR DESCRIPTION
Rebase of #815 onto latest main after parallel merges caused a conflict in `packages/ui/src/App.test.tsx` (both #815 and #817 added a top-level describe block). Both test suites are preserved.\n\nCloses #815.