### PR TITLE
fix: preserve attachments on failed send (C-012) [review follow-up]

### DIFF
--- a/packages/cli/src/extensions/remote-input.test.ts
+++ b/packages/cli/src/extensions/remote-input.test.ts
@@ -127,6 +127,17 @@ describe("remote-input", () => {
             expect(result).toBe("hello");
         });
 
+        test("throws when an explicitly supplied relay attachment cannot be retrieved", async () => {
+            const originalFetch = globalThis.fetch;
+            globalThis.fetch = (async () => new Response("expired", { status: 404 })) as typeof fetch;
+            try {
+                await expect(buildUserMessageFromRemoteInput("see this", [{ attachmentId: "expired-1" }], "https://relay", "key"))
+                    .rejects.toThrow(/could not be retrieved|expired/);
+            } finally {
+                globalThis.fetch = originalFetch;
+            }
+        });
+
         test("includes image attachments as image parts", async () => {
             const attachments = [{ url: "data:image/png;base64,iVBOR" }];
             const result = await buildUserMessageFromRemoteInput("look", attachments, "", "");

--- a/packages/cli/src/extensions/remote-input.test.ts
+++ b/packages/cli/src/extensions/remote-input.test.ts
@@ -129,7 +129,7 @@ describe("remote-input", () => {
 
         test("throws when an explicitly supplied relay attachment cannot be retrieved", async () => {
             const originalFetch = globalThis.fetch;
-            globalThis.fetch = (async () => new Response("expired", { status: 404 })) as typeof fetch;
+            globalThis.fetch = (async () => new Response("expired", { status: 404 })) as unknown as typeof fetch;
             try {
                 await expect(buildUserMessageFromRemoteInput("see this", [{ attachmentId: "expired-1" }], "https://relay", "key"))
                     .rejects.toThrow(/could not be retrieved|expired/);

--- a/packages/cli/src/extensions/remote-input.ts
+++ b/packages/cli/src/extensions/remote-input.ts
@@ -154,17 +154,21 @@ export async function buildUserMessageFromRemoteInput(
 
         if (attachment.attachmentId) {
             const loaded = await loadAttachmentFromRelay(attachment.attachmentId, httpBaseUrl, apiKey);
-            if (loaded) {
-                mediaType = loaded.mediaType;
-                filename = loaded.filename ?? filename;
-                dataBase64 = loaded.dataBase64;
+            if (!loaded) {
+                throw new Error(`Attachment ${attachment.attachmentId} could not be retrieved or has expired`);
             }
+            mediaType = loaded.mediaType;
+            filename = loaded.filename ?? filename;
+            dataBase64 = loaded.dataBase64;
         } else if (attachment.url) {
             const parsed = parseDataUrl(attachment.url);
-            if (parsed) {
-                mediaType = parsed.mediaType;
-                dataBase64 = parsed.data;
+            if (!parsed || !parsed.data) {
+                throw new Error(`Attachment ${filename || "file"} contains invalid data`);
             }
+            mediaType = parsed.mediaType;
+            dataBase64 = parsed.data;
+        } else {
+            throw new Error(`Attachment ${filename || "file"} has no usable data`);
         }
 
         // Persist attachment to session-scoped storage.
@@ -181,6 +185,7 @@ export async function buildUserMessageFromRemoteInput(
                 savedPath = saved.filePath;
             } catch (err) {
                 log.error(`pizzapi: failed to persist attachment: ${err instanceof Error ? err.message : String(err)}`);
+                throw new Error(`Attachment ${attachFilename} could not be persisted`);
             }
         }
 
@@ -215,9 +220,8 @@ export async function buildUserMessageFromRemoteInput(
             continue;
         }
 
-        // Attachment bytes unavailable (relay fetch failed or data URL invalid) — keep a
-        // visible placeholder so the agent/user knows the file was sent but not decoded.
-        parts.push({ type: "text", text: `[Attached file: ${label} — content unavailable]` });
+        // Explicit attachments must never degrade into successful placeholder text.
+        throw new Error(`Attachment ${label} has no readable content`);
     }
 
     return parts.length > 0 ? parts : text;

--- a/packages/cli/src/extensions/remote/connection-session-host.integration.test.ts
+++ b/packages/cli/src/extensions/remote/connection-session-host.integration.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { SessionHost } from "../../runner/session-host.js";
 
 class FakeSocket {
-    handlers = new Map<string, Array<(data: any) => void>>();
+    handlers = new Map<string, Array<(...args: any[]) => void>>();
     connected = true;
     emit = mock((_event: string, _data?: any) => {});
     removeAllListeners = mock(() => this.handlers.clear());
@@ -24,13 +24,14 @@ class FakeSocket {
         return this;
     }
     off() { return this; }
-    trigger(event: string, data?: any) {
-        for (const handler of this.handlers.get(event) ?? []) handler(data);
+    trigger(event: string, ...args: any[]) {
+        for (const handler of this.handlers.get(event) ?? []) handler(...args);
     }
     io = { on: () => this.io };
 }
 
 let lastSocket: FakeSocket | null = null;
+let consumeApproval = false;
 
 mock.module("socket.io-client", () => ({
     io: mock(() => { lastSocket = new FakeSocket(); return lastSocket; }),
@@ -65,6 +66,15 @@ mock.module("../remote-meta-events.js", () => ({
     emitApprovalPending: mock(() => {}), emitApprovalCleared: mock(() => {}),
 }));
 mock.module("../remote-auth-source.js", () => ({ getAuthSource: mock(() => null), authSourceLabel: mock(() => "") }));
+mock.module("../remote-approval.js", () => ({
+    consumePendingApprovalFromWeb: mock(() => consumeApproval),
+    cancelPendingApproval: mock(() => {}),
+    registerApprovalBridge: mock(() => () => {}),
+    setApprovalHandler: mock(() => {}),
+    clearApprovalHandler: mock(() => {}),
+    getApprovalHandler: mock(() => null),
+    requestApprovalViaWeb: mock(async () => false),
+}));
 mock.module("../remote-ask-user.js", () => ({
     cancelPendingAskUserQuestion: mock(() => {}),
     consumePendingAskUserQuestionFromWeb: mock(() => false),
@@ -146,6 +156,7 @@ function makeState() {
 describe("connection handler -> SessionHost -> AgentSession.prompt integration", () => {
     beforeEach(() => {
         lastSocket = null;
+        consumeApproval = false;
         _resetWorkerStartupGateForTesting();
     });
     afterEach(() => {
@@ -187,6 +198,33 @@ describe("connection handler -> SessionHost -> AgentSession.prompt integration",
             images: undefined,
             source: "extension",
         });
+    });
+
+    test("acknowledges an interactive response consumed by the runner", async () => {
+        const fakeSession = { prompt: mock(async () => {}) } as any;
+        const host = new SessionHost(() => fakeSession, {
+            newSession: async () => ({ cancelled: false }),
+            switchSession: async () => ({ cancelled: false }),
+            fork: async () => ({ cancelled: false }),
+        });
+        const { rctx } = makeRctx(host);
+        const { connectionHandlers } = createConnectionHandlers({
+            rctx,
+            state: makeState() as any,
+            triggerWaits: { cancelAll: () => 0 } as any,
+            delinkManager: {} as any,
+            cancellationManager: {} as any,
+            followUpGrace: { clearFollowUpGrace: () => {} } as any,
+            setModelFromWeb: async () => {},
+        });
+        consumeApproval = true;
+        const ack = mock((_delivered: boolean) => {});
+
+        connect(rctx, connectionHandlers);
+        lastSocket!.trigger("input", { text: "approve" }, ack);
+
+        expect(ack).toHaveBeenCalledWith(true);
+        expect(fakeSession.prompt).not.toHaveBeenCalled();
     });
 
     test("trigger batch does NOT opt into prompt-template expansion and uses steer streaming", async () => {

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -427,12 +427,19 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         emitSessionActive(rctx, recoveryNonce);
     });
 
-    sock.on("input", (data) => {
+    sock.on("input", (data, ack?: (delivered: boolean) => void) => {
+        let settled = false;
+        const settle = (delivered: boolean) => {
+            if (settled) return;
+            settled = true;
+            ack?.(delivered === true);
+        };
         // While waiting for delink_own_parent to be confirmed by the server,
         // the old parent can still inject tell_child / follow-up input.
         // Drop agent-originated input until the server-side link is severed.
         if (handlers.isPendingDelinkOwnParent() && (data as any).client === "agent") {
             log.info("pizzapi: dropping stale parent tell_child/follow-up input — delink_own_parent pending");
+            settle(false);
             return;
         }
 
@@ -441,9 +448,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         handlers.clearFollowUpGrace();
 
         const inputText = data.text;
-        if (consumePendingApprovalFromWeb(rctx, inputText)) return;
-        if (consumePendingAskUserQuestionFromWeb(rctx, inputText)) return;
-        if (consumePendingPlanModeFromWeb(rctx, inputText)) return;
+        if (consumePendingApprovalFromWeb(rctx, inputText)) { settle(false); return; }
+        if (consumePendingAskUserQuestionFromWeb(rctx, inputText)) { settle(false); return; }
+        if (consumePendingPlanModeFromWeb(rctx, inputText)) { settle(false); return; }
 
         const attachments = normalizeRemoteInputAttachments(data.attachments);
         const deliverAs = data.deliverAs === "followUp" ? "followUp" as const
@@ -473,6 +480,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 try {
                     if (abortForSlashCommand) await rctx.sessionHost?.abort();
                     await handlers.sendUserMessage(message, { expandPromptTemplates: true, ...(effectiveDeliverAs ? { deliverAs: effectiveDeliverAs } : {}) });
+                    settle(true);
                 } finally {
                     if (abortForSlashCommand) rctx.pendingSteeringSlashCommands -= 1;
                 }
@@ -480,6 +488,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 const errMessage = err instanceof Error ? err.message : String(err);
                 log.error(`pizzapi: failed to deliver remote input: ${errMessage}`);
                 rctx.forwardEvent({ type: "cli_error", message: `Failed to deliver remote input: ${errMessage}`, source: "remote", ts: Date.now() });
+                settle(false);
             }
         })();
     });

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -448,9 +448,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         handlers.clearFollowUpGrace();
 
         const inputText = data.text;
-        if (consumePendingApprovalFromWeb(rctx, inputText)) { settle(false); return; }
-        if (consumePendingAskUserQuestionFromWeb(rctx, inputText)) { settle(false); return; }
-        if (consumePendingPlanModeFromWeb(rctx, inputText)) { settle(false); return; }
+        if (consumePendingApprovalFromWeb(rctx, inputText)) { settle(true); return; }
+        if (consumePendingAskUserQuestionFromWeb(rctx, inputText)) { settle(true); return; }
+        if (consumePendingPlanModeFromWeb(rctx, inputText)) { settle(true); return; }
 
         const attachments = normalizeRemoteInputAttachments(data.attachments);
         const deliverAs = data.deliverAs === "followUp" ? "followUp" as const

--- a/packages/protocol/src/relay.test.ts
+++ b/packages/protocol/src/relay.test.ts
@@ -276,10 +276,18 @@ describe("relay — RelayServerToClientEvents payloads", () => {
       attachments: [attachment],
       client: "mobile-web",
       deliverAs: "steer",
+      requestId: "req-1",
     };
     expect(full.attachments).toHaveLength(1);
     expect(full.client).toBe("mobile-web");
     expect(full.deliverAs).toBe("steer");
+    expect(full.requestId).toBe("req-1");
+  });
+
+  test("input supports an optional delivery acknowledgement", () => {
+    type Ack = Parameters<RelayServerToClientEvents["input"]>[1];
+    const ack: Ack = (delivered) => expect(delivered).toBe(true);
+    ack?.(true);
   });
 
   test("model_set carries provider and modelId", () => {

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -157,7 +157,9 @@ export interface RelayServerToClientEvents {
     attachments?: Attachment[];
     client?: string;
     deliverAs?: "steer" | "followUp";
-  }) => void;
+    /** Viewer delivery attempt ID, preserved for mixed-version idempotency. */
+    requestId?: string;
+  }, ack?: (delivered: boolean) => void) => void;
 
   /** Instructs TUI to switch model */
   model_set: (data: {

--- a/packages/protocol/src/viewer.test.ts
+++ b/packages/protocol/src/viewer.test.ts
@@ -166,10 +166,12 @@ describe("viewer — ViewerClientToServerEvents payloads", () => {
       attachments: [attachment],
       client: "web",
       deliverAs: "followUp",
+      requestId: "req-1",
     };
     expect(full.attachments).toHaveLength(1);
     expect(full.client).toBe("web");
     expect(full.deliverAs).toBe("followUp");
+    expect(full.requestId).toBe("req-1");
   });
 
   test("input deliverAs can be 'steer' or 'followUp'", () => {
@@ -178,6 +180,12 @@ describe("viewer — ViewerClientToServerEvents payloads", () => {
     const followUp: Payload = { text: "follow up", deliverAs: "followUp" };
     expect(steer.deliverAs).toBe("steer");
     expect(followUp.deliverAs).toBe("followUp");
+  });
+
+  test("input supports an optional delivery acknowledgement", () => {
+    type Ack = Parameters<ViewerClientToServerEvents["input"]>[1];
+    const ack: Ack = (delivered) => expect(delivered).toBe(true);
+    ack?.(true);
   });
 
   test("model_set carries provider and modelId", () => {

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -139,6 +139,8 @@ export interface ViewerClientToServerEvents {
     attachments?: Attachment[];
     client?: string;
     deliverAs?: "steer" | "followUp";
+    /** Identifies this delivery attempt across acknowledgement-capable versions. */
+    requestId?: string;
   }, ack?: (delivered: boolean) => void) => void;
 
   /** Instruct TUI to switch model (collab mode) */

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -139,7 +139,7 @@ export interface ViewerClientToServerEvents {
     attachments?: Attachment[];
     client?: string;
     deliverAs?: "steer" | "followUp";
-  }) => void;
+  }, ack?: (delivered: boolean) => void) => void;
 
   /** Instruct TUI to switch model (collab mode) */
   model_set: (data: {

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -22,7 +22,55 @@ import {
     sendCachedDeltaReplayEvents,
     checkServiceMessageSize,
     checkServiceMessageRateLimit,
+    forwardInputToRunner,
 } from "./viewer.js";
+
+describe("forwardInputToRunner", () => {
+    test("reports success when an acknowledgement-capable runner consumes input", async () => {
+        const clear = mock(() => {});
+        const socket = {
+            connected: true,
+            emit: mock((_event: string, _payload: Record<string, unknown>, ack: (delivered: boolean) => void) => ack(true)),
+        };
+
+        const delivered = await forwardInputToRunner(socket, { text: "hello", requestId: "req-1" }, 9_500, {
+            set: mock(() => 1 as unknown as ReturnType<typeof setTimeout>),
+            clear,
+        });
+
+        expect(delivered).toBe(true);
+        expect(clear).toHaveBeenCalledTimes(1);
+    });
+
+    test("reports an explicit runner rejection", async () => {
+        const socket = {
+            connected: true,
+            emit: mock((_event: string, _payload: Record<string, unknown>, ack: (delivered: boolean) => void) => ack(false)),
+        };
+
+        expect(await forwardInputToRunner(socket, { text: "bad" }, 20)).toBe(false);
+    });
+
+    test("treats acknowledgement timeout from an old runner as delivered", async () => {
+        let fireTimeout: (() => void) | undefined;
+        const clear = mock(() => {});
+        const socket = {
+            connected: true,
+            emit: mock(() => true),
+        };
+        const result = forwardInputToRunner(socket, { text: "legacy", requestId: "req-legacy" }, 9_500, {
+            set: mock((callback: () => void) => {
+                fireTimeout = callback;
+                return 1 as unknown as ReturnType<typeof setTimeout>;
+            }),
+            clear,
+        });
+
+        fireTimeout?.();
+        expect(await result).toBe(true);
+        expect(clear).toHaveBeenCalledTimes(1);
+    });
+});
 
 // ── isAgentEndEvent ──────────────────────────────────────────────────────────
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -57,6 +57,45 @@ export { hydrateViewerFromCache, sendCachedDeltaReplayEvents } from "./viewer-ca
 
 const log = createLogger("sio/viewer");
 
+interface InputRelaySocket {
+    connected: boolean;
+    emit: (event: string, payload: Record<string, unknown>, ack: (delivered: boolean) => void) => unknown;
+}
+
+/**
+ * Forward input to a runner and normalize acknowledgement semantics.
+ * A missing callback is success because pre-ack runners still consume the emitted
+ * input. Explicit false and synchronous emit failures remain real failures.
+ * @internal — exported for unit tests only
+ */
+export function forwardInputToRunner(
+    tuiSocket: InputRelaySocket,
+    payload: Record<string, unknown>,
+    timeoutMs = 9_500,
+    timers: {
+        set: (callback: () => void, ms: number) => ReturnType<typeof setTimeout>;
+        clear: (timer: ReturnType<typeof setTimeout>) => void;
+    } = { set: setTimeout, clear: clearTimeout },
+): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        let settled = false;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const finish = (delivered: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (timeout !== undefined) timers.clear(timeout);
+            resolve(delivered === true);
+        };
+
+        timeout = timers.set(() => finish(true), timeoutMs);
+        try {
+            tuiSocket.emit("input", payload, (delivered: boolean) => finish(delivered));
+        } catch {
+            finish(false);
+        }
+    });
+}
+
 type ViewerSocket = Socket<
     ViewerClientToServerEvents,
     ViewerServerToClientEvents,
@@ -784,7 +823,6 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 settled = true;
                 ack?.(delivered === true);
             };
-            const timeout = setTimeout(() => settle(false), 10_000);
             try {
                 const currentSessionId = getCurrentSessionId();
                 if (!currentSessionId) return;
@@ -794,57 +832,42 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 const tuiSocket = getLocalTuiSocket(currentSessionId);
                 if (!tuiSocket || !tuiSocket.connected) return;
 
-            // Parse and validate attachments
-            const attachments = Array.isArray(data.attachments)
-                ? data.attachments
-                      .filter(
-                          (entry): entry is Record<string, unknown> =>
-                              entry !== null && typeof entry === "object",
-                      )
-                      .map((item) => ({
-                          attachmentId:
-                              typeof item.attachmentId === "string" ? item.attachmentId : undefined,
-                          mediaType: typeof item.mediaType === "string" ? item.mediaType : undefined,
-                          filename: typeof item.filename === "string" ? item.filename : undefined,
-                          url: typeof item.url === "string" ? item.url : undefined,
-                      }))
-                      .filter(
-                          (item) =>
-                              (typeof item.attachmentId === "string" && item.attachmentId.length > 0) ||
-                              (typeof item.url === "string" && item.url.length > 0),
-                      )
-                : [];
+                // Parse and validate attachments
+                const attachments = Array.isArray(data.attachments)
+                    ? data.attachments
+                          .filter(
+                              (entry): entry is Record<string, unknown> =>
+                                  entry !== null && typeof entry === "object",
+                          )
+                          .map((item) => ({
+                              attachmentId:
+                                  typeof item.attachmentId === "string" ? item.attachmentId : undefined,
+                              mediaType: typeof item.mediaType === "string" ? item.mediaType : undefined,
+                              filename: typeof item.filename === "string" ? item.filename : undefined,
+                              url: typeof item.url === "string" ? item.url : undefined,
+                          }))
+                          .filter(
+                              (item) =>
+                                  (typeof item.attachmentId === "string" && item.attachmentId.length > 0) ||
+                                  (typeof item.url === "string" && item.url.length > 0),
+                          )
+                    : [];
 
-            const payload: Record<string, unknown> = {
-                text: data.text,
-                attachments,
-            };
-            if (data.client) payload.client = data.client;
-            if (data.deliverAs === "steer" || data.deliverAs === "followUp") {
-                payload.deliverAs = data.deliverAs;
-            }
+                const payload: Record<string, unknown> = {
+                    text: data.text,
+                    attachments,
+                };
+                if (data.client) payload.client = data.client;
+                if (data.deliverAs === "steer" || data.deliverAs === "followUp") {
+                    payload.deliverAs = data.deliverAs;
+                }
+                const requestId = (data as typeof data & { requestId?: unknown }).requestId;
+                if (typeof requestId === "string") payload.requestId = requestId;
 
-                await new Promise<boolean>((resolve) => {
-                    let done = false;
-                    const finish = (value: boolean) => {
-                        if (done) return;
-                        done = true;
-                        resolve(value === true);
-                    };
-                    try {
-                        tuiSocket.emit("input" as string, payload, (delivered: boolean) => finish(delivered));
-                    } catch {
-                        finish(false);
-                    }
-                    setTimeout(() => finish(false), 9_500);
-                }).then((delivered) => {
-                    if (delivered === true && tuiSocket.connected) settle(true);
-                    else settle(false);
-                });
+                settle(await forwardInputToRunner(tuiSocket, payload));
             } catch {
                 settle(false);
             } finally {
-                clearTimeout(timeout);
                 settle(false);
             }
         });

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -777,14 +777,22 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         });
 
         // ── input — collab mode: forward user input to TUI ──────────────────
-        socket.on("input", async (data) => {
-            const currentSessionId = getCurrentSessionId();
-            if (!currentSessionId) return;
-            const currentSession = await getSharedSessionSummary(currentSessionId);
-            if (!currentSession?.collabMode) return;
+        socket.on("input", async (data, ack?: (delivered: boolean) => void) => {
+            let settled = false;
+            const settle = (delivered: boolean) => {
+                if (settled) return;
+                settled = true;
+                ack?.(delivered === true);
+            };
+            const timeout = setTimeout(() => settle(false), 10_000);
+            try {
+                const currentSessionId = getCurrentSessionId();
+                if (!currentSessionId) return;
+                const currentSession = await getSharedSessionSummary(currentSessionId);
+                if (!currentSession?.collabMode) return;
 
-            const tuiSocket = getLocalTuiSocket(currentSessionId);
-            if (!tuiSocket) return;
+                const tuiSocket = getLocalTuiSocket(currentSessionId);
+                if (!tuiSocket || !tuiSocket.connected) return;
 
             // Parse and validate attachments
             const attachments = Array.isArray(data.attachments)
@@ -816,7 +824,29 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 payload.deliverAs = data.deliverAs;
             }
 
-            tuiSocket.emit("input" as string, payload);
+                await new Promise<boolean>((resolve) => {
+                    let done = false;
+                    const finish = (value: boolean) => {
+                        if (done) return;
+                        done = true;
+                        resolve(value === true);
+                    };
+                    try {
+                        tuiSocket.emit("input" as string, payload, (delivered: boolean) => finish(delivered));
+                    } catch {
+                        finish(false);
+                    }
+                    setTimeout(() => finish(false), 9_500);
+                }).then((delivered) => {
+                    if (delivered === true && tuiSocket.connected) settle(true);
+                    else settle(false);
+                });
+            } catch {
+                settle(false);
+            } finally {
+                clearTimeout(timeout);
+                settle(false);
+            }
         });
 
         // ── model_set — collab mode: forward model switch to TUI ─────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3761,6 +3761,8 @@ export function App() {
   // Dedup guard: prevent sending the exact same message text within a short window.
   const inputDedupeRef = React.useRef<InputDedupeState | null>(null);
   const inputAttemptIdRef = React.useRef(0);
+  const fileIdentityRef = React.useRef(new WeakMap<File, number>());
+  const nextFileIdentityRef = React.useRef(0);
 
   type SessionInputMessage = { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean } | string;
 
@@ -3798,7 +3800,10 @@ export function App() {
       // runner). Queue the message and flush it once the snapshot completes
       // instead of rejecting and forcing the user to retry.
       pendingHydrationInputsRef.current.push({ sessionId, message });
-      return true;
+      // PromptInput clears/revokes files only for a strict true result. The
+      // queued send has not been delivered yet, so retain the files until the
+      // flush can report actual delivery.
+      return false;
     }
     if (gate === "reject") return false;
     if (!socket || !socket.connected) {
@@ -3809,16 +3814,32 @@ export function App() {
     const payload = typeof message === "string" ? { text: message, files: [] } : message;
     const trimmed = payload.text.trim();
 
-    // Dedup guard: skip if the same text was sent/started in the last 500ms.
+    // Dedup only an identical text + file selection. File object identity is
+    // enough to distinguish two same-caption submissions without reading the
+    // files before upload; URL/name metadata covers non-File inputs.
+    const fileKey = (payload.files ?? []).map((file) => {
+      const identity = file.file
+        ? (() => {
+            let id = fileIdentityRef.current.get(file.file);
+            if (id === undefined) {
+              id = ++nextFileIdentityRef.current;
+              fileIdentityRef.current.set(file.file, id);
+            }
+            return `file:${id}`;
+          })()
+        : `url:${file.url ?? ""}`;
+      return `${identity}:${file.filename ?? ""}:${file.mediaType ?? ""}`;
+    }).join("|");
+    const dedupeKey = `${trimmed}\u0000${fileKey}`;
     const now = Date.now();
-    if (shouldDeduplicateInput(inputDedupeRef.current, trimmed, now, 500)) {
+    if (shouldDeduplicateInput(inputDedupeRef.current, dedupeKey, now, 500)) {
       return true; // silently deduplicate
     }
 
     let attemptId: number | null = null;
     if (trimmed) {
       attemptId = ++inputAttemptIdRef.current;
-      inputDedupeRef.current = beginInputAttempt(trimmed, now, attemptId);
+      inputDedupeRef.current = beginInputAttempt(dedupeKey, now, attemptId);
     }
 
     const failCurrentAttempt = () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3325,6 +3325,13 @@ export function App() {
     // in the header / model selector.
     const sessions = liveSessionsRef.current;
     const prevSessionId = lifecycleRefs.activeSessionId.current;
+    // Session switches cancel queued sends for the old session. Never leave
+    // PromptInput awaiting a promise that can no longer be flushed.
+    const retainedHydrationInputs = pendingHydrationInputsRef.current.filter((item) => item.sessionId === relaySessionId);
+    for (const item of pendingHydrationInputsRef.current) {
+      if (item.sessionId !== relaySessionId) item.resolve(false);
+    }
+    pendingHydrationInputsRef.current = retainedHydrationInputs;
     const prevRunnerId = prevSessionId
       ? sessions.find((s) => s.sessionId === prevSessionId)?.runnerId ?? null
       : null;
@@ -3768,7 +3775,7 @@ export function App() {
 
   // Messages submitted while the session was still hydrating (e.g. the runner
   // was loading MCP servers). Flushed once the snapshot completes.
-  const pendingHydrationInputsRef = React.useRef<Array<{ sessionId: string; message: SessionInputMessage }>>([]);
+  const pendingHydrationInputsRef = React.useRef<Array<{ sessionId: string; message: SessionInputMessage; resolve: (delivered: boolean) => void }>>([]);
 
   const requestOlderMessages = React.useCallback(() => {
     const socket = viewerWsRef.current;
@@ -3799,11 +3806,12 @@ export function App() {
       // Session is still hydrating (usually MCP servers loading on the
       // runner). Queue the message and flush it once the snapshot completes
       // instead of rejecting and forcing the user to retry.
-      pendingHydrationInputsRef.current.push({ sessionId, message });
       // PromptInput clears/revokes files only for a strict true result. The
       // queued send has not been delivered yet, so retain the files until the
       // flush can report actual delivery.
-      return false;
+      return new Promise<boolean>((resolve) => {
+        pendingHydrationInputsRef.current.push({ sessionId, message, resolve });
+      });
     }
     if (gate === "reject") return false;
     if (!socket || !socket.connected) {
@@ -3813,6 +3821,15 @@ export function App() {
 
     const payload = typeof message === "string" ? { text: message, files: [] } : message;
     const trimmed = payload.text.trim();
+
+    const rawFiles = (payload.files ?? [])
+      .filter((f) => typeof f?.url === "string" && f.url.length > 0)
+      .map((f) => ({
+        file: f.file instanceof File ? f.file : undefined,
+        mediaType: typeof f.mediaType === "string" ? f.mediaType : undefined,
+        filename: typeof f.filename === "string" ? f.filename : undefined,
+        url: f.url as string,
+      }));
 
     // Dedup only an identical text + file selection. File object identity is
     // enough to distinguish two same-caption submissions without reading the
@@ -3833,11 +3850,13 @@ export function App() {
     const dedupeKey = `${trimmed}\u0000${fileKey}`;
     const now = Date.now();
     if (shouldDeduplicateInput(inputDedupeRef.current, dedupeKey, now, 500)) {
-      return true; // silently deduplicate
+      // A pending duplicate must not clear/revoke the caller's draft. A sent
+      // duplicate is harmless and can report the same successful phase.
+      return inputDedupeRef.current?.phase === "sent";
     }
 
     let attemptId: number | null = null;
-    if (trimmed) {
+    if (trimmed || rawFiles.length > 0) {
       attemptId = ++inputAttemptIdRef.current;
       inputDedupeRef.current = beginInputAttempt(dedupeKey, now, attemptId);
     }
@@ -3846,15 +3865,6 @@ export function App() {
       if (attemptId === null) return;
       inputDedupeRef.current = failInputAttempt(inputDedupeRef.current, attemptId);
     };
-
-    const rawFiles = (payload.files ?? [])
-      .filter((f) => typeof f?.url === "string" && f.url.length > 0)
-      .map((f) => ({
-        file: f.file instanceof File ? f.file : undefined,
-        mediaType: typeof f.mediaType === "string" ? f.mediaType : undefined,
-        filename: typeof f.filename === "string" ? f.filename : undefined,
-        url: f.url as string,
-      }));
 
     let attachments: Array<{ attachmentId: string; filename?: string; mediaType?: string; size?: number; expiresAt?: string }> = [];
 
@@ -3931,14 +3941,40 @@ export function App() {
     const suppressOptimistic = typeof message === "object" && message.suppressOptimistic;
 
     try {
-      socket.emit("input", {
-        text: trimmed,
-        attachments,
-        client: "web",
-        ...(deliverAs ? { deliverAs } : {}),
+      const delivered = await new Promise<boolean>((resolve) => {
+        let settled = false;
+        const settle = (value: boolean) => {
+          if (settled) return;
+          settled = true;
+          socket.off("disconnect", onDisconnect);
+          resolve(value === true);
+        };
+        const onDisconnect = () => settle(false);
+        const timeout = window.setTimeout(() => settle(false), 10_000);
+        const ack = (value: boolean) => {
+          window.clearTimeout(timeout);
+          settle(value);
+        };
+        socket.once("disconnect", onDisconnect);
+        try {
+          (socket.emit as (...args: unknown[]) => void)("input", {
+            text: trimmed,
+            attachments,
+            client: "web",
+            ...(deliverAs ? { deliverAs } : {}),
+          }, ack);
+        } catch {
+          window.clearTimeout(timeout);
+          settle(false);
+        }
       });
+      if (!delivered) {
+        setLifecycleStatus("Failed to send message");
+        failCurrentAttempt();
+        return false;
+      }
 
-      // Mark dedupe as sent only after successful emit.
+      // Mark dedupe as sent only after the server and runner acknowledge delivery.
       if (attemptId !== null) {
         inputDedupeRef.current = completeInputAttempt(inputDedupeRef.current, attemptId, Date.now());
       }
@@ -3991,6 +4027,10 @@ export function App() {
 
   const sendSessionInputRef = React.useRef(sendSessionInput);
   React.useEffect(() => { sendSessionInputRef.current = sendSessionInput; });
+  React.useEffect(() => () => {
+    for (const item of pendingHydrationInputsRef.current) item.resolve(false);
+    pendingHydrationInputsRef.current = [];
+  }, []);
 
   // Flush input queued during hydration once the session goes live. Entries
   // for a session the user has since switched away from are dropped.
@@ -4000,10 +4040,19 @@ export function App() {
     if (pending.length === 0) return;
     pendingHydrationInputsRef.current = [];
     const activeId = lifecycleRefs.activeSessionId.current;
-    for (const item of pending) {
-      if (item.sessionId !== activeId) continue;
-      void sendSessionInputRef.current(item.message);
-    }
+    void (async () => {
+      for (const item of pending) {
+        if (item.sessionId !== activeId) {
+          item.resolve(false);
+          continue;
+        }
+        try {
+          item.resolve((await sendSessionInputRef.current(item.message)) === true);
+        } catch {
+          item.resolve(false);
+        }
+      }
+    })();
   }, [lifecycle.isLive, lifecycleRefs]);
 
   const sendRemoteExec = React.useCallback((payload: any) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -72,6 +72,7 @@ import { HubSocketContext } from "@/lib/hub-socket-context";
 import { resetStaleBaselineOnVisibilityChange, shouldStopViewerReconnect } from "@/lib/viewer-connection";
 import { mapUserError } from "@/lib/user-error-message";
 import { classifySessionInput } from "@/lib/session-empty-state";
+import { emitInputWithAck } from "@/lib/input-delivery";
 import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
 import { evaluateVersionNegotiation } from "@/lib/version-negotiation";
 import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, setViewerSwitchGeneration } from "@/hooks/useRunnerServices";
@@ -3941,32 +3942,12 @@ export function App() {
     const suppressOptimistic = typeof message === "object" && message.suppressOptimistic;
 
     try {
-      const delivered = await new Promise<boolean>((resolve) => {
-        let settled = false;
-        const settle = (value: boolean) => {
-          if (settled) return;
-          settled = true;
-          socket.off("disconnect", onDisconnect);
-          resolve(value === true);
-        };
-        const onDisconnect = () => settle(false);
-        const timeout = window.setTimeout(() => settle(false), 10_000);
-        const ack = (value: boolean) => {
-          window.clearTimeout(timeout);
-          settle(value);
-        };
-        socket.once("disconnect", onDisconnect);
-        try {
-          (socket.emit as (...args: unknown[]) => void)("input", {
-            text: trimmed,
-            attachments,
-            client: "web",
-            ...(deliverAs ? { deliverAs } : {}),
-          }, ack);
-        } catch {
-          window.clearTimeout(timeout);
-          settle(false);
-        }
+      const delivered = await emitInputWithAck(socket, {
+        text: trimmed,
+        attachments,
+        client: "web",
+        requestId: crypto.randomUUID(),
+        ...(deliverAs ? { deliverAs } : {}),
       });
       if (!delivered) {
         setLifecycleStatus("Failed to send message");

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -216,7 +216,7 @@ export function SessionViewer({
       if (!onSendInput || !sessionId) return false;
       try {
         const result = await Promise.resolve(onSendInput(text));
-        return result !== false;
+        return result === true;
       } catch {
         return false;
       }
@@ -571,7 +571,7 @@ export function SessionViewer({
 
       try {
         const result = await onSendInput(payload);
-        if (result !== false) {
+        if (result === true) {
           if (sessionIdRef.current === originSessionId) {
             setInput("");
             setCommandOpen(false);
@@ -1122,7 +1122,7 @@ export function SessionViewer({
                   const text = formatAnswersForAgent(answers);
                   return Promise.resolve(onSendInput(text))
                     .then((result) => {
-                      if (result !== false) {
+                      if (result === true) {
                         setComposerError(null);
                         setInput("");
                         if (sessionId) void dismissNotificationsForSession(sessionId);
@@ -1156,7 +1156,7 @@ export function SessionViewer({
                   });
                   return Promise.resolve(onSendInput(payload))
                     .then((result) => {
-                      if (result !== false) {
+                      if (result === true) {
                         setComposerError(null);
                         setInput("");
                         if (sessionId) void dismissNotificationsForSession(sessionId);

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -550,44 +550,47 @@ export function SessionViewer({
 
   // ── handleSubmit ──────────────────────────────────────────────────────────
   const handleSubmit = React.useCallback(
-    (message: PromptInputMessage) => {
+    async (message: PromptInputMessage): Promise<boolean> => {
       if (!composerReady) {
         if (isSessionHydrating(viewerStatus)) {
           setComposerError("Session is still connecting — your draft is preserved, try again shortly.");
         }
-        return;
+        return false;
       }
       const text = message.text.trim();
       const hasAttachments = Array.isArray(message.files) && message.files.length > 0;
-      if (!text && !hasAttachments) return;
+      if (!text && !hasAttachments) return false;
 
       setComposerError(null);
-      if (text && executeSlashCommand(text)) return;
-      if (!onSendInput) return;
+      if (text && executeSlashCommand(text)) return true;
+      if (!onSendInput) return false;
 
       const payload = agentActive ? { ...message, deliverAs: deliveryMode } : message;
       const originSessionId = sessionId;
       const sentText = text;
 
-      Promise.resolve(onSendInput(payload))
-        .then((result) => {
-          if (result !== false) {
-            if (sessionIdRef.current === originSessionId) {
+      try {
+        const result = await onSendInput(payload);
+        if (result !== false) {
+          if (sessionIdRef.current === originSessionId) {
+            setInput("");
+            setCommandOpen(false);
+            setCommandQuery("");
+          } else if (originSessionId) {
+            // User switched away — only clear draft if it still matches sent text
+            const saved = inputRef.current.trim();
+            if (saved === sentText || saved === "") {
               setInput("");
-              setCommandOpen(false);
-              setCommandQuery("");
-            } else if (originSessionId) {
-              // User switched away — only clear draft if it still matches sent text
-              const saved = inputRef.current.trim();
-              if (saved === sentText || saved === "") {
-                setInput("");
-              }
             }
-          } else {
-            setComposerError("Failed to send message.");
           }
-        })
-        .catch(() => { setComposerError("Failed to send message."); });
+          return true;
+        }
+      } catch {
+        // Fall through to preserve the prompt and attachments for retry.
+      }
+
+      setComposerError("Failed to send message.");
+      return false;
     },
     [composerReady, viewerStatus, executeSlashCommand, onSendInput, agentActive, deliveryMode, setInput, setCommandOpen, setCommandQuery, sessionIdRef, inputRef],
   );

--- a/packages/ui/src/components/ai-elements/prompt-input.test.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.test.tsx
@@ -100,4 +100,13 @@ describe("PromptInput submit", () => {
     expect(revokeObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:attachment");
   });
+
+  test("revokes retained attachment URLs when unmounted", async () => {
+    const view = await submitWithAttachment(false);
+
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    view.unmount();
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:attachment");
+  });
 });

--- a/packages/ui/src/components/ai-elements/prompt-input.test.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.test.tsx
@@ -1,13 +1,103 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import React from "react";
 
-const { shouldClearPromptInputAfterSubmit } = await import("./prompt-input");
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(win as any).SyntaxError = SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).File = win.File;
+(globalThis as any).FileReader = win.FileReader;
+(globalThis as any).FormData = win.FormData;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
-describe("PromptInput submit", () => {
-  test("preserves attachments and blob URLs when a send fails", () => {
-    expect(shouldClearPromptInputAfterSubmit(false)).toBe(false);
+const {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  usePromptInputAttachments,
+} = await import("./prompt-input");
+
+type SubmitResult = boolean | undefined;
+
+const AttachmentCount = () => {
+  const { files } = usePromptInputAttachments();
+  return <div data-count={files.length} data-testid="attachment-count" />;
+};
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+let revokeObjectURL = mock(() => {});
+
+beforeEach(() => {
+  revokeObjectURL = mock(() => {});
+  URL.createObjectURL = () => "blob:attachment";
+  URL.revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  cleanup();
+  win.document.body.innerHTML = "";
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+async function submitWithAttachment(result: SubmitResult) {
+  // Simulates an untyped callback violating the boolean contract at runtime.
+  const onSubmit = mock(async (): Promise<boolean> => result!);
+  const view = render(
+    <PromptInput onSubmit={onSubmit}>
+      <AttachmentCount />
+      <PromptInputTextarea />
+      <PromptInputSubmit />
+    </PromptInput>,
+  );
+
+  const file = new File(["attachment"], "attachment.txt", { type: "text/plain" });
+  fireEvent.change(view.getByLabelText("Upload files"), { target: { files: [file] } });
+  await waitFor(() => expect(view.getByTestId("attachment-count").dataset.count).toBe("1"));
+
+  await act(async () => {
+    fireEvent.submit(view.container.querySelector("form")!);
   });
 
-  test("clears attachments and blob URLs after a successful send", () => {
-    expect(shouldClearPromptInputAfterSubmit(true)).toBe(true);
+  return view;
+}
+
+describe("PromptInput submit", () => {
+  test("retains attachments and blob URLs when send returns false", async () => {
+    const view = await submitWithAttachment(false);
+
+    expect(view.getByTestId("attachment-count").dataset.count).toBe("1");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  test("retains attachments and blob URLs when send returns undefined", async () => {
+    const view = await submitWithAttachment(undefined);
+
+    expect(view.getByTestId("attachment-count").dataset.count).toBe("1");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  test("clears attachments and revokes blob URLs once when send returns true", async () => {
+    const view = await submitWithAttachment(true);
+
+    await waitFor(() => expect(view.getByTestId("attachment-count").dataset.count).toBe("0"));
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:attachment");
   });
 });

--- a/packages/ui/src/components/ai-elements/prompt-input.test.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+const { shouldClearPromptInputAfterSubmit } = await import("./prompt-input");
+
+describe("PromptInput submit", () => {
+  test("preserves attachments and blob URLs when a send fails", () => {
+    expect(shouldClearPromptInputAfterSubmit(false)).toBe(false);
+  });
+
+  test("clears attachments and blob URLs after a successful send", () => {
+    expect(shouldClearPromptInputAfterSubmit(true)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -365,7 +365,7 @@ export interface PromptInputMessage {
   files: PromptInputAttachment[];
 }
 
-export const shouldClearPromptInputAfterSubmit = (succeeded: boolean) => succeeded;
+export const shouldClearPromptInputAfterSubmit = (succeeded: unknown) => succeeded === true;
 
 export type PromptInputProps = Omit<
   HTMLAttributes<HTMLFormElement>,

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -365,6 +365,8 @@ export interface PromptInputMessage {
   files: PromptInputAttachment[];
 }
 
+export const shouldClearPromptInputAfterSubmit = (succeeded: boolean) => succeeded;
+
 export type PromptInputProps = Omit<
   HTMLAttributes<HTMLFormElement>,
   "onSubmit" | "onError"
@@ -389,7 +391,7 @@ export type PromptInputProps = Omit<
   onSubmit: (
     message: PromptInputMessage,
     event: FormEvent<HTMLFormElement>
-  ) => void | Promise<void>;
+  ) => boolean | Promise<boolean>;
 };
 
 export const PromptInput = ({
@@ -760,21 +762,8 @@ export const PromptInput = ({
           })
         );
 
-        const result = onSubmit({ files: convertedFiles, text }, event);
-
-        // Handle both sync and async onSubmit
-        if (result instanceof Promise) {
-          try {
-            await result;
-            clear();
-            if (usingProvider) {
-              controller.textInput.clear();
-            }
-          } catch {
-            // Don't clear on error - user may want to retry
-          }
-        } else {
-          // Sync function completed without throwing, clear inputs
+        const succeeded = await onSubmit({ files: convertedFiles, text }, event);
+        if (shouldClearPromptInputAfterSubmit(succeeded)) {
           clear();
           if (usingProvider) {
             controller.textInput.clear();

--- a/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
+++ b/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
@@ -72,7 +72,7 @@ describe("slash command delivery", () => {
         const { view } = setup({
             input: "/goal finish the task",
             isAgentActive: true,
-            onSendInput: (message) => { sent.push(message); },
+            onSendInput: (message) => { sent.push(message); return true; },
         });
 
         act(() => { view.result.current.executeSlashCommand("/goal finish the task"); });

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -39,7 +39,7 @@ export interface SlashCommandDeps {
   onExec?: (payload: unknown) => boolean | void;
   onSendInput?: (
     message: (PromptInputMessage & { deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean }) | string,
-  ) => boolean | void | Promise<boolean | void>;
+  ) => boolean | Promise<boolean>;
   isAgentActive?: boolean;
   resumeSessions?: ResumeSessionOption[];
   onRequestResumeSessions?: () => boolean | void;

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -48,7 +48,7 @@ export interface SessionViewerProps {
   forkMessages?: ForkMessageOption[];
   forkMessagesLoading?: boolean;
   onRequestForkMessages?: () => boolean | void;
-  onSendInput?: (message: PromptInputMessage & { deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean } | string) => boolean | void | Promise<boolean | void>;
+  onSendInput?: (message: PromptInputMessage & { deliverAs?: "steer" | "followUp"; suppressOptimistic?: boolean } | string) => boolean | Promise<boolean>;
   onExec?: (payload: unknown) => boolean | void;
   onShowModelSelector?: () => void;
   /** Opens the new-session wizard (renders a CTA in the empty state). */

--- a/packages/ui/src/lib/input-dedupe.test.ts
+++ b/packages/ui/src/lib/input-dedupe.test.ts
@@ -49,4 +49,10 @@ describe("input dedupe state", () => {
 
     expect(shouldDeduplicateInput(state, "world", 1100, 500)).toBe(false);
   });
+
+  test("does not deduplicate the same caption with different file identity", () => {
+    const state = beginInputAttempt("hello\u0000file:1", 1000, 1);
+
+    expect(shouldDeduplicateInput(state, "hello\u0000file:2", 1100, 500)).toBe(false);
+  });
 });

--- a/packages/ui/src/lib/input-delivery.test.ts
+++ b/packages/ui/src/lib/input-delivery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, mock, test } from "bun:test";
+import { emitInputWithAck } from "./input-delivery";
+
+function socketWithEmit(emit: (...args: unknown[]) => unknown) {
+  return {
+    emit: mock(emit),
+    once: mock(() => undefined),
+    off: mock(() => undefined),
+  };
+}
+
+describe("emitInputWithAck", () => {
+  test("returns an explicit acknowledgement and clears its timeout", async () => {
+    const socket = socketWithEmit((...args) => {
+      (args[2] as (delivered: boolean) => void)(true);
+    });
+
+    expect(await emitInputWithAck(socket, { text: "hello", requestId: "req-1" }, 20)).toBe(true);
+    expect(socket.off).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports an explicit delivery failure", async () => {
+    const socket = socketWithEmit((...args) => {
+      (args[2] as (delivered: boolean) => void)(false);
+    });
+
+    expect(await emitInputWithAck(socket, { text: "hello" }, 20)).toBe(false);
+  });
+
+  test("treats a missing acknowledgement from an old server as delivered", async () => {
+    const socket = socketWithEmit(() => undefined);
+
+    expect(await emitInputWithAck(socket, { text: "legacy" }, 5)).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/input-delivery.ts
+++ b/packages/ui/src/lib/input-delivery.ts
@@ -1,0 +1,38 @@
+interface AckSocketLifecycle {
+  once: (event: "disconnect", listener: () => void) => unknown;
+  off: (event: "disconnect", listener: () => void) => unknown;
+}
+
+/**
+ * Emit viewer input and wait for an explicit acknowledgement when supported.
+ * Old servers consume the input but never invoke the callback, so an ack timeout
+ * is treated as success. Explicit false, disconnect, and synchronous failures
+ * remain failures.
+ */
+export function emitInputWithAck(
+  socket: AckSocketLifecycle,
+  payload: Record<string, unknown>,
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const onDisconnect = () => settle(false);
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timeout !== undefined) clearTimeout(timeout);
+      socket.off("disconnect", onDisconnect);
+      resolve(value === true);
+    };
+
+    timeout = setTimeout(() => settle(true), timeoutMs);
+    socket.once("disconnect", onDisconnect);
+    try {
+      (socket as unknown as { emit: (...args: unknown[]) => unknown })
+        .emit("input", payload, (value: boolean) => settle(value));
+    } catch {
+      settle(false);
+    }
+  });
+}


### PR DESCRIPTION
Addresses review feedback for #822: fixes typecheck, corrects acknowledgement semantics, and adds backward-compatible delivery.

Follow-up to #822