### PR TITLE
fix(usage): daemon-coordinated Anthropic refresh, preserve windows on 403/401/429

### DIFF
--- a/packages/cli/src/extensions/remote-provider-usage.test.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "bun:test";
-import { activeUsageWindows } from "./remote-provider-usage.js";
+import { describe, expect, test } from "bun:test";
+import { activeUsageWindows, preserveUsageWindowsOnError } from "./remote-provider-usage.js";
 
 const NOW = Date.parse("2026-03-10T12:00:00Z");
 
@@ -34,5 +34,42 @@ describe("activeUsageWindows", () => {
             NOW,
         );
         expect(result).toEqual([]);
+    });
+});
+
+describe("preserveUsageWindowsOnError", () => {
+    test("preserves existing windows and marks unknown with error code", () => {
+        const existing = {
+            windows: [{ label: "5-hour", utilization: 42, resets_at: "2026-12-31T23:59:59Z" }],
+            status: "ok" as const,
+        };
+        expect(preserveUsageWindowsOnError(existing, 403)).toEqual({
+            windows: existing.windows,
+            status: "unknown",
+            errorCode: 403,
+        });
+    });
+
+    test("uses empty windows when no cached data exists", () => {
+        expect(preserveUsageWindowsOnError(undefined, 429)).toEqual({
+            windows: [],
+            status: "unknown",
+            errorCode: 429,
+        });
+    });
+
+    test("does not drop existing windows on 401", () => {
+        const existing = {
+            windows: [
+                { label: "5-hour", utilization: 88, resets_at: "2026-12-31T23:59:59Z" },
+                { label: "7-day", utilization: 15, resets_at: "2026-12-31T23:59:59Z" },
+            ],
+            status: "ok" as const,
+        };
+        expect(preserveUsageWindowsOnError(existing, 401)).toEqual({
+            windows: existing.windows,
+            status: "unknown",
+            errorCode: 401,
+        });
     });
 });

