### PR TITLE
fix: stamp runner service messages per target session (A2-008) [rebase]

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -50,6 +50,7 @@ mock.module("../../sio-registry.js", () => ({
 
 mock.module("../../../sessions/redis.js", () => ({
     appendRelayEventToCache: async () => {},
+    deleteRelayEventCache: async () => {},
 }));
 
 mock.module("./viewer-gate.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -28,6 +28,7 @@ mock.module("../../sio-registry.js", () => ({
         wasDelinked: false,
     }),
     getLocalTuiSocket: () => undefined,
+    getSessionOwnerToken: async () => "tok",
     broadcastToViewers: mockBroadcastToViewers,
     endSharedSession: async () => {},
 }));

--- a/packages/server/src/ws/namespaces/runner.test.ts
+++ b/packages/server/src/ws/namespaces/runner.test.ts
@@ -3,9 +3,9 @@ import { randomUUID } from "node:crypto";
 import {
     MAX_PENDING_REQUESTS,
     cancelRunnerFileRead,
+    forwardServiceMessageToSession,
     isPendingRequestCapReached,
     pendingSocketMatches,
-    stampServiceMessageSession,
 } from "./runner.js";
 
 // NOTE: These tests deliberately import ONLY the pure helpers and do NOT use
@@ -14,23 +14,6 @@ import {
 // those modules for every other test file in the same run (see TODO(ltl2EKmU)),
 // breaking runners.broadcast/terminals suites. Testing the extracted predicates
 // covers the same security-relevant behaviour with zero cross-file bleed.
-
-describe("runner service-message fanout", () => {
-    test("stamps unscoped envelopes for each target viewer session", () => {
-        const envelope = { serviceId: "tunnel", type: "tunnel_registered", payload: {} };
-
-        expect(stampServiceMessageSession(envelope, "session-y")).toEqual({
-            ...envelope,
-            sessionId: "session-y",
-        });
-    });
-
-    test("preserves a runner-provided target session", () => {
-        const envelope = { serviceId: "tunnel", type: "tunnel_registered", sessionId: "session-x", payload: {} };
-
-        expect(stampServiceMessageSession(envelope, "session-y")).toBe(envelope);
-    });
-});
 
 describe("runner namespace pending-request hardening", () => {
     test("request IDs are crypto-random UUID v4", () => {
@@ -69,5 +52,66 @@ describe("runner namespace pending-request hardening", () => {
         cancelRunnerFileRead(socket as any, "list_files", "list-1");
 
         expect(emitted).toEqual([["cancel_file_request", { requestId: "read-1" }]]);
+    });
+});
+
+describe("forwardServiceMessageToSession", () => {
+    test("targeted envelope is cloned and stamped with the destination sessionId", () => {
+        const envelope = { serviceId: "svc", type: "x", payload: { foo: 1 } };
+        const target = "sess-target";
+        const broadcasts: Array<unknown> = [];
+        const relays: Array<unknown> = [];
+
+        forwardServiceMessageToSession(
+            envelope,
+            target,
+            (_sid, _event, data) => broadcasts.push(data),
+            (_sid, _event, data) => relays.push(data),
+        );
+
+        expect(broadcasts).toHaveLength(1);
+        expect(relays).toHaveLength(1);
+        expect(broadcasts[0]).toEqual({ ...envelope, sessionId: target });
+        expect(relays[0]).toEqual({ ...envelope, sessionId: target });
+        expect(broadcasts[0]).not.toBe(envelope);
+        expect(relays[0]).not.toBe(envelope);
+        // Original envelope must remain untouched.
+        expect(envelope).toEqual({ serviceId: "svc", type: "x", payload: { foo: 1 } });
+    });
+
+    test("broadcast recipients each get a distinct envelope stamped with their own sessionId", () => {
+        const envelope = { serviceId: "svc", type: "y", payload: { bar: 2 } };
+        const sessions = ["sess-a", "sess-b"];
+        const calls: Array<{ sessionId: string; kind: "broadcast" | "relay"; data: unknown }> = [];
+
+        for (const sid of sessions) {
+            forwardServiceMessageToSession(
+                envelope,
+                sid,
+                (sessionId, _event, data) => calls.push({ sessionId, kind: "broadcast", data }),
+                (sessionId, _event, data) => calls.push({ sessionId, kind: "relay", data }),
+            );
+        }
+
+        expect(calls).toHaveLength(4);
+        for (const sid of sessions) {
+            const bc = calls.filter((c) => c.kind === "broadcast" && c.sessionId === sid);
+            const rl = calls.filter((c) => c.kind === "relay" && c.sessionId === sid);
+            expect(bc).toHaveLength(1);
+            expect(rl).toHaveLength(1);
+            expect(bc[0].data).toEqual({ ...envelope, sessionId: sid });
+            expect(rl[0].data).toEqual({ ...envelope, sessionId: sid });
+            expect(bc[0].data).not.toBe(envelope);
+            expect(rl[0].data).not.toBe(envelope);
+        }
+
+        // No cross-stamping: the two broadcast envelopes are different objects.
+        const bcA = calls.find((c) => c.kind === "broadcast" && c.sessionId === "sess-a")!.data;
+        const bcB = calls.find((c) => c.kind === "broadcast" && c.sessionId === "sess-b")!.data;
+        expect(bcA).not.toBe(bcB);
+        expect((bcA as any).sessionId).not.toBe((bcB as any).sessionId);
+
+        // Original envelope must remain untouched.
+        expect(envelope).toEqual({ serviceId: "svc", type: "y", payload: { bar: 2 } });
     });
 });

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -55,11 +55,24 @@ import { listRunnerTriggerListeners } from "../../sessions/runner-trigger-listen
 // Using local aliases avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
-type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; sessionId?: string; payload: unknown };
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+type ServiceMessageEnvelope = ServiceEnvelope & { sessionId?: string };
 
-/** Stamp runner-wide messages separately for each session fanout. */
-export function stampServiceMessageSession(envelope: ServiceEnvelope, sessionId: string): ServiceEnvelope {
-    return envelope.sessionId ? envelope : { ...envelope, sessionId };
+/**
+ * Clone a runner-originated service_message envelope and stamp it with the
+ * destination session ID before forwarding. The original envelope is never
+ * mutated, and each recipient receives its own distinct object so cross-session
+ * stamping cannot leak between viewers or relay workers.
+ */
+export function forwardServiceMessageToSession(
+    envelope: ServiceMessageEnvelope,
+    sessionId: string,
+    broadcast: (sessionId: string, event: string, data: unknown) => void,
+    relay: (sessionId: string, event: string, data: unknown) => void,
+): void {
+    const stamped = { ...envelope, sessionId };
+    broadcast(sessionId, "service_message", stamped);
+    relay(sessionId, "service_message", stamped);
 }
 
 // ── Trigger subscription reconciliation ──────────────────────────────────────
@@ -1233,7 +1246,7 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
         // ── Generic service message relay: runner → viewers ──────────────────
         // Forward service envelopes verbatim to all viewers watching sessions
         // on this runner. The relay does not inspect serviceId — it just routes.
-        socket.on("service_message", async (envelope: ServiceEnvelope) => {
+        socket.on("service_message", async (envelope: ServiceMessageEnvelope) => {
             const runnerId = socket.data.runnerId;
             if (!runnerId) return;
             // If envelope carries a sessionId, route only to that session's viewers.
@@ -1257,18 +1270,12 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
                     log.warn(`service_message rejected: session ${targetSessionId} not owned by runner ${runnerId}`);
                     return;
                 }
-                const scopedEnvelope = stampServiceMessageSession(envelope, targetSessionId);
-                broadcastToSessionViewers(targetSessionId, "service_message", scopedEnvelope);
-                // Also route to the session's relay socket (TUI worker) so
-                // agent-initiated service_message requests get their responses.
-                emitToRelaySession(targetSessionId, "service_message", scopedEnvelope);
+                forwardServiceMessageToSession(envelope, targetSessionId, broadcastToSessionViewers, emitToRelaySession);
             } else {
                 const sessionIds = runnerSessionIds.get(runnerId);
                 if (!sessionIds || sessionIds.size === 0) return;
                 for (const sid of sessionIds) {
-                    const scopedEnvelope = stampServiceMessageSession(envelope, sid);
-                    broadcastToSessionViewers(sid, "service_message", scopedEnvelope);
-                    emitToRelaySession(sid, "service_message", scopedEnvelope);
+                    forwardServiceMessageToSession(envelope, sid, broadcastToSessionViewers, emitToRelaySession);
                 }
             }
         });

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -58,6 +58,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionEnd: noopAsync,
     recordRelaySessionState: noopAsync,
     recordRelaySessionStateSerialized: noopAsync,
+    recordRelaySessionOverlay: noopAsync,
     touchRelaySession: noopAsync,
     updateRelaySessionName: noopAsync,
 }));


### PR DESCRIPTION
Rebase of #766 to resolve merge conflicts with `main`.

Original: fix: stamp runner service messages per target session (A2-008)

Merged the conflict with the already-landed `stampServiceMessageSession` helper: replaced it with the PR's `forwardServiceMessageToSession` helper, which clones every envelope and stamps it with the destination session ID before broadcasting and relaying. Removed the now-unused `stampServiceMessageSession` import/tests.

Supersedes #766.