### PR TITLE
fix: abort resync hydration when viewer switches sessions (A2-016) [rebase]

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -50,6 +50,7 @@ mock.module("../../sio-registry.js", () => ({
 
 mock.module("../../../sessions/redis.js", () => ({
     appendRelayEventToCache: async () => {},
+    deleteRelayEventCache: async () => {},
 }));
 
 mock.module("./viewer-gate.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -28,6 +28,7 @@ mock.module("../../sio-registry.js", () => ({
         wasDelinked: false,
     }),
     getLocalTuiSocket: () => undefined,
+    getSessionOwnerToken: async () => "tok",
     broadcastToViewers: mockBroadcastToViewers,
     endSharedSession: async () => {},
 }));

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -78,6 +78,7 @@ function emitSnapshotWithTrailingDeltas(
     cached: LatestCachedSnapshot,
     generation: number | undefined,
     snapshotOverlay?: string | null,
+    sessionId?: string,
 ): void {
     // The cached session_active predates any later metadata-only updates (queue,
     // model, todo list), which are carried by the overlay rather than re-cached.
@@ -86,10 +87,10 @@ function emitSnapshotWithTrailingDeltas(
     if (snapshotOverlay && event.type === "session_active") {
         event = { ...event, state: applySnapshotOverlayToState(event.state, snapshotOverlay) };
     }
-    socket.emit("event", { event, replay: true, generation });
+    socket.emit("event", { event, replay: true, generation, ...(sessionId !== undefined ? { sessionId } : {}) });
     // Replay deltas cached after the snapshot so the viewer isn't left stale
     // between the snapshot and the seq advertised in "connected".
-    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
+    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation, sessionId);
 }
 
 export async function sendLatestSnapshotFromCache(
@@ -102,7 +103,7 @@ export async function sendLatestSnapshotFromCache(
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return false;
 
-    emitSnapshotWithTrailingDeltas(socket, cached, generation, snapshotOverlay);
+    emitSnapshotWithTrailingDeltas(socket, cached, generation, snapshotOverlay, sessionId);
     return true;
 }
 
@@ -110,6 +111,7 @@ export function sendCachedDeltaReplayEvents(
     socket: ViewerEventEmitter,
     cachedEvents: CachedRelayEvent[],
     generation?: number,
+    sessionId?: string,
 ): boolean {
     let sentAny = false;
 
@@ -124,6 +126,7 @@ export function sendCachedDeltaReplayEvents(
             replay: true,
             deltaReplay: true,
             generation,
+            ...(sessionId !== undefined ? { sessionId } : {}),
         });
     }
 
