### PR TITLE
fix: clean tunnel state on mid-stream HTTP failure (rebase of #808)

### DIFF
--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -765,7 +765,7 @@ describe("tunnel route streaming proxy", () => {
         expect(relayCancelCount).toBe(0);
     });
 
-    test("closes an already-started streaming response cleanly when relay reports a late error", async () => {
+    test("errors an already-started streaming response when relay reports a late error", async () => {
         let callbacks: {
             onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;
             onResponseData: (data: Buffer) => void;
@@ -805,7 +805,8 @@ describe("tunnel route streaming proxy", () => {
         expect(Buffer.from(first.value!).toString("utf8")).toBe("hello");
 
         callbacks!.onError("Tunnel request timed out");
-        await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+        // Stream must be errored (not cleanly closed) so the client sees a broken response.
+        await expect(reader.read()).rejects.toThrow("Tunnel request timed out");
         reader.releaseLock();
     });
 });

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -523,6 +523,16 @@ function proxyTunnelRequestViaRelay(
             }
         };
 
+        const errorStream = (err: unknown): void => {
+            if (streamClosed) return;
+            streamClosed = true;
+            try {
+                streamController?.error(err instanceof Error ? err : new Error(String(err)));
+            } catch {
+                // Stream may already be closed or the client disconnected.
+            }
+        };
+
         const resolveOnce = (response: Response): void => {
             if (resolved) return;
             resolved = true;
@@ -642,12 +652,10 @@ function proxyTunnelRequestViaRelay(
                         return;
                     }
 
-                    // Once a streaming HTTP response has started, we can no
-                    // longer change the status code. Do not error the fetch
-                    // stream: Bun surfaces that as an unhandled server write
-                    // after the response may already be ended. Close the body
-                    // instead so the connection terminates cleanly.
-                    closeStream();
+                    // The response headers are already sent — error the
+                    // ReadableStream so the browser observes a failed/truncated
+                    // response rather than a clean end-of-body.
+                    errorStream(error);
                 },
             },
         );


### PR DESCRIPTION
Clean rebase of #808.

This PR supersedes #808, which was dirty against current `main`. The mid-stream abort behavior in `packages/server/src/routes/tunnel.ts` applied cleanly; the only conflict was in `tunnel.test.ts` with newer regression tests that landed on `main`. I kept both the new main tests and updated the original #808 test to assert that the downstream stream is errored (not cleanly closed).

Changes:
- Error (not clean-close) the downstream `ReadableStream` when the relay reports a late error mid-stream.
- Update regression test to expect a rejected `reader.read()` with the error message.

Closes #808