### PR TITLE
fix: preserve tunnel-origin Host header in host-based tunnels (rebase of #772)

### DIFF
--- a/packages/server/src/routes/tunnel-host.test.ts
+++ b/packages/server/src/routes/tunnel-host.test.ts
@@ -257,3 +257,66 @@ describe("passthrough proxy mode (basePath \"\")", () => {
         expect(res.headers.get("x-pizzapi-tunnel-frame")).toBe("cross-origin");
     });
 });
+
+describe("host header forwarding", () => {
+    type CapturedRequest = { host?: string; preserveAuth?: boolean; port: number };
+
+    function captureRelayRequest(tunnelHost?: string): Promise<CapturedRequest> {
+        return new Promise((resolve) => {
+            const relay = {
+                proxyHttpRequest: (_runnerId: string, request: CapturedRequest, cb: { onError: (e: string) => void }) => {
+                    resolve(request);
+                    // Immediately error so the response promise doesn’t hang.
+                    cb.onError("test-done");
+                    return { cancel() {} };
+                },
+                sendRequestDataEnd() {},
+            };
+
+            proxyTunnelRequestViaRelay(
+                new Request("http://abc.t.localhost/path"),
+                relay as never,
+                "runner-1",
+                "req-capture",
+                "", // basePath "" → host-based passthrough
+                3000,
+                "/path",
+                "/path",
+                {},
+                true,
+                tunnelHost,
+            ).catch(() => { /* expected */ });
+        });
+    }
+
+    test("host-based tunnel: relay receives tunnel-origin host field", async () => {
+        const req = await captureRelayRequest("abc123.t.example.com");
+        expect(req.host).toBe("abc123.t.example.com");
+    });
+
+    test("path-based tunnel: relay receives no host field (undefined)", async () => {
+        const relay = {
+            proxyHttpRequest: (_runnerId: string, request: CapturedRequest, cb: { onError: (e: string) => void }) => {
+                cb.onError("test-done");
+                // Capture happens synchronously.
+                expect(request.host).toBeUndefined();
+                return { cancel() {} };
+            },
+            sendRequestDataEnd() {},
+        };
+
+        await proxyTunnelRequestViaRelay(
+            new Request("http://example.com/path"),
+            relay as never,
+            "runner-1",
+            "req-path",
+            "/tunnel/session/3000", // non-empty basePath → path-based
+            3000,
+            "/path",
+            "/path",
+            {},
+            false,
+            // no tunnelHost → path-based
+        ).catch(() => { /* expected */ });
+    });
+});

