### PR TITLE
fix: native push child-notification suppression parity (C-001) [review follow-up]

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -238,6 +238,12 @@ export interface NativePushRegistrationTable {
     /** Per-device ntfy password (Phase 3; null in Phase 1). */
     ntfyPass: string | null;
     createdAt: string;
+    /**
+     * When 1, notifications triggered by linked child sessions are suppressed
+     * for this registration (feature parity with Web Push per-subscription flag).
+     * Defaults to 0 (deliver child notifications).
+     */
+    suppressChildNotifications: number;
 }
 
 export interface DB {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -241,7 +241,7 @@ export interface NativePushRegistrationTable {
     /**
      * When 1, notifications triggered by linked child sessions are suppressed
      * for this registration (feature parity with Web Push per-subscription flag).
-     * Defaults to 0 (deliver child notifications).
+     * Defaults to 1, preserving native push's historical child suppression.
      */
     suppressChildNotifications: number;
 }

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -307,6 +307,50 @@ describe("isValidPushEndpoint", () => {
 // on PIZZAPI_NTFY_URL — tests set it via env to exercise the publish path.
 
 describe("native push registration", () => {
+    it("migration preserves suppression for existing native registrations", async () => {
+        const migrationDir = mkdtempSync(join(tmpdir(), "push-migration-test-"));
+        const migrationContext = createTestAuthContext({ dbPath: join(migrationDir, "test.db") });
+        try {
+            await runWithAuthContext(migrationContext, async () => {
+                const db = getKysely();
+                await db.schema
+                    .createTable("native_push_registration")
+                    .addColumn("id", "text", (col) => col.primaryKey())
+                    .addColumn("userId", "text", (col) => col.notNull())
+                    .addColumn("platform", "text", (col) => col.notNull())
+                    .addColumn("topic", "text", (col) => col.notNull())
+                    .addColumn("ntfyUser", "text")
+                    .addColumn("ntfyPass", "text")
+                    .addColumn("createdAt", "text", (col) => col.notNull())
+                    .execute();
+                await db
+                    .insertInto("native_push_registration" as any)
+                    .values({
+                        id: "legacy-registration",
+                        userId: "legacy-user",
+                        platform: "android",
+                        topic: "pizzapi-legacy",
+                        ntfyUser: null,
+                        ntfyPass: null,
+                        createdAt: new Date().toISOString(),
+                    })
+                    .execute();
+
+                await ensureNativePushRegistrationTable();
+
+                const row = await db
+                    .selectFrom("native_push_registration" as any)
+                    .selectAll()
+                    .where("id", "=", "legacy-registration")
+                    .executeTakeFirstOrThrow();
+                expect((row as any).suppressChildNotifications).toBe(1);
+                await db.destroy();
+            });
+        } finally {
+            rmSync(migrationDir, { recursive: true, force: true });
+        }
+    });
+
     authIt("registerNativePush assigns an unguessable topic and persists it", async () => {
         const reg = await registerNativePush({ userId: "user-A", platform: "android" });
         expect(reg.userId).toBe("user-A");
@@ -314,6 +358,7 @@ describe("native push registration", () => {
         expect(reg.topic).toMatch(/^pizzapi-[0-9a-f]{48}$/);
         expect(reg.ntfyUser).toBeNull();
         expect(reg.ntfyPass).toBeNull();
+        expect(reg.suppressChildNotifications).toBe(1);
 
         // Round-trips through the store.
         const rows = await getNativeRegistrationsForUser("user-A");
@@ -691,8 +736,8 @@ describe("sendPushToUser — child-session suppression", () => {
         expect(subs).toHaveLength(0);
     });
 
-    authIt("ntfy: suppresses child session when suppressChildNotifications is true", async () => {
-        await registerNativePush({ userId: "user-child-ntfy-1", platform: "android", suppressChildNotifications: true });
+    authIt("ntfy: suppresses child sessions by default", async () => {
+        await registerNativePush({ userId: "user-child-ntfy-1", platform: "android" });
         process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
 
         let fetchCalled = false;

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -754,6 +754,32 @@ describe("sendPushToUser — child-session suppression", () => {
         expect(fetchCalled).toBe(true);
     });
 
+    authIt("ntfy: non-child notification is delivered even when suppressChildNotifications is true", async () => {
+        // Regression: the suppressChildNotifications flag must ONLY gate child
+        // sessions (isChildSession=true). A top-level session notification must
+        // still be published regardless of how the flag is set.
+        await registerNativePush({ userId: "user-suppress-nochild", platform: "android", suppressChildNotifications: true });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok", { status: 200 })); };
+        try {
+            await sendPushToUser("user-suppress-nochild", {
+                type: "agent_needs_input",
+                title: "Input needed",
+                body: "Agent asks a question",
+                sessionId: "sess-suppress-nochild",
+            }, false /* isChildSession=false → must deliver despite suppressChildNotifications=true */);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        // suppressChildNotifications only suppresses child-session notifications —
+        // a top-level session must always be delivered.
+        expect(fetchCalled).toBe(true);
+    });
+
     authIt("ntfy: per-registration: suppressed reg skipped, unsuppressed reg delivered", async () => {
         // Two registrations for different users: one suppress=true, one suppress=false.
         // Only the unsuppressed one should receive the child-session notification.

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, spyOn } from "bun:test";
 import { createTestAuthContext, getKysely, runWithAuthContext } from "./auth.js";
-import { unsubscribePush, updateSuppressChildNotifications, getSubscriptionsForUser, isValidPushEndpoint, registerNativePush, unregisterNativePush, getNativeRegistrationsForUser, ensureNativePushRegistrationTable, sendPushToUser } from "./push.js";
+import { unsubscribePush, updateSuppressChildNotifications, getSubscriptionsForUser, isValidPushEndpoint, registerNativePush, unregisterNativePush, getNativeRegistrationsForUser, ensureNativePushRegistrationTable, sendPushToUser, updateNativeSuppressChildNotifications } from "./push.js";
 import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -691,8 +691,8 @@ describe("sendPushToUser — child-session suppression", () => {
         expect(subs).toHaveLength(0);
     });
 
-    authIt("ntfy: suppresses by default for a child session (no fetch attempted)", async () => {
-        await registerNativePush({ userId: "user-child-ntfy-1", platform: "android" });
+    authIt("ntfy: suppresses child session when suppressChildNotifications is true", async () => {
+        await registerNativePush({ userId: "user-child-ntfy-1", platform: "android", suppressChildNotifications: true });
         process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
 
         let fetchCalled = false;
@@ -704,12 +704,33 @@ describe("sendPushToUser — child-session suppression", () => {
                 title: "Agent finished",
                 body: "done",
                 sessionId: "sess-child-ntfy-1",
-            }, true);
+            }, true /* isChildSession */);
         } finally {
             (globalThis as any).fetch = origFetch;
             delete process.env.PIZZAPI_NTFY_URL;
         }
         expect(fetchCalled).toBe(false);
+    });
+
+    authIt("ntfy: delivers child session when suppressChildNotifications is false", async () => {
+        await registerNativePush({ userId: "user-child-ntfy-deliver", platform: "android", suppressChildNotifications: false });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok", { status: 200 })); };
+        try {
+            await sendPushToUser("user-child-ntfy-deliver", {
+                type: "agent_finished",
+                title: "Agent finished",
+                body: "done",
+                sessionId: "sess-child-ntfy-deliver",
+            }, true /* isChildSession */);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        expect(fetchCalled).toBe(true);
     });
 
     authIt("ntfy: still publishes for a non-child session", async () => {
@@ -731,5 +752,96 @@ describe("sendPushToUser — child-session suppression", () => {
             delete process.env.PIZZAPI_NTFY_URL;
         }
         expect(fetchCalled).toBe(true);
+    });
+
+    authIt("ntfy: per-registration: suppressed reg skipped, unsuppressed reg delivered", async () => {
+        // Two registrations for different users: one suppress=true, one suppress=false.
+        // Only the unsuppressed one should receive the child-session notification.
+        await registerNativePush({ userId: "user-multi-suppress", platform: "android", suppressChildNotifications: true });
+        await registerNativePush({ userId: "user-multi-deliver", platform: "android", suppressChildNotifications: false });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let deliverCount = 0;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { deliverCount++; return Promise.resolve(new Response("ok", { status: 200 })); };
+        try {
+            // isChildSession=true: suppress reg must skip, deliver reg must publish.
+            await sendPushToUser("user-multi-suppress", {
+                type: "agent_needs_input",
+                title: "Input needed",
+                body: "child asks",
+                sessionId: "sess-multi",
+            }, true);
+            const afterSuppress = deliverCount;
+
+            await sendPushToUser("user-multi-deliver", {
+                type: "agent_needs_input",
+                title: "Input needed",
+                body: "child asks",
+                sessionId: "sess-multi-2",
+            }, true);
+            const afterDeliver = deliverCount;
+
+            expect(afterSuppress).toBe(0); // suppressed → no fetch
+            expect(afterDeliver).toBe(1);  // deliver → one fetch
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+    });
+});
+
+// ── updateNativeSuppressChildNotifications ────────────────────────────────────
+
+describe("updateNativeSuppressChildNotifications", () => {
+    authIt("persists true and makes sendNtfyToUser skip the registration for child sessions", async () => {
+        await registerNativePush({ userId: "user-nscn-1", platform: "android" });
+        await updateNativeSuppressChildNotifications("user-nscn-1", "android", true);
+
+        const rows = await getNativeRegistrationsForUser("user-nscn-1");
+        expect(rows[0].suppressChildNotifications).toBe(1);
+
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok")); };
+        try {
+            await sendPushToUser("user-nscn-1", { type: "agent_finished", title: "done", body: "x", sessionId: "s" }, true);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        expect(fetchCalled).toBe(false);
+    });
+
+    authIt("persists false and makes sendNtfyToUser deliver to the registration for child sessions", async () => {
+        await registerNativePush({ userId: "user-nscn-2", platform: "android", suppressChildNotifications: true });
+        await updateNativeSuppressChildNotifications("user-nscn-2", "android", false);
+
+        const rows = await getNativeRegistrationsForUser("user-nscn-2");
+        expect(rows[0].suppressChildNotifications).toBe(0);
+
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok", { status: 200 })); };
+        try {
+            await sendPushToUser("user-nscn-2", { type: "agent_finished", title: "done", body: "x", sessionId: "s" }, true);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        expect(fetchCalled).toBe(true);
+    });
+
+    authIt("returns 0 when no registration exists", async () => {
+        const count = await updateNativeSuppressChildNotifications("user-nscn-none", "android", true);
+        expect(count).toBe(0);
+    });
+
+    authIt("returns 1 when a registration is updated", async () => {
+        await registerNativePush({ userId: "user-nscn-3", platform: "android" });
+        const count = await updateNativeSuppressChildNotifications("user-nscn-3", "android", true);
+        expect(count).toBe(1);
     });
 });

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -253,6 +253,8 @@ export interface NativePushRegistrationTable {
     ntfyUser: string | null;
     ntfyPass: string | null;
     createdAt: string;
+    /** 0 = deliver child-session notifications; 1 = suppress them. Defaults to 0. */
+    suppressChildNotifications: number;
 }
 
 export async function ensureNativePushRegistrationTable(): Promise<void> {
@@ -267,6 +269,18 @@ export async function ensureNativePushRegistrationTable(): Promise<void> {
         .addColumn("ntfyPass", "text")
         .addColumn("createdAt", "text", (col) => col.notNull())
         .execute();
+
+    // Migration: add suppressChildNotifications if the column doesn't exist yet.
+    // Same idempotent pattern used for push_subscription above.
+    try {
+        await getKysely().schema
+            .alterTable("native_push_registration")
+            .addColumn("suppressChildNotifications", "integer", (col) => col.notNull().defaultTo(0))
+            .execute();
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes("duplicate column name")) throw err;
+    }
 
     await getKysely().schema
         .createIndex("native_push_registration_user_idx")
@@ -286,6 +300,8 @@ export async function ensureNativePushRegistrationTable(): Promise<void> {
 export interface RegisterNativeInput {
     userId: string;
     platform: string;
+    /** When provided, persisted as the per-registration child-suppression preference. */
+    suppressChildNotifications?: boolean;
 }
 
 /**
@@ -304,7 +320,19 @@ export async function registerNativePush(input: RegisterNativeInput): Promise<Na
         .where("userId", "=", input.userId)
         .where("platform", "=", platform)
         .executeTakeFirst();
-    if (existing) return existing as unknown as NativePushRegistrationTable;
+    if (existing) {
+        // Update suppressChildNotifications if a new preference was provided.
+        if (input.suppressChildNotifications !== undefined) {
+            const val = input.suppressChildNotifications ? 1 : 0;
+            await getKysely()
+                .updateTable("native_push_registration" as any)
+                .set({ suppressChildNotifications: val })
+                .where("id", "=", (existing as any).id)
+                .execute();
+            return { ...(existing as unknown as NativePushRegistrationTable), suppressChildNotifications: val };
+        }
+        return existing as unknown as NativePushRegistrationTable;
+    }
 
     const row: NativePushRegistrationTable = {
         id: crypto.randomUUID(),
@@ -313,6 +341,7 @@ export async function registerNativePush(input: RegisterNativeInput): Promise<Na
         topic: generateNtfyTopic(),
         ntfyUser: null,
         ntfyPass: null,
+        suppressChildNotifications: input.suppressChildNotifications ? 1 : 0,
         createdAt: new Date().toISOString(),
     };
     await getKysely()
@@ -320,6 +349,24 @@ export async function registerNativePush(input: RegisterNativeInput): Promise<Na
         .values(row as any)
         .execute();
     return row;
+}
+
+/**
+ * Update the child-notification suppression preference for a user's native registration.
+ * Returns the number of rows updated (0 if no registration exists for user+platform).
+ */
+export async function updateNativeSuppressChildNotifications(
+    userId: string,
+    platform: string,
+    suppress: boolean,
+): Promise<number> {
+    const result = await getKysely()
+        .updateTable("native_push_registration" as any)
+        .set({ suppressChildNotifications: suppress ? 1 : 0 })
+        .where("userId", "=", userId)
+        .where("platform", "=", platform)
+        .execute();
+    return Number((result as any)[0]?.numUpdatedRows ?? 0);
 }
 
 export async function unregisterNativePush(userId: string, platform: string): Promise<boolean> {
@@ -380,14 +427,13 @@ function buildNtfyPublish(payload: PushPayload): Record<string, unknown> {
  * (sendPushToUser) treats this as best-effort alongside the Web Push fan-out.
  * Native devices alert only when the agent needs input or finishes.
  *
- * Linked child sessions never send native push by default (docs: "only
- * top-level sessions send push notifications") — native registrations have
- * no per-subscription preference columns to offer a granular opt-out today,
- * so this is unconditional. (Unlike the Web Push path below, there is no
- * per-registration escape hatch yet — add one here if that's ever needed.)
+ * Child-session suppression is now per-registration: each registration's
+ * `suppressChildNotifications` column controls whether child-session
+ * notifications are delivered (0 = deliver, 1 = suppress). This is feature
+ * parity with the Web Push per-subscription `suppressChildNotifications` flag.
  */
 async function sendNtfyToUser(userId: string, payload: PushPayload, isChildSession: boolean): Promise<void> {
-    if (isChildSession || (payload.type !== "agent_needs_input" && payload.type !== "agent_finished")) return;
+    if (payload.type !== "agent_needs_input" && payload.type !== "agent_finished") return;
     const cfg = ntfyConfig();
     if (!cfg.url) return;
     const registrations = await getNativeRegistrationsForUser(userId);
@@ -419,6 +465,10 @@ async function sendNtfyToUser(userId: string, payload: PushPayload, isChildSessi
 
     await Promise.allSettled(
         registrations.map(async (reg) => {
+            // Per-registration child-session suppression: skip if the user opted out
+            // of child-session notifications for this device registration.
+            if (isChildSession && reg.suppressChildNotifications) return;
+
             let res: Response;
             try {
                 res = await publishOnce(reg);

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -253,7 +253,7 @@ export interface NativePushRegistrationTable {
     ntfyUser: string | null;
     ntfyPass: string | null;
     createdAt: string;
-    /** 0 = deliver child-session notifications; 1 = suppress them. Defaults to 0. */
+    /** 0 = deliver child-session notifications; 1 = suppress them. Defaults to 1. */
     suppressChildNotifications: number;
 }
 
@@ -275,7 +275,7 @@ export async function ensureNativePushRegistrationTable(): Promise<void> {
     try {
         await getKysely().schema
             .alterTable("native_push_registration")
-            .addColumn("suppressChildNotifications", "integer", (col) => col.notNull().defaultTo(0))
+            .addColumn("suppressChildNotifications", "integer", (col) => col.notNull().defaultTo(1))
             .execute();
     } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -341,7 +341,7 @@ export async function registerNativePush(input: RegisterNativeInput): Promise<Na
         topic: generateNtfyTopic(),
         ntfyUser: null,
         ntfyPass: null,
-        suppressChildNotifications: input.suppressChildNotifications ? 1 : 0,
+        suppressChildNotifications: input.suppressChildNotifications === false ? 0 : 1,
         createdAt: new Date().toISOString(),
     };
     await getKysely()

--- a/packages/server/src/routes/push.test.ts
+++ b/packages/server/src/routes/push.test.ts
@@ -25,7 +25,7 @@ const mockRegisterNativePush = mock(async (_input: any) => ({
     topic: "pizzapi-abc123",
     ntfyUser: null,
     ntfyPass: null,
-    suppressChildNotifications: 0,
+    suppressChildNotifications: 1,
     createdAt: new Date().toISOString(),
 }));
 const mockUpdateNativeSuppressChildNotifications = mock(async (_userId: string, _platform: string, _suppress: boolean): Promise<number> => 1);
@@ -140,14 +140,14 @@ describe("POST /api/push/register-native", () => {
         mockRequireSession.mockImplementation(async () => ({ userId: "user-route-1", userName: "Test User" }));
     });
 
-    it("response includes suppressChildNotifications boolean (false by default)", async () => {
+    it("response includes suppressChildNotifications boolean (true by default)", async () => {
         mockRegisterNativePush.mockImplementation(async () => ({
             userId: "user-route-1",
             platform: "android",
             topic: "pizzapi-abc123",
             ntfyUser: null,
             ntfyPass: null,
-            suppressChildNotifications: 0, // stored as integer
+            suppressChildNotifications: 1, // stored as integer
             createdAt: new Date().toISOString(),
         }));
 
@@ -157,7 +157,7 @@ describe("POST /api/push/register-native", () => {
         const json = await res!.json();
         expect(json.ok).toBe(true);
         expect(typeof json.suppressChildNotifications).toBe("boolean");
-        expect(json.suppressChildNotifications).toBe(false);
+        expect(json.suppressChildNotifications).toBe(true);
     });
 
     it("response includes suppressChildNotifications=true when previously set", async () => {

--- a/packages/server/src/routes/push.test.ts
+++ b/packages/server/src/routes/push.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Route-level tests for handlePushRoute.
+ *
+ * Mocks all dependencies so no DB or network is needed.
+ * Focuses on: auth guards, 404 path, success path for native-child-suppression
+ * routes, and the suppressChildNotifications field in register-native response.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// ── Mocks (must be declared before the import under test) ────────────────────
+
+const mockRequireSession = mock(
+    async (_req: Request): Promise<{ userId: string; userName: string } | Response> => ({
+        userId: "user-route-1",
+        userName: "Test User",
+    }),
+);
+
+const mockIsNtfyConfigured = mock(() => true);
+const mockGetNtfyPublicUrl = mock(() => "https://push.example.com");
+const mockRegisterNativePush = mock(async (_input: any) => ({
+    userId: "user-route-1",
+    platform: "android",
+    topic: "pizzapi-abc123",
+    ntfyUser: null,
+    ntfyPass: null,
+    suppressChildNotifications: 0,
+    createdAt: new Date().toISOString(),
+}));
+const mockUpdateNativeSuppressChildNotifications = mock(async (_userId: string, _platform: string, _suppress: boolean): Promise<number> => 1);
+
+mock.module("../middleware.js", () => ({ requireSession: mockRequireSession }));
+
+mock.module("../push.js", () => ({
+    getVapidPublicKey: mock(() => "vapid-key"),
+    subscribePush: mock(async () => ({ id: "sub-1" })),
+    unsubscribePush: mock(async () => true),
+    getSubscriptionsForUser: mock(async () => []),
+    updateEnabledEvents: mock(async () => 1),
+    updateSuppressChildNotifications: mock(async () => 1),
+    isValidPushEndpoint: mock(() => true),
+    isNtfyConfigured: mockIsNtfyConfigured,
+    getNtfyPublicUrl: mockGetNtfyPublicUrl,
+    registerNativePush: mockRegisterNativePush,
+    unregisterNativePush: mock(async () => true),
+    updateNativeSuppressChildNotifications: mockUpdateNativeSuppressChildNotifications,
+}));
+
+mock.module("../ws/sio-registry.js", () => ({
+    getSharedSession: mock(() => null),
+    getLocalTuiSocket: mock(() => null),
+}));
+
+mock.module("../ws/sio-state/index.js", () => ({
+    getPushPendingQuestion: mock(() => null),
+    consumePushPendingQuestionIfMatches: mock(() => null),
+}));
+
+// Import under test AFTER mocks are registered.
+import { handlePushRoute } from "./push.js";
+
+afterAll(() => mock.restore());
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(path: string, method = "GET", body?: unknown): [Request, URL] {
+    const url = new URL(`http://localhost${path}`);
+    const init: RequestInit = { method };
+    if (body !== undefined) {
+        init.body = JSON.stringify(body);
+        init.headers = { "content-type": "application/json" };
+    }
+    return [new Request(url, init), url];
+}
+
+function unauthorized(): Response {
+    return new Response("Unauthorized", { status: 401 });
+}
+
+// ── PUT /api/push/child-notifications-native ──────────────────────────────────
+
+describe("PUT /api/push/child-notifications-native", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockUpdateNativeSuppressChildNotifications.mockReset();
+        // Default: authenticated
+        mockRequireSession.mockImplementation(async () => ({ userId: "user-route-1", userName: "Test User" }));
+        // Default: registration found
+        mockUpdateNativeSuppressChildNotifications.mockImplementation(async () => 1);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+        mockRequireSession.mockImplementation(async () => unauthorized());
+
+        const [req, url] = makeReq("/api/push/child-notifications-native", "PUT", { suppress: true });
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(401);
+    });
+
+    it("returns 404 when user has no native registration", async () => {
+        mockUpdateNativeSuppressChildNotifications.mockImplementation(async () => 0);
+
+        const [req, url] = makeReq("/api/push/child-notifications-native", "PUT", { suppress: true });
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(404);
+        const json = await res!.json();
+        expect(json.error).toMatch(/no native push registration/i);
+    });
+
+    it("returns 400 when suppress field is missing", async () => {
+        const [req, url] = makeReq("/api/push/child-notifications-native", "PUT", {});
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(400);
+    });
+
+    it("persists suppress=true and returns ok", async () => {
+        const [req, url] = makeReq("/api/push/child-notifications-native", "PUT", { suppress: true });
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(200);
+        const json = await res!.json();
+        expect(json.ok).toBe(true);
+        expect(mockUpdateNativeSuppressChildNotifications).toHaveBeenCalledWith("user-route-1", "android", true);
+    });
+
+    it("persists suppress=false and returns ok", async () => {
+        const [req, url] = makeReq("/api/push/child-notifications-native", "PUT", { suppress: false });
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(200);
+        expect(mockUpdateNativeSuppressChildNotifications).toHaveBeenCalledWith("user-route-1", "android", false);
+    });
+});
+
+// ── POST /api/push/register-native ───────────────────────────────────────────
+
+describe("POST /api/push/register-native", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockRegisterNativePush.mockReset();
+        mockRequireSession.mockImplementation(async () => ({ userId: "user-route-1", userName: "Test User" }));
+    });
+
+    it("response includes suppressChildNotifications boolean (false by default)", async () => {
+        mockRegisterNativePush.mockImplementation(async () => ({
+            userId: "user-route-1",
+            platform: "android",
+            topic: "pizzapi-abc123",
+            ntfyUser: null,
+            ntfyPass: null,
+            suppressChildNotifications: 0, // stored as integer
+            createdAt: new Date().toISOString(),
+        }));
+
+        const [req, url] = makeReq("/api/push/register-native", "POST");
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(200);
+        const json = await res!.json();
+        expect(json.ok).toBe(true);
+        expect(typeof json.suppressChildNotifications).toBe("boolean");
+        expect(json.suppressChildNotifications).toBe(false);
+    });
+
+    it("response includes suppressChildNotifications=true when previously set", async () => {
+        mockRegisterNativePush.mockImplementation(async () => ({
+            userId: "user-route-1",
+            platform: "android",
+            topic: "pizzapi-abc123",
+            ntfyUser: null,
+            ntfyPass: null,
+            suppressChildNotifications: 1, // stored as integer
+            createdAt: new Date().toISOString(),
+        }));
+
+        const [req, url] = makeReq("/api/push/register-native", "POST");
+        const res = await handlePushRoute(req, url);
+        const json = await res!.json();
+        expect(json.suppressChildNotifications).toBe(true);
+    });
+
+    it("returns 401 without auth", async () => {
+        mockRequireSession.mockImplementation(async () => unauthorized());
+
+        const [req, url] = makeReq("/api/push/register-native", "POST");
+        const res = await handlePushRoute(req, url);
+        expect(res?.status).toBe(401);
+    });
+});

--- a/packages/server/src/routes/push.ts
+++ b/packages/server/src/routes/push.ts
@@ -15,6 +15,7 @@ import {
     getNtfyPublicUrl,
     registerNativePush,
     unregisterNativePush,
+    updateNativeSuppressChildNotifications,
 } from "../push.js";
 import { getSharedSession, getLocalTuiSocket } from "../ws/sio-registry.js";
 import { getPushPendingQuestion, consumePushPendingQuestionIfMatches } from "../ws/sio-state/index.js";
@@ -229,6 +230,7 @@ export const handlePushRoute: RouteHandler = async (req, url) => {
             // per-device ntfy users are provisioned.
             ntfyUser: reg.ntfyUser,
             ntfyPass: reg.ntfyPass,
+            suppressChildNotifications: !!reg.suppressChildNotifications,
         });
     }
 
@@ -239,6 +241,23 @@ export const handlePushRoute: RouteHandler = async (req, url) => {
         const platform = "android";
         const removed = await unregisterNativePush(identity.userId, platform);
         return Response.json({ ok: true, removed });
+    }
+
+    if (url.pathname === "/api/push/child-notifications-native" && req.method === "PUT") {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const body = (await req.json()) as { suppress?: boolean };
+        if (typeof body.suppress !== "boolean") {
+            return Response.json({ error: "Missing suppress (boolean)" }, { status: 400 });
+        }
+
+        const platform = "android";
+        const updated = await updateNativeSuppressChildNotifications(identity.userId, platform, body.suppress);
+        if (updated === 0) {
+            return Response.json({ error: "No native push registration found" }, { status: 404 });
+        }
+        return Response.json({ ok: true });
     }
 
     return undefined;

--- a/packages/ui/src/components/NotificationToggle.test.tsx
+++ b/packages/ui/src/components/NotificationToggle.test.tsx
@@ -1,27 +1,23 @@
 /**
- * Tests for NotificationToggle's native (Android/ntfy) subscribed state.
+ * Tests for native push child-suppression parity in NotificationToggle.
  *
- * The bug this guards against: `startNtfyPush()` used to swallow every
- * failure (503 unconfigured, fetch error, malformed response) and the toggle
- * derived `subscribed` purely from OS permission + a localStorage flag — so a
- * user could see "Notifications enabled" with zero server registration.
- *
- * We avoid `mock.module("@/lib/ntfy-push", ...)` / `mock.module("./ntfy-push", ...)`
- * on purpose: Bun's `mock.module` keys off the resolved file, so mocking it
- * here would leak into ntfy-push.test.ts (run in the same process per the
- * project's test command) and stub out the real function this test exists to
- * exercise. Instead we monkeypatch `Capacitor` platform methods directly
- * (same technique as mobile-native.test.ts) and control `fetch` per test.
+ * Key invariants verified:
+ *  1. usePushState.toggleSuppressChild routes to setNativeSuppressChildNotifications
+ *     for native users (not setSuppressChildNotifications).
+ *  2. usePushState.toggleSuppressChild routes to setSuppressChildNotifications
+ *     for web push users.
+ *  3. After toggle, suppressChild state reflects the new value.
  */
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Window } from "happy-dom";
-import React from "react";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
-import { Capacitor } from "@capacitor/core";
-import * as realLocalNotifications from "@capacitor/local-notifications";
 
+import { afterAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { Window } from "happy-dom";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import React from "react"; // needed so JSX transform is happy when components pull it in
+
+// Set up DOM globals BEFORE importing the component.
 const win = new Window({ url: "http://localhost/" });
-(win as any).SyntaxError = globalThis.SyntaxError;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(win as any).SyntaxError = SyntaxError;
 (globalThis as any).window = win;
 (globalThis as any).document = win.document;
 (globalThis as any).navigator = win.navigator;
@@ -29,138 +25,181 @@ const win = new Window({ url: "http://localhost/" });
 (globalThis as any).Element = win.Element;
 (globalThis as any).Node = win.Node;
 (globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).KeyboardEvent = win.KeyboardEvent;
 (globalThis as any).MutationObserver = win.MutationObserver;
-(globalThis as any).getComputedStyle = () => ({
-    getPropertyValue: () => "",
-    paddingRight: "",
-    paddingTop: "",
-    paddingLeft: "",
-    paddingBottom: "",
-});
-(globalThis as any).ResizeObserver = class {
+(globalThis as any).CustomEvent = win.CustomEvent;
+(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}
     unobserve() {}
     disconnect() {}
 };
-(globalThis as any).IntersectionObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-};
+(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
+(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
-const origGetPlatform = Capacitor.getPlatform;
-const origIsNativePlatform = Capacitor.isNativePlatform;
-const origLocalStorage = (globalThis as any).localStorage;
+// ── Controllable mock state ──────────────────────────────────────────────────
+// Variables captured by mock closures (set per-test via beforeEach/test body).
 
-// Permission check/request always report "granted" — these tests are about
-// what happens to `subscribed` *after* permission is already granted.
-let permissionCalls = 0;
-mock.module("@capacitor/local-notifications", () => ({
-    LocalNotifications: {
-        checkPermissions: () => {
-            permissionCalls++;
-            return Promise.resolve({ display: "granted" });
-        },
-        requestPermissions: () => {
-            permissionCalls++;
-            return Promise.resolve({ display: "granted" });
-        },
+let isNativeAvailable = true;
+let hasPermission = true;
+let isDisabled = false;
+let startResult: { ok: boolean; reason?: string } = { ok: true };
+let nativeSuppressValue = false;
+let webSuppressValue = false;
+
+const nativeSetCalls: boolean[] = [];
+const webSetCalls: boolean[] = [];
+
+mock.module("@/lib/ntfy-push", () => ({
+    isNativePushAvailable: () => isNativeAvailable,
+    hasNativePushPermission: () => Promise.resolve(hasPermission),
+    isNativePushDisabled: () => isDisabled,
+    setNativePushDisabled: () => {},
+    requestNativePushPermission: () => Promise.resolve(true),
+    startNtfyPush: () => Promise.resolve(startResult),
+    stopNtfyPush: () => Promise.resolve(),
+    getNativeSuppressChildNotifications: () => nativeSuppressValue,
+    setNativeSuppressChildNotifications: (suppress: boolean) => {
+        nativeSetCalls.push(suppress);
+        nativeSuppressValue = suppress;
+        return Promise.resolve(true);
     },
 }));
 
-afterAll(() => {
-    // Restore the real plugin module so other test files see the real plugin.
-    mock.module("@capacitor/local-notifications", () => realLocalNotifications);
-    Capacitor.getPlatform = origGetPlatform;
-    Capacitor.isNativePlatform = origIsNativePlatform;
-    (globalThis as any).localStorage = origLocalStorage;
-});
+mock.module("@/lib/push", () => ({
+    isPushSupported: () => !isNativeAvailable,
+    isPushSubscribed: () => Promise.resolve(!isNativeAvailable),
+    getNotificationPermission: () => "granted",
+    // Return the current tracked value so refreshState() gets the up-to-date preference
+    // when the pp-push-state-changed event triggers a re-read.
+    getSuppressChildNotifications: () => Promise.resolve(webSuppressValue),
+    setSuppressChildNotifications: (suppress: boolean) => {
+        webSetCalls.push(suppress);
+        webSuppressValue = suppress;
+        return Promise.resolve(true);
+    },
+    subscribeToPush: () => Promise.resolve(null),
+    unsubscribeFromPush: () => Promise.resolve(false),
+}));
 
-function makeLocalStorage(serverUrl: string | null): Storage {
-    const store: Record<string, string> = {};
-    return {
-        getItem: (key: string) => (key === "pizzapi.serverUrl" ? serverUrl : (store[key] ?? null)),
-        setItem: (key: string, value: string) => {
-            store[key] = value;
-        },
-        removeItem: (key: string) => {
-            delete store[key];
-        },
-        clear: () => {
-            for (const key of Object.keys(store)) delete store[key];
-        },
-        key: (index: number) => Object.keys(store)[index] ?? null,
-        length: 0,
-    } as unknown as Storage;
-}
+mock.module("@pizzapi/tools", () => ({
+    createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }),
+}));
 
-function goAndroidNative() {
-    Object.defineProperty(globalThis, "localStorage", {
-        value: makeLocalStorage("https://relay.example.com"),
-        configurable: true,
-        writable: true,
-    });
-    Capacitor.getPlatform = () => "android";
-    Capacitor.isNativePlatform = () => true;
-}
+// Stub heavy UI components so they don't blow up without a full Radix/Tailwind env.
+mock.module("@/components/ui/button", () => ({
+    Button: ({ children, ...p }: any) => React.createElement("button", p, children),
+}));
+mock.module("@/components/ui/switch", () => ({
+    Switch: (p: any) => React.createElement("input", { type: "checkbox", ...p }),
+}));
+mock.module("@/components/ui/tooltip", () => ({
+    TooltipProvider: ({ children }: any) => children,
+    Tooltip: ({ children }: any) => children,
+    TooltipTrigger: ({ children }: any) => children,
+    TooltipContent: ({ children }: any) => React.createElement("div", null, children),
+}));
+mock.module("@/components/ui/dropdown-menu", () => ({
+    DropdownMenu: ({ children }: any) => React.createElement("div", null, children),
+    DropdownMenuTrigger: ({ children }: any) => React.createElement("div", null, children),
+    DropdownMenuContent: ({ children }: any) => React.createElement("div", null, children),
+    DropdownMenuLabel: ({ children }: any) => React.createElement("div", null, children),
+    DropdownMenuSeparator: () => React.createElement("hr"),
+    DropdownMenuItem: ({ children, onSelect, disabled }: any) =>
+        React.createElement("div", { onClick: onSelect, "aria-disabled": disabled }, children),
+}));
 
-const { NotificationToggle } = await import("./NotificationToggle");
+const { usePushState } = await import("./NotificationToggle");
 
-beforeEach(() => {
-    permissionCalls = 0;
-    goAndroidNative();
-});
-
+afterAll(() => mock.restore());
 afterEach(() => {
     cleanup();
-    document.body.innerHTML = "";
+    nativeSetCalls.length = 0;
+    webSetCalls.length = 0;
+    nativeSuppressValue = false;
+    webSuppressValue = false;
+    isNativeAvailable = true;
+    hasPermission = true;
+    isDisabled = false;
+    startResult = { ok: true };
 });
 
-function ariaLabel(container: HTMLElement): string | null {
-    return container.querySelector("button[aria-label]")?.getAttribute("aria-label") ?? null;
-}
+// ── Tests ────────────────────────────────────────────────────────────────────
 
-describe("NotificationToggle (native/ntfy registration outcome)", () => {
-    test("503 (ntfy unconfigured) surfaces as unconfigured, not subscribed", async () => {
-        (globalThis as any).fetch = mock(async () => ({ ok: false, status: 503 }) as Response);
+describe("usePushState — native child-suppression routing", () => {
+    test("toggleSuppressChild calls setNativeSuppressChildNotifications for native users", async () => {
+        isNativeAvailable = true;
+        hasPermission = true;
+        isDisabled = false;
+        startResult = { ok: true };
+        nativeSuppressValue = false;
 
-        let container!: HTMLElement;
+        const { result } = renderHook(() => usePushState());
+
+        // Wait for async refreshState to complete (hasNativePushPermission + startNtfyPush).
         await act(async () => {
-            ({ container } = render(<NotificationToggle />));
+            await new Promise((r) => setTimeout(r, 20));
         });
 
-        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
-        expect(ariaLabel(container)).toBe("Push not configured on this server");
-        // Not-subscribed path renders a plain button, no dropdown trigger.
-        expect(container.querySelector("[aria-haspopup]")).toBeNull();
+        expect(result.current.subscribed).toBe(true);
+        expect(result.current.native).toBe(true);
+        expect(result.current.suppressChild).toBe(false);
+
+        await act(async () => {
+            await result.current.toggleSuppressChild();
+        });
+
+        // Must have called the NATIVE api, not the web one.
+        expect(nativeSetCalls).toEqual([true]);
+        expect(webSetCalls).toEqual([]);
+        expect(result.current.suppressChild).toBe(true);
     });
 
-    test("successful registration surfaces as subscribed", async () => {
-        (globalThis as any).fetch = mock(async () => ({
-            ok: true,
-            json: async () => ({ ntfyPublicUrl: "https://ntfy.example.com", topic: "pizzapi-abc123" }),
-        }) as Response);
+    test("toggleSuppressChild calls setSuppressChildNotifications for web push users", async () => {
+        isNativeAvailable = false; // web push path
+        hasPermission = false;     // irrelevant for web
+        isDisabled = false;
+        startResult = { ok: false, reason: "error" };
+        nativeSuppressValue = false;
+        webSuppressValue = false;
 
-        let container!: HTMLElement;
+        const { result } = renderHook(() => usePushState());
+
+        // Wait for async isPushSubscribed (which we mock to return true when !native).
         await act(async () => {
-            ({ container } = render(<NotificationToggle />));
+            await new Promise((r) => setTimeout(r, 20));
         });
 
-        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
-        expect(ariaLabel(container)).toBe("Notifications enabled");
+        // Web path: subscribed from isPushSubscribed mock (returns !isNativeAvailable = true).
+        expect(result.current.native).toBe(false);
+        expect(result.current.subscribed).toBe(true);
+
+        await act(async () => {
+            await result.current.toggleSuppressChild();
+        });
+
+        // Must have called the WEB api, not the native one.
+        expect(webSetCalls).toEqual([true]);
+        expect(nativeSetCalls).toEqual([]);
+        expect(result.current.suppressChild).toBe(true);
     });
 
-    test("fetch throw surfaces as not subscribed (generic, not unconfigured)", async () => {
-        (globalThis as any).fetch = mock(async () => {
-            throw new Error("network down");
-        });
+    test("toggleSuppressChild toggles back to false for native", async () => {
+        isNativeAvailable = true;
+        hasPermission = true;
+        isDisabled = false;
+        startResult = { ok: true };
+        nativeSuppressValue = true; // start as suppressed
 
-        let container!: HTMLElement;
-        await act(async () => {
-            ({ container } = render(<NotificationToggle />));
-        });
+        const { result } = renderHook(() => usePushState());
+        await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
 
-        await waitFor(() => expect(ariaLabel(container)).not.toBe("Loading…"));
-        expect(ariaLabel(container)).toBe("Enable notifications");
+        expect(result.current.suppressChild).toBe(true);
+
+        await act(async () => { await result.current.toggleSuppressChild(); });
+
+        expect(nativeSetCalls).toEqual([false]);
+        expect(result.current.suppressChild).toBe(false);
     });
 });

--- a/packages/ui/src/components/NotificationToggle.test.tsx
+++ b/packages/ui/src/components/NotificationToggle.test.tsx
@@ -1,23 +1,16 @@
-/**
- * Tests for native push child-suppression parity in NotificationToggle.
- *
- * Key invariants verified:
- *  1. usePushState.toggleSuppressChild routes to setNativeSuppressChildNotifications
- *     for native users (not setSuppressChildNotifications).
- *  2. usePushState.toggleSuppressChild routes to setSuppressChildNotifications
- *     for web push users.
- *  3. After toggle, suppressChild state reflects the new value.
- */
-
-import { afterAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
-import { renderHook, act, cleanup } from "@testing-library/react";
-import React from "react"; // needed so JSX transform is happy when components pull it in
+import React from "react";
+import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react";
+import {
+    NotificationToggle,
+    usePushState,
+    type PushDependencies,
+} from "./NotificationToggle";
 
-// Set up DOM globals BEFORE importing the component.
+const originalCustomEvent = globalThis.CustomEvent;
 const win = new Window({ url: "http://localhost/" });
-/* eslint-disable @typescript-eslint/no-explicit-any */
-(win as any).SyntaxError = SyntaxError;
+(win as any).SyntaxError = globalThis.SyntaxError;
 (globalThis as any).window = win;
 (globalThis as any).document = win.document;
 (globalThis as any).navigator = win.navigator;
@@ -25,181 +18,135 @@ const win = new Window({ url: "http://localhost/" });
 (globalThis as any).Element = win.Element;
 (globalThis as any).Node = win.Node;
 (globalThis as any).SVGElement = win.SVGElement;
-(globalThis as any).KeyboardEvent = win.KeyboardEvent;
 (globalThis as any).MutationObserver = win.MutationObserver;
 (globalThis as any).CustomEvent = win.CustomEvent;
-(globalThis as any).ResizeObserver = class ResizeObserver {
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).ResizeObserver = class {
     observe() {}
     unobserve() {}
     disconnect() {}
 };
-(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
-(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
-(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
-/* eslint-enable @typescript-eslint/no-explicit-any */
+(globalThis as any).IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
 
-// ── Controllable mock state ──────────────────────────────────────────────────
-// Variables captured by mock closures (set per-test via beforeEach/test body).
-
-let isNativeAvailable = true;
-let hasPermission = true;
-let isDisabled = false;
-let startResult: { ok: boolean; reason?: string } = { ok: true };
-let nativeSuppressValue = false;
-let webSuppressValue = false;
-
+let native = true;
+let nativeSuppress = true;
+let webSuppress = false;
+let startResult: Awaited<ReturnType<PushDependencies["startNtfyPush"]>> = { ok: true };
 const nativeSetCalls: boolean[] = [];
 const webSetCalls: boolean[] = [];
 
-mock.module("@/lib/ntfy-push", () => ({
-    isNativePushAvailable: () => isNativeAvailable,
-    hasNativePushPermission: () => Promise.resolve(hasPermission),
-    isNativePushDisabled: () => isDisabled,
-    setNativePushDisabled: () => {},
-    requestNativePushPermission: () => Promise.resolve(true),
-    startNtfyPush: () => Promise.resolve(startResult),
-    stopNtfyPush: () => Promise.resolve(),
-    getNativeSuppressChildNotifications: () => nativeSuppressValue,
-    setNativeSuppressChildNotifications: (suppress: boolean) => {
-        nativeSetCalls.push(suppress);
-        nativeSuppressValue = suppress;
-        return Promise.resolve(true);
-    },
-}));
-
-mock.module("@/lib/push", () => ({
-    isPushSupported: () => !isNativeAvailable,
-    isPushSubscribed: () => Promise.resolve(!isNativeAvailable),
+const dependencies: PushDependencies = {
+    isPushSupported: () => !native,
+    isPushSubscribed: async () => !native,
+    subscribeToPush: async () => null,
+    unsubscribeFromPush: async () => false,
     getNotificationPermission: () => "granted",
-    // Return the current tracked value so refreshState() gets the up-to-date preference
-    // when the pp-push-state-changed event triggers a re-read.
-    getSuppressChildNotifications: () => Promise.resolve(webSuppressValue),
-    setSuppressChildNotifications: (suppress: boolean) => {
+    getSuppressChildNotifications: async () => webSuppress,
+    setSuppressChildNotifications: async (suppress) => {
         webSetCalls.push(suppress);
-        webSuppressValue = suppress;
-        return Promise.resolve(true);
+        webSuppress = suppress;
+        return true;
     },
-    subscribeToPush: () => Promise.resolve(null),
-    unsubscribeFromPush: () => Promise.resolve(false),
-}));
+    isNativePushAvailable: () => native,
+    isNativePushDisabled: () => false,
+    setNativePushDisabled: () => {},
+    hasNativePushPermission: async () => true,
+    requestNativePushPermission: async () => true,
+    startNtfyPush: async () => startResult,
+    stopNtfyPush: async () => {},
+    getNativeSuppressChildNotifications: () => nativeSuppress,
+    setNativeSuppressChildNotifications: async (suppress) => {
+        nativeSetCalls.push(suppress);
+        nativeSuppress = suppress;
+        return true;
+    },
+};
 
-mock.module("@pizzapi/tools", () => ({
-    createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }),
-}));
-
-// Stub heavy UI components so they don't blow up without a full Radix/Tailwind env.
-mock.module("@/components/ui/button", () => ({
-    Button: ({ children, ...p }: any) => React.createElement("button", p, children),
-}));
-mock.module("@/components/ui/switch", () => ({
-    Switch: (p: any) => React.createElement("input", { type: "checkbox", ...p }),
-}));
-mock.module("@/components/ui/tooltip", () => ({
-    TooltipProvider: ({ children }: any) => children,
-    Tooltip: ({ children }: any) => children,
-    TooltipTrigger: ({ children }: any) => children,
-    TooltipContent: ({ children }: any) => React.createElement("div", null, children),
-}));
-mock.module("@/components/ui/dropdown-menu", () => ({
-    DropdownMenu: ({ children }: any) => React.createElement("div", null, children),
-    DropdownMenuTrigger: ({ children }: any) => React.createElement("div", null, children),
-    DropdownMenuContent: ({ children }: any) => React.createElement("div", null, children),
-    DropdownMenuLabel: ({ children }: any) => React.createElement("div", null, children),
-    DropdownMenuSeparator: () => React.createElement("hr"),
-    DropdownMenuItem: ({ children, onSelect, disabled }: any) =>
-        React.createElement("div", { onClick: onSelect, "aria-disabled": disabled }, children),
-}));
-
-const { usePushState } = await import("./NotificationToggle");
-
-afterAll(() => mock.restore());
-afterEach(() => {
-    cleanup();
+beforeEach(() => {
+    native = true;
+    nativeSuppress = true;
+    webSuppress = false;
+    startResult = { ok: true };
     nativeSetCalls.length = 0;
     webSetCalls.length = 0;
-    nativeSuppressValue = false;
-    webSuppressValue = false;
-    isNativeAvailable = true;
-    hasPermission = true;
-    isDisabled = false;
-    startResult = { ok: true };
 });
 
-// ── Tests ────────────────────────────────────────────────────────────────────
+afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+});
 
-describe("usePushState — native child-suppression routing", () => {
-    test("toggleSuppressChild calls setNativeSuppressChildNotifications for native users", async () => {
-        isNativeAvailable = true;
-        hasPermission = true;
-        isDisabled = false;
-        startResult = { ok: true };
-        nativeSuppressValue = false;
+afterAll(() => {
+    (globalThis as any).CustomEvent = originalCustomEvent;
+});
 
-        const { result } = renderHook(() => usePushState());
+async function waitForHook() {
+    const hook = renderHook(() => usePushState(dependencies));
+    await waitFor(() => expect(hook.result.current.loading).toBe(false));
+    return hook;
+}
 
-        // Wait for async refreshState to complete (hasNativePushPermission + startNtfyPush).
-        await act(async () => {
-            await new Promise((r) => setTimeout(r, 20));
-        });
+function ariaLabel(container: HTMLElement): string | null {
+    return container.querySelector("button[aria-label]")?.getAttribute("aria-label") ?? null;
+}
 
-        expect(result.current.subscribed).toBe(true);
-        expect(result.current.native).toBe(true);
-        expect(result.current.suppressChild).toBe(false);
+describe("usePushState child-suppression routing", () => {
+    test("routes native preferences to the native API", async () => {
+        nativeSuppress = false;
+        const { result } = await waitForHook();
 
-        await act(async () => {
-            await result.current.toggleSuppressChild();
-        });
+        await act(async () => result.current.toggleSuppressChild());
 
-        // Must have called the NATIVE api, not the web one.
         expect(nativeSetCalls).toEqual([true]);
         expect(webSetCalls).toEqual([]);
         expect(result.current.suppressChild).toBe(true);
     });
 
-    test("toggleSuppressChild calls setSuppressChildNotifications for web push users", async () => {
-        isNativeAvailable = false; // web push path
-        hasPermission = false;     // irrelevant for web
-        isDisabled = false;
-        startResult = { ok: false, reason: "error" };
-        nativeSuppressValue = false;
-        webSuppressValue = false;
+    test("routes web preferences to the Web Push API", async () => {
+        native = false;
+        const { result } = await waitForHook();
 
-        const { result } = renderHook(() => usePushState());
+        await act(async () => result.current.toggleSuppressChild());
 
-        // Wait for async isPushSubscribed (which we mock to return true when !native).
-        await act(async () => {
-            await new Promise((r) => setTimeout(r, 20));
-        });
-
-        // Web path: subscribed from isPushSubscribed mock (returns !isNativeAvailable = true).
-        expect(result.current.native).toBe(false);
-        expect(result.current.subscribed).toBe(true);
-
-        await act(async () => {
-            await result.current.toggleSuppressChild();
-        });
-
-        // Must have called the WEB api, not the native one.
         expect(webSetCalls).toEqual([true]);
         expect(nativeSetCalls).toEqual([]);
         expect(result.current.suppressChild).toBe(true);
     });
 
-    test("toggleSuppressChild toggles back to false for native", async () => {
-        isNativeAvailable = true;
-        hasPermission = true;
-        isDisabled = false;
-        startResult = { ok: true };
-        nativeSuppressValue = true; // start as suppressed
-
-        const { result } = renderHook(() => usePushState());
-        await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
-
+    test("can opt in to child notifications for native push", async () => {
+        const { result } = await waitForHook();
         expect(result.current.suppressChild).toBe(true);
 
-        await act(async () => { await result.current.toggleSuppressChild(); });
+        await act(async () => result.current.toggleSuppressChild());
 
         expect(nativeSetCalls).toEqual([false]);
         expect(result.current.suppressChild).toBe(false);
+    });
+});
+
+describe("NotificationToggle native registration outcome", () => {
+    test("shows ntfy configuration failures instead of subscribed", async () => {
+        startResult = { ok: false, reason: "unconfigured" };
+        const { container } = render(<NotificationToggle dependencies={dependencies} />);
+
+        await waitFor(() => expect(ariaLabel(container)).toBe("Push not configured on this server"));
+        expect(container.querySelector("[aria-haspopup]")).toBeNull();
+    });
+
+    test("shows generic registration failures as not subscribed", async () => {
+        startResult = { ok: false, reason: "error" };
+        const { container } = render(<NotificationToggle dependencies={dependencies} />);
+
+        await waitFor(() => expect(ariaLabel(container)).toBe("Enable notifications"));
+    });
+
+    test("shows a successful registration as subscribed", async () => {
+        const { container } = render(<NotificationToggle dependencies={dependencies} />);
+
+        await waitFor(() => expect(ariaLabel(container)).toBe("Notifications enabled"));
     });
 });

--- a/packages/ui/src/components/NotificationToggle.tsx
+++ b/packages/ui/src/components/NotificationToggle.tsx
@@ -40,7 +40,63 @@ import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("push");
 
-export function usePushState() {
+export interface PushDependencies {
+    isPushSupported: typeof isPushSupported;
+    isPushSubscribed: typeof isPushSubscribed;
+    subscribeToPush: typeof subscribeToPush;
+    unsubscribeFromPush: typeof unsubscribeFromPush;
+    getNotificationPermission: typeof getNotificationPermission;
+    getSuppressChildNotifications: typeof getSuppressChildNotifications;
+    setSuppressChildNotifications: typeof setSuppressChildNotifications;
+    isNativePushAvailable: typeof isNativePushAvailable;
+    isNativePushDisabled: typeof isNativePushDisabled;
+    setNativePushDisabled: typeof setNativePushDisabled;
+    hasNativePushPermission: typeof hasNativePushPermission;
+    requestNativePushPermission: typeof requestNativePushPermission;
+    startNtfyPush: typeof startNtfyPush;
+    stopNtfyPush: typeof stopNtfyPush;
+    getNativeSuppressChildNotifications: typeof getNativeSuppressChildNotifications;
+    setNativeSuppressChildNotifications: typeof setNativeSuppressChildNotifications;
+}
+
+const defaultPushDependencies: PushDependencies = {
+    isPushSupported,
+    isPushSubscribed,
+    subscribeToPush,
+    unsubscribeFromPush,
+    getNotificationPermission,
+    getSuppressChildNotifications,
+    setSuppressChildNotifications,
+    isNativePushAvailable,
+    isNativePushDisabled,
+    setNativePushDisabled,
+    hasNativePushPermission,
+    requestNativePushPermission,
+    startNtfyPush,
+    stopNtfyPush,
+    getNativeSuppressChildNotifications,
+    setNativeSuppressChildNotifications,
+};
+
+export function usePushState(dependencies: PushDependencies = defaultPushDependencies) {
+    const {
+        isPushSupported,
+        isPushSubscribed,
+        subscribeToPush,
+        unsubscribeFromPush,
+        getNotificationPermission,
+        getSuppressChildNotifications,
+        setSuppressChildNotifications,
+        isNativePushAvailable,
+        isNativePushDisabled,
+        setNativePushDisabled,
+        hasNativePushPermission,
+        requestNativePushPermission,
+        startNtfyPush,
+        stopNtfyPush,
+        getNativeSuppressChildNotifications,
+        setNativeSuppressChildNotifications,
+    } = dependencies;
     // Android native app: no service worker / Web Push in the WebView — use the
     // ntfy foreground-service path gated on the OS notification permission.
     const native = isNativePushAvailable();
@@ -179,8 +235,8 @@ export function usePushState() {
     return { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild };
 }
 
-export function NotificationToggle() {
-    const { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState();
+export function NotificationToggle({ dependencies }: { dependencies?: PushDependencies } = {}) {
+    const { subscribed, loading, supported, native, permissionDenied, nativeUnconfigured, toggle, suppressChild, suppressChildLoading, toggleSuppressChild } = usePushState(dependencies);
 
     if (!supported) return null;
 

--- a/packages/ui/src/components/NotificationToggle.tsx
+++ b/packages/ui/src/components/NotificationToggle.tsx
@@ -33,6 +33,8 @@ import {
     requestNativePushPermission,
     startNtfyPush,
     stopNtfyPush,
+    getNativeSuppressChildNotifications,
+    setNativeSuppressChildNotifications,
 } from "@/lib/ntfy-push";
 import { createLogger } from "@pizzapi/tools";
 
@@ -60,6 +62,7 @@ export function usePushState() {
                 if (!granted || isNativePushDisabled()) {
                     setSubscribed(false);
                     setNativeUnconfigured(false);
+                    setSuppressChild(false);
                     setLoading(false);
                     return;
                 }
@@ -69,6 +72,8 @@ export function usePushState() {
                 const result = await startNtfyPush();
                 setSubscribed(result.ok);
                 setNativeUnconfigured(!result.ok && result.reason === "unconfigured");
+                // startNtfyPush caches the server value in localStorage.
+                if (result.ok) setSuppressChild(getNativeSuppressChildNotifications());
                 setLoading(false);
             });
             return;
@@ -151,7 +156,10 @@ export function usePushState() {
         setSuppressChildLoading(true);
         try {
             const next = !suppressChild;
-            const ok = await setSuppressChildNotifications(next);
+            // Route to the native or web API depending on platform.
+            const ok = native
+                ? await setNativeSuppressChildNotifications(next)
+                : await setSuppressChildNotifications(next);
             if (ok) {
                 setSuppressChild(next);
                 window.dispatchEvent(new CustomEvent("pp-push-state-changed"));
@@ -161,7 +169,7 @@ export function usePushState() {
         } finally {
             setSuppressChildLoading(false);
         }
-    }, [suppressChild, suppressChildLoading, subscribed]);
+    }, [suppressChild, suppressChildLoading, subscribed, native]);
 
     // On native, "denied" only after an explicit request came back denied —
     // Android can't distinguish never-asked from denied, and the fix lives in
@@ -230,10 +238,9 @@ export function NotificationToggle() {
                 <DropdownMenuContent align="end" className="w-64">
                     <DropdownMenuLabel>Notification settings</DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {/* Suppress-child is a Web Push (endpoint) setting — hidden on native. */}
-                    {!native && (<>
                     {/*
                      * Suppress child session notifications.
+                     * Available for both Web Push and native (ntfy) registrations.
                      * The Switch is a pure visual indicator — clicking anywhere on the
                      * row (text or switch) fires onSelect exactly once via the MenuItem.
                      * We do NOT attach onCheckedChange to Switch to avoid a double-toggle
@@ -256,7 +263,6 @@ export function NotificationToggle() {
                         />
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    </>)}
                     <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         onSelect={(e) => {
@@ -326,7 +332,7 @@ export function MobileNotificationMenuItem() {
                       ? "Push not configured on this server"
                       : "Enable notifications"}
             </DropdownMenuItem>
-            {subscribed && !native && (
+            {subscribed && (
                 <DropdownMenuItem
                     className="md:hidden flex items-center justify-between gap-2 cursor-default"
                     disabled={suppressChildLoading}

--- a/packages/ui/src/components/UserPreferencesPanel.test.tsx
+++ b/packages/ui/src/components/UserPreferencesPanel.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Tests for UserPreferencesPanel — native push child-suppression parity.
+ *
+ * Key invariant: The "Suppress child session notifications" toggle must render
+ * on the Notifications tab when the user is subscribed AND native (the `!native`
+ * guard in NotificationsPreferencesSection was removed by this PR).
+ */
+
+import { afterAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { Window } from "happy-dom";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+// Set up DOM globals before any component imports.
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(win as any).SyntaxError = SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).CustomEvent = win.CustomEvent;
+(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
+(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// ── Controllable push state ─────────────────────────────────────────────────
+
+let mockNative = false;
+let mockSubscribed = false;
+let mockSuppressChild = false;
+const suppressToggleCalls: boolean[] = [];
+
+const basePushState = () => ({
+    subscribed: mockSubscribed,
+    loading: false,
+    supported: true,
+    native: mockNative,
+    permissionDenied: false,
+    nativeUnconfigured: false,
+    toggle: () => Promise.resolve(),
+    suppressChild: mockSuppressChild,
+    suppressChildLoading: false,
+    toggleSuppressChild: async () => {
+        suppressToggleCalls.push(!mockSuppressChild);
+        mockSuppressChild = !mockSuppressChild;
+    },
+});
+
+// Mock NotificationToggle to inject controlled state.
+mock.module("./NotificationToggle", () => ({
+    usePushState: basePushState,
+    // Stub the rendered components (UserPreferencesPanel only uses usePushState from here).
+    NotificationToggle: () => React.createElement("div", null, "NotificationToggle"),
+    MobileNotificationMenuItem: () => null,
+}));
+
+// Mock HapticsToggle.
+mock.module("./HapticsToggle", () => ({
+    useHapticsState: () => ({ enabled: false, supported: false, toggle: () => {} }),
+    HapticsToggle: () => null,
+}));
+
+// Mock AppearanceSettings (not under test here).
+mock.module("./AppearanceSettings", () => ({
+    AppearanceSettings: () => React.createElement("div", null, "AppearanceSettings"),
+}));
+
+mock.module("@pizzapi/tools", () => ({
+    createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }),
+}));
+
+// Stub UI primitives that need Radix/Tailwind internals.
+mock.module("@/components/ui/button", () => ({
+    Button: ({ children, onClick, ...p }: any) =>
+        React.createElement("button", { onClick, ...p }, children),
+}));
+mock.module("@/components/ui/switch", () => ({
+    Switch: ({ checked, onCheckedChange, disabled }: any) =>
+        React.createElement("input", {
+            type: "checkbox",
+            checked: !!checked,
+            onChange: onCheckedChange ? () => onCheckedChange(!checked) : undefined,
+            disabled: !!disabled,
+            readOnly: !onCheckedChange,
+        }),
+}));
+mock.module("@/components/ui/tooltip", () => ({
+    Tooltip: ({ children }: any) => React.createElement("div", null, children),
+    TooltipTrigger: ({ children, asChild }: any) => React.createElement("div", null, children),
+    TooltipContent: ({ children }: any) => React.createElement("div", null, children),
+}));
+mock.module("lucide-react", () => ({
+    X: () => React.createElement("span", null, "X"),
+    Palette: () => React.createElement("span", null, "Palette"),
+    Bell: () => React.createElement("span", null, "Bell"),
+    Layers: () => React.createElement("span", null, "Layers"),
+    EyeOff: () => React.createElement("span", null, "EyeOff"),
+}));
+
+const { UserPreferencesPanel } = await import("./UserPreferencesPanel");
+
+afterAll(() => mock.restore());
+afterEach(() => {
+    cleanup();
+    suppressToggleCalls.length = 0;
+    mockSubscribed = false;
+    mockNative = false;
+    mockSuppressChild = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+function renderPanel() {
+    return render(
+        React.createElement(UserPreferencesPanel, {
+            onClose: () => {},
+            onShowHiddenModels: () => {},
+            hiddenModelCount: 0,
+        }),
+    );
+}
+
+/** Click the Notifications tab so NotificationsPreferencesSection is visible. */
+function clickNotificationsTab(container: HTMLElement) {
+    const tabs = container.querySelectorAll("button");
+    const notifTab = Array.from(tabs).find((b) => b.textContent?.includes("Notifications"));
+    if (notifTab) fireEvent.click(notifTab);
+}
+
+describe("UserPreferencesPanel — suppress-child section (native parity)", () => {
+    test("renders 'Suppress child session notifications' for native subscribed users", () => {
+        mockNative = true;
+        mockSubscribed = true;
+
+        const { container } = renderPanel();
+        clickNotificationsTab(container);
+
+        expect(container.textContent).toContain("Suppress child session notifications");
+    });
+
+    test("renders 'Suppress child session notifications' for web subscribed users (regression guard)", () => {
+        mockNative = false;
+        mockSubscribed = true;
+
+        const { container } = renderPanel();
+        clickNotificationsTab(container);
+
+        expect(container.textContent).toContain("Suppress child session notifications");
+    });
+
+    test("does NOT render suppress section when not subscribed (native)", () => {
+        mockNative = true;
+        mockSubscribed = false;
+
+        const { container } = renderPanel();
+        clickNotificationsTab(container);
+
+        expect(container.textContent).not.toContain("Suppress child session notifications");
+    });
+
+    test("suppress switch reflects suppressChild state for native users", () => {
+        mockNative = true;
+        mockSubscribed = true;
+        mockSuppressChild = true;
+
+        const { container } = renderPanel();
+        clickNotificationsTab(container);
+
+        // Two checkboxes render: push-enabled (subscribed=true) and suppress-child.
+        // The suppress-child one is the last checkbox in the section.
+        const checkboxes = Array.from(container.querySelectorAll("input[type='checkbox']")) as HTMLInputElement[];
+        expect(checkboxes.length).toBeGreaterThan(0);
+        const suppressCheckbox = checkboxes[checkboxes.length - 1];
+        expect(suppressCheckbox?.checked).toBe(true);
+    });
+
+    test("suppress switch is unchecked when suppressChild is false for native users", () => {
+        mockNative = true;
+        mockSubscribed = true;
+        mockSuppressChild = false;
+
+        const { container } = renderPanel();
+        clickNotificationsTab(container);
+
+        const checkboxes = Array.from(container.querySelectorAll("input[type='checkbox']")) as HTMLInputElement[];
+        expect(checkboxes.length).toBeGreaterThan(0);
+        const suppressCheckbox = checkboxes[checkboxes.length - 1];
+        expect(suppressCheckbox?.checked).toBe(false);
+    });
+});

--- a/packages/ui/src/components/UserPreferencesPanel.test.tsx
+++ b/packages/ui/src/components/UserPreferencesPanel.test.tsx
@@ -1,20 +1,12 @@
-/**
- * Tests for UserPreferencesPanel — native push child-suppression parity.
- *
- * Key invariant: The "Suppress child session notifications" toggle must render
- * on the Notifications tab when the user is subscribed AND native (the `!native`
- * guard in NotificationsPreferencesSection was removed by this PR).
- */
-
-import { afterAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
-import { render, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { type usePushState } from "./NotificationToggle";
+import { NotificationsPreferencesSection } from "./UserPreferencesPanel";
 
-// Set up DOM globals before any component imports.
 const win = new Window({ url: "http://localhost/" });
-/* eslint-disable @typescript-eslint/no-explicit-any */
-(win as any).SyntaxError = SyntaxError;
+(win as any).SyntaxError = globalThis.SyntaxError;
 (globalThis as any).window = win;
 (globalThis as any).document = win.document;
 (globalThis as any).navigator = win.navigator;
@@ -23,179 +15,90 @@ const win = new Window({ url: "http://localhost/" });
 (globalThis as any).Node = win.Node;
 (globalThis as any).SVGElement = win.SVGElement;
 (globalThis as any).MutationObserver = win.MutationObserver;
-(globalThis as any).CustomEvent = win.CustomEvent;
-(globalThis as any).ResizeObserver = class ResizeObserver {
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).ResizeObserver = class {
     observe() {}
     unobserve() {}
     disconnect() {}
 };
-(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
-(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
-(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
-// ── Controllable push state ─────────────────────────────────────────────────
+let subscribed = false;
+let native = false;
+let suppressChild = true;
+const toggleCalls: boolean[] = [];
 
-let mockNative = false;
-let mockSubscribed = false;
-let mockSuppressChild = false;
-const suppressToggleCalls: boolean[] = [];
+function pushState(): ReturnType<typeof usePushState> {
+    return {
+        subscribed,
+        loading: false,
+        supported: true,
+        native,
+        permissionDenied: false,
+        nativeUnconfigured: false,
+        toggle: async () => {},
+        suppressChild,
+        suppressChildLoading: false,
+        toggleSuppressChild: async () => {
+            toggleCalls.push(!suppressChild);
+            suppressChild = !suppressChild;
+        },
+    };
+}
 
-const basePushState = () => ({
-    subscribed: mockSubscribed,
-    loading: false,
-    supported: true,
-    native: mockNative,
-    permissionDenied: false,
-    nativeUnconfigured: false,
-    toggle: () => Promise.resolve(),
-    suppressChild: mockSuppressChild,
-    suppressChildLoading: false,
-    toggleSuppressChild: async () => {
-        suppressToggleCalls.push(!mockSuppressChild);
-        mockSuppressChild = !mockSuppressChild;
-    },
-});
+const hapticsState = () => ({ enabled: false, supported: false, toggle: () => {} });
 
-// Mock NotificationToggle to inject controlled state.
-mock.module("./NotificationToggle", () => ({
-    usePushState: basePushState,
-    // Stub the rendered components (UserPreferencesPanel only uses usePushState from here).
-    NotificationToggle: () => React.createElement("div", null, "NotificationToggle"),
-    MobileNotificationMenuItem: () => null,
-}));
-
-// Mock HapticsToggle.
-mock.module("./HapticsToggle", () => ({
-    useHapticsState: () => ({ enabled: false, supported: false, toggle: () => {} }),
-    HapticsToggle: () => null,
-}));
-
-// Mock AppearanceSettings (not under test here).
-mock.module("./AppearanceSettings", () => ({
-    AppearanceSettings: () => React.createElement("div", null, "AppearanceSettings"),
-}));
-
-mock.module("@pizzapi/tools", () => ({
-    createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }),
-}));
-
-// Stub UI primitives that need Radix/Tailwind internals.
-mock.module("@/components/ui/button", () => ({
-    Button: ({ children, onClick, ...p }: any) =>
-        React.createElement("button", { onClick, ...p }, children),
-}));
-mock.module("@/components/ui/switch", () => ({
-    Switch: ({ checked, onCheckedChange, disabled }: any) =>
-        React.createElement("input", {
-            type: "checkbox",
-            checked: !!checked,
-            onChange: onCheckedChange ? () => onCheckedChange(!checked) : undefined,
-            disabled: !!disabled,
-            readOnly: !onCheckedChange,
-        }),
-}));
-mock.module("@/components/ui/tooltip", () => ({
-    Tooltip: ({ children }: any) => React.createElement("div", null, children),
-    TooltipTrigger: ({ children, asChild }: any) => React.createElement("div", null, children),
-    TooltipContent: ({ children }: any) => React.createElement("div", null, children),
-}));
-mock.module("lucide-react", () => ({
-    X: () => React.createElement("span", null, "X"),
-    Palette: () => React.createElement("span", null, "Palette"),
-    Bell: () => React.createElement("span", null, "Bell"),
-    Layers: () => React.createElement("span", null, "Layers"),
-    EyeOff: () => React.createElement("span", null, "EyeOff"),
-}));
-
-const { UserPreferencesPanel } = await import("./UserPreferencesPanel");
-
-afterAll(() => mock.restore());
-afterEach(() => {
-    cleanup();
-    suppressToggleCalls.length = 0;
-    mockSubscribed = false;
-    mockNative = false;
-    mockSuppressChild = false;
-});
-
-// ── Tests ────────────────────────────────────────────────────────────────────
-
-function renderPanel() {
+function renderSection() {
     return render(
-        React.createElement(UserPreferencesPanel, {
-            onClose: () => {},
-            onShowHiddenModels: () => {},
-            hiddenModelCount: 0,
-        }),
+        <NotificationsPreferencesSection
+            usePushStateHook={pushState}
+            useHapticsStateHook={hapticsState}
+        />,
     );
 }
 
-/** Click the Notifications tab so NotificationsPreferencesSection is visible. */
-function clickNotificationsTab(container: HTMLElement) {
-    const tabs = container.querySelectorAll("button");
-    const notifTab = Array.from(tabs).find((b) => b.textContent?.includes("Notifications"));
-    if (notifTab) fireEvent.click(notifTab);
-}
+afterEach(() => {
+    cleanup();
+    subscribed = false;
+    native = false;
+    suppressChild = true;
+    toggleCalls.length = 0;
+});
 
-describe("UserPreferencesPanel — suppress-child section (native parity)", () => {
-    test("renders 'Suppress child session notifications' for native subscribed users", () => {
-        mockNative = true;
-        mockSubscribed = true;
+describe("NotificationsPreferencesSection child suppression", () => {
+    test("renders the preference for subscribed native users", () => {
+        native = true;
+        subscribed = true;
 
-        const { container } = renderPanel();
-        clickNotificationsTab(container);
-
-        expect(container.textContent).toContain("Suppress child session notifications");
-    });
-
-    test("renders 'Suppress child session notifications' for web subscribed users (regression guard)", () => {
-        mockNative = false;
-        mockSubscribed = true;
-
-        const { container } = renderPanel();
-        clickNotificationsTab(container);
+        const { container } = renderSection();
 
         expect(container.textContent).toContain("Suppress child session notifications");
     });
 
-    test("does NOT render suppress section when not subscribed (native)", () => {
-        mockNative = true;
-        mockSubscribed = false;
+    test("renders the preference for subscribed web users", () => {
+        subscribed = true;
 
-        const { container } = renderPanel();
-        clickNotificationsTab(container);
+        const { container } = renderSection();
+
+        expect(container.textContent).toContain("Suppress child session notifications");
+    });
+
+    test("does not render the preference when native push is not subscribed", () => {
+        native = true;
+
+        const { container } = renderSection();
 
         expect(container.textContent).not.toContain("Suppress child session notifications");
     });
 
-    test("suppress switch reflects suppressChild state for native users", () => {
-        mockNative = true;
-        mockSubscribed = true;
-        mockSuppressChild = true;
+    test("reflects the default suppressed state and allows opting in", () => {
+        native = true;
+        subscribed = true;
+        const { container } = renderSection();
+        const switches = container.querySelectorAll("button[role='switch']");
+        const suppressSwitch = switches[switches.length - 1];
 
-        const { container } = renderPanel();
-        clickNotificationsTab(container);
-
-        // Two checkboxes render: push-enabled (subscribed=true) and suppress-child.
-        // The suppress-child one is the last checkbox in the section.
-        const checkboxes = Array.from(container.querySelectorAll("input[type='checkbox']")) as HTMLInputElement[];
-        expect(checkboxes.length).toBeGreaterThan(0);
-        const suppressCheckbox = checkboxes[checkboxes.length - 1];
-        expect(suppressCheckbox?.checked).toBe(true);
-    });
-
-    test("suppress switch is unchecked when suppressChild is false for native users", () => {
-        mockNative = true;
-        mockSubscribed = true;
-        mockSuppressChild = false;
-
-        const { container } = renderPanel();
-        clickNotificationsTab(container);
-
-        const checkboxes = Array.from(container.querySelectorAll("input[type='checkbox']")) as HTMLInputElement[];
-        expect(checkboxes.length).toBeGreaterThan(0);
-        const suppressCheckbox = checkboxes[checkboxes.length - 1];
-        expect(suppressCheckbox?.checked).toBe(false);
+        expect(suppressSwitch?.getAttribute("aria-checked")).toBe("true");
+        fireEvent.click(suppressSwitch!);
+        expect(toggleCalls).toEqual([false]);
     });
 });

--- a/packages/ui/src/components/UserPreferencesPanel.tsx
+++ b/packages/ui/src/components/UserPreferencesPanel.tsx
@@ -21,7 +21,15 @@ interface UserPreferencesPanelProps {
   hiddenModelCount: number;
 }
 
-function NotificationsPreferencesSection() {
+interface NotificationsPreferencesSectionProps {
+  usePushStateHook?: typeof usePushState;
+  useHapticsStateHook?: typeof useHapticsState;
+}
+
+export function NotificationsPreferencesSection({
+  usePushStateHook = usePushState,
+  useHapticsStateHook = useHapticsState,
+}: NotificationsPreferencesSectionProps = {}) {
   const {
     subscribed,
     loading,
@@ -32,8 +40,8 @@ function NotificationsPreferencesSection() {
     suppressChild,
     suppressChildLoading,
     toggleSuppressChild,
-  } = usePushState();
-  const { enabled, supported: hapticsSupported, toggle: toggleHaptics } = useHapticsState();
+  } = usePushStateHook();
+  const { enabled, supported: hapticsSupported, toggle: toggleHaptics } = useHapticsStateHook();
 
   if (!supported && !hapticsSupported) {
     return (

--- a/packages/ui/src/components/UserPreferencesPanel.tsx
+++ b/packages/ui/src/components/UserPreferencesPanel.tsx
@@ -69,7 +69,7 @@ function NotificationsPreferencesSection() {
         </div>
       )}
 
-      {supported && subscribed && !native && (
+      {supported && subscribed && (
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
             <p className="text-sm font-medium">Suppress child session notifications</p>

--- a/packages/ui/src/lib/ntfy-push.ts
+++ b/packages/ui/src/lib/ntfy-push.ts
@@ -58,8 +58,12 @@ export function isNativePushAvailable(): boolean {
     return androidNative();
 }
 
-// ponytail: one localStorage flag is the entire "disabled" preference store.
+// ponytail: two localStorage flags are the entire preference store — one for
+// disabled state, one for child-suppression. Both are synced to the server on
+// write; on read they serve as a cache so no round-trip is needed in the
+// render path.
 const NTFY_DISABLED_KEY = "pizzapi.ntfyPushDisabled";
+const NTFY_SUPPRESS_CHILD_KEY = "pizzapi.ntfySuppressChild";
 
 /** User preference: native push explicitly disabled from the UI. */
 export function isNativePushDisabled(): boolean {
@@ -76,6 +80,42 @@ export function setNativePushDisabled(disabled: boolean): void {
         else localStorage.removeItem(NTFY_DISABLED_KEY);
     } catch {
         // ignore
+    }
+}
+
+/**
+ * Read the cached native child-suppression preference (from localStorage).
+ * Written by `setNativeSuppressChildNotifications` and by `startNtfyPush`
+ * when the server returns the current value.
+ */
+export function getNativeSuppressChildNotifications(): boolean {
+    try {
+        return localStorage.getItem(NTFY_SUPPRESS_CHILD_KEY) === "1";
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Persist the native child-suppression preference to the server and update
+ * the local cache. Returns true on success, false on network/server error.
+ */
+export async function setNativeSuppressChildNotifications(suppress: boolean): Promise<boolean> {
+    try {
+        const res = await fetch(resolveMobileUrl("/api/push/child-notifications-native"), {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ suppress }),
+        });
+        if (!res.ok) return false;
+        // Update local cache after confirmed server write.
+        try {
+            if (suppress) localStorage.setItem(NTFY_SUPPRESS_CHILD_KEY, "1");
+            else localStorage.removeItem(NTFY_SUPPRESS_CHILD_KEY);
+        } catch { /* ignore */ }
+        return true;
+    } catch {
+        return false;
     }
 }
 
@@ -142,7 +182,13 @@ export async function startNtfyPush(): Promise<NtfyStartResult> {
             topic?: string;
             ntfyUser?: string | null;
             ntfyPass?: string | null;
+            suppressChildNotifications?: boolean;
         };
+        // Cache the current server-side preference locally.
+        try {
+            if (body.suppressChildNotifications) localStorage.setItem(NTFY_SUPPRESS_CHILD_KEY, "1");
+            else localStorage.removeItem(NTFY_SUPPRESS_CHILD_KEY);
+        } catch { /* ignore */ }
         if (!body.ntfyPublicUrl || !body.topic) {
             console.error("ntfy register-native returned no topic/url");
             return { ok: false, reason: "error" };

--- a/packages/ui/src/lib/ntfy-push.ts
+++ b/packages/ui/src/lib/ntfy-push.ts
@@ -184,9 +184,10 @@ export async function startNtfyPush(): Promise<NtfyStartResult> {
             ntfyPass?: string | null;
             suppressChildNotifications?: boolean;
         };
-        // Cache the current server-side preference locally.
+        // Cache the server preference. Older servers omit this field, so retain
+        // the historical safe default of suppressing child-session pushes.
         try {
-            if (body.suppressChildNotifications) localStorage.setItem(NTFY_SUPPRESS_CHILD_KEY, "1");
+            if (body.suppressChildNotifications !== false) localStorage.setItem(NTFY_SUPPRESS_CHILD_KEY, "1");
             else localStorage.removeItem(NTFY_SUPPRESS_CHILD_KEY);
         } catch { /* ignore */ }
         if (!body.ntfyPublicUrl || !body.topic) {


### PR DESCRIPTION
Addresses review feedback for #811: fixes leaking test mocks and preserves default child-session suppression for native push.

Follow-up to #811