### PR TITLE
fix: reconcile ownership on anonymous adoption (A2-010) [rebase]

### DIFF
--- a/packages/server/src/sessions/store.ownership.test.ts
+++ b/packages/server/src/sessions/store.ownership.test.ts
@@ -162,15 +162,43 @@ describe("recordRelaySessionStart — ended-session ownership guard", () => {
             isEphemeral: false,
         });
 
-        // The upsert should have proceeded (userId was null, so no conflict)
+        // The upsert must RECONCILE ownership: the null owner is replaced by the
+        // adopting user, not preserved as null.
         const row = await memDb
             .selectFrom("relay_session")
             .select(["id", "userId"])
             .where("id", "=", "own-anon")
             .executeTakeFirst();
-        // userId stays null (the upsert doesn't overwrite userId on conflict),
-        // but the important thing is it didn't throw or skip entirely.
-        expect(row).toBeDefined();
+        expect(row?.userId).toBe(USER_A);
+    });
+
+    it("does not overwrite a real owner with null on anonymous reconnect", async () => {
+        // User A owns the session
+        await recordRelaySessionStart({
+            sessionId: "own-keep-owner",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/own-keep-owner",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // An anonymous reconnect (userId undefined) must NOT clear the owner
+        await recordRelaySessionStart({
+            sessionId: "own-keep-owner",
+            userId: undefined,
+            cwd: "/repo",
+            shareUrl: "http://test/own-keep-owner",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const row = await memDb
+            .selectFrom("relay_session")
+            .select(["id", "userId"])
+            .where("id", "=", "own-keep-owner")
+            .executeTakeFirst();
+        expect(row?.userId).toBe(USER_A);
     });
 });
 

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -253,6 +253,19 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
         })
         .onConflict((oc) =>
             oc.column("id").doUpdateSet((eb) => ({
+                // Reconcile ownership on anonymous adoption: if the persisted row
+                // has no owner (userId IS NULL) and the incoming registration
+                // carries a real user, adopt the session by writing that user.
+                // Never overwrite an existing non-null owner — the pre-check above
+                // already skips cross-user takeovers, and this CASE keeps a real
+                // owner intact even when the incoming userId is null (anonymous
+                // reconnect of an already-adopted session).
+                userId: eb
+                    .case()
+                    .when(eb.ref("relay_session.userId"), "is", null)
+                    .then(incomingUserId)
+                    .else(eb.ref("relay_session.userId"))
+                    .end(),
                 // On reconnect, preserve existing runner info if the incoming data
                 // doesn't carry a runner association (e.g. session predates the
                 // association key or the Redis key has already expired).  Only

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -50,6 +50,7 @@ mock.module("../../sio-registry.js", () => ({
 
 mock.module("../../../sessions/redis.js", () => ({
     appendRelayEventToCache: async () => {},
+    deleteRelayEventCache: async () => {},
 }));
 
 mock.module("./viewer-gate.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -28,6 +28,7 @@ mock.module("../../sio-registry.js", () => ({
         wasDelinked: false,
     }),
     getLocalTuiSocket: () => undefined,
+    getSessionOwnerToken: async () => "tok",
     broadcastToViewers: mockBroadcastToViewers,
     endSharedSession: async () => {},
 }));

--- a/packages/server/src/ws/sio-registry/runners.ownership.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.ownership.test.ts
@@ -17,7 +17,7 @@ const store = new Map<string, string>();
 const setStore = new Map<string, Set<string>>();
 
 const mockMulti = () => {
-    const ops: Array<>() => void> = [];
+    const ops: Array<() => void> = [];
     const readKeys: string[] = [];
     return {
         hSet: mock((key: string, fields: Record<string, string>) => {

--- a/packages/server/src/ws/sio-registry/runners.ownership.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.ownership.test.ts
@@ -1,4 +1,15 @@
-import { afterAll, describe, it, expect, mock, beforeEach } from "bun:test";
+/**
+ * Regression tests for runner/session ownership reconciliation.
+ *
+ * Covers both:
+ *   - registerRunner rejecting cross-user claims and anonymous-adoption edge cases.
+ *   - getConnectedSessionsForRunner not re-adopting sessions owned by a different user
+ *     (cross-user session/event leak on Redis-loss fallback).
+ *
+ * Uses a mock Redis backend injected via initStateRedis() so the real code paths run
+ * against controllable state.
+ */
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // ── In-memory Redis mock (same harness as runners.broadcast.test.ts) ─────────
 
@@ -6,7 +17,8 @@ const store = new Map<string, string>();
 const setStore = new Map<string, Set<string>>();
 
 const mockMulti = () => {
-    const ops: Array<() => void> = [];
+    const ops: Array<>() => void> = [];
+    const readKeys: string[] = [];
     return {
         hSet: mock((key: string, fields: Record<string, string>) => {
             ops.push(() => {
@@ -39,9 +51,16 @@ const mockMulti = () => {
             });
             return mockMulti();
         }),
+        hGetAll: mock((key: string) => {
+            readKeys.push(key);
+            return mockMulti();
+        }),
         exec: mock(async () => {
             for (const op of ops) op();
-            return [];
+            return readKeys.map((key) => {
+                const raw = store.get(`__hash__:${key}`);
+                return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+            });
         }),
     };
 };
@@ -85,6 +104,7 @@ const mockRedis = {
 };
 
 mock.module("./hub.js", () => ({ broadcastToHub: mock(async () => {}) }));
+mock.module("./runners-broadcast.js", () => ({ broadcastToRunnersNs: mock(async () => {}) }));
 
 // Restore all module mocks after this file so they don't bleed into other
 // test files running in the same worker process.
@@ -92,9 +112,9 @@ afterAll(() => mock.restore());
 
 mock.restore();
 
-const { initSioRegistry, runnerSecrets, localRunnerSockets } = await import("./context.js");
-const { initStateRedis } = await import("../sio-state/index.js");
-const { registerRunner, getRunnerData, getLocalRunnerSocket } = await import("./runners.js");
+const { initStateRedis, setSession, setRunner } = await import("../sio-state/index.js");
+const { initSioRegistry, runnerSecrets, localRunnerSockets, localTuiSockets } = await import("./context.js");
+const { registerRunner, getRunnerData, getLocalRunnerSocket, getConnectedSessionsForRunner } = await import("./runners.js");
 
 function fakeSocket() {
     return { join: mock(async () => {}), data: {} } as any;
@@ -113,6 +133,54 @@ const baseOpts = {
     version: null,
     platform: null,
 };
+
+const USER_A = "user-alpha";
+const USER_B = "user-bravo";
+
+function seedRunner(runnerId: string, userId: string | null): void {
+    void setRunner(runnerId, {
+        runnerId,
+        userId,
+        userName: null,
+        name: "runner",
+        roots: "[]",
+        skills: "[]",
+        agents: "[]",
+        plugins: "[]",
+        hooks: "[]",
+        version: null,
+        platform: null,
+    });
+}
+
+function seedSession(sessionId: string, userId: string | null, runnerId: string | null): void {
+    void setSession(sessionId, {
+        sessionId,
+        token: "tok",
+        collabMode: false,
+        shareUrl: `http://test/${sessionId}`,
+        cwd: "/repo",
+        startedAt: new Date().toISOString(),
+        userId,
+        userName: null,
+        sessionName: null,
+        isEphemeral: false,
+        expiresAt: null,
+        isActive: true,
+        lastHeartbeatAt: null,
+        lastHeartbeat: null,
+        lastState: null,
+        runnerId,
+        runnerName: null,
+        seq: 0,
+        parentSessionId: null,
+        linkedParentId: null,
+    });
+}
+
+function connectTui(sessionId: string): void {
+    localTuiSockets.set(sessionId, { connected: true, data: {} } as never);
+}
 
 describe("runner ownership guard", () => {
     beforeEach(async () => {
@@ -243,5 +311,50 @@ describe("runner ownership guard", () => {
         expect(result).toBeInstanceOf(Error);
         const runner = await getRunnerData("runner-anon");
         expect(runner!.userId).toBeNull();
+    });
+});
+
+describe("getConnectedSessionsForRunner — ownership guard", () => {
+    beforeEach(async () => {
+        store.clear();
+        setStore.clear();
+        localTuiSockets.clear();
+        await initStateRedis(mockRedis as never);
+    });
+
+    it("does not re-adopt a session owned by a different user", async () => {
+        seedRunner("runner-b", USER_B);
+        seedSession("s-foreign", USER_A, "runner-b");
+        connectTui("s-foreign");
+
+        const sessions = await getConnectedSessionsForRunner("runner-b");
+        expect(sessions.map((s) => s.sessionId)).not.toContain("s-foreign");
+    });
+
+    it("re-adopts a session owned by the same user", async () => {
+        seedRunner("runner-b", USER_B);
+        seedSession("s-own", USER_B, "runner-b");
+        connectTui("s-own");
+
+        const sessions = await getConnectedSessionsForRunner("runner-b");
+        expect(sessions.map((s) => s.sessionId)).toContain("s-own");
+    });
+
+    it("re-adopts an anonymous session (no owner)", async () => {
+        seedRunner("runner-b", USER_B);
+        seedSession("s-anon", null, "runner-b");
+        connectTui("s-anon");
+
+        const sessions = await getConnectedSessionsForRunner("runner-b");
+        expect(sessions.map((s) => s.sessionId)).toContain("s-anon");
+    });
+
+    it("does not re-adopt a user-owned session when the runner is anonymous", async () => {
+        seedRunner("runner-anon", null);
+        seedSession("s-user", USER_A, "runner-anon");
+        connectTui("s-user");
+
+        const sessions = await getConnectedSessionsForRunner("runner-anon");
+        expect(sessions.map((s) => s.sessionId)).not.toContain("s-user");
     });
 });

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -418,10 +418,26 @@ export async function removeRunnerSession(runnerId: string, sessionId: string): 
  * Used after a runner daemon restart to let it re-adopt orphaned worker processes.
  */
 export async function getConnectedSessionsForRunner(runnerId: string): Promise<Array<{ sessionId: string; cwd: string; sessionFile?: string }>> {
+    // Ownership guard: a runner may only re-adopt sessions it actually owns.
+    // On Redis-loss fallback a persisted runner can otherwise be re-attached to
+    // a session that was adopted by a *different* user, letting the old runner
+    // re-adopt foreign events (cross-user session/event leak).
+    const runner = await getRunnerState(runnerId);
+    const runnerUserId = runner?.userId ?? null;
+
     const allSessions = await getAllSessionSummaries();
     const results: Array<{ sessionId: string; cwd: string; sessionFile?: string }> = [];
     for (const s of allSessions) {
         if (s.runnerId !== runnerId) continue;
+        // Skip sessions owned by a user other than this runner's owner (or by a
+        // user when this runner is anonymous). Anonymous sessions (userId null)
+        // remain adoptable by any runner.
+        if (s.userId !== null && s.userId !== runnerUserId) {
+            log.warn(
+                `getConnectedSessionsForRunner: skipping session ${s.sessionId} owned by a different user (runner ${runnerId})`,
+            );
+            continue;
+        }
         // Only include sessions whose TUI socket is still connected (worker is alive)
         const tuiSocket = localTuiSockets.get(s.sessionId);
         if (tuiSocket && tuiSocket.connected) {

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -58,6 +58,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionEnd: noopAsync,
     recordRelaySessionState: noopAsync,
     recordRelaySessionStateSerialized: noopAsync,
+    recordRelaySessionOverlay: noopAsync,
     touchRelaySession: noopAsync,
     updateRelaySessionName: noopAsync,
 }));


### PR DESCRIPTION
Rebase of #782 to resolve merge conflicts with `main`.

Original: fix: reconcile ownership on anonymous adoption (A2-010)

Resolved the `runners.ownership.test.ts` add/add conflict by merging both test suites into one file:
- The existing `registerRunner` ownership guard tests (cross-user claim, same-owner re-registration, wrong secret, null-owner re-registration, authenticated claim over anonymous runner).
- The PR's `getConnectedSessionsForRunner` ownership guard tests (foreign user skip, same user re-adoption, anonymous re-adoption, anonymous runner skip).

Both suites share the same in-memory Redis mock, which was updated to support `hGetAll`/`readKeys` for the new tests.

Typecheck and the ownership test files pass locally.

Supersedes #782.