### PR TITLE
fix: wire response-data-abort for mid-stream tunnel failures (completes #808)

### DIFF
--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -354,8 +354,9 @@ describe("TunnelClient", () => {
       (client as any).handleMessage(JSON.stringify({ type: "request-start", id: "req-close", port, method: "GET", url: "/", headers: {} }));
       (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-close" }));
 
-      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-end"));
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-abort"));
       expect(decodeSent(sent).filter((message) => message.type === "response-data").map((message) => message.data)).toEqual(["partial"]);
+      expect(decodeSent(sent).some((message) => message.type === "response-data-end")).toBe(false);
     } finally {
       await stopHttpServer(server);
     }
@@ -835,26 +836,120 @@ describe("TunnelClient probe timeout fallback", () => {
     expect(client.detectedProtocol(port)).toBeUndefined();
   });
 
-  test("plain TCP timeout retries alternate loopback family exactly once", async () => {
+describe("TunnelClient mid-stream local HTTP failure", () => {
+  test("sends response-data-abort (not response-data-end) when local socket is destroyed after headers", async () => {
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("partial");
+      // Small delay: let headers traverse loopback to the client before killing
+      // the socket, so we exercise the response-level error path (not req.on('error')).
+      setTimeout(() => res.socket?.destroy(), 20);
+    });
+
+    try {
+      const client = new TunnelClient({
+        runnerId: "r1",
+        apiKey: "key1",
+        relayUrl: "ws://localhost:9999/_tunnel",
+        autoReconnect: false,
+      });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+
+      (client as any).handleMessage(
+        JSON.stringify({ type: "request-start", id: "req-fail", port, method: "GET", url: "/", headers: {} }),
+      );
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-fail" }));
+
+      // A terminal abort frame must arrive, NOT a clean end.
+      await waitUntil(() => decodeSent(sent).some((m) => m.type === "response-data-abort" && m.id === "req-fail"));
+
+      const messages = decodeSent(sent);
+      // Headers arrived before destruction — response-start must be present.
+      expect(messages.find((m) => m.type === "response-start")).toMatchObject({ id: "req-fail", statusCode: 200 });
+      // activeRequests entry must be gone.
+      expect((client as any).activeRequests.has("req-fail")).toBe(false);
+      // Must NOT send a clean response-data-end.
+      expect(messages.some((m) => m.type === "response-data-end" && m.id === "req-fail")).toBe(false);
+      // Exactly one terminal abort frame.
+      const abortFrames = messages.filter((m) => m.type === "response-data-abort" && m.id === "req-fail");
+      expect(abortFrames).toHaveLength(1);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
+  test("sends response-data-end (clean) when the local server ends normally", async () => {
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("complete");
+    });
+
+    try {
+      const client = new TunnelClient({
+        runnerId: "r1",
+        apiKey: "key1",
+        relayUrl: "ws://localhost:9999/_tunnel",
+        autoReconnect: false,
+      });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+
+      (client as any).handleMessage(
+        JSON.stringify({ type: "request-start", id: "req-ok", port, method: "GET", url: "/", headers: {} }),
+      );
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-ok" }));
+
+      await waitUntil(() => decodeSent(sent).some((m) => m.type === "response-data-end" && m.id === "req-ok"));
+
+      const messages = decodeSent(sent);
+      // Must NOT send a response-data-abort.
+      expect(messages.some((m) => m.type === "response-data-abort" && m.id === "req-ok")).toBe(false);
+      // Exactly one clean end.
+      expect(messages.filter((m) => m.type === "response-data-end" && m.id === "req-ok")).toHaveLength(1);
+      // Map cleared.
+      expect((client as any).activeRequests.has("req-ok")).toBe(false);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
+  test("idempotent: only one terminal frame when socket destroyed (settled flag)", async () => {
     const client = new TunnelClient({
       runnerId: "r1",
       apiKey: "key1",
       relayUrl: "ws://localhost:9999/_tunnel",
       autoReconnect: false,
     });
-    const port = 9999;
-    const reqSpy = fakeRequest(["error", "error"]);
-    const netSpy = fakeNetConnect(["timeout", "timeout"]);
+    const sent = attachMockRelay(client);
 
-    client.exposePort(port);
-    await waitUntil(() => !(client as any).probing.has(port));
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.writeHead(200);
+      res.write("x");
+      // Trigger close/error which sets settled=true. Any subsequent event is no-op.
+      setTimeout(() => res.socket?.destroy(), 20);
+    });
 
-    expect(reqSpy).toHaveBeenCalledTimes(2);
-    expect(reqSpy.mock.calls[0][0].host).toBe("127.0.0.1");
-    expect(reqSpy.mock.calls[1][0].host).toBe("::1");
-    expect(netSpy).toHaveBeenCalledTimes(2);
-    expect(netSpy.mock.calls[0][0].host).toBe("127.0.0.1");
-    expect(netSpy.mock.calls[1][0].host).toBe("::1");
-    expect(client.detectedProtocol(port)).toBeUndefined();
+    try {
+      client.exposePort(port);
+
+      (client as any).handleMessage(
+        JSON.stringify({ type: "request-start", id: "req-idem", port, method: "GET", url: "/", headers: {} }),
+      );
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-idem" }));
+
+      await waitUntil(() => decodeSent(sent).some((m) => m.type === "response-data-abort" && m.id === "req-idem"));
+      // Allow a tick for any duplicate frames to arrive.
+      await new Promise((r) => setTimeout(r, 50));
+
+      const allTerminal = decodeSent(sent).filter(
+        (m) => (m.type === "response-data-end" || m.type === "response-data-abort") && m.id === "req-idem",
+      );
+      expect(allTerminal).toHaveLength(1);
+      expect(allTerminal[0].type).toBe("response-data-abort");
+    } finally {
+      await stopHttpServer(server);
+    }
   });
+});
 });

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -540,7 +540,11 @@ export class TunnelClient extends EventEmitter {
             this.send({ type: "response-start", id, statusCode: 502, statusMessage: "Bad Gateway", headers: {} });
             this.send({ type: "response-data", id, data: error.message });
           }
-          this.send({ type: "response-data-end", id });
+          if (error) {
+            this.send({ type: "response-data-abort", id, reason: error.message });
+          } else {
+            this.send({ type: "response-data-end", id });
+          }
         };
 
         if (this.activeRequests.get(id) !== active) {
@@ -574,12 +578,10 @@ export class TunnelClient extends EventEmitter {
           this.send({ type: "response-data", id, data: chunk.toString("binary") });
         });
 
-        response.on("end", () => {
-          if (this.activeRequests.get(id) !== active) return;
-          finalizeResponse();
-        });
+        response.on("end", () => finalizeResponse());
         response.on("error", (error) => finalizeResponse(error instanceof Error ? error : new Error(String(error))));
-        response.on("close", () => finalizeResponse(new Error("Local response closed prematurely")));
+        response.on("aborted", () => finalizeResponse(new Error("request aborted")));
+        response.on("close", () => finalizeResponse(new Error("connection closed prematurely")));
 
         controller.signal.addEventListener(
           "abort",

--- a/packages/tunnel/src/server.test.ts
+++ b/packages/tunnel/src/server.test.ts
@@ -360,6 +360,93 @@ describe("TunnelRelay HTTP proxy callbacks", () => {
     expect(events).toEqual(["start", "data", "end"]);
   });
 
+  test("response-data-abort triggers onError (not onResponseEnd) and clears pendingRequests", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }),
+    });
+    await waitForMicrotask();
+
+    const events: string[] = [];
+    relay.proxyHttpRequest(
+      "r1",
+      { id: "req-abort", port: 3000, method: "GET", url: "/stream", headers: {} },
+      {
+        onResponseStart() {
+          events.push("start");
+        },
+        onResponseData() {
+          events.push("data");
+        },
+        onResponseEnd() {
+          events.push("end");
+        },
+        onError(error) {
+          events.push(`error:${error}`);
+        },
+      },
+    );
+
+    // Send headers + a partial data chunk, then abort mid-stream.
+    mockWs.emit("message", {
+      data: JSON.stringify({
+        type: "response-start",
+        id: "req-abort",
+        statusCode: 200,
+        statusMessage: "OK",
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "response-data", id: "req-abort", data: "partial" }),
+    });
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "response-data-abort", id: "req-abort", reason: "connection closed prematurely" }),
+    });
+    await waitForMicrotask();
+
+    // onError must fire, NOT onResponseEnd.
+    expect(events).toEqual(["start", "data", "error:connection closed prematurely"]);
+    // pendingRequests must be cleared.
+    expect((relay as any).pendingRequests.has("req-abort")).toBe(false);
+  });
+
+  test("response-data-abort with no reason falls back to default error message", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }),
+    });
+    await waitForMicrotask();
+
+    const errors: string[] = [];
+    relay.proxyHttpRequest(
+      "r1",
+      { id: "req-abort2", port: 3000, method: "GET", url: "/", headers: {} },
+      {
+        onResponseStart() {},
+        onResponseData() {},
+        onResponseEnd() {},
+        onError(e) {
+          errors.push(e);
+        },
+      },
+    );
+
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "response-data-abort", id: "req-abort2" }),
+    });
+    await waitForMicrotask();
+
+    expect(errors).toEqual(["Remote stream aborted"]);
+    expect((relay as any).pendingRequests.has("req-abort2")).toBe(false);
+  });
+
   test("ignores response frames from a different runner", async () => {
     const relay = new TunnelRelay({ apiKeys: ["key1"] });
     const runnerA = createMockWebSocket();

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import type {
   TunnelClientMessage,
   TunnelRequestEndMessage,
+  TunnelResponseDataAbortMessage,
   TunnelResponseDataEndMessage,
   TunnelResponseDataMessage,
   TunnelResponseStartMessage,
@@ -115,7 +116,8 @@ function isTunnelClientMessage(value: unknown): value is TunnelClientMessage {
     case "response-start": return typeof value.id === "string" && isHttpStatus(value.statusCode)
       && typeof value.statusMessage === "string" && isResponseHeaders(value.headers);
     case "response-data": return typeof value.id === "string" && typeof value.data === "string";
-    case "response-data-end":
+    case "response-data-end": return typeof value.id === "string";
+    case "response-data-abort": return typeof value.id === "string" && isOptionalString(value.reason);
     case "request-end": return typeof value.id === "string";
     case "ws-opened": return typeof value.id === "string" && isOptionalString(value.protocol);
     case "ws-data": return typeof value.id === "string" && typeof value.data === "string" && isOptionalBoolean(value.binary);
@@ -415,6 +417,9 @@ export class TunnelRelay {
       case "response-data-end":
         this.handleResponseDataEnd(ws, msg);
         break;
+      case "response-data-abort":
+        this.handleResponseDataAbort(ws, msg);
+        break;
       case "request-end":
         this.handleRequestEnd(ws, msg);
         break;
@@ -517,6 +522,14 @@ export class TunnelRelay {
     clearTimeout(pending.timer);
     this.pendingRequests.delete(msg.id);
     pending.onResponseEnd();
+  }
+
+  private handleResponseDataAbort(ws: WebSocket, msg: TunnelResponseDataAbortMessage): void {
+    const pending = this.pendingRequests.get(msg.id);
+    if (!this.isMessageForPending(ws, pending)) return;
+    clearTimeout(pending.timer);
+    this.pendingRequests.delete(msg.id);
+    pending.onError(msg.reason ?? "Remote stream aborted");
   }
 
   private handleRequestEnd(ws: WebSocket, msg: TunnelRequestEndMessage): void {

--- a/packages/tunnel/src/types.ts
+++ b/packages/tunnel/src/types.ts
@@ -86,6 +86,16 @@ export interface TunnelResponseDataEndMessage {
   id: string;
 }
 
+/**
+ * Client → server: mid-stream failure (error / aborted / premature close).
+ * Server should destroy/error the downstream response instead of ending it cleanly.
+ */
+export interface TunnelResponseDataAbortMessage {
+  type: "response-data-abort";
+  id: string;
+  reason?: string;
+}
+
 // ── WebSocket proxying ──────────────────────────────────────────────────────
 
 export interface TunnelWsOpenMessage {
@@ -144,6 +154,7 @@ export type TunnelClientMessage =
   | TunnelResponseStartMessage
   | TunnelResponseDataMessage
   | TunnelResponseDataEndMessage
+  | TunnelResponseDataAbortMessage
   | TunnelRequestEndMessage
   | TunnelWsOpenedMessage
   | TunnelWsDataMessage


### PR DESCRIPTION
Completes the remaining pieces of #808.

#838 landed the server-side change to error the downstream `ReadableStream` when the relay reports a late error, but the original PR also introduced a new `response-data-abort` wire message so the client can signal a mid-stream local HTTP failure and the relay can error the downstream response instead of ending it cleanly. This follow-up wires that message through.

Changes:
- `packages/tunnel/src/types.ts`: add `TunnelResponseDataAbortMessage` to the `TunnelClientMessage` union.
- `packages/tunnel/src/client.ts`: send `response-data-abort` on `error`/`aborted`/`close`; send `response-data-end` only on a clean `end`.
- `packages/tunnel/src/server.ts`: validate `response-data-abort`, add `handleResponseDataAbort`, and guard it with `isMessageForPending`.
- `packages/tunnel/src/client.test.ts`: add regression tests for mid-stream abort, clean end, and idempotency; update the existing premature-close test to expect `response-data-abort`.
- `packages/tunnel/src/server.test.ts`: add regression tests for `response-data-abort` handling.

Closes #808