### PR TITLE
fix: reset per-session relay state on reconnect (A2-009) [rebase]

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.cross-node.test.ts
@@ -50,6 +50,7 @@ mock.module("../../sio-registry.js", () => ({
 
 mock.module("../../../sessions/redis.js", () => ({
     appendRelayEventToCache: async () => {},
+    deleteRelayEventCache: async () => {},
 }));
 
 mock.module("./viewer-gate.js", () => ({

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
     applyChunkToPendingState,
     applySnapshotPatchToPendingState,
@@ -7,10 +7,19 @@ import {
     finalizeChunkedSnapshot,
     getPendingChunkedSnapshot,
     pendingChunkedStates,
+    resetPerSessionRelayState,
     CHUNK_STREAM_STALE_MS,
     sessionEventQueues,
     type ChunkedSessionState,
 } from "./event-pipeline.js";
+import {
+    thinkingStartTimes,
+    thinkingDurations,
+} from "./thinking-tracker.js";
+import {
+    _injectRedisForTesting,
+    _resetRedisForTesting,
+} from "../../../sessions/redis.js";
 import {
     consumePendingRecovery,
     markPendingRecovery,
@@ -311,5 +320,100 @@ describe("getPendingChunkedSnapshot — stale stream expiry", () => {
             isFinalChunk: false,
         });
         expect(getPendingChunkedSnapshot("s-refresh")?.stale).toBe(false);
+    });
+});
+
+describe("resetPerSessionRelayState — reconnect state reset", () => {
+    beforeEach(() => {
+        // Inject a mock Redis client so the reset helper's cache deletion is
+        // deterministic and never depends on a live Redis instance.
+        _injectRedisForTesting({ del: async (_key: string) => 1 } as unknown);
+    });
+
+    afterEach(() => {
+        pendingChunkedStates.clear();
+        sessionEventQueues.clear();
+        thinkingStartTimes.clear();
+        thinkingDurations.clear();
+        _resetRedisForTesting();
+    });
+
+    test("drains the event queue before clearing half-assembled chunk state", async () => {
+        const order: string[] = [];
+        let release!: () => void;
+        const blocked = new Promise<void>((resolve) => { release = resolve; });
+
+        // A chunk handler from the OLD generation is still in flight.
+        enqueueSessionEvent("sess-reconnect", async () => {
+            await blocked;
+            order.push("old-chunk-handler");
+        });
+        pendingChunkedStates.set("sess-reconnect", {
+            snapshotId: "old-snap",
+            metadata: {},
+            chunks: [[{ id: "old-m1" }]],
+            totalChunks: 2,
+            receivedChunkIndexes: new Set<number>([0]),
+            finalChunkSeen: false,
+            lastActivityAt: Date.now(),
+        });
+
+        const resetPromise = resetPerSessionRelayState("sess-reconnect");
+        // The reset must NOT complete until the in-flight handler drains.
+        await Promise.resolve();
+        expect(order).toEqual([]);
+        release();
+        await resetPromise;
+
+        expect(order).toEqual(["old-chunk-handler"]);
+        expect(pendingChunkedStates.has("sess-reconnect")).toBe(false);
+        expect(sessionEventQueues.has("sess-reconnect")).toBe(false);
+    });
+
+    test("clears thinking maps and pending chunk state for the session", async () => {
+        thinkingStartTimes.set("sess-reconnect", new Map([[0, Date.now()]]));
+        thinkingDurations.set("sess-reconnect", new Map([[0, 1234]]));
+        pendingChunkedStates.set("sess-reconnect", {
+            snapshotId: "old-snap",
+            metadata: {},
+            chunks: [[{ id: "old-m1" }]],
+            totalChunks: 1,
+            receivedChunkIndexes: new Set<number>([0]),
+            finalChunkSeen: true,
+            lastActivityAt: Date.now(),
+        });
+
+        await resetPerSessionRelayState("sess-reconnect");
+
+        expect(thinkingStartTimes.has("sess-reconnect")).toBe(false);
+        expect(thinkingDurations.has("sess-reconnect")).toBe(false);
+        expect(pendingChunkedStates.has("sess-reconnect")).toBe(false);
+    });
+
+    test("deletes the relay event cache for the session", async () => {
+        const del = spyOn({
+            del: async (_key: string) => 1,
+        }, "del");
+        _injectRedisForTesting({ del } as unknown);
+
+        await resetPerSessionRelayState("sess-reconnect");
+
+        expect(del).toHaveBeenCalledWith("pizzapi:relay:session:sess-reconnect:events");
+    });
+
+    test("does not clear state for other sessions", async () => {
+        pendingChunkedStates.set("sess-other", {
+            snapshotId: "other-snap",
+            metadata: {},
+            chunks: [[{ id: "other-m1" }]],
+            totalChunks: 1,
+            receivedChunkIndexes: new Set<number>([0]),
+            finalChunkSeen: false,
+            lastActivityAt: Date.now(),
+        });
+
+        await resetPerSessionRelayState("sess-reconnect");
+
+        expect(pendingChunkedStates.has("sess-other")).toBe(true);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -38,98 +38,31 @@ import { sendCumulativeEventAck } from "./ack-tracker.js";
 import { trackPushPendingState, checkPushNotifications } from "./push-tracker.js";
 import type { RelaySocket } from "./types.js";
 import { createLogger } from "@pizzapi/tools";
+import {
+    type ChunkedSessionState,
+    pendingChunkedStates,
+    applyChunkToPendingState,
+    applySnapshotPatchToPendingState,
+    canFinalizeChunkedSnapshot,
+    enqueueSessionEvent,
+} from "./relay-state.js";
+
+export {
+    type ChunkedSessionState,
+    CHUNK_STREAM_STALE_MS,
+    type PendingChunkUpdate,
+    pendingChunkedStates,
+    applyChunkToPendingState,
+    applySnapshotPatchToPendingState,
+    hasAllChunkIndexes,
+    canFinalizeChunkedSnapshot,
+    sessionEventQueues,
+    enqueueSessionEvent,
+    resetPerSessionRelayState,
+    getPendingChunkedSnapshot,
+} from "./relay-state.js";
 
 const log = createLogger("sio/relay");
-
-export interface ChunkedSessionState {
-    snapshotId: string;
-    metadata: Record<string, unknown>; // everything except messages
-    chunks: unknown[][]; // ordered message slices
-    totalChunks: number;
-    receivedChunkIndexes: Set<number>;
-    finalChunkSeen: boolean;
-    /** Recovery nonce echoed by the runner on the chunk-start session_active. */
-    recoveryNonce?: string;
-    /** Timestamp of the chunk-start SA or the most recent chunk. */
-    lastActivityAt: number;
-}
-
-/**
- * A chunk stream that has gone this long without a new chunk is dead — the
- * runner hung or lost the worker without its relay socket disconnecting.
- * Left in place, the pending entry makes every viewer hydration skip the
- * snapshot cache (viewer.ts chunkedPending gate) and wait on a runner signal
- * that never comes, which is unrecoverable even across client retries.
- *
- * Healthy streams emit chunks sub-second (setImmediate cadence on the
- * runner), so 10s of silence is unambiguous. Timing alignment matters: the
- * client retries hydration at ~4s and ~12s after its last progress event,
- * then surfaces a terminal error — the threshold must sit BELOW the final
- * retry (12s) or the bypass is never exercised before the client gives up.
- * Both clocks anchor to the same event (a chunk arrival), so 10s here
- * guarantees the ~12s retry sees the stream as stale.
- */
-export const CHUNK_STREAM_STALE_MS = 10_000;
-
-export interface PendingChunkUpdate {
-    chunkIndex: number;
-    chunkMessages: unknown[];
-    totalChunks: number;
-    isFinalChunk: boolean;
-}
-
-export const pendingChunkedStates = new Map<string, ChunkedSessionState>();
-
-export function applyChunkToPendingState(
-    pending: ChunkedSessionState,
-    update: PendingChunkUpdate,
-): boolean {
-    const { chunkIndex, chunkMessages, totalChunks, isFinalChunk } = update;
-
-    if (pending.receivedChunkIndexes.has(chunkIndex)) {
-        if (isFinalChunk) {
-            pending.finalChunkSeen = true;
-        }
-        return false;
-    }
-
-    if (Number.isInteger(totalChunks) && totalChunks > 0) {
-        pending.totalChunks = totalChunks;
-    }
-
-    if (isFinalChunk) {
-        pending.finalChunkSeen = true;
-    }
-
-    pending.receivedChunkIndexes.add(chunkIndex);
-    pending.chunks[chunkIndex] = chunkMessages;
-    pending.lastActivityAt = Date.now();
-    return true;
-}
-
-export function applySnapshotPatchToPendingState(
-    pending: ChunkedSessionState | null | undefined,
-    patch: Record<string, unknown>,
-): void {
-    if (!pending || Object.keys(patch).length === 0) return;
-    pending.metadata = { ...pending.metadata, ...patch };
-}
-
-export function hasAllChunkIndexes(pending: ChunkedSessionState): boolean {
-    if (!Number.isInteger(pending.totalChunks) || pending.totalChunks <= 0) {
-        return false;
-    }
-    for (let i = 0; i < pending.totalChunks; i++) {
-        if (!pending.receivedChunkIndexes.has(i)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-export function canFinalizeChunkedSnapshot(pending: ChunkedSessionState): boolean {
-    return pending.finalChunkSeen && hasAllChunkIndexes(pending);
-}
 
 export interface FinalizeChunkedSnapshotDeps {
     consumePendingRecovery: typeof consumePendingRecovery;
@@ -189,71 +122,6 @@ export async function finalizeChunkedSnapshot(
     });
 
     return fullState;
-}
-
-// ── Per-session event serialization ──────────────────────────────────────────
-// The async event handler must process events in arrival order per session.
-// Without serialization, concurrent async handlers (e.g. chunk 0 hitting a
-// Redis round-trip while chunk 1 skips it) can publish chunks out of order,
-// scrambling the viewer's message assembly.
-export const sessionEventQueues = new Map<string, Promise<void>>();
-
-export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): Promise<void> {
-    const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
-    const next = prev
-        .then(fn, fn) // always chain, even on prior rejection
-        .catch((error) => {
-            console.error(`[sio/relay] Session event pipeline failed for ${sessionId}:`, error);
-        });
-    sessionEventQueues.set(sessionId, next);
-    // Clean up the map entry when the chain settles to avoid unbounded growth.
-    // Use .finally() so cleanup runs even if fn rejects (otherwise the map
-    // entry leaks indefinitely on error, causing unbounded memory growth).
-    next.finally(() => {
-        if (sessionEventQueues.get(sessionId) === next) {
-            sessionEventQueues.delete(sessionId);
-        }
-    });
-    return next;
-}
-
-/**
- * Get the partially assembled snapshot for a session that's mid-chunked-delivery.
- * Returns metadata + chunks received so far, or null if no chunked delivery is active.
- */
-export function getPendingChunkedSnapshot(sessionId: string): {
-    metadata: Record<string, unknown>;
-    messages: unknown[];
-    snapshotId: string;
-    totalMessages: number;
-    receivedChunks: number;
-    totalChunks: number;
-    /**
-     * True when the stream has gone CHUNK_STREAM_STALE_MS without a chunk.
-     * Callers should stop gating hydration on it (serve the cache) AND request
-     * a fresh runner snapshot instead of suppressing recovery — but the entry
-     * is deliberately NOT deleted: a hung runner that resumes sending refreshes
-     * lastActivityAt and the stream can still finalize normally, and deleting
-     * it would silently discard chunks the runner still believes it delivered.
-     */
-    stale: boolean;
-} | null {
-    const pending = pendingChunkedStates.get(sessionId);
-    if (!pending) return null;
-    const stale = Date.now() - pending.lastActivityAt > CHUNK_STREAM_STALE_MS;
-    if (stale) {
-        log.warn(`Chunked snapshot for ${sessionId} is stale (no chunk for ${CHUNK_STREAM_STALE_MS}ms) — bypassing hydration gate`);
-    }
-    const messages = pending.chunks.flat();
-    return {
-        metadata: pending.metadata,
-        messages,
-        snapshotId: pending.snapshotId,
-        totalMessages: (pending.metadata as any).totalMessages ?? messages.length,
-        receivedChunks: pending.receivedChunkIndexes.size,
-        totalChunks: pending.totalChunks,
-        stale,
-    };
 }
 
 /** Register the main event pipeline handler on the given socket. */

--- a/packages/server/src/ws/namespaces/relay/relay-state.ts
+++ b/packages/server/src/ws/namespaces/relay/relay-state.ts
@@ -1,0 +1,193 @@
+// ── Per-session relay state (chunk assembly + event serialization) ──────────
+// Pure in-memory state keyed by session id, plus the reconnect reset helper.
+// Deliberately free of any sio-registry import so that sio-registry/sessions.ts
+// can import the reset helper without creating a static import cycle
+// (event-pipeline.ts imports the sio-registry barrel, so importing it from
+// sessions.ts would form sessions.ts → event-pipeline.ts → sio-registry.js →
+// sessions.ts).
+
+import { clearThinkingMaps } from "./thinking-tracker.js";
+import { deleteRelayEventCache } from "../../../sessions/redis.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
+
+export interface ChunkedSessionState {
+    snapshotId: string;
+    metadata: Record<string, unknown>; // everything except messages
+    chunks: unknown[][]; // ordered message slices
+    totalChunks: number;
+    receivedChunkIndexes: Set<number>;
+    finalChunkSeen: boolean;
+    /** Recovery nonce echoed by the runner on the chunk-start session_active. */
+    recoveryNonce?: string;
+    /** Timestamp of the chunk-start SA or the most recent chunk. */
+    lastActivityAt: number;
+}
+
+/**
+ * A chunk stream that has gone this long without a new chunk is dead — the
+ * runner hung or lost the worker without its relay socket disconnecting.
+ * Left in place, the pending entry makes every viewer hydration skip the
+ * snapshot cache (viewer.ts chunkedPending gate) and wait on a runner signal
+ * that never comes, which is unrecoverable even across client retries.
+ *
+ * Healthy streams emit chunks sub-second (setImmediate cadence on the
+ * runner), so 10s of silence is unambiguous. Timing alignment matters: the
+ * client retries hydration at ~4s and ~12s after its last progress event,
+ * then surfaces a terminal error — the threshold must sit BELOW the final
+ * retry (12s) or the bypass is never exercised before the client gives up.
+ * Both clocks anchor to the same event (a chunk arrival), so 10s here
+ * guarantees the ~12s retry sees the stream as stale.
+ */
+export const CHUNK_STREAM_STALE_MS = 10_000;
+
+export interface PendingChunkUpdate {
+    chunkIndex: number;
+    chunkMessages: unknown[];
+    totalChunks: number;
+    isFinalChunk: boolean;
+}
+
+export const pendingChunkedStates = new Map<string, ChunkedSessionState>();
+
+export function applyChunkToPendingState(
+    pending: ChunkedSessionState,
+    update: PendingChunkUpdate,
+): boolean {
+    const { chunkIndex, chunkMessages, totalChunks, isFinalChunk } = update;
+
+    if (pending.receivedChunkIndexes.has(chunkIndex)) {
+        if (isFinalChunk) {
+            pending.finalChunkSeen = true;
+        }
+        return false;
+    }
+
+    if (Number.isInteger(totalChunks) && totalChunks > 0) {
+        pending.totalChunks = totalChunks;
+    }
+
+    if (isFinalChunk) {
+        pending.finalChunkSeen = true;
+    }
+
+    pending.receivedChunkIndexes.add(chunkIndex);
+    pending.chunks[chunkIndex] = chunkMessages;
+    pending.lastActivityAt = Date.now();
+    return true;
+}
+
+export function applySnapshotPatchToPendingState(
+    pending: ChunkedSessionState | null | undefined,
+    patch: Record<string, unknown>,
+): void {
+    if (!pending || Object.keys(patch).length === 0) return;
+    pending.metadata = { ...pending.metadata, ...patch };
+}
+
+export function hasAllChunkIndexes(pending: ChunkedSessionState): boolean {
+    if (!Number.isInteger(pending.totalChunks) || pending.totalChunks <= 0) {
+        return false;
+    }
+    for (let i = 0; i < pending.totalChunks; i++) {
+        if (!pending.receivedChunkIndexes.has(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function canFinalizeChunkedSnapshot(pending: ChunkedSessionState): boolean {
+    return pending.finalChunkSeen && hasAllChunkIndexes(pending);
+}
+
+// ── Per-session event serialization ──────────────────────────────────────────
+// The async event handler must process events in arrival order per session.
+// Without serialization, concurrent async handlers (e.g. chunk 0 hitting a
+// Redis round-trip while chunk 1 skips it) can publish chunks out of order,
+// scrambling the viewer's message assembly.
+export const sessionEventQueues = new Map<string, Promise<void>>();
+
+export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): Promise<void> {
+    const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
+    const next = prev
+        .then(fn, fn) // always chain, even on prior rejection
+        .catch((error) => {
+            console.error(`[sio/relay] Session event pipeline failed for ${sessionId}:`, error);
+        });
+    sessionEventQueues.set(sessionId, next);
+    // Clean up the map entry when the chain settles to avoid unbounded growth.
+    // Use .finally() so cleanup runs even if fn rejects (otherwise the map
+    // entry leaks indefinitely on error, causing unbounded memory growth).
+    next.finally(() => {
+        if (sessionEventQueues.get(sessionId) === next) {
+            sessionEventQueues.delete(sessionId);
+        }
+    });
+    return next;
+}
+
+/**
+ * Reset all per-session relay state for a session that is being replaced by a
+ * reconnect (same session ID, new TUI socket).  Drains the event pipeline
+ * queue, discards any half-assembled chunked snapshot, clears thinking-block
+ * maps, and deletes the Redis relay event cache so stale queued work and
+ * half-assembled chunk state cannot leak into the new session generation.
+ *
+ * Unlike terminal session ends (which preserve the relay event cache for
+ * ended-session replay), a reconnect starts a fresh event stream under the
+ * same session ID — old cached events would race with the new sequence.
+ */
+export async function resetPerSessionRelayState(sessionId: string): Promise<void> {
+    clearThinkingMaps(sessionId);
+    // Drain the queue before discarding chunk state: a queued chunk handler
+    // that wakes up after we delete pendingChunkedStates would otherwise skip
+    // final assembly, or worse, apply an old chunk to the new session's
+    // pending state (same sessionId).
+    await enqueueSessionEvent(sessionId, async () => {
+        pendingChunkedStates.delete(sessionId);
+    });
+    // Clear the relay event cache AFTER draining so any cache writes from
+    // in-flight handlers are also removed.
+    await deleteRelayEventCache(sessionId);
+}
+
+/**
+ * Get the partially assembled snapshot for a session that's mid-chunked-delivery.
+ * Returns metadata + chunks received so far, or null if no chunked delivery is active.
+ */
+export function getPendingChunkedSnapshot(sessionId: string): {
+    metadata: Record<string, unknown>;
+    messages: unknown[];
+    snapshotId: string;
+    totalMessages: number;
+    receivedChunks: number;
+    totalChunks: number;
+    /**
+     * True when the stream has gone CHUNK_STREAM_STALE_MS without a chunk.
+     * Callers should stop gating hydration on it (serve the cache) AND request
+     * a fresh runner snapshot instead of suppressing recovery — but the entry
+     * is deliberately NOT deleted: a hung runner that resumes sending refreshes
+     * lastActivityAt and the stream can still finalize normally, and deleting
+     * it would silently discard chunks the runner still believes it delivered.
+     */
+    stale: boolean;
+} | null {
+    const pending = pendingChunkedStates.get(sessionId);
+    if (!pending) return null;
+    const stale = Date.now() - pending.lastActivityAt > CHUNK_STREAM_STALE_MS;
+    if (stale) {
+        log.warn(`Chunked snapshot for ${sessionId} is stale (no chunk for ${CHUNK_STREAM_STALE_MS}ms) — bypassing hydration gate`);
+    }
+    const messages = pending.chunks.flat();
+    return {
+        metadata: pending.metadata,
+        messages,
+        snapshotId: pending.snapshotId,
+        totalMessages: (pending.metadata as any).totalMessages ?? messages.length,
+        receivedChunks: pending.receivedChunkIndexes.size,
+        totalChunks: pending.totalChunks,
+        stale,
+    };
+}

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.exec-result.test.ts
@@ -28,6 +28,7 @@ mock.module("../../sio-registry.js", () => ({
         wasDelinked: false,
     }),
     getLocalTuiSocket: () => undefined,
+    getSessionOwnerToken: async () => "tok",
     broadcastToViewers: mockBroadcastToViewers,
     endSharedSession: async () => {},
 }));

--- a/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.owner-token.test.ts
@@ -58,6 +58,7 @@ mock.module("../../sessions/store.js", () => ({
     recordRelaySessionEnd: noopAsync,
     recordRelaySessionState: noopAsync,
     recordRelaySessionStateSerialized: noopAsync,
+    recordRelaySessionOverlay: noopAsync,
     touchRelaySession: noopAsync,
     updateRelaySessionName: noopAsync,
 }));

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -228,7 +228,6 @@ async function registerTuiSessionUnlocked(
             if (oldSocket && oldSocket !== socket) {
                 oldSocket.data.sessionId = undefined;
             }
-<<<<<<< HEAD
             await endSharedSessionUnlocked(sessionId, "Session reconnected");
             // Reset per-session relay state so stale queued work and
             // half-assembled chunk state from the old generation cannot leak

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -56,6 +56,7 @@ import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-im
 import { extractMetaFromHeartbeat } from "./meta.js";
 import { truncateSnapshotMessages } from "../namespaces/snapshot-provider.js";
 import { applySnapshotOverlayToState, mergeSnapshotOverlay } from "./snapshot-state.js";
+import { resetPerSessionRelayState } from "../namespaces/relay/relay-state.js";
 
 /**
  * Prepare an event for broadcast to viewers.
@@ -227,7 +228,13 @@ async function registerTuiSessionUnlocked(
             if (oldSocket && oldSocket !== socket) {
                 oldSocket.data.sessionId = undefined;
             }
+<<<<<<< HEAD
             await endSharedSessionUnlocked(sessionId, "Session reconnected");
+            // Reset per-session relay state so stale queued work and
+            // half-assembled chunk state from the old generation cannot leak
+            // into the new one.  Lives in relay-state.ts (barrel-free) so this
+            // static import does not create a cycle back through sio-registry.
+            await resetPerSessionRelayState(sessionId);
         }
     }
 


### PR DESCRIPTION
Rebase of #781 to resolve merge conflicts and fix the failing Unit Tests check.

Original: fix: reset per-session relay state on reconnect (A2-009)

Changes:
- Resolved the `sessions.ts` conflict by keeping the existing `endSharedSessionUnlocked` call (the reconnect path already holds the session ownership lock) and adding the PR's `resetPerSessionRelayState(sessionId)` call immediately after it.
- Fixed three test mocks that were missing newly exported functions:
  - `event-pipeline.cross-node.test.ts`: added `deleteRelayEventCache` to the mocked `redis.js`.
  - `sessions.owner-token.test.ts`: added `recordRelaySessionOverlay` to the mocked `store.js`.
  - `session-lifecycle.exec-result.test.ts`: added `getSessionOwnerToken` to the mocked `sio-registry.js` barrel.

Local verification:
- `bun run typecheck` passes.
- `bun scripts/test-isolated.ts packages/server/src` passes (101 tests).

Supersedes #781.