### PR TITLE
fix: cancel inbound tunnel request bodies on timeout (D-014) [review follow-up]

### DIFF
--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -647,6 +647,66 @@ import bar from "../lib/bar.js";`;
 });
 
 describe("tunnel route streaming proxy", () => {
+    test("cancels a stalled request body on timeout and forwards no later chunks", async () => {
+        let cancelled = false;
+        let sendCount = 0;
+        const body = new ReadableStream<Uint8Array>({
+            pull() {
+                return new Promise<void>(() => {});
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        const relay = {
+            proxyHttpRequest: (_runnerId: string, _request: unknown, cb: {
+                onResponseStart: (code: number, message: string, headers: Record<string, string>) => void;
+                onResponseData: (data: Buffer) => void;
+                onResponseEnd: () => void;
+                onError: (error: string) => void;
+            }) => {
+                setTimeout(() => cb.onError("Tunnel request timed out"), 0);
+                return { cancel() {} };
+            },
+            sendRequestData() { sendCount++; },
+            sendRequestDataEnd() {},
+        };
+        const response = await proxyTunnelRequestViaRelay(
+            new Request("http://localhost/api/tunnel/s-1/3000/data", { method: "POST", body, duplex: "half" }),
+            relay as never,
+            "runner-1", "request-1", "/api/tunnel/s-1/3000", 3000, "/data", "/data", {},
+        );
+        expect(response.status).toBe(504);
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        expect(cancelled).toBe(true);
+        expect(sendCount).toBe(0);
+    });
+
+    test("cancels a stalled request body when the client disconnects", async () => {
+        let cancelled = false;
+        let sendCount = 0;
+        const body = new ReadableStream<Uint8Array>({
+            pull() { return new Promise<void>(() => {}); },
+            cancel() { cancelled = true; },
+        });
+        const client = new AbortController();
+        const relay = {
+            proxyHttpRequest: () => ({ cancel() {} }),
+            sendRequestData() { sendCount++; },
+            sendRequestDataEnd() {},
+        };
+        void proxyTunnelRequestViaRelay(
+            new Request("http://localhost/api/tunnel/s-1/3000/data", { method: "POST", body, signal: client.signal, duplex: "half" }),
+            relay as never,
+            "runner-1", "request-1", "/api/tunnel/s-1/3000", 3000, "/data", "/data", {},
+        );
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        client.abort();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        expect(cancelled).toBe(true);
+        expect(sendCount).toBe(0);
+    });
+
     test("closes an already-started streaming response cleanly when relay reports a late error", async () => {
         let callbacks: {
             onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;

--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -672,7 +672,12 @@ describe("tunnel route streaming proxy", () => {
             sendRequestDataEnd() {},
         };
         const response = await proxyTunnelRequestViaRelay(
-            new Request("http://localhost/api/tunnel/s-1/3000/data", { method: "POST", body, duplex: "half" }),
+            new Request("http://localhost/api/tunnel/s-1/3000/data", {
+                method: "POST",
+                body,
+                // @ts-expect-error Bun supports duplex
+                duplex: "half",
+            }),
             relay as never,
             "runner-1", "request-1", "/api/tunnel/s-1/3000", 3000, "/data", "/data", {},
         );
@@ -696,7 +701,13 @@ describe("tunnel route streaming proxy", () => {
             sendRequestDataEnd() {},
         };
         void proxyTunnelRequestViaRelay(
-            new Request("http://localhost/api/tunnel/s-1/3000/data", { method: "POST", body, signal: client.signal, duplex: "half" }),
+            new Request("http://localhost/api/tunnel/s-1/3000/data", {
+                method: "POST",
+                body,
+                signal: client.signal,
+                // @ts-expect-error Bun supports duplex
+                duplex: "half",
+            }),
             relay as never,
             "runner-1", "request-1", "/api/tunnel/s-1/3000", 3000, "/data", "/data", {},
         );
@@ -705,6 +716,53 @@ describe("tunnel route streaming proxy", () => {
         await new Promise<void>((resolve) => queueMicrotask(resolve));
         expect(cancelled).toBe(true);
         expect(sendCount).toBe(0);
+    });
+
+    test("cancels a stalled request body and detaches the client listener when the response ends", async () => {
+        let callbacks: {
+            onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;
+            onResponseData: (data: Buffer) => void;
+            onResponseEnd: () => void;
+            onError: (error: string) => void;
+        } | undefined;
+        let bodyCancelled = false;
+        let relayCancelCount = 0;
+        const body = new ReadableStream<Uint8Array>({
+            pull() { return new Promise<void>(() => {}); },
+            cancel() { bodyCancelled = true; },
+        });
+        const client = new AbortController();
+        const relay = {
+            proxyHttpRequest: (_runnerId: string, _request: unknown, cb: NonNullable<typeof callbacks>) => {
+                callbacks = cb;
+                return { cancel() { relayCancelCount++; } };
+            },
+            sendRequestData() {},
+            sendRequestDataEnd() {},
+        };
+
+        const responsePromise = proxyTunnelRequestViaRelay(
+            new Request("http://localhost/api/tunnel/s-1/3000/data", {
+                method: "POST",
+                body,
+                signal: client.signal,
+                // @ts-expect-error Bun supports duplex
+                duplex: "half",
+            }),
+            relay as never,
+            "runner-1", "request-1", "/api/tunnel/s-1/3000", 3000, "/data", "/data", {},
+        );
+        callbacks!.onResponseStart(200, "OK", { "content-type": "text/plain" });
+        callbacks!.onResponseEnd();
+
+        const response = await responsePromise;
+        expect(response.status).toBe(200);
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        expect(bodyCancelled).toBe(true);
+
+        client.abort();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        expect(relayCancelCount).toBe(0);
     });
 
     test("closes an already-started streaming response cleanly when relay reports a late error", async () => {

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -431,25 +431,35 @@ async function streamRequestBodyToRelay(
     relay: TunnelRelay,
     runnerId: string,
     requestId: string,
+    signal: AbortSignal,
 ): Promise<void> {
     if (!req.body || req.method === "GET" || req.method === "HEAD") {
-        relay.sendRequestDataEnd(runnerId, requestId);
+        if (!signal.aborted) relay.sendRequestDataEnd(runnerId, requestId);
         return;
     }
 
     const reader = req.body.getReader();
+    let cancelled = false;
+    const cancelReader = (): void => {
+        if (cancelled) return;
+        cancelled = true;
+        void reader.cancel(signal.reason).catch(() => {});
+    };
+    signal.addEventListener("abort", cancelReader, { once: true });
     try {
-        while (true) {
+        while (!signal.aborted) {
             const { done, value } = await reader.read();
-            if (done) break;
+            if (done || signal.aborted) break;
             if (!value || value.byteLength === 0) continue;
             relay.sendRequestData(runnerId, requestId, Buffer.from(value));
         }
     } finally {
+        signal.removeEventListener("abort", cancelReader);
+        if (signal.aborted) cancelReader();
         reader.releaseLock();
     }
 
-    relay.sendRequestDataEnd(runnerId, requestId);
+    if (!signal.aborted) relay.sendRequestDataEnd(runnerId, requestId);
 }
 
 function proxyTunnelRequestViaRelay(
@@ -465,6 +475,13 @@ function proxyTunnelRequestViaRelay(
     allowCrossOriginFrame = false,
 ): Promise<Response> {
     return new Promise<Response>((resolve) => {
+        const bodyAbortController = new AbortController();
+        let relayCancel: () => void = () => {};
+        const cancelRequest = (): void => {
+            bodyAbortController.abort();
+            relayCancel();
+        };
+        req.signal.addEventListener("abort", cancelRequest, { once: true });
         let responseStarted = false;
         let resolved = false;
         let statusCode = 502;
@@ -529,7 +546,7 @@ function proxyTunnelRequestViaRelay(
                     if (shouldBuffer && contentLength) {
                         const length = Number.parseInt(contentLength, 10);
                         if (Number.isFinite(length) && length > TUNNEL_MAX_BUFFERED_BYTES) {
-                            cancel();
+                            cancelRequest();
                             resolveOnce(tunnelErrorResponse("Response body too large"));
                             return;
                         }
@@ -543,7 +560,7 @@ function proxyTunnelRequestViaRelay(
                         },
                         cancel() {
                             streamClosed = true;
-                            cancel();
+                            cancelRequest();
                         },
                     });
 
@@ -555,7 +572,7 @@ function proxyTunnelRequestViaRelay(
                 onResponseData: (chunk) => {
                     if (shouldBuffer) {
                         if (bufferedBytes + chunk.length > TUNNEL_MAX_BUFFERED_BYTES) {
-                            cancel();
+                            cancelRequest();
                             resolveOnce(tunnelErrorResponse("Response body too large"));
                             return;
                         }
@@ -597,6 +614,7 @@ function proxyTunnelRequestViaRelay(
                     closeStream();
                 },
                 onError: (error) => {
+                    cancelRequest();
                     if (!responseStarted || shouldBuffer) {
                         resolveOnce(tunnelErrorResponse(error));
                         return;
@@ -611,9 +629,11 @@ function proxyTunnelRequestViaRelay(
                 },
             },
         );
+        relayCancel = cancel;
+        if (req.signal.aborted) cancelRequest();
 
-        void streamRequestBodyToRelay(req, relay, runnerId, requestId).catch((error) => {
-            cancel();
+        void streamRequestBodyToRelay(req, relay, runnerId, requestId, bodyAbortController.signal).catch((error) => {
+            cancelRequest();
             const message = error instanceof Error ? error.message : String(error);
 
             if (!responseStarted) {

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -476,10 +476,29 @@ function proxyTunnelRequestViaRelay(
 ): Promise<Response> {
     return new Promise<Response>((resolve) => {
         const bodyAbortController = new AbortController();
-        let relayCancel: () => void = () => {};
-        const cancelRequest = (): void => {
-            bodyAbortController.abort();
+        let relayCancel: (() => void) | undefined;
+        let relayCancelRequested = false;
+        let relayCancelled = false;
+        let clientAbortListenerAttached = true;
+
+        const cancelRelay = (): void => {
+            relayCancelRequested = true;
+            if (!relayCancel || relayCancelled) return;
+            relayCancelled = true;
             relayCancel();
+        };
+        const removeClientAbortListener = (): void => {
+            if (!clientAbortListenerAttached) return;
+            clientAbortListenerAttached = false;
+            req.signal.removeEventListener("abort", cancelRequest);
+        };
+        const finishRequestBody = (): void => {
+            removeClientAbortListener();
+            bodyAbortController.abort();
+        };
+        const cancelRequest = (): void => {
+            finishRequestBody();
+            cancelRelay();
         };
         req.signal.addEventListener("abort", cancelRequest, { once: true });
         let responseStarted = false;
@@ -591,6 +610,7 @@ function proxyTunnelRequestViaRelay(
                     }
                 },
                 onResponseEnd: () => {
+                    finishRequestBody();
                     if (shouldBuffer) {
                         if (!responseStarted) {
                             resolveOnce(tunnelErrorResponse("Tunnel response missing headers"));
@@ -630,6 +650,7 @@ function proxyTunnelRequestViaRelay(
             },
         );
         relayCancel = cancel;
+        if (relayCancelRequested) cancelRelay();
         if (req.signal.aborted) cancelRequest();
 
         void streamRequestBodyToRelay(req, relay, runnerId, requestId, bodyAbortController.signal).catch((error) => {

--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -246,6 +246,77 @@ describe("TunnelClient", () => {
     }
   });
 
+  test("does not forward response data after cancellation", async () => {
+    let sendLateData!: () => void;
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.writeHead(200);
+      res.write("before-cancel");
+      sendLateData = () => {
+        res.write("after-cancel");
+        res.end();
+      };
+    });
+
+    try {
+      const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel", autoReconnect: false });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+      (client as any).handleMessage(JSON.stringify({ type: "request-start", id: "req-cancel", port, method: "GET", url: "/", headers: {} }));
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-cancel" }));
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data"));
+
+      (client as any).handleMessage(JSON.stringify({ type: "request-end", id: "req-cancel" }));
+      sendLateData();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(decodeSent(sent).filter((message) => message.type === "response-data").map((message) => message.data)).toEqual(["before-cancel"]);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
+  test("finalizes a response when the local stream closes prematurely", async () => {
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.writeHead(200);
+      res.write("partial");
+      setTimeout(() => res.socket?.destroy(), 5);
+    });
+
+    try {
+      const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel", autoReconnect: false });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+      (client as any).handleMessage(JSON.stringify({ type: "request-start", id: "req-close", port, method: "GET", url: "/", headers: {} }));
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-close" }));
+
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-end"));
+      expect(decodeSent(sent).filter((message) => message.type === "response-data").map((message) => message.data)).toEqual(["partial"]);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
+  test("ignores a request error emitted after the response completed", async () => {
+    const { server, port } = await startHttpServer((_req, res) => res.end("ok"));
+
+    try {
+      const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel", autoReconnect: false });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+      (client as any).handleMessage(JSON.stringify({ type: "request-start", id: "req-late-error", port, method: "GET", url: "/", headers: {} }));
+      const request = (client as any).activeRequests.get("req-late-error").req;
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-late-error" }));
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-end"));
+
+      request.emit("error", new Error("late body failure"));
+      await Promise.resolve();
+      expect(decodeSent(sent).filter((message) => message.type === "response-start")).toHaveLength(1);
+      expect(decodeSent(sent).filter((message) => message.statusCode === 502)).toHaveLength(0);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
   test("preserves multiple Set-Cookie headers as an array instead of joining them", async () => {
     const { server, port } = await startHttpServer((_req, res) => {
       res.setHeader("set-cookie", [

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -117,6 +117,7 @@ export class TunnelClient extends EventEmitter {
       bodyChunks: Buffer[] | null;
       bodyBytes: number;
       bodyEnded: boolean;
+      responseStarted: boolean;
     }
   >();
   /**
@@ -459,9 +460,35 @@ export class TunnelClient extends EventEmitter {
         ...(useTls ? { rejectUnauthorized: false } : {}),
       },
       (response) => {
+        const requestIsActive = (): boolean => {
+          const active = this.activeRequests.get(id);
+          return active?.req === req && !controller.signal.aborted;
+        };
+        let responseStarted = false;
+        let responseSettled = false;
+        const finalizeResponse = (error?: Error): void => {
+          if (responseSettled) return;
+          responseSettled = true;
+          const active = this.activeRequests.get(id);
+          if (!active || active.req !== req || controller.signal.aborted) return;
+          this.activeRequests.delete(id);
+          if (!responseStarted && error) {
+            this.send({ type: "response-start", id, statusCode: 502, statusMessage: "Bad Gateway", headers: {} });
+            this.send({ type: "response-data", id, data: error.message });
+          }
+          this.send({ type: "response-data-end", id });
+        };
+
+        if (!requestIsActive()) {
+          response.destroy();
+          return;
+        }
         this.loopbackHost.set(port, hostname);
         const active = this.activeRequests.get(id);
-        if (active) active.bodyChunks = null; // connected — replay buffer no longer needed
+        if (active) {
+          active.bodyChunks = null; // connected — replay buffer no longer needed
+          active.responseStarted = true;
+        }
         const responseHeaders: Record<string, string | string[]> = {};
         for (const [key, value] of Object.entries(response.headers)) {
           if (value === undefined) continue;
@@ -472,6 +499,7 @@ export class TunnelClient extends EventEmitter {
           responseHeaders[key] = value;
         }
 
+        responseStarted = true;
         this.send({
           type: "response-start",
           id,
@@ -481,13 +509,16 @@ export class TunnelClient extends EventEmitter {
         });
 
         response.on("data", (chunk: Buffer) => {
+          if (!requestIsActive() || responseSettled) return;
           this.send({ type: "response-data", id, data: chunk.toString("binary") });
         });
 
         response.on("end", () => {
-          this.activeRequests.delete(id);
-          this.send({ type: "response-data-end", id });
+          if (!requestIsActive()) return;
+          finalizeResponse();
         });
+        response.on("error", (error) => finalizeResponse(error instanceof Error ? error : new Error(String(error))));
+        response.on("close", () => finalizeResponse(new Error("Local response closed prematurely")));
 
         controller.signal.addEventListener(
           "abort",
@@ -500,13 +531,15 @@ export class TunnelClient extends EventEmitter {
     );
 
     req.on("error", (error) => {
+      const active = this.activeRequests.get(id);
+      if (!active || active.req !== req || controller.signal.aborted) return;
       const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ABORT_ERR" || controller.signal.aborted) {
+      if (code === "ABORT_ERR") {
         this.activeRequests.delete(id);
         return;
       }
-      const active = this.activeRequests.get(id);
-      if (code === "ECONNREFUSED" && canRetry && active?.bodyChunks) {
+      if (active.responseStarted) return;
+      if (code === "ECONNREFUSED" && canRetry && active.bodyChunks) {
         // Local service may be listening on the other loopback family
         // (IPv6-only binds are common on Windows). Retry once, replaying
         // any buffered request body.
@@ -542,7 +575,7 @@ export class TunnelClient extends EventEmitter {
     };
 
     const req = attempt(this.loopbackHost.get(port) ?? "127.0.0.1", true);
-    this.activeRequests.set(id, { controller, req, bodyChunks: [], bodyBytes: 0, bodyEnded: false });
+    this.activeRequests.set(id, { controller, req, bodyChunks: [], bodyBytes: 0, bodyEnded: false, responseStarted: false });
   }
 
   private handleRequestData(msg: TunnelRequestDataMessage): void {


### PR DESCRIPTION
Addresses review feedback for #825: fixes the `duplex` TypeScript error and completes request-body cancellation on successful response end.

Follow-up to #825