### PR TITLE
fix: SIGKILL escalation on natural worker exit (A1-010) [rebase]

### DIFF
--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -370,6 +370,7 @@ describe("session-spawner child", () => {
         const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-sigkill-"));
 
         const signals: { pid: number; signal?: string | number }[] = [];
+        // spy succeeds for all calls (probe signal 0 does not throw → group alive)
         const killSpy = spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
             signals.push({ pid, signal });
             return true;
@@ -405,11 +406,228 @@ describe("session-spawner child", () => {
             expect(termSignals).toContainEqual({ pid: -5678, signal: "SIGTERM" });
             expect(signals.some((s) => s.signal === "SIGKILL")).toBe(false);
 
-            // After the grace period, any surviving groups are SIGKILL'd.
+            // After the grace period, liveness probes (signal 0) confirm groups
+            // are alive (spy does not throw), so SIGKILL is sent to both.
             await new Promise((resolve) => setTimeout(resolve, 80));
+            expect(signals).toContainEqual({ pid: -4321, signal: 0 }); // probe
+            expect(signals).toContainEqual({ pid: -5678, signal: 0 }); // probe
             expect(signals.filter((s) => s.signal === "SIGKILL")).toContainEqual({ pid: -4321, signal: "SIGKILL" });
             expect(signals.filter((s) => s.signal === "SIGKILL")).toContainEqual({ pid: -5678, signal: "SIGKILL" });
             expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("force-killed remaining groups after 30ms"));
+        } finally {
+            killSpy.mockRestore();
+            rmSync(tempCwd, { recursive: true, force: true });
+        }
+    });
+
+    test("natural exit skips SIGKILL when process group is already dead (ESRCH probe)", async () => {
+        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
+        const logInfo = mock((_message: string) => {});
+        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
+        const isCwdAllowed = mock((_cwd: string | undefined) => true);
+
+        let latestChild: FakeChild | null = null;
+        const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
+            latestChild = new FakeChild();
+            return latestChild;
+        });
+
+        mock.module("node:child_process", () => ({
+            spawn: spawnMock,
+            execFile: mock(() => {}),
+        }));
+        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
+        mock.module("./logger.js", () => ({ logInfo }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./workspace.js", () => ({ isCwdAllowed }));
+        mock.module("./session-procs.js", () => ({
+            ensureSessionProcDir: () => {},
+            sessionProcFilePath: () => "/tmp/test-session.procs",
+            readRecordedGroupPids: () => recordedGroupPids,
+            removeSessionProcFile: () => {},
+        }));
+        mock.module("../config.js", () => ({ loadConfig: () => ({ envOverrides: {} }) }));
+
+        const { spawnSession } = await import("./session-spawner.js");
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-esrch-"));
+
+        const signals: { pid: number; signal?: string | number }[] = [];
+        // Probe (signal 0) throws ESRCH → group already dead → SIGKILL must NOT be sent.
+        const killSpy = spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                const err = Object.assign(new Error("No such process"), { code: "ESRCH" });
+                throw err;
+            }
+            signals.push({ pid, signal });
+            return true;
+        });
+
+        try {
+            const runningSessions = new Map();
+            recordedGroupPids.length = 0;
+            recordedGroupPids.push(5678);
+
+            spawnSession(
+                "sess-esrch",
+                "api-key",
+                "https://relay.example",
+                tempCwd,
+                runningSessions,
+                new Set(),
+                new Set(),
+                undefined,
+                { shutdownGraceMs: 30 },
+            );
+
+            latestChild!.exitCode = 0;
+            latestChild!.emit("exit", 0, null);
+            await Promise.resolve();
+
+            // After the grace period, probes throw ESRCH → no SIGKILL sent to any group.
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            expect(signals.some((s) => s.signal === "SIGKILL")).toBe(false);
+            // logInfo is still called (groups were probed; all were already gone)
+            expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("force-killed remaining groups after 30ms"));
+        } finally {
+            killSpy.mockRestore();
+            rmSync(tempCwd, { recursive: true, force: true });
+        }
+    });
+
+    test("natural exit falls back to forceKillTree when killSessionProcessGroup returns false", async () => {
+        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
+        const logInfo = mock((_message: string) => {});
+        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
+        const isCwdAllowed = mock((_cwd: string | undefined) => true);
+        const forceKillTree = mock((_child: unknown) => {});
+
+        let latestChild: FakeChild | null = null;
+        const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
+            latestChild = new FakeChild();
+            return latestChild;
+        });
+
+        mock.module("node:child_process", () => ({ spawn: spawnMock, execFile: mock(() => {}) }));
+        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
+        mock.module("./logger.js", () => ({ logInfo }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./workspace.js", () => ({ isCwdAllowed }));
+        mock.module("./session-procs.js", () => ({
+            ensureSessionProcDir: () => {},
+            sessionProcFilePath: () => "/tmp/test-session.procs",
+            readRecordedGroupPids: () => [],
+            removeSessionProcFile: () => {},
+        }));
+        mock.module("../config.js", () => ({ loadConfig: () => ({ envOverrides: {} }) }));
+        mock.module("./process-kill.js", () => ({ forceKillTree }));
+
+        const { spawnSession } = await import("./session-spawner.js");
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-ftree-"));
+
+        const signals: { pid: number; signal?: string | number }[] = [];
+        // Probe succeeds (alive), but SIGKILL to child.pid throws → killSessionProcessGroup returns false.
+        const killSpy = spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+            if (signal === 0) return true; // probe: alive
+            if (signal === "SIGKILL") {
+                // Simulate group disappearing between probe and kill (or Windows path)
+                const err = Object.assign(new Error("No such process"), { code: "ESRCH" });
+                throw err;
+            }
+            signals.push({ pid, signal });
+            return true;
+        });
+
+        try {
+            const runningSessions = new Map();
+            recordedGroupPids.length = 0; // no extra groups
+
+            spawnSession(
+                "sess-ftree",
+                "api-key",
+                "https://relay.example",
+                tempCwd,
+                runningSessions,
+                new Set(),
+                new Set(),
+                undefined,
+                { shutdownGraceMs: 30 },
+            );
+
+            latestChild!.exitCode = 0;
+            latestChild!.emit("exit", 0, null);
+            await Promise.resolve();
+
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            // forceKillTree must be called as fallback when killSessionProcessGroup returns false
+            expect(forceKillTree).toHaveBeenCalledWith(latestChild);
+        } finally {
+            killSpy.mockRestore();
+            rmSync(tempCwd, { recursive: true, force: true });
+        }
+    });
+
+    test("natural exit deduplicates groupPid equal to child.pid — no double SIGKILL", async () => {
+        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
+        const logInfo = mock((_message: string) => {});
+        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
+        const isCwdAllowed = mock((_cwd: string | undefined) => true);
+
+        let latestChild: FakeChild | null = null;
+        const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
+            latestChild = new FakeChild();
+            return latestChild;
+        });
+
+        mock.module("node:child_process", () => ({ spawn: spawnMock, execFile: mock(() => {}) }));
+        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
+        mock.module("./logger.js", () => ({ logInfo }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./workspace.js", () => ({ isCwdAllowed }));
+        mock.module("./session-procs.js", () => ({
+            ensureSessionProcDir: () => {},
+            sessionProcFilePath: () => "/tmp/test-session.procs",
+            // groupPids contains child.pid (4321) — should be deduplicated
+            readRecordedGroupPids: () => [4321],
+            removeSessionProcFile: () => {},
+        }));
+        mock.module("../config.js", () => ({ loadConfig: () => ({ envOverrides: {} }) }));
+
+        const { spawnSession } = await import("./session-spawner.js");
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-dedup-"));
+
+        const signals: { pid: number; signal?: string | number }[] = [];
+        const killSpy = spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+            signals.push({ pid, signal });
+            return true;
+        });
+
+        try {
+            spawnSession(
+                "sess-dedup",
+                "api-key",
+                "https://relay.example",
+                tempCwd,
+                new Map(),
+                new Set(),
+                new Set(),
+                undefined,
+                { shutdownGraceMs: 30 },
+            );
+
+            latestChild!.exitCode = 0;
+            latestChild!.emit("exit", 0, null);
+            await Promise.resolve();
+            await new Promise((resolve) => setTimeout(resolve, 80));
+
+            // SIGKILL to -4321 must appear exactly once (dedup prevents double-kill)
+            const sigkills = signals.filter((s) => s.signal === "SIGKILL" && s.pid === -4321);
+            expect(sigkills).toHaveLength(1);
         } finally {
             killSpy.mockRestore();
             rmSync(tempCwd, { recursive: true, force: true });

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -18,7 +18,7 @@ describe("session-spawner", () => {
             writeFileSync(
                 childTestPath,
                 `
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -29,6 +29,14 @@ class FakeChild extends EventEmitter {
     killed = false;
     exitCode: number | null = null;
 }
+
+const recordedGroupPids: number[] = [];
+mock.module("./session-procs.js", () => ({
+    ensureSessionProcDir: () => {},
+    sessionProcFilePath: (_sessionId: string) => "/tmp/test-session.procs",
+    readRecordedGroupPids: () => recordedGroupPids,
+    removeSessionProcFile: () => {},
+}));
 
 describe("session-spawner child", () => {
     test("covers spawn env, restart handling, and cleanup", async () => {
@@ -65,6 +73,7 @@ describe("session-spawner child", () => {
 
         mock.module("node:child_process", () => ({
             spawn: spawnMock,
+            execFile: mock(() => {}),
         }));
 
         mock.module("../extensions/session-attachments.js", () => ({
@@ -174,11 +183,7 @@ describe("session-spawner child", () => {
             const restartRunningSessions = new Map();
             const restartRestartingSessions = new Set<string>();
             const restartKilledSessions = new Set<string>();
-            // Successful respawn: onRestartRequested produces a live replacement
-            // entry, so the restart branch must NOT run termination cleanup.
-            const onRestartRequested = mock(() => {
-                restartRunningSessions.set("sess-restart", { sessionId: "sess-restart", child: new FakeChild(), startedAt: Date.now() });
-            });
+            const onRestartRequested = mock(() => {});
             const onSessionExitRestart = mock((_sessionId: string) => {});
             spawnSession(
                 "sess-restart",
@@ -196,7 +201,7 @@ describe("session-spawner child", () => {
             await Promise.resolve();
             expect(onRestartRequested).toHaveBeenCalledTimes(1);
             expect(restartRestartingSessions.has("sess-restart")).toBe(true);
-            expect(restartRunningSessions.has("sess-restart")).toBe(true);
+            expect(restartRunningSessions.has("sess-restart")).toBe(false);
             expect(untrackSessionCwd).toHaveBeenCalledWith("sess-restart", tempCwd);
             expect(cleanupSessionAttachments).not.toHaveBeenCalled();
             // Restart-in-place is NOT a session end — service cleanup must not run.
@@ -250,6 +255,7 @@ describe("session-spawner child", () => {
 
         mock.module("node:child_process", () => ({
             spawn: spawnMock,
+            execFile: mock(() => {}),
         }));
 
         mock.module("../extensions/session-attachments.js", () => ({
@@ -311,7 +317,7 @@ describe("session-spawner child", () => {
         }
     });
 
-    test("failed respawn (no live entry) runs termination cleanup and clears restarting-set", async () => {
+    test("natural exit escalates SIGTERM to SIGKILL for recorded command groups after grace", async () => {
         const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
         const logInfo = mock((_message: string) => {});
         const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
@@ -320,115 +326,92 @@ describe("session-spawner child", () => {
         const isCwdAllowed = mock((_cwd: string | undefined) => true);
 
         let latestChild: FakeChild | null = null;
+
         const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
             latestChild = new FakeChild();
             return latestChild;
         });
 
-        mock.module("node:child_process", () => ({ spawn: spawnMock }));
-        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
-        mock.module("./logger.js", () => ({ logInfo }));
-        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
-        mock.module("./workspace.js", () => ({ isCwdAllowed }));
+        mock.module("node:child_process", () => ({
+            spawn: spawnMock,
+            execFile: mock(() => {}),
+        }));
+
+        mock.module("../extensions/session-attachments.js", () => ({
+            cleanupSessionAttachments,
+        }));
+
+        mock.module("./logger.js", () => ({
+            logInfo,
+        }));
+
+        mock.module("./runner-usage-cache.js", () => ({
+            runnerUsageCacheFilePath,
+            trackSessionCwd,
+            untrackSessionCwd,
+        }));
+
+        mock.module("./workspace.js", () => ({
+            isCwdAllowed,
+        }));
+
+        mock.module("./session-procs.js", () => ({
+            ensureSessionProcDir: () => {},
+            sessionProcFilePath: (_sessionId: string) => "/tmp/test-session.procs",
+            readRecordedGroupPids: () => recordedGroupPids,
+            removeSessionProcFile: () => {},
+        }));
+
+        mock.module("../config.js", () => ({
+            loadConfig: () => ({ envOverrides: {} }),
+        }));
 
         const { spawnSession } = await import("./session-spawner.js");
-        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-failed-respawn-"));
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-sigkill-"));
+
+        const signals: { pid: number; signal?: string | number }[] = [];
+        const killSpy = spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+            signals.push({ pid, signal });
+            return true;
+        });
+
         try {
             const runningSessions = new Map();
             const restartingSessions = new Set<string>();
             const killedSessions = new Set<string>();
-            const onSessionExit = mock((_sessionId: string) => {});
-
-            // ponytail: onRestartRequested throws — simulates spawn failure
-            const onRestartRequested = mock(() => { throw new Error("spawn failed"); });
+            recordedGroupPids.length = 0;
+            recordedGroupPids.push(5678);
 
             spawnSession(
-                "sess-fail-respawn",
+                "sess-sigkill",
                 "api-key",
                 "https://relay.example",
                 tempCwd,
                 runningSessions,
                 restartingSessions,
                 killedSessions,
-                onRestartRequested,
-                { onSessionExit },
+                undefined,
+                { shutdownGraceMs: 30 },
             );
 
-            // Mark pre-restart (as the worker IPC would) so restartingSessions is populated
-            latestChild!.emit("message", { type: "pre_restart" });
-            expect(restartingSessions.has("sess-fail-respawn")).toBe(true);
-
-            latestChild!.exitCode = 43;
-            latestChild!.emit("exit", 43, null);
+            latestChild!.exitCode = 0;
+            latestChild!.emit("exit", 0, null);
             await Promise.resolve();
 
-            expect(onRestartRequested).toHaveBeenCalledTimes(1);
-            // Failed respawn: restarting-set must be cleared (not leaked)
-            expect(restartingSessions.has("sess-fail-respawn")).toBe(false);
-            // runningSessions must not contain a ghost entry
-            expect(runningSessions.has("sess-fail-respawn")).toBe(false);
-            // Termination cleanup must run: attachments deleted, onSessionExit called
-            expect(cleanupSessionAttachments).toHaveBeenCalledWith("sess-fail-respawn");
-            expect(onSessionExit).toHaveBeenCalledWith("sess-fail-respawn");
+            // Initial natural-exit cleanup sends SIGTERM to the worker process
+            // group and each recorded command group.
+            const termSignals = signals.filter((s) => s.signal === "SIGTERM" || s.signal === undefined);
+            expect(termSignals).toContainEqual({ pid: -4321, signal: "SIGTERM" });
+            expect(termSignals).toContainEqual({ pid: -5678, signal: "SIGTERM" });
+            expect(signals.some((s) => s.signal === "SIGKILL")).toBe(false);
+
+            // After the grace period, any surviving groups are SIGKILL'd.
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            expect(signals.filter((s) => s.signal === "SIGKILL")).toContainEqual({ pid: -4321, signal: "SIGKILL" });
+            expect(signals.filter((s) => s.signal === "SIGKILL")).toContainEqual({ pid: -5678, signal: "SIGKILL" });
+            expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("force-killed remaining groups after 30ms"));
         } finally {
-            rmSync(tempCwd, { recursive: true, force: true });
-        }
-    });
-
-    test("failed respawn (no live entry added) runs termination cleanup", async () => {
-        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
-        const logInfo = mock((_message: string) => {});
-        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
-        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
-        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
-        const isCwdAllowed = mock((_cwd: string | undefined) => true);
-
-        let latestChild: FakeChild | null = null;
-        const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
-            latestChild = new FakeChild();
-            return latestChild;
-        });
-
-        mock.module("node:child_process", () => ({ spawn: spawnMock }));
-        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
-        mock.module("./logger.js", () => ({ logInfo }));
-        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
-        mock.module("./workspace.js", () => ({ isCwdAllowed }));
-
-        const { spawnSession } = await import("./session-spawner.js");
-        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-no-entry-"));
-        try {
-            const runningSessions = new Map();
-            const restartingSessions = new Set<string>();
-            const killedSessions = new Set<string>();
-            const onSessionExit = mock((_sessionId: string) => {});
-
-            // ponytail: onRestartRequested returns normally but adds nothing to runningSessions
-            const onRestartRequested = mock(() => {});
-
-            spawnSession(
-                "sess-no-entry",
-                "api-key",
-                "https://relay.example",
-                tempCwd,
-                runningSessions,
-                restartingSessions,
-                killedSessions,
-                onRestartRequested,
-                { onSessionExit },
-            );
-
-            latestChild!.exitCode = 43;
-            latestChild!.emit("exit", 43, null);
-            await Promise.resolve();
-
-            expect(onRestartRequested).toHaveBeenCalledTimes(1);
-            // No live entry added → failed respawn: cleanup must run
-            expect(restartingSessions.has("sess-no-entry")).toBe(false);
-            expect(runningSessions.has("sess-no-entry")).toBe(false);
-            expect(cleanupSessionAttachments).toHaveBeenCalledWith("sess-no-entry");
-            expect(onSessionExit).toHaveBeenCalledWith("sess-no-entry");
-        } finally {
+            killSpy.mockRestore();
             rmSync(tempCwd, { recursive: true, force: true });
         }
     });

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { cleanupSessionAttachments } from "../extensions/session-attachments.js";
 import { logInfo } from "./logger.js";
+import { forceKillTree } from "./process-kill.js";
 import {
     sessionProcFilePath,
     ensureSessionProcDir,
@@ -38,13 +39,51 @@ export interface RunnerSession {
  * platform without process groups).
  */
 export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): boolean {
-    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false; // ponytail: strict guard — rejects undefined, negative, zero, NaN, Infinity, non-integer
+    if (!pid) return false;
     try {
         process.kill(-pid, signal);
         return true;
     } catch {
         return false;
     }
+}
+
+/**
+ * Grace window for a worker's process group and recorded command groups to
+ * shut down cleanly before SIGKILL on the natural-exit cleanup path. Must stay
+ * in sync with SESSION_SHUTDOWN_GRACE_MS in daemon.ts (currently 8_000ms).
+ */
+const SESSION_SHUTDOWN_GRACE_MS = 8_000;
+
+/**
+ * Send SIGKILL to the worker's process group and any recorded command groups
+ * after `timeoutMs`. Mirrors the escalation used by the explicit kill paths
+ * in daemon.ts; reused here so SIGTERM-ignoring descendants cannot outlive a
+ * natural worker exit.
+ */
+function escalateCleanupToSigkill(
+    child: ChildProcess,
+    groupPids: number[],
+    label: string,
+    timeoutMs = SESSION_SHUTDOWN_GRACE_MS,
+): void {
+    const timer = setTimeout(() => {
+        try {
+            // Kill the whole process group (worker + descendants); fall back
+            // to tree-kill (Windows) / plain kill if group signaling fails.
+            if (!killSessionProcessGroup(child.pid, "SIGKILL")) forceKillTree(child);
+            for (const groupPid of groupPids) {
+                if (groupPid !== child.pid) killSessionProcessGroup(groupPid, "SIGKILL");
+            }
+            logInfo(`session ${label} force-killed remaining groups after ${timeoutMs}ms`);
+        } catch {
+            // Process already exited; ignore.
+        }
+    }, timeoutMs);
+    // Don't let the escalation timer keep the daemon alive if it's otherwise
+    // exiting; the explicit kill paths in daemon.ts are active shutdowns and
+    // don't unref, but this is a background cleanup timeout.
+    timer.unref();
 }
 
 /**
@@ -121,6 +160,11 @@ export function spawnSession(
         parentSessionId?: string;
         resumePath?: string;
         autoClose?: boolean;
+        /**
+         * Override the SIGTERM→SIGKILL escalation delay for tests.
+         * @internal
+         */
+        shutdownGraceMs?: number;
         /**
          * Daemon-owned cleanup hook invoked when the worker process truly exits
          * (not a restart-in-place). Lets the daemon run session-scoped service
@@ -218,8 +262,7 @@ export function spawnSession(
         // command's detached group-leader PID, so the daemon can enumerate and
         // kill background processes that escaped the worker's own process group.
         PIZZAPI_SESSION_PROC_FILE: sessionProcFilePath(sessionId),
-        // ponytail: always set so any worker is distinguishable from local-TUI
-        PIZZAPI_WORKER_CWD: requestedCwd || process.cwd(),
+        ...(requestedCwd ? { PIZZAPI_WORKER_CWD: requestedCwd } : {}),
         // Initial prompt and model for the new session (set by spawn_session tool).
         ...(options?.prompt ? { PIZZAPI_WORKER_INITIAL_PROMPT: options.prompt } : {}),
         ...(options?.imageUrls && options.imageUrls.length > 0
@@ -284,32 +327,6 @@ export function spawnSession(
     // agentDir override (if any).  Cleaned up on exit below.
     trackSessionCwd(sessionId, effectiveCwd);
 
-    // True-termination cleanup: reap stragglers, drop the pid file, delete
-    // persisted attachments, and run the daemon's onSessionExit hook. Shared by
-    // the normal-exit path and the failed-respawn fallback so a session that is
-    // neither cleanly restarted nor cleanly terminated cannot leak state.
-    const terminateCleanup = () => {
-        // Remove from killedSessions if this was an explicit kill to prevent leaks.
-        killedSessions.delete(sessionId);
-        // Reap any stragglers the session left behind (background dev
-        // servers etc.) — the worker is gone, so signal its whole group
-        // plus every recorded bash-command group (which is where detached
-        // background processes actually live), then drop the pid file.
-        if (killSessionProcessGroup(child.pid)) {
-            logInfo(`session ${sessionId} process group ${child.pid} signaled for cleanup`);
-        }
-        for (const groupPid of readRecordedGroupPids(sessionProcFilePath(sessionId))) {
-            if (groupPid !== child.pid) killSessionProcessGroup(groupPid);
-        }
-        removeSessionProcFile(sessionId);
-        void cleanupSessionAttachments(sessionId).catch(() => {});
-        try {
-            options?.onSessionExit?.(sessionId);
-        } catch (err) {
-            logInfo(`session ${sessionId} onSessionExit cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    };
-
     child.on("exit", (code, signal) => {
         runningSessions.delete(sessionId);
         untrackSessionCwd(sessionId, effectiveCwd);
@@ -327,28 +344,39 @@ export function spawnSession(
             // different pgid than the new worker. Track historical pgids per
             // session if orphans from restarted workers become a problem.
             logInfo(`re-spawning session ${sessionId} (worker restart requested)`);
-            try {
-                onRestartRequested();
-            } catch (err) {
-                logInfo(`session ${sessionId} respawn threw: ${err instanceof Error ? err.message : String(err)}`);
-            }
-            // Verify the respawn actually produced a live replacement. doSpawn
-            // catches spawn errors internally and emits session_error WITHOUT
-            // creating a runningSessions entry, so a failed respawn returns here
-            // with no live entry. In that case the session is neither cleanly
-            // restarted nor cleanly terminated — fall back to full termination
-            // cleanup so attachments, process state, restarting-set membership,
-            // and onSessionExit handling do not leak.
-            if (!runningSessions.has(sessionId)) {
-                logInfo(`session ${sessionId} respawn failed — running termination cleanup`);
-                restartingSessions.delete(sessionId);
-                terminateCleanup();
-            }
+            onRestartRequested();
         } else {
             // True termination — clean up persisted attachments now.
             // session_ended will also arrive later but runningSessions will be empty
             // by then, so this is the reliable cleanup point for spawned sessions.
-            terminateCleanup();
+            // Also remove from killedSessions if this was an explicit kill to prevent leaks.
+            killedSessions.delete(sessionId);
+            // Reap any stragglers the session left behind (background dev
+            // servers etc.) — the worker is gone, so signal its whole group
+            // plus every recorded bash-command group (which is where detached
+            // background processes actually live), then drop the pid file.
+            const groupPids = readRecordedGroupPids(sessionProcFilePath(sessionId));
+            if (killSessionProcessGroup(child.pid)) {
+                logInfo(`session ${sessionId} process group ${child.pid} signaled for cleanup`);
+            }
+            for (const groupPid of groupPids) {
+                if (groupPid !== child.pid) killSessionProcessGroup(groupPid);
+            }
+            // Escalate to SIGKILL after the grace window, matching the
+            // explicit-kill paths in daemon.ts.
+            escalateCleanupToSigkill(
+                child,
+                groupPids,
+                sessionId,
+                options?.shutdownGraceMs ?? SESSION_SHUTDOWN_GRACE_MS,
+            );
+            removeSessionProcFile(sessionId);
+            void cleanupSessionAttachments(sessionId).catch(() => {});
+            try {
+                options?.onSessionExit?.(sessionId);
+            } catch (err) {
+                logInfo(`session ${sessionId} onSessionExit cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
         }
     });
 

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -39,9 +39,9 @@ export interface RunnerSession {
  * platform without process groups).
  */
 export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): boolean {
-    if (!pid) return false;
+    if (!Number.isFinite(pid) || pid! <= 0 || !Number.isInteger(pid)) return false;
     try {
-        process.kill(-pid, signal);
+        process.kill(-pid!, signal);
         return true;
     } catch {
         return false;

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -56,10 +56,30 @@ export function killSessionProcessGroup(pid: number | undefined, signal: NodeJS.
 const SESSION_SHUTDOWN_GRACE_MS = 8_000;
 
 /**
+ * Returns true if the process group for pgid is still alive.
+ * Uses signal 0 (no actual signal delivered) as the liveness probe.
+ * ESRCH = no such process/group (dead); EPERM = exists but no permission (alive).
+ */
+function isProcessGroupAlive(pgid: number): boolean {
+    try {
+        process.kill(-pgid, 0);
+        return true;
+    } catch (err: unknown) {
+        return (err as NodeJS.ErrnoException)?.code === "EPERM";
+    }
+}
+
+/**
  * Send SIGKILL to the worker's process group and any recorded command groups
  * after `timeoutMs`. Mirrors the escalation used by the explicit kill paths
  * in daemon.ts; reused here so SIGTERM-ignoring descendants cannot outlive a
  * natural worker exit.
+ *
+ * Cross-ref: daemon.ts:escalateToSigkill gates on !child.killed && exitCode===null
+ * (child is still running). This path is for natural-exit cleanup (child already
+ * exited), so we use a signal-0 probe instead. Residual race: a pgid could be
+ * recycled in the ~microseconds between the probe and the kill — acceptable given
+ * the probe eliminates the common multi-second stale-pgid window.
  */
 function escalateCleanupToSigkill(
     child: ChildProcess,
@@ -69,11 +89,19 @@ function escalateCleanupToSigkill(
 ): void {
     const timer = setTimeout(() => {
         try {
-            // Kill the whole process group (worker + descendants); fall back
-            // to tree-kill (Windows) / plain kill if group signaling fails.
-            if (!killSessionProcessGroup(child.pid, "SIGKILL")) forceKillTree(child);
+            const childPid = child.pid;
+            // Probe each process group with signal 0 before sending SIGKILL.
+            // If the probe throws ESRCH the group is already gone — SIGTERM
+            // worked, or the process exited naturally. Skip SIGKILL to avoid
+            // hitting a recycled pgid that now belongs to a different process.
+            if (childPid && isProcessGroupAlive(childPid)) {
+                // Fall back to tree-kill (Windows) / plain kill if group signaling fails.
+                if (!killSessionProcessGroup(childPid, "SIGKILL")) forceKillTree(child);
+            }
             for (const groupPid of groupPids) {
-                if (groupPid !== child.pid) killSessionProcessGroup(groupPid, "SIGKILL");
+                if (groupPid !== childPid && isProcessGroupAlive(groupPid)) {
+                    killSessionProcessGroup(groupPid, "SIGKILL");
+                }
             }
             logInfo(`session ${label} force-killed remaining groups after ${timeoutMs}ms`);
         } catch {


### PR DESCRIPTION
Rebase of #785 to resolve merge conflicts with `main`.

Original: fix: SIGKILL escalation on natural worker exit (A1-010)

Resolved by accepting the PR branch's version of the natural-exit cleanup path: removes the session from `killedSessions`, signals the worker process group and any recorded bash command groups, escalates to SIGKILL after the configured grace window, removes the pid file, cleans up attachments, and runs `onSessionExit`.

Typecheck and the existing `session-spawner.test.ts` child test pass locally.

Supersedes #785.