--- a/packages/server/src/routes/tunnel-host.ts
+++ b/packages/server/src/routes/tunnel-host.ts
@@ -285,6 +285,7 @@ export async function handleTunnelHostRequest(req: Request, url: URL): Promise<R
     const requestId = `host-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
     // basePath "" → passthrough mode: no buffering, no rewriting, no injection.
+    // Pass url.host so the local service receives the tunnel origin as Host header.
     return proxyTunnelRequestViaRelay(
         req,
         relay,
@@ -296,5 +297,6 @@ export async function handleTunnelHostRequest(req: Request, url: URL): Promise<R
         pathWithQuery,
         forwardHeaders,
         true,
+        url.host,
     );
 }

--- a/packages/server/src/routes/tunnel-ws.ts
+++ b/packages/server/src/routes/tunnel-ws.ts
@@ -108,6 +108,7 @@ async function handleHostUpgradeAsync(
     // [full, scope, port, path]. scope + runnerId are preauthenticated.
     // fullUrl is forwarded verbatim — host tunnels must not strip the app's
     // own apiKey/tunnelToken query params.
+    // req.headers.host is the tunnel origin (e.g. abc123.t.example.com).
     await handleUpgradeAsync(
         req,
         rawSocket,
@@ -117,6 +118,7 @@ async function handleHostUpgradeAsync(
         auth.record.userId,
         auth.runnerId,
         fullUrl,
+        req.headers.host,
     );
 }
 
@@ -189,6 +191,7 @@ async function handleUpgradeAsync(
     preauthenticatedUserId?: string,
     preauthenticatedRunnerId?: string,
     rawPathWithQuery?: string,
+    tunnelHost?: string,
 ): Promise<void> {
     let sessionId: string;
     try {
@@ -343,6 +346,7 @@ async function handleUpgradeAsync(
             protocols,
             headers: forwardHeaders,
             preserveAuth: isHostTunnel || undefined,
+            host: tunnelHost,
         },
         {
             onOpened: (protocol) => {

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -473,6 +473,7 @@ function proxyTunnelRequestViaRelay(
     pathWithQuery: string,
     forwardHeaders: Record<string, string>,
     allowCrossOriginFrame = false,
+    tunnelHost?: string,
 ): Promise<Response> {
     return new Promise<Response>((resolve) => {
         const bodyAbortController = new AbortController();
@@ -538,6 +539,7 @@ function proxyTunnelRequestViaRelay(
                 headers: forwardHeaders,
                 // Host-based tunnels forward the app's own credentials end-to-end.
                 preserveAuth: basePath === "" || undefined,
+                host: tunnelHost,
             },
             {
                 onResponseStart: (code, _statusMessage, headers) => {

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -468,7 +468,16 @@ export class TunnelClient extends EventEmitter {
   }
 
   private handleRequestStart(msg: TunnelRequestStartMessage): void {
-    const { id, port, method, url: requestUrl, headers, preserveAuth } = msg;
+    const { id, port, method, url: requestUrl, headers, preserveAuth, host: tunnelHost } = msg;
+
+    // Guard against request-id reuse: abort and destroy any in-flight request
+    // sharing the same id before registering the new one.
+    const stale = this.activeRequests.get(id);
+    if (stale) {
+      stale.controller.abort();
+      stale.req.destroy();
+      this.activeRequests.delete(id);
+    }
 
     if (!this.exposedPorts.has(port)) {
       this.log.warn("[tunnel-client] Request for unexposed port", port);
@@ -511,7 +520,9 @@ export class TunnelClient extends EventEmitter {
       if (!preserveAuth && STRIP_AUTH.has(lowerKey)) continue;
       forwardHeaders[key] = value;
     }
-    forwardHeaders.host = `127.0.0.1:${port}`;
+    // Host-based tunnels: use the tunnel origin so local services that build
+    // absolute URLs from `Host` produce correct tunnel-origin URLs.
+    forwardHeaders.host = tunnelHost ?? `127.0.0.1:${port}`;
 
     const controller = new AbortController();
     const attempt = (hostname: LoopbackHost, canRetry: boolean): http.ClientRequest => {
@@ -677,7 +688,7 @@ export class TunnelClient extends EventEmitter {
   }
 
   private handleWsOpen(msg: TunnelWsOpenMessage): void {
-    const { id, port, path, protocols, headers, preserveAuth } = msg;
+    const { id, port, path, protocols, headers, preserveAuth, host: tunnelHost } = msg;
 
     if (!this.exposedPorts.has(port)) {
       this.send({ type: "ws-error", id, message: `Port ${port} is not exposed` });
@@ -707,7 +718,9 @@ export class TunnelClient extends EventEmitter {
       if (!preserveAuth && STRIP_AUTH.has(lowerKey)) continue;
       forwardHeaders[key] = value;
     }
-    forwardHeaders.host = `127.0.0.1:${port}`;
+    // Host-based tunnels: use the tunnel origin so local services that build
+    // absolute URLs from `Host` produce correct tunnel-origin URLs.
+    forwardHeaders.host = tunnelHost ?? `127.0.0.1:${port}`;
 
     const connect = (hostname: LoopbackHost, canRetry: boolean): void => {
     try {

--- a/packages/tunnel/src/integration.test.ts
+++ b/packages/tunnel/src/integration.test.ts
@@ -131,6 +131,7 @@ async function proxyHttpRequestThroughTunnel(
     headers?: Record<string, string>;
     requestBody?: Buffer;
     preserveAuth?: boolean;
+    host?: string;
   },
 ): Promise<{
   statusCode: number;
@@ -158,6 +159,7 @@ async function proxyHttpRequestThroughTunnel(
         url: options.url ?? "/",
         headers: options.headers ?? {},
         preserveAuth: options.preserveAuth,
+        host: options.host,
       },
       {
         onResponseStart(code, message, responseHeaders) {
@@ -450,5 +452,41 @@ describe("Streaming tunnel integration", () => {
     expect(seenMethod).toBe("GET");
     expect(response.statusCode).toBe(200);
     expect(response.body.toString("utf-8")).toBe("secure-ok");
+  });
+
+  test("host-based tunnel: local service receives tunnel-origin as Host header", async () => {
+    let seenHost = "";
+    localHttpServer = http.createServer((req, res) => {
+      seenHost = req.headers.host ?? "";
+      res.writeHead(200);
+      res.end("ok");
+    });
+    const localPort = await listen(localHttpServer);
+    await startRelayAndClient([localPort]);
+
+    await proxyHttpRequestThroughTunnel(localPort, {
+      id: "req-host-based",
+      host: `abc123.t.localhost:7492`,
+      preserveAuth: true,
+    });
+
+    // The local service must see the tunnel origin, not the loopback address.
+    expect(seenHost).toBe("abc123.t.localhost:7492");
+  });
+
+  test("path-based tunnel: local service receives 127.0.0.1:<port> as Host header (unchanged)", async () => {
+    let seenHost = "";
+    localHttpServer = http.createServer((req, res) => {
+      seenHost = req.headers.host ?? "";
+      res.writeHead(200);
+      res.end("ok");
+    });
+    const localPort = await listen(localHttpServer);
+    await startRelayAndClient([localPort]);
+
+    // No `host` field — path-based tunnel behavior, must not change.
+    await proxyHttpRequestThroughTunnel(localPort, { id: "req-path-based" });
+
+    expect(seenHost).toBe(`127.0.0.1:${localPort}`);
   });
 });

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -184,6 +184,7 @@ export class TunnelRelay {
       url: string;
       headers: Record<string, string>;
       preserveAuth?: boolean;
+      host?: string;
     },
     callbacks: {
       onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string | string[]>) => void;
@@ -197,6 +198,15 @@ export class TunnelRelay {
     if (!runner) {
       callbacks.onError(`Runner ${runnerId} not connected`);
       return { cancel() {} };
+    }
+
+    // Evict any stale pending request sharing this id so its timer cannot
+    // fire and delete the new entry.
+    const staleRequest = this.pendingRequests.get(request.id);
+    if (staleRequest) {
+      clearTimeout(staleRequest.timer);
+      this.pendingRequests.delete(request.id);
+      staleRequest.onError("Tunnel request timed out");
     }
 
     const timer = setTimeout(() => {
@@ -224,6 +234,7 @@ export class TunnelRelay {
       url: request.url,
       headers: request.headers,
       preserveAuth: request.preserveAuth,
+      host: request.host,
     });
 
     return {
@@ -262,6 +273,7 @@ export class TunnelRelay {
       protocols?: string[];
       headers: Record<string, string>;
       preserveAuth?: boolean;
+      host?: string;
     },
     callbacks: {
       onOpened: (protocol?: string) => void;
@@ -301,6 +313,7 @@ export class TunnelRelay {
       protocols: request.protocols,
       headers: request.headers,
       preserveAuth: request.preserveAuth,
+      host: request.host,
     });
 
     return {

--- a/packages/tunnel/src/types.ts
+++ b/packages/tunnel/src/types.ts
@@ -37,6 +37,14 @@ export interface TunnelRequestStartMessage {
    * to the app, not the relay). Old runners ignore this and keep stripping.
    */
   preserveAuth?: boolean;
+  /**
+   * Host-based tunnels: the tunnel origin host (e.g. "abc123.t.example.com")
+   * that the local service should see as its Host header. When present the
+   * client uses this instead of the default "127.0.0.1:<port>", so apps that
+   * construct absolute URLs from `Host` produce correct tunnel-origin URLs.
+   * Absent for path-based tunnels — those keep "127.0.0.1:<port>".
+   */
+  host?: string;
 }
 
 export interface TunnelRequestDataMessage {
@@ -89,6 +97,8 @@ export interface TunnelWsOpenMessage {
   headers: Record<string, string>;
   /** See TunnelRequestStartMessage.preserveAuth. */
   preserveAuth?: boolean;
+  /** See TunnelRequestStartMessage.host. */
+  host?: string;
 }
 
 export interface TunnelWsOpenedMessage {


### PR DESCRIPTION
Clean rebase of #772.

This PR supersedes #772, which had unrelated Night Shift integration test files mixed into its branch and failed Unit Tests on CI. I rebased the tunnel-only changes onto current `main` and dropped the extra files.

Changes (same as #772):
- Preserve the tunnel-origin `Host` header in host-based tunnels.
- Keep path-based tunnels sending `127.0.0.1:<port>` as `Host`.

Closes #772