### PR TITLE
fix: clean tunnel state on request-id collision (rebase of #807)

### DIFF
--- a/packages/server/src/routes/tunnel-ws.ts
+++ b/packages/server/src/routes/tunnel-ws.ts
@@ -288,7 +288,7 @@ async function handleUpgradeAsync(
         forwardHeaders[key] = Array.isArray(value) ? value.join(", ") : value;
     }
 
-    const tunnelWsId = `tws-${sessionId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tunnelWsId = crypto.randomUUID();
     let viewerWs: NodeWebSocket | null = null;
     let closingFromRelay = false;
     let handshakeComplete = false;
@@ -474,7 +474,7 @@ async function handleRunnerUpgradeAsync(
         forwardHeaders[key] = Array.isArray(value) ? value.join(", ") : value;
     }
 
-    const tunnelWsId = `tws-runner-${runnerId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tunnelWsId = crypto.randomUUID();
     let viewerWs: NodeWebSocket | null = null;
     let closingFromRelay = false;
     let handshakeComplete = false;

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -796,7 +796,7 @@ async function handleAuthTunnel(req: Request, url: URL, match: RegExpMatchArray)
         return tunnelErrorResponse(`Runner ${runnerId} not connected`);
     }
 
-    const requestId = `auth-${sessionId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const requestId = crypto.randomUUID();
     return proxyTunnelRequestViaRelay(
         req,
         relay,
@@ -917,7 +917,7 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
     });
 
     // ── Build requestId and proxy the request ────────────────────────────────
-    const requestId = `${sessionId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const requestId = crypto.randomUUID();
 
     const relay = getTunnelRelay();
     if (!relay?.hasRunner(runnerId)) {
@@ -1016,7 +1016,7 @@ async function handleRunnerTunnel(req: Request, url: URL, match: RegExpMatchArra
         return tunnelErrorResponse(`Runner ${runnerId} not connected`);
     }
 
-    const requestId = `runner-${runnerId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const requestId = crypto.randomUUID();
 
     return proxyTunnelRequestViaRelay(
         req,

--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -116,6 +116,68 @@ describe("TunnelClient", () => {
     expect(ended).toBe(true);
   });
 
+  test("evicts a reused HTTP id by aborting and destroying the old request", () => {
+    const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel" });
+    const controller = new AbortController();
+    let destroyed = false;
+    const old = { controller, req: { destroy() { destroyed = true; } } };
+    const replacement = { controller: new AbortController(), req: { destroy() {} } };
+
+    (client as any).activeRequests.set("reused", old);
+    (client as any).replaceActiveRequest("reused", replacement);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(destroyed).toBe(true);
+    expect((client as any).activeRequests.get("reused")).toBe(replacement);
+  });
+
+  test("evicts a reused WebSocket id by closing the old connection", () => {
+    const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel" });
+    let closed = false;
+    const old = { close() { closed = true; } } as unknown as WebSocket;
+    const replacement = { close() {} } as unknown as WebSocket;
+
+    (client as any).activeWs.set("reused", old);
+    (client as any).replaceActiveWs("reused", replacement);
+
+    expect(closed).toBe(true);
+    expect((client as any).activeWs.get("reused")).toBe(replacement);
+  });
+
+  test("ignores stale WebSocket open and data events after an id collision", () => {
+    const OriginalWebSocket = globalThis.WebSocket;
+    class FakeWebSocket {
+      static OPEN = 1;
+      readyState = FakeWebSocket.OPEN;
+      protocol = "";
+      binaryType = "";
+      private listeners = new Map<string, Array<(event: any) => void>>();
+      static instances: FakeWebSocket[] = [];
+      constructor() { FakeWebSocket.instances.push(this); }
+      addEventListener(type: string, listener: (event: any) => void) {
+        this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+      }
+      close() { this.readyState = 3; }
+      emit(type: string, event: any = {}) { for (const listener of this.listeners.get(type) ?? []) listener(event); }
+    }
+
+    try {
+      (globalThis as any).WebSocket = FakeWebSocket;
+      const client = new TunnelClient({ runnerId: "r1", apiKey: "key1", relayUrl: "ws://localhost:9999/_tunnel" });
+      const sent = attachMockRelay(client);
+      (client as any).exposedPorts.add(3000);
+      (client as any).handleWsOpen({ id: "reused", port: 3000, path: "/", headers: {} });
+      (client as any).handleWsOpen({ id: "reused", port: 3000, path: "/", headers: {} });
+
+      FakeWebSocket.instances[0].emit("open");
+      FakeWebSocket.instances[0].emit("message", { data: "stale" });
+
+      expect(decodeSent(sent)).toEqual([]);
+    } finally {
+      (globalThis as any).WebSocket = OriginalWebSocket;
+    }
+  });
+
   test("returns 404 for requests to unexposed ports", () => {
     const client = new TunnelClient({
       runnerId: "r1",

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -67,6 +67,15 @@ const HOP_BY_HOP = new Set([
 const STRIP_AUTH = new Set(["cookie", "authorization", "x-api-key"]);
 
 type LoopbackHost = "127.0.0.1" | "[::1]";
+type ActiveRequest = {
+  controller: AbortController;
+  req: http.ClientRequest;
+  /** Body chunks buffered for loopback retry replay; null once connected or over limit. */
+  bodyChunks: Buffer[] | null;
+  bodyBytes: number;
+  bodyEnded: boolean;
+  responseStarted: boolean;
+};
 
 function otherLoopback(host: LoopbackHost): LoopbackHost {
   return host === "127.0.0.1" ? "[::1]" : "127.0.0.1";
@@ -153,18 +162,7 @@ export class TunnelClient extends EventEmitter {
   private connectionStartedAt = 0;
 
   /** Active HTTP requests: requestId → { controller, req } */
-  private activeRequests = new Map<
-    string,
-    {
-      controller: AbortController;
-      req: http.ClientRequest;
-      /** Body chunks buffered for loopback retry replay; null once connected or over limit. */
-      bodyChunks: Buffer[] | null;
-      bodyBytes: number;
-      bodyEnded: boolean;
-      responseStarted: boolean;
-    }
-  >();
+  private activeRequests = new Map<string, ActiveRequest>();
   /**
    * ponytail: on Windows `localhost` often resolves to ::1 first, so local dev
    * servers can be IPv6-only and 127.0.0.1 gets ECONNREFUSED. We retry the
@@ -470,15 +468,6 @@ export class TunnelClient extends EventEmitter {
   private handleRequestStart(msg: TunnelRequestStartMessage): void {
     const { id, port, method, url: requestUrl, headers, preserveAuth, host: tunnelHost } = msg;
 
-    // Guard against request-id reuse: abort and destroy any in-flight request
-    // sharing the same id before registering the new one.
-    const stale = this.activeRequests.get(id);
-    if (stale) {
-      stale.controller.abort();
-      stale.req.destroy();
-      this.activeRequests.delete(id);
-    }
-
     if (!this.exposedPorts.has(port)) {
       this.log.warn("[tunnel-client] Request for unexposed port", port);
       this.send({ type: "response-start", id, statusCode: 404, statusMessage: "Not Found", headers: {} });
@@ -525,6 +514,7 @@ export class TunnelClient extends EventEmitter {
     forwardHeaders.host = tunnelHost ?? `127.0.0.1:${port}`;
 
     const controller = new AbortController();
+    let active!: ActiveRequest;
     const attempt = (hostname: LoopbackHost, canRetry: boolean): http.ClientRequest => {
     const target = new URL(parsed.toString());
     target.hostname = hostname;
@@ -539,17 +529,12 @@ export class TunnelClient extends EventEmitter {
         ...(useTls ? { rejectUnauthorized: false } : {}),
       },
       (response) => {
-        const requestIsActive = (): boolean => {
-          const active = this.activeRequests.get(id);
-          return active?.req === req && !controller.signal.aborted;
-        };
         let responseStarted = false;
         let responseSettled = false;
         const finalizeResponse = (error?: Error): void => {
           if (responseSettled) return;
           responseSettled = true;
-          const active = this.activeRequests.get(id);
-          if (!active || active.req !== req || controller.signal.aborted) return;
+          if (this.activeRequests.get(id) !== active || controller.signal.aborted) return;
           this.activeRequests.delete(id);
           if (!responseStarted && error) {
             this.send({ type: "response-start", id, statusCode: 502, statusMessage: "Bad Gateway", headers: {} });
@@ -558,16 +543,13 @@ export class TunnelClient extends EventEmitter {
           this.send({ type: "response-data-end", id });
         };
 
-        if (!requestIsActive()) {
+        if (this.activeRequests.get(id) !== active) {
           response.destroy();
           return;
         }
         this.loopbackHost.set(port, hostname);
-        const active = this.activeRequests.get(id);
-        if (active) {
-          active.bodyChunks = null; // connected — replay buffer no longer needed
-          active.responseStarted = true;
-        }
+        active.bodyChunks = null; // connected — replay buffer no longer needed
+        active.responseStarted = true;
         const responseHeaders: Record<string, string | string[]> = {};
         for (const [key, value] of Object.entries(response.headers)) {
           if (value === undefined) continue;
@@ -588,12 +570,12 @@ export class TunnelClient extends EventEmitter {
         });
 
         response.on("data", (chunk: Buffer) => {
-          if (!requestIsActive() || responseSettled) return;
+          if (this.activeRequests.get(id) !== active || responseSettled) return;
           this.send({ type: "response-data", id, data: chunk.toString("binary") });
         });
 
         response.on("end", () => {
-          if (!requestIsActive()) return;
+          if (this.activeRequests.get(id) !== active) return;
           finalizeResponse();
         });
         response.on("error", (error) => finalizeResponse(error instanceof Error ? error : new Error(String(error))));
@@ -610,8 +592,7 @@ export class TunnelClient extends EventEmitter {
     );
 
     req.on("error", (error) => {
-      const active = this.activeRequests.get(id);
-      if (!active || active.req !== req || controller.signal.aborted) return;
+      if (this.activeRequests.get(id) !== active || controller.signal.aborted) return;
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ABORT_ERR") {
         this.activeRequests.delete(id);
@@ -654,7 +635,8 @@ export class TunnelClient extends EventEmitter {
     };
 
     const req = attempt(this.loopbackHost.get(port) ?? "127.0.0.1", true);
-    this.activeRequests.set(id, { controller, req, bodyChunks: [], bodyBytes: 0, bodyEnded: false, responseStarted: false });
+    active = { controller, req, bodyChunks: [], bodyBytes: 0, bodyEnded: false, responseStarted: false };
+    this.replaceActiveRequest(id, active);
   }
 
   private handleRequestData(msg: TunnelRequestDataMessage): void {
@@ -746,16 +728,18 @@ export class TunnelClient extends EventEmitter {
         ...(wsUseTls ? { tls: { rejectUnauthorized: false } } : {}),
       });
 
-      this.activeWs.set(id, ws);
+      this.replaceActiveWs(id, ws);
       ws.binaryType = "arraybuffer";
 
       ws.addEventListener("open", () => {
+        if (this.activeWs.get(id) !== ws) return;
         opened = true;
         this.loopbackHost.set(port, hostname);
         this.send({ type: "ws-opened", id, protocol: ws.protocol || undefined });
       });
 
       ws.addEventListener("message", (event: MessageEvent) => {
+        if (this.activeWs.get(id) !== ws) return;
         const data = event.data;
         const isBinary = data instanceof ArrayBuffer || ArrayBuffer.isView(data);
         this.send({
@@ -822,6 +806,29 @@ export class TunnelClient extends EventEmitter {
     } catch {
       // ignore close errors
     }
+  }
+
+  private replaceActiveRequest(id: string, active: ActiveRequest): void {
+    const old = this.activeRequests.get(id);
+    if (old) {
+      this.activeRequests.delete(id);
+      old.controller.abort();
+      old.req.destroy();
+    }
+    this.activeRequests.set(id, active);
+  }
+
+  private replaceActiveWs(id: string, ws: WebSocket): void {
+    const old = this.activeWs.get(id);
+    if (old) {
+      this.activeWs.delete(id);
+      try {
+        old.close(1001, "tunnel request replaced");
+      } catch {
+        // ignore close errors
+      }
+    }
+    this.activeWs.set(id, ws);
   }
 
   private cleanup(): void {

--- a/packages/tunnel/src/server.test.ts
+++ b/packages/tunnel/src/server.test.ts
@@ -282,6 +282,31 @@ describe("TunnelRelay HTTP proxy callbacks", () => {
     expect(JSON.parse(mockWs.sent.at(-1)!)).toMatchObject({ type: "request-end", id: "req-timeout" });
   });
 
+  test("evicts a reused request id without letting its timeout remove the replacement", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", { data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }) });
+    await waitForMicrotask();
+
+    const events: string[] = [];
+    const callbacks = (label: string) => ({
+      onResponseStart() { events.push(`${label}:start`); },
+      onResponseData() {},
+      onResponseEnd() { events.push(`${label}:end`); },
+      onError(error: string) { events.push(`${label}:error:${error}`); },
+    });
+    const oldProxy = relay.proxyHttpRequest("r1", { id: "reused", port: 3000, method: "GET", url: "/", headers: {} }, callbacks("old"), 5);
+    relay.proxyHttpRequest("r1", { id: "reused", port: 3000, method: "GET", url: "/", headers: {} }, callbacks("new"), 100);
+    oldProxy.cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    mockWs.emit("message", { data: JSON.stringify({ type: "response-start", id: "reused", statusCode: 200, statusMessage: "OK", headers: {} }) });
+    mockWs.emit("message", { data: JSON.stringify({ type: "response-data-end", id: "reused" }) });
+
+    expect(events).toEqual(["old:error:Tunnel request replaced", "new:start", "new:end"]);
+  });
+
   test("does not time out long-lived streams after response headers arrive", async () => {
     const relay = new TunnelRelay({ apiKeys: ["key1"] });
     const mockWs = createMockWebSocket();
@@ -333,6 +358,28 @@ describe("TunnelRelay HTTP proxy callbacks", () => {
     await waitForMicrotask();
 
     expect(events).toEqual(["start", "data", "end"]);
+  });
+
+  test("ignores response frames from a different runner", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const runnerA = createMockWebSocket();
+    const runnerB = createMockWebSocket();
+    relay.handleConnection(runnerA.ws);
+    relay.handleConnection(runnerB.ws);
+    runnerA.emit("message", { data: JSON.stringify({ type: "register", runnerId: "runner-a", apiKey: "key1" }) });
+    runnerB.emit("message", { data: JSON.stringify({ type: "register", runnerId: "runner-b", apiKey: "key1" }) });
+    await waitForMicrotask();
+
+    const events: string[] = [];
+    relay.proxyHttpRequest("runner-a", { id: "shared", port: 3000, method: "GET", url: "/", headers: {} }, {
+      onResponseStart() { events.push("start"); }, onResponseData() {}, onResponseEnd() { events.push("end"); }, onError() {},
+    });
+    runnerB.emit("message", { data: JSON.stringify({ type: "response-start", id: "shared", statusCode: 200, statusMessage: "OK", headers: {} }) });
+    runnerB.emit("message", { data: JSON.stringify({ type: "response-data-end", id: "shared" }) });
+    runnerA.emit("message", { data: JSON.stringify({ type: "response-start", id: "shared", statusCode: 200, statusMessage: "OK", headers: {} }) });
+    runnerA.emit("message", { data: JSON.stringify({ type: "response-data-end", id: "shared" }) });
+
+    expect(events).toEqual(["start", "end"]);
   });
 
   test("disconnect only fails requests for the matching runner", async () => {
@@ -538,6 +585,30 @@ describe("TunnelRelay WebSocket proxy callbacks", () => {
     relay.sendWsClose("r1", "ws1", 1000, "viewer closed");
     expect(events).toEqual(["close:1000:viewer closed"]);
     expect(mockWs.sent).toHaveLength(sentBeforeSecondClose);
+  });
+
+  test("evicts a reused websocket id without letting its timeout remove the replacement", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", { data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }) });
+    await waitForMicrotask();
+
+    const events: string[] = [];
+    const callbacks = (label: string) => ({
+      onOpened() { events.push(`${label}:opened`); },
+      onData() {},
+      onClose() {},
+      onError(error: string) { events.push(`${label}:error:${error}`); },
+    });
+    const oldProxy = relay.proxyWsOpen("r1", { id: "reused", port: 3000, path: "/", headers: {} }, callbacks("old"), 5);
+    relay.proxyWsOpen("r1", { id: "reused", port: 3000, path: "/", headers: {} }, callbacks("new"), 100);
+    oldProxy.cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    mockWs.emit("message", { data: JSON.stringify({ type: "ws-opened", id: "reused" }) });
+
+    expect(events).toEqual(["old:error:WebSocket connection replaced", "new:opened"]);
   });
 
   test("ws-opened, ws-data, and ws-close route to callbacks", async () => {

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -200,22 +200,14 @@ export class TunnelRelay {
       return { cancel() {} };
     }
 
-    // Evict any stale pending request sharing this id so its timer cannot
-    // fire and delete the new entry.
-    const staleRequest = this.pendingRequests.get(request.id);
-    if (staleRequest) {
-      clearTimeout(staleRequest.timer);
-      this.pendingRequests.delete(request.id);
-      staleRequest.onError("Tunnel request timed out");
-    }
-
+    let pending!: PendingProxyRequest;
     const timer = setTimeout(() => {
+      if (this.pendingRequests.get(request.id) !== pending) return;
       this.send(runner.ws, { type: "request-end", id: request.id });
       this.pendingRequests.delete(request.id);
       callbacks.onError("Tunnel request timed out");
     }, timeoutMs);
-
-    this.pendingRequests.set(request.id, {
+    pending = {
       id: request.id,
       runnerId,
       port: request.port,
@@ -224,7 +216,8 @@ export class TunnelRelay {
       onResponseEnd: callbacks.onResponseEnd,
       onError: callbacks.onError,
       timer,
-    });
+    };
+    this.replacePendingRequest(request.id, pending);
 
     this.send(runner.ws, {
       type: "request-start",
@@ -239,8 +232,7 @@ export class TunnelRelay {
 
     return {
       cancel: () => {
-        const pending = this.pendingRequests.get(request.id);
-        if (!pending) return;
+        if (this.pendingRequests.get(request.id) !== pending) return;
         clearTimeout(pending.timer);
         this.pendingRequests.delete(request.id);
         this.send(runner.ws, { type: "request-end", id: request.id });
@@ -289,13 +281,14 @@ export class TunnelRelay {
       return { cancel() {} };
     }
 
+    let pending!: PendingWsProxy;
     const timer = setTimeout(() => {
+      if (this.pendingWs.get(request.id) !== pending) return;
       this.send(runner.ws, { type: "ws-close", id: request.id, code: 1001, reason: "open timeout" });
       this.pendingWs.delete(request.id);
       callbacks.onError("WebSocket open timed out");
     }, timeoutMs);
-
-    this.pendingWs.set(request.id, {
+    pending = {
       id: request.id,
       runnerId,
       onOpened: callbacks.onOpened,
@@ -303,7 +296,8 @@ export class TunnelRelay {
       onClose: callbacks.onClose,
       onError: callbacks.onError,
       timer,
-    });
+    };
+    this.replacePendingWs(request.id, pending);
 
     this.send(runner.ws, {
       type: "ws-open",
@@ -318,8 +312,7 @@ export class TunnelRelay {
 
     return {
       cancel: () => {
-        const pending = this.pendingWs.get(request.id);
-        if (!pending) return;
+        if (this.pendingWs.get(request.id) !== pending) return;
         clearTimeout(pending.timer);
         this.pendingWs.delete(request.id);
         this.send(runner.ws, { type: "ws-close", id: request.id, code: 1001, reason: "cancelled" });
@@ -367,6 +360,26 @@ export class TunnelRelay {
 
     this.runners.clear();
     this.wsToRunner.clear();
+  }
+
+  private replacePendingRequest(id: string, pending: PendingProxyRequest): void {
+    const old = this.pendingRequests.get(id);
+    if (old) {
+      clearTimeout(old.timer);
+      this.pendingRequests.delete(id);
+      old.onError("Tunnel request replaced");
+    }
+    this.pendingRequests.set(id, pending);
+  }
+
+  private replacePendingWs(id: string, pending: PendingWsProxy): void {
+    const old = this.pendingWs.get(id);
+    if (old) {
+      clearTimeout(old.timer);
+      this.pendingWs.delete(id);
+      old.onError("WebSocket connection replaced");
+    }
+    this.pendingWs.set(id, pending);
   }
 
   private send(ws: WebSocket, msg: TunnelServerMessage): void {
@@ -484,7 +497,7 @@ export class TunnelRelay {
 
   private handleResponseStart(ws: WebSocket, msg: TunnelResponseStartMessage): void {
     const pending = this.pendingRequests.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     // The timeout only protects the initial response handshake. Once headers
     // have arrived, the response may legitimately be long-lived (SSE, logs,
     // streaming dev servers), so do not abort it solely because it stays open.
@@ -494,13 +507,13 @@ export class TunnelRelay {
 
   private handleResponseData(ws: WebSocket, msg: TunnelResponseDataMessage): void {
     const pending = this.pendingRequests.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     pending.onResponseData(Buffer.from(msg.data, "binary"));
   }
 
   private handleResponseDataEnd(ws: WebSocket, msg: TunnelResponseDataEndMessage): void {
     const pending = this.pendingRequests.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     clearTimeout(pending.timer);
     this.pendingRequests.delete(msg.id);
     pending.onResponseEnd();
@@ -508,7 +521,7 @@ export class TunnelRelay {
 
   private handleRequestEnd(ws: WebSocket, msg: TunnelRequestEndMessage): void {
     const pending = this.pendingRequests.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     clearTimeout(pending.timer);
     this.pendingRequests.delete(msg.id);
     pending.onError("Runner aborted request");
@@ -516,20 +529,20 @@ export class TunnelRelay {
 
   private handleWsOpened(ws: WebSocket, msg: TunnelWsOpenedMessage): void {
     const pending = this.pendingWs.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     clearTimeout(pending.timer);
     pending.onOpened(msg.protocol);
   }
 
   private handleWsData(ws: WebSocket, msg: TunnelWsDataMessage): void {
     const pending = this.pendingWs.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     pending.onData(msg.data, msg.binary);
   }
 
   private handleWsClose(ws: WebSocket, msg: TunnelWsCloseMessage): void {
     const pending = this.pendingWs.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     clearTimeout(pending.timer);
     this.pendingWs.delete(msg.id);
     pending.onClose(browserCloseCode(msg.code), msg.reason);
@@ -537,14 +550,14 @@ export class TunnelRelay {
 
   private handleWsError(ws: WebSocket, msg: TunnelWsErrorMessage): void {
     const pending = this.pendingWs.get(msg.id);
-    if (!pending || !this.isCurrentRunnerSocket(ws, pending.runnerId)) return;
+    if (!this.isMessageForPending(ws, pending)) return;
     clearTimeout(pending.timer);
     this.pendingWs.delete(msg.id);
     pending.onError(msg.message);
   }
 
-  private isCurrentRunnerSocket(ws: WebSocket, runnerId: string): boolean {
-    return this.runners.get(runnerId)?.ws === ws;
+  private isMessageForPending<T extends PendingProxyRequest | PendingWsProxy>(ws: WebSocket, pending: T | undefined): pending is T {
+    return pending !== undefined && this.runners.get(pending.runnerId)?.ws === ws;
   }
 
   private sendHeartbeats(): void {


### PR DESCRIPTION
Clean rebase of #807.

This PR supersedes #807, which was dirty against current `main`. The request-id collision behavior in `TunnelRelay` and `TunnelClient` was rebased onto the current tunnel hardening stack (cross-runner isolation, response finalization, WebSocket retry identity checks) and the regression tests were kept.

Changes:
- `packages/server/src/routes/tunnel.ts` and `tunnel-ws.ts`: use `crypto.randomUUID()` for request/tunnel IDs to avoid collisions.
- `packages/tunnel/src/server.ts`: replace stale pending entries via `replacePendingRequest` / `replacePendingWs`, and use `isMessageForPending` to ignore frames from a superseded or wrong-runner pending entry.
- `packages/tunnel/src/client.ts`: replace stale active HTTP/WebSocket entries via `replaceActiveRequest` / `replaceActiveWs`, and guard callbacks by identity so stale events cannot overwrite a replacement.
- Add regression tests for HTTP/WebSocket id collisions and cross-runner frame injection.

Closes #807