@@ -138,7 +141,7 @@ async function sendDeltaReplayFromCache(
     deps: ViewerCacheDeps,
 ): Promise<boolean> {
     const cachedEvents = await deps.getCachedRelayEventsAfterSeq(sessionId, afterSeq);
-    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation);
+    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation, sessionId);
 }
 
 /**
@@ -180,7 +183,7 @@ export async function hydrateViewerFromCache(
             // reach is decidable. Refusing outright left resyncing viewers blank.
             const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
             if (cached && snapshotCoversCursor(cached, opts.lastSeq)) {
-                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation, opts.snapshotOverlay);
+                emitSnapshotWithTrailingDeltas(socket, cached, opts.generation, opts.snapshotOverlay, sessionId);
                 return true;
             }
 

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -419,6 +419,34 @@ describe("checkServiceMessageRateLimit", () => {
     });
 });
 
+// ── sendCachedDeltaReplayEvents — sessionId stamp (A2-016) ──────────────────
+
+describe("sendCachedDeltaReplayEvents — sessionId stamp", () => {
+    test("stamps replay envelopes with sessionId when provided", () => {
+        const calls: unknown[][] = [];
+        const socket = { emit: (...args: unknown[]) => { calls.push(args); return true; } } as any;
+
+        sendCachedDeltaReplayEvents(socket, [
+            { seq: 1, event: { type: "text_delta" } },
+        ], 3, "session-A");
+
+        expect(calls.length).toBe(1);
+        expect((calls[0][1] as Record<string, unknown>).sessionId).toBe("session-A");
+    });
+
+    test("omits sessionId when not provided (backward-compat)", () => {
+        const calls: unknown[][] = [];
+        const socket = { emit: (...args: unknown[]) => { calls.push(args); return true; } } as any;
+
+        sendCachedDeltaReplayEvents(socket, [
+            { seq: 1, event: { type: "text_delta" } },
+        ], 3);
+
+        expect(calls.length).toBe(1);
+        expect((calls[0][1] as Record<string, unknown>).sessionId).toBeUndefined();
+    });
+});
+
 describe("runnerLooksLive", () => {
     test("live: isActive with a fresh heartbeat", () => {
         expect(runnerLooksLive({ isActive: true, lastHeartbeatAt: new Date().toISOString() })).toBe(true);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -756,6 +756,13 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("resync", async (data) => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
+            // Capture generation BEFORE any await so we can detect a viewer
+            // switch that happens while Redis reads are in flight. If the
+            // viewer switches from A→B during the await, getCurrentGeneration()
+            // returns B's generation — replaying A's cache with B's generation
+            // passes the client's matchesHydrationGeneration check and corrupts
+            // B's state. Capturing here lets us abort the continuation.
+            const resyncGeneration = getCurrentGeneration();
             // Never answer an in-flight chunk resync with lastState: it is the
             // previous completed checkpoint until server assembly finishes.
             // The client keeps the last good transcript visible and retries on
@@ -775,15 +782,21 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                     getSharedSession(currentSessionId),
                     getSessionSeq(currentSessionId),
                 ]);
+                // Viewer switched sessions while we were awaiting Redis — abort.
+                // Emitting A's cache replay under B's (post-switch) generation
+                // would pass the client's generation guard and corrupt B's state.
+                // The client-side matchesViewerSession guard provides a second
+                // layer of defence via the sessionId stamp on replay envelopes.
+                if (getCurrentGeneration() !== resyncGeneration) return;
                 const cacheHydrated = await hydrateViewerFromCache(socket, currentSessionId, {
                     lastSeq: requestedLastSeq,
-                    generation: getCurrentGeneration(),
+                    generation: resyncGeneration,
                     snapshotOverlay: resyncSession?.snapshotOverlay,
                     latestSessionSeq: resyncSeq,
                 });
                 if (cacheHydrated) {
                     if (resyncStaleStream) {
-                        forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                        forwardRecoverySignalOrNotify(currentSessionId, socket, resyncGeneration);
                     }
                     return;
                 }
@@ -794,7 +807,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 // Reaching here means only unsequenced state is left, which
                 // cannot safely fill the gap — ask the runner for a fresh one.
                 if (requestedLastSeq !== undefined && !resyncChunkedPending) {
-                    forwardRecoverySignalOrNotify(currentSessionId, socket, getCurrentGeneration());
+                    forwardRecoverySignalOrNotify(currentSessionId, socket, resyncGeneration);
                 }
                 return;
             }

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -58,6 +58,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionEnd: noopAsync,
     recordRelaySessionState: noopAsync,
     recordRelaySessionStateSerialized: noopAsync,
+    recordRelaySessionOverlay: noopAsync,
     touchRelaySession: noopAsync,
     updateRelaySessionName: noopAsync,
 }));

--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -24,3 +24,19 @@ describe("Tunnel service-message viewer switch guard", () => {
     expect(handler).not.toMatch(/typeof envelope\.sessionId !== "string"/);
   });
 });
+
+describe("App.tsx wiring — matchesViewerSession applied to resync replay path", () => {
+  const src = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
+
+  test("imports matchesViewerSession from viewer-switch", () => {
+    expect(src).toMatch(/matchesViewerSession/);
+  });
+
+  test("reads sessionId from the viewer event envelope", () => {
+    expect(src).toMatch(/sessionId.*envelopeSessionId|envelopeSessionId.*sessionId/);
+  });
+
+  test("calls matchesViewerSession before processing envelope events", () => {
+    expect(src).toMatch(/matchesViewerSession\(.*activeSessionId.*envelopeSessionId/s);
+  });
+});


### PR DESCRIPTION
Rebase of #818 to resolve merge conflicts with `main`.

Original: fix: abort resync hydration when viewer switches sessions (A2-016)

Changes preserved:
- Server-side resync generation capture and abort if the viewer switches sessions while cache reads are in flight.
- Session ID stamping on cached snapshot/delta replay envelopes.
- Client-side `matchesViewerSession` guard on the resync replay path.

Merged `App.test.tsx` with the existing main-branch switch-guard tests and added wiring assertions for the resync replay path.

Supersedes #818.