--- a/packages/cli/src/extensions/remote-provider-usage.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.ts
@@ -20,6 +20,49 @@ const usageCache = new Map<string, { data: ProviderUsageData; fetchedAt: number 
 // fetching provider quota data and writing it to a shared cache file.
 const runnerUsageCachePath: string | null = process.env.PIZZAPI_RUNNER_USAGE_CACHE_PATH ?? null;
 
+// ── Runner-daemon IPC for forced usage refreshes ─────────────────────────────
+//
+// The daemon is the single source of truth for provider quota on a runner
+// node. When the web UI asks for a forced refresh, ask the daemon to update
+// its shared cache file rather than every worker hammering the provider APIs
+// independently.
+
+const pendingRefreshRequests = new Map<string, () => void>();
+
+function isRefreshCompleteMessage(msg: unknown): msg is { type: "refresh_usage_complete"; requestId: string } {
+    return (
+        typeof msg === "object" && msg !== null &&
+        (msg as Record<string, unknown>).type === "refresh_usage_complete" &&
+        typeof (msg as Record<string, unknown>).requestId === "string"
+    );
+}
+
+if (typeof process !== "undefined" && typeof process.send === "function") {
+    process.on("message", (msg: unknown) => {
+        if (!isRefreshCompleteMessage(msg)) return;
+        const resolve = pendingRefreshRequests.get(msg.requestId);
+        if (!resolve) return;
+        resolve();
+        pendingRefreshRequests.delete(msg.requestId);
+    });
+}
+
+function requestRunnerUsageRefresh(timeoutMs = 5000): Promise<boolean> {
+    if (typeof process.send !== "function") return Promise.resolve(false);
+    const requestId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+            pendingRefreshRequests.delete(requestId);
+            resolve(false);
+        }, timeoutMs);
+        pendingRefreshRequests.set(requestId, () => {
+            clearTimeout(timer);
+            resolve(true);
+        });
+        process.send!({ type: "refresh_usage_request", requestId });
+    });
+}
+
 export function getOAuthToken(providerId: string): string | null {
     try {
         const config = loadConfig(process.cwd());
@@ -92,6 +135,18 @@ async function refreshFromRunnerCache(): Promise<void> {
     }
 }
 
+/** Preserve existing usage windows when a provider auth/rate-limit error occurs. */
+export function preserveUsageWindowsOnError(
+    existing: ProviderUsageData | undefined,
+    status: number,
+): ProviderUsageData {
+    return {
+        windows: existing?.windows ?? [],
+        status: "unknown",
+        errorCode: status,
+    };
+}
+
 async function refreshAnthropicUsage(opts: { force?: boolean } = {}): Promise<void> {
     if (isCached("anthropic", opts)) return;
     // auth.json first, then Claude Code's own OAuth token (Keychain /
@@ -108,9 +163,12 @@ async function refreshAnthropicUsage(opts: { force?: boolean } = {}): Promise<vo
             },
         });
         if (!res.ok) {
-            if (res.status === 403) {
+            if (res.status === 401 || res.status === 403 || res.status === 429) {
+                // Auth/rate-limit errors should not erase known-good cached quota
+                // data. Preserve existing windows and surface the error code so
+                // the UI can show "UNKNOWN" without dropping the percentage.
                 usageCache.set("anthropic", {
-                    data: { windows: [], status: "unknown", errorCode: 403 },
+                    data: preserveUsageWindowsOnError(usageCache.get("anthropic")?.data, res.status),
                     fetchedAt: Date.now(),
                 });
             }
@@ -152,9 +210,9 @@ async function refreshCodexUsage(opts: { force?: boolean } = {}): Promise<void> 
             },
         });
         if (!res.ok) {
-            if (res.status === 403) {
+            if (res.status === 401 || res.status === 403 || res.status === 429) {
                 usageCache.set("openai-codex", {
-                    data: { windows: [], status: "unknown", errorCode: 403 },
+                    data: preserveUsageWindowsOnError(usageCache.get("openai-codex")?.data, res.status),
                     fetchedAt: Date.now(),
                 });
             }
@@ -249,6 +307,18 @@ export async function refreshAllUsage(opts: { force?: boolean } = {}): Promise<v
     if (runnerUsageCachePath && !force) {
         await refreshFromRunnerCache();
         return;
+    }
+
+    // When running under a runner daemon, ask it to force-refresh the shared
+    // cache rather than every worker hitting the provider APIs. This preserves
+    // the daemon's rate-limiting and credential discovery, and updates the file
+    // for all sessions. Fall back to a direct fetch if IPC is unavailable.
+    if (runnerUsageCachePath && force) {
+        const refreshed = await requestRunnerUsageRefresh();
+        if (refreshed) {
+            await refreshFromRunnerCache();
+            return;
+        }
     }
 
     await Promise.allSettled([

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -236,7 +236,7 @@ export function singleFlight<A extends unknown[]>(fn: (...args: A) => Promise<vo
     };
 }
 
-const refreshAndWriteRunnerUsageCache = singleFlight(doRefreshAndWriteRunnerUsageCache);
+export const refreshAndWriteRunnerUsageCache = singleFlight(doRefreshAndWriteRunnerUsageCache);
 
 async function doRefreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean } = {}): Promise<void> {
     const [anthropicResult, codexResult] = await Promise.allSettled([

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { execFileSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -88,6 +89,7 @@ describe("session-spawner child", () => {
             runnerUsageCacheFilePath,
             trackSessionCwd,
             untrackSessionCwd,
+            refreshAndWriteRunnerUsageCache: mock(async () => {}),
         }));
 
         mock.module("./workspace.js", () => ({
@@ -270,6 +272,7 @@ describe("session-spawner child", () => {
             runnerUsageCacheFilePath,
             trackSessionCwd,
             untrackSessionCwd,
+            refreshAndWriteRunnerUsageCache: mock(async () => {}),
         }));
 
         mock.module("./workspace.js", () => ({
@@ -349,6 +352,7 @@ describe("session-spawner child", () => {
             runnerUsageCacheFilePath,
             trackSessionCwd,
             untrackSessionCwd,
+            refreshAndWriteRunnerUsageCache: mock(async () => {}),
         }));
 
         mock.module("./workspace.js", () => ({
@@ -440,7 +444,7 @@ describe("session-spawner child", () => {
         }));
         mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
         mock.module("./logger.js", () => ({ logInfo }));
-        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd, refreshAndWriteRunnerUsageCache: mock(async () => {}) }));
         mock.module("./workspace.js", () => ({ isCwdAllowed }));
         mock.module("./session-procs.js", () => ({
             ensureSessionProcDir: () => {},
@@ -514,7 +518,7 @@ describe("session-spawner child", () => {
         mock.module("node:child_process", () => ({ spawn: spawnMock, execFile: mock(() => {}) }));
         mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
         mock.module("./logger.js", () => ({ logInfo }));
-        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd, refreshAndWriteRunnerUsageCache: mock(async () => {}) }));
         mock.module("./workspace.js", () => ({ isCwdAllowed }));
         mock.module("./session-procs.js", () => ({
             ensureSessionProcDir: () => {},
@@ -587,7 +591,7 @@ describe("session-spawner child", () => {
         mock.module("node:child_process", () => ({ spawn: spawnMock, execFile: mock(() => {}) }));
         mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
         mock.module("./logger.js", () => ({ logInfo }));
-        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd }));
+        mock.module("./runner-usage-cache.js", () => ({ runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd, refreshAndWriteRunnerUsageCache: mock(async () => {}) }));
         mock.module("./workspace.js", () => ({ isCwdAllowed }));
         mock.module("./session-procs.js", () => ({
             ensureSessionProcDir: () => {},
@@ -651,6 +655,69 @@ describe("session-spawner child", () => {
         } finally {
             rmSync(childTestPath, { force: true });
             rmSync(tmpHome, { recursive: true, force: true });
+        }
+    });
+
+    test("handles refresh_usage_request IPC by forcing usage cache refresh and replying", async () => {
+        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
+        const logInfo = mock((_message: string) => {});
+        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
+        const refreshCalls: { forceAnthropic?: boolean }[] = [];
+        const refreshAndWriteRunnerUsageCache = mock(async (opts: { forceAnthropic?: boolean } = {}) => {
+            refreshCalls.push(opts);
+        });
+        const isCwdAllowed = mock((_cwd: string | undefined) => true);
+
+        class FakeChild extends EventEmitter {
+            pid = 4321;
+            killed = false;
+            exitCode: number | null = null;
+            send = mock((msg: unknown) => {});
+        }
+
+        const spawnMock = mock((_execPath: string, _args: string[], _options: any) => new FakeChild());
+
+        mock.module("node:child_process", () => ({
+            spawn: spawnMock,
+            execFile: mock(() => {}),
+        }));
+        mock.module("../extensions/session-attachments.js", () => ({ cleanupSessionAttachments }));
+        mock.module("./logger.js", () => ({ logInfo }));
+        mock.module("./runner-usage-cache.js", () => ({
+            runnerUsageCacheFilePath,
+            trackSessionCwd,
+            untrackSessionCwd,
+            refreshAndWriteRunnerUsageCache,
+        }));
+        mock.module("./workspace.js", () => ({ isCwdAllowed }));
+
+        const { spawnSession } = await import("./session-spawner.js");
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-refresh-test-"));
+        try {
+            const runningSessions = new Map();
+            spawnSession(
+                "sess-refresh",
+                "api-key",
+                "https://relay.example",
+                tempCwd,
+                runningSessions,
+                new Set(),
+                new Set(),
+            );
+            const child = runningSessions.get("sess-refresh")?.child as FakeChild;
+            expect(child).toBeDefined();
+
+            child.emit("message", { type: "refresh_usage_request", requestId: "req-1" });
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(refreshAndWriteRunnerUsageCache).toHaveBeenCalledTimes(1);
+            expect(refreshCalls[0]).toEqual({ forceAnthropic: true });
+            expect(child.send).toHaveBeenCalledWith({ type: "refresh_usage_complete", requestId: "req-1" });
+        } finally {
+            rmSync(tempCwd, { recursive: true, force: true });
         }
     });
 });

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -10,7 +10,7 @@ import {
     readRecordedGroupPids,
     removeSessionProcFile,
 } from "./session-procs.js";
-import { runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd } from "./runner-usage-cache.js";
+import { runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd, refreshAndWriteRunnerUsageCache } from "./runner-usage-cache.js";
 import { recordTranscriptLink } from "./session-transcript-links.js";
 import { isCwdAllowed } from "./workspace.js";
 import { loadConfig } from "../config.js";
@@ -340,6 +340,15 @@ export function spawnSession(
         if (message.type === "pre_restart") {
             restartingSessions.add(sessionId);
             logInfo(`session ${sessionId} signaled pre-restart via IPC`);
+            return;
+        }
+        if (message.type === "refresh_usage_request" && typeof message.requestId === "string") {
+            // Worker asked for an immediate usage refresh (e.g. user clicked
+            // Refresh in the web UI). Force Anthropic so the UI sees current
+            // quota, but still refresh Codex on the normal path.
+            void refreshAndWriteRunnerUsageCache({ forceAnthropic: true }).finally(() => {
+                child.send?.({ type: "refresh_usage_complete", requestId: message.requestId });
+            });
             return;
         }
         if (message.type === "session_metadata" && typeof message.sessionFile === "string") {

--- a/packages/cli/src/runner/usage-auth.test.ts
+++ b/packages/cli/src/runner/usage-auth.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+
+function writeImportedCredential(path: string, token: string, expiresAt: number, nested = true): void {
+    mkdirSync(join(path, ".."), { recursive: true });
+    const oauth = { accessToken: token, refreshToken: "r", expiresAt };
+    writeFileSync(path, JSON.stringify(nested ? { claudeAiOauth: oauth } : oauth));
+}
 
 describe("getOAuthAccessToken", () => {
     test("returns OAuth access token", () => {
@@ -51,6 +60,59 @@ describe("getAnthropicKeychainToken", () => {
         }));
         const { getAnthropicKeychainToken } = await import("./usage-auth.js");
         expect(getAnthropicKeychainToken()).toBeNull();
+    });
+
+    test("prefers minimalcc-pi imported credentials when unexpired", async () => {
+        const tmpHome = mkdtempSync(join(tmpdir(), "usage-auth-test-"));
+        const importedPath = join(tmpHome, "imported-credentials.json");
+        writeImportedCredential(importedPath, "mcc-imported-token", Date.now() + 60_000);
+
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => ({
+                credentials: { claudeAiOauth: { accessToken: "kc-token", refreshToken: "r", expiresAt: Date.now() + 60_000 } },
+                source: "keychain",
+                sourceLabel: "Claude Code-credentials",
+            }),
+        }));
+
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken({ importedCredentialPath: importedPath })).toBe("mcc-imported-token");
+
+        rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    test("falls back to keychain when minimalcc-pi imported credential is expired", async () => {
+        const tmpHome = mkdtempSync(join(tmpdir(), "usage-auth-test-"));
+        const importedPath = join(tmpHome, "imported-credentials.json");
+        writeImportedCredential(importedPath, "mcc-imported-token", Date.now() - 1_000);
+
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => ({
+                credentials: { claudeAiOauth: { accessToken: "kc-token", refreshToken: "r", expiresAt: Date.now() + 60_000 } },
+                source: "keychain",
+                sourceLabel: "Claude Code-credentials",
+            }),
+        }));
+
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken({ importedCredentialPath: importedPath })).toBe("kc-token");
+
+        rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    test("reads flat minimalcc-pi credential shape", async () => {
+        const tmpHome = mkdtempSync(join(tmpdir(), "usage-auth-test-"));
+        const importedPath = join(tmpHome, "imported-credentials.json");
+        writeImportedCredential(importedPath, "flat-token", Date.now() + 60_000, false);
+
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => null,
+        }));
+
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken({ importedCredentialPath: importedPath })).toBe("flat-token");
+
+        rmSync(tmpHome, { recursive: true, force: true });
     });
 });
 

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -1,9 +1,46 @@
 import { readBestExternalCredential } from "./keychain-auth.js";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 export type RunnerAuthRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;
+}
+
+/** Read a Claude Code OAuth credential file, handling both the nested
+ *  `{ claudeAiOauth: {...} }` shape and the flat `{ accessToken, ... }` shape. */
+function readClaudeCodeCredentialsFile(path: string): { accessToken: string; expiresAt: number } | null {
+    try {
+        if (!existsSync(path)) return null;
+        const raw = readFileSync(path, "utf-8").trim();
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const oauth = isRecord(parsed.claudeAiOauth) ? (parsed.claudeAiOauth as Record<string, unknown>) : parsed;
+        const accessToken = oauth.accessToken;
+        const expiresAt = oauth.expiresAt;
+        if (typeof accessToken !== "string" || accessToken.trim().length === 0) return null;
+        if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return null;
+        return { accessToken, expiresAt };
+    } catch {
+        return null;
+    }
+}
+
+/** Path to minimalcc-pi's imported Claude Code OAuth credentials.
+ *  When the user has run `/claude-subscription-import`, the credentials are
+ *  copied here and kept refreshed by the extension. */
+function minimalccPiImportedCredentialPath(): string {
+    return join(homedir(), ".pizzapi", "agent", "pi-claude-subscription", "imported-credentials.json");
+}
+
+function readMinimalccPiImportedCredential(opts: { now?: number; path?: string } = {}): { accessToken: string; expiresAt: number } | null {
+    const now = opts.now ?? Date.now();
+    const path = opts.path ?? minimalccPiImportedCredentialPath();
+    const cred = readClaudeCodeCredentialsFile(path);
+    if (!cred || cred.expiresAt <= now) return null;
+    return cred;
 }
 
 /**
@@ -24,15 +61,21 @@ export function getOAuthAccessToken(raw: unknown): string | null {
 
 /**
  * Fallback Anthropic usage-check token: reads Claude Code's own OAuth token
- * straight from the macOS Keychain / `~/.claude/.credentials.json` (same
- * read-only lookup `readBestExternalCredential` already does) for users who
- * only ever logged into Claude Code directly and have no `anthropic` entry
- * in auth.json.
+ * from the macOS Keychain / `~/.claude/.credentials.json`, and also from
+ * minimalcc-pi's imported credential store if the user uses the
+ * claude-subscription extension. This covers users who never ran /login inside
+ * pizzapi and rely on Claude Code OAuth.
  *
- * Never refreshes or persists anything — an expired token is simply treated
- * as absent so we can't accidentally rotate Claude Code's own credentials.
+ * Read-only — never refreshes or persists anything. An expired token is
+ * treated as absent so we can't accidentally rotate credentials owned by
+ * another process. (The minimalcc-pi extension keeps its imported credentials
+ * refreshed independently.)
  */
-export function getAnthropicKeychainToken(now = Date.now()): string | null {
+export function getAnthropicKeychainToken(opts?: { now?: number; importedCredentialPath?: string }): string | null {
+    const now = opts?.now ?? Date.now();
+    const imported = readMinimalccPiImportedCredential({ now, path: opts?.importedCredentialPath });
+    if (imported) return imported.accessToken;
+
     const oauth = readBestExternalCredential()?.credentials.claudeAiOauth;
     if (!oauth || oauth.expiresAt <= now) return null;
     return oauth.accessToken;


### PR DESCRIPTION
## Summary\n\nFixes Anthropic usage not refreshing reliably from the web UI.\n\n## Changes\n\n- **Daemon-coordinated refresh**: the web UI's Refresh button now sends a `refresh_usage_request` IPC message to the runner daemon, which force-refreshes the shared `~/.pizzapi/usage-cache.json` and replies with `refresh_usage_complete`. This keeps the daemon as the single source of truth and avoids every worker independently hammering provider usage endpoints.\n- **Preserve quota windows on auth/rate errors**: 401/403/429 responses no longer replace good cached Anthropic/OpenAI Codex windows with an empty `unknown` state. Existing windows are kept and marked `status: \"unknown\"` with the HTTP error code.\n- **minimalcc-pi credential fallback**: `getAnthropicKeychainToken()` now reads imported Claude Code OAuth credentials from `~/.pizzapi/agent/pi-claude-subscription/imported-credentials.json` (managed by the minimalcc-pi extension) before falling back to the macOS Keychain / `~/.claude/.credentials.json`. This lets Anthropic usage checks work when `~/.pizzapi/auth.json` has no `anthropic` entry or the Claude Code credentials file is missing/stale.\n- Export `refreshAndWriteRunnerUsageCache` and handle `refresh_usage_request` IPC in `session-spawner`.\n- Add tests for the IPC handler, `preserveUsageWindowsOnError`, and the minimalcc-pi credential fallback.\n\n## Files changed\n\n- `packages/cli/src/extensions/remote-provider-usage.ts`\n- `packages/cli/src/extensions/remote-provider-usage.test.ts`\n- `packages/cli/src/runner/runner-usage-cache.ts`\n- `packages/cli/src/runner/session-spawner.ts`\n- `packages/cli/src/runner/session-spawner.test.ts`\n- `packages/cli/src/runner/usage-auth.ts`\n- `packages/cli/src/runner/usage-auth.test.ts`\n\n## Verification\n\n- `bun run typecheck` clean.\n- Relevant tests pass:\n  - `bun test packages/cli/src/extensions/remote-provider-usage.test.ts`\n  - `bun test packages/cli/src/runner/session-spawner.test.ts`\n  - `bun test packages/cli/src/runner/runner-usage-cache.test.ts`\n  - `bun test packages/cli/src/runner/usage-auth.test.ts`\n\n## Related idea\n\nFollow-up to [[idea:yIpEtcW0]].\n