### PR TITLE
chore: bump pi-* suite to 0.84.3 and migrate patches

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-updater": "^8",
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2",
-        "@earendil-works/pi-tui": "^0.84.2",
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-tui": "^0.84.3",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -40,14 +40,14 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.71-dev.1",
+      "version": "0.5.71-dev.2",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.2",
-        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-coding-agent": "^0.84.3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/extension-sdk": "workspace:*",
         "@pizzapi/protocol": "workspace:*",
@@ -81,7 +81,7 @@
         "@pizzapi/protocol": "workspace:*",
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@earendil-works/pi-coding-agent": "^0.84.3",
         "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
       },
@@ -101,8 +101,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -130,8 +130,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -226,11 +226,11 @@
     },
   },
   "patchedDependencies": {
+    "@earendil-works/pi-agent-core@0.84.3": "patches/@earendil-works%2Fpi-agent-core@0.84.3.patch",
     "pptx-browser@4.1.5": "patches/pptx-browser@4.1.5.patch",
-    "@earendil-works/pi-coding-agent@0.84.2": "patches/@earendil-works%2Fpi-coding-agent@0.84.2.patch",
-    "@earendil-works/pi-ai@0.84.2": "patches/@earendil-works%2Fpi-ai@0.84.2.patch",
-    "@earendil-works/pi-agent-core@0.84.2": "patches/@earendil-works%2Fpi-agent-core@0.84.2.patch",
-    "@earendil-works/pi-tui@0.84.2": "patches/@earendil-works%2Fpi-tui@0.84.2.patch",
+    "@earendil-works/pi-ai@0.84.3": "patches/@earendil-works%2Fpi-ai@0.84.3.patch",
+    "@earendil-works/pi-coding-agent@0.84.3": "patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch",
+    "@earendil-works/pi-tui@0.84.3": "patches/@earendil-works%2Fpi-tui@0.84.3.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -623,19 +623,19 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-telemetry": "^0.84.2", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-telemetry": "^0.84.3", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.2", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.2", "@google/genai": "1.52.0", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.2", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.2" } }, "sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.3", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.3" } }, "sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.2", "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-client": "^0.84.2", "@earendil-works/pi-protocol": "^0.84.2", "@earendil-works/pi-tui": "^0.84.2", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.3", "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-client": "^0.84.3", "@earendil-works/pi-protocol": "^0.84.3", "@earendil-works/pi-tui": "^0.84.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.2", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ=="],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.3", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.2", "", {}, "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-updater": "^8",
-    "@earendil-works/pi-agent-core": "^0.84.2",
-    "@earendil-works/pi-ai": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-agent-core": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-tui": "^0.84.3",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -72,10 +72,10 @@
   },
   "version": "",
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.84.2": "patches/@earendil-works%2Fpi-agent-core@0.84.2.patch",
-    "@earendil-works/pi-ai@0.84.2": "patches/@earendil-works%2Fpi-ai@0.84.2.patch",
-    "@earendil-works/pi-coding-agent@0.84.2": "patches/@earendil-works%2Fpi-coding-agent@0.84.2.patch",
-    "@earendil-works/pi-tui@0.84.2": "patches/@earendil-works%2Fpi-tui@0.84.2.patch",
-    "pptx-browser@4.1.5": "patches/pptx-browser@4.1.5.patch"
+    "pptx-browser@4.1.5": "patches/pptx-browser@4.1.5.patch",
+    "@earendil-works/pi-agent-core@0.84.3": "patches/@earendil-works%2Fpi-agent-core@0.84.3.patch",
+    "@earendil-works/pi-ai@0.84.3": "patches/@earendil-works%2Fpi-ai@0.84.3.patch",
+    "@earendil-works/pi-coding-agent@0.84.3": "patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch",
+    "@earendil-works/pi-tui@0.84.3": "patches/@earendil-works%2Fpi-tui@0.84.3.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,8 +29,8 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.84.2",
-    "@earendil-works/pi-coding-agent": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/extension-sdk": "workspace:*",
     "@pizzapi/protocol": "workspace:*",

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -36,7 +36,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.3",
     "@types/bun": "^1.3.9",
     "typescript": "^5.7.0"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2"
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@earendil-works%2Fpi-agent-core@0.84.3.patch
+++ b/patches/@earendil-works%2Fpi-agent-core@0.84.3.patch
@@ -1,6 +1,8 @@
 diff --git a/dist/agent-loop.js b/dist/agent-loop.js
-index 0000000..0000000 100644
-@@ -102,6 +102,9 @@
+index 569149f9328920cda8c637ef4cdd0b11cac1a9eb..02225294934406cd9e05be88ec50ed8d66af604b 100644
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -102,6 +102,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
                  }
                  pendingMessages = [];
              }
@@ -11,8 +13,10 @@ index 0000000..0000000 100644
              const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
              newMessages.push(message);
 diff --git a/dist/agent.js b/dist/agent.js
-index 0000000..0000000 100644
-@@ -280,6 +280,9 @@
+index ee4f2259470dca6959d26b2ffecb69d173f4093d..d22f01962fd1511b5bf1f342bad68d0efcc420ef 100644
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -280,6 +280,9 @@ export class Agent {
      createContextSnapshot() {
          return {
              systemPrompt: this._state.systemPrompt,

--- a/patches/@earendil-works%2Fpi-ai@0.84.3.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.84.3.patch
@@ -1,6 +1,8 @@
 diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
-index 0000000..0000000 100644
-@@ -450,6 +450,29 @@
+index d04d7a9f59f3700a7e3bacb02aa68256215bee27..9805b75e36389df83bfd43aa133282b1fed5b5af 100644
+--- a/dist/api/anthropic-messages.js
++++ b/dist/api/anthropic-messages.js
+@@ -452,6 +452,29 @@ export const stream = (model, context, options) => {
                          output.content.push(block);
                          stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
                      }
@@ -30,7 +32,7 @@ index 0000000..0000000 100644
                  }
                  else if (event.type === "content_block_delta") {
                      if (event.delta.type === "text_delta") {
-@@ -491,6 +514,10 @@
+@@ -493,6 +516,10 @@ export const stream = (model, context, options) => {
                                  partial: output,
                              });
                          }
@@ -41,7 +43,7 @@ index 0000000..0000000 100644
                      }
                      else if (event.delta.type === "signature_delta") {
                          const index = blocks.findIndex((b) => b.index === event.index);
-@@ -507,6 +534,16 @@
+@@ -509,6 +536,16 @@ export const stream = (model, context, options) => {
                      if (block) {
                          delete block.index;
                          if (block.type === "text") {
@@ -58,7 +60,7 @@ index 0000000..0000000 100644
                              stream.push({
                                  type: "text_end",
                                  contentIndex: index,
-@@ -769,6 +806,22 @@
+@@ -780,6 +817,22 @@ function buildParams(model, context, isOAuthToken, options) {
              ...convertTools(deferredTools, isOAuthToken, compat.supportsEagerToolInputStreaming, compat.supportsStrictTools, undefined, true),
          ];
      }
@@ -81,7 +83,7 @@ index 0000000..0000000 100644
      // Configure thinking mode: adaptive, budget-based, or explicitly disabled.
      if (model.reasoning) {
          if (options?.thinkingEnabled) {
-@@ -897,7 +950,23 @@
+@@ -912,7 +965,23 @@ function convertMessages(transformedMessages, isOAuthToken, cacheControl, allowE
          else if (msg.role === "assistant") {
              const blocks = [];
              for (const block of msg.content) {
@@ -106,7 +108,7 @@ index 0000000..0000000 100644
                      if (block.text.trim().length === 0)
                          continue;
                      blocks.push({
-@@ -1008,6 +1077,10 @@
+@@ -1023,6 +1092,10 @@ function convertTools(tools, isOAuthToken, supportsEagerToolInputStreaming, supp
      if (!tools)
          return [];
      return tools.map((tool, index) => {
@@ -118,8 +120,10 @@ index 0000000..0000000 100644
          const parameters = getJsonSchemaToolParameters(tool, strict);
          const schema = parameters;
 diff --git a/dist/auth/oauth/anthropic.js b/dist/auth/oauth/anthropic.js
-index 0000000..0000000 100644
-@@ -296,11 +296,49 @@
+index 8692e906caa2609396bdccae98d4d593e024ecf6..815bf6fcfd39cec32e7943a931d1e02dc1c6b269 100644
+--- a/dist/auth/oauth/anthropic.js
++++ b/dist/auth/oauth/anthropic.js
+@@ -296,11 +296,49 @@ async function refreshAnthropicToken(refreshToken, signal) {
          expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
      };
  }
@@ -171,8 +175,10 @@ index 0000000..0000000 100644
          return { apiKey: credential.access };
      },
 diff --git a/dist/utils/retry.js b/dist/utils/retry.js
-index 0000000..0000000 100644
-@@ -64,6 +64,9 @@
+index 65c7c9efd7667445b711fcd43549062ee3eb5ecf..a20dab36b194559c5a40f42fa13a8ecf69a92940 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -64,6 +64,9 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
      "stream ended before message_stop",
      "stream ended before a terminal response event",
      "http2 request did not get a response",

--- a/patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch
@@ -1,11 +1,19 @@
-diff --git a/node_modules/.bun/@earendil-works+pi-coding-agent@0.84.2+36935d20367572cb/node_modules/@earendil-works/pi-coding-agent/.bun-tag-7c795784f70518c1 b/.bun-tag-7c795784f70518c1
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
-index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed05659f958 100644
+index f04269f78b199c72277de9debb6948b654e7ee6f..e6d8366e3dcc976aead52d62170eebe6f9f62d54 100644
 --- a/dist/config.js
 +++ b/dist/config.js
-@@ -358,6 +358,10 @@ export function getExamplesPath() {
+@@ -358,6 +358,10 @@ export function getReadmePath() {
+ }
+ /** Get path to docs directory */
+ export function getDocsPath() {
++    // PATCH(pizzapi): allow PizzaPi to display its wrapper changelog.
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "docs"));
+ }
+ /** Get path to examples directory */
+@@ -366,6 +370,10 @@ export function getExamplesPath() {
  }
  /** Get path to CHANGELOG.md */
  export function getChangelogPath() {
@@ -16,7 +24,7 @@ index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed0
      return resolve(join(getPackageDir(), "CHANGELOG.md"));
  }
  /**
-@@ -391,7 +395,7 @@ const piConfigName = pkg.piConfig?.name;
+@@ -399,7 +407,7 @@ const piConfigName = pkg.piConfig?.name;
  export const PACKAGE_NAME = pkg.name || "@earendil-works/pi-coding-agent";
  export const APP_NAME = piConfigName || "pi";
  export const APP_TITLE = piConfigName ? APP_NAME : "π";
@@ -25,7 +33,7 @@ index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed0
  export const VERSION = pkg.version || "0.0.0";
  // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
  export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
-@@ -414,7 +418,8 @@ export function getAgentDir() {
+@@ -422,7 +430,8 @@ export function getAgentDir() {
      if (envDir) {
          return expandTildePath(envDir);
      }
@@ -36,10 +44,10 @@ index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed0
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index 4bcf0d4b823d1cc847d1fa26a86a850761758194..ad31a0c8388e072ef932ed51b89d1bca0b1af609 100644
+index f4fd9f37d9826a3e791f25c9ec748645a33d5616..47dfba66f381888bff1cf849e2244fe5edbf7658 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -951,29 +951,40 @@ export class AgentSession {
+@@ -954,29 +954,40 @@ export class AgentSession {
       * Emits errors via extension runner if file read fails.
       */
      _expandSkillCommand(text) {
@@ -104,7 +112,7 @@ index 4bcf0d4b823d1cc847d1fa26a86a850761758194..ad31a0c8388e072ef932ed51b89d1bca
      /**
       * Queue a steering message while the agent is running.
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
-index 6b2143e141ad2865616e42ae60b2f382fe443544..2c370fc2129a8a6e53e809070ff4f16f7eb40cf4 100644
+index d7940e14deb53a3a18237c51c5afb5712686f0ba..36a3d2be5dc5ec31199601965583eed0b3bd7503 100644
 --- a/dist/core/model-resolver.js
 +++ b/dist/core/model-resolver.js
 @@ -21,6 +21,7 @@ export const defaultModelPerProvider = {
@@ -113,7 +121,7 @@ index 6b2143e141ad2865616e42ae60b2f382fe443544..2c370fc2129a8a6e53e809070ff4f16f
      openrouter: "moonshotai/kimi-k2.6",
 +    "ollama-cloud": "glm-5.1",
      "vercel-ai-gateway": "zai/glm-5.1",
-     xai: "grok-4.5",
+     xai: "grok-4.6",
      groq: "openai/gpt-oss-120b",
 diff --git a/dist/core/model-runtime.js b/dist/core/model-runtime.js
 index 7d93ba62bdb5d47e129751e8075cbb34620322ad..fcd96e85d1b7f290f48e25df14d39fcd8b61afeb 100644
@@ -162,7 +170,7 @@ index 7d93ba62bdb5d47e129751e8075cbb34620322ad..fcd96e85d1b7f290f48e25df14d39fcd
          if (!base && !this.config.getProvider(providerId) && !extension) {
              this.models.deleteProvider(providerId);
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index f43bc9620f36d198d75abeeb5c84e171de0d5ffe..0d2aab1a54452a0105eb291325ea97fa99e541b7 100644
+index cd12d9e885c21ea14c3a1e681e9ca1544087600a..07ca8137332a28a1997b341cfb8a3eb282632a7d 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -13,6 +13,7 @@ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveMode
@@ -172,9 +180,9 @@ index f43bc9620f36d198d75abeeb5c84e171de0d5ffe..0d2aab1a54452a0105eb291325ea97fa
 +export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
  export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.ts";
  export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
- export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
+ export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createPowerShellTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
 diff --git a/dist/index.js b/dist/index.js
-index 76d728eb6fa4cac493dfe1ba623ef8170235a310..9ef49b59878f45b35ccb210f8393061431b8fcc4 100644
+index 7bc4467f5af64aba74ab6cafd136e468b6aab803..59fdb706baf9674063152c6d10ba8ee7de4d0e1d 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -13,6 +13,7 @@ export { ModelRegistry } from "./core/model-registry.js";
@@ -186,18 +194,18 @@ index 76d728eb6fa4cac493dfe1ba623ef8170235a310..9ef49b59878f45b35ccb210f83930614
  // SDK for programmatic usage
  export { AgentSessionRuntime, 
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 6a88679e03161d2c048e2abab0041e96d214e67b..823413825e1b4e272123359e1add807a1cbe28a0 100644
+index 19dafecadb76dab709f82544fa72de58d8fd1164..1d7ac0630bfa6b7b2d24069380db983fbeb6c70c 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
-@@ -36,7 +36,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";
- import { getPiUserAgent } from "../../utils/pi-user-agent.js";
+@@ -38,7 +38,6 @@ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
  import { killTrackedDetachedChildren } from "../../utils/shell.js";
+ import { loadAllHighlightLanguages } from "../../utils/syntax-highlight.js";
  import { ensureTool } from "../../utils/tools-manager.js";
 -import { checkForNewPiVersion } from "../../utils/version-check.js";
  import { ArminComponent } from "./components/armin.js";
  import { AssistantMessageComponent } from "./components/assistant-message.js";
  import { BashExecutionComponent } from "./components/bash-execution.js";
-@@ -777,12 +776,6 @@ export class InteractiveMode {
+@@ -805,12 +804,6 @@ export class InteractiveMode {
                  .catch(() => { })
                  .finally(() => clearTimeout(timeout));
          }
@@ -210,7 +218,7 @@ index 6a88679e03161d2c048e2abab0041e96d214e67b..823413825e1b4e272123359e1add807a
          // Start package update check asynchronously
          this.checkForPackageUpdates()
              .then((updates) => {
-@@ -3417,29 +3410,6 @@ export class InteractiveMode {
+@@ -3496,29 +3489,6 @@ export class InteractiveMode {
          this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
          this.ui.requestRender();
      }

--- a/patches/@earendil-works%2Fpi-tui@0.84.3.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.84.3.patch
@@ -1,7 +1,9 @@
+diff --git a/dist/terminal.js b/dist/terminal.js
+index de2c7e49c351d2b084f7df1e939070f895eb3225..35ec8c7c76199ef30632eb980c9ae7e9b5f0fdd7 100644
 --- a/dist/terminal.js
 +++ b/dist/terminal.js
-@@ -6,6 +6,100 @@
- import { isNativeModifierPressed } from "./native-modifiers.js";
+@@ -6,6 +6,100 @@ import { isNativeModifierPressed } from "./native-modifiers.js";
+ import { getNativeModuleCandidates } from "./native-module-path.js";
  import { StdinBuffer } from "./stdin-buffer.js";
  const cjsRequire = createRequire(import.meta.url);
 +// PATCH(pizzapi): Windows console output lifecycle helpers
@@ -101,7 +103,7 @@
  const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
  const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
  const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0\x07";
-@@ -69,6 +163,7 @@
+@@ -69,6 +163,7 @@ export class ProcessTerminal {
      stdinBuffer;
      stdinDataHandler;
      progressInterval;
@@ -109,7 +111,7 @@
      writeLogPath = (() => {
          const env = process.env.PI_TUI_WRITE_LOG || "";
          if (!env)
-@@ -115,11 +210,30 @@
+@@ -115,10 +210,29 @@ export class ProcessTerminal {
          // events that lose modifier information. Must run AFTER setRawMode(true)
          // since that resets console mode flags.
          this.enableWindowsVTInput();
@@ -119,7 +121,7 @@
          // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
          this.queryAndEnableKittyProtocol();
      }
-     /**
++    /**
 +     * On Windows, set up VT output and UTF-8 code page for Unicode rendering,
 +     * and publish a capability signal for downstream renderers.
 +     */
@@ -136,11 +138,10 @@
 +            // Best-effort: if console API setup fails, leave it alone
 +        }
 +    }
-+    /**
+     /**
       * Set up StdinBuffer to split batched input into individual sequences.
       * This ensures components receive single events, making matchesKey/isKeyRelease work correctly.
-      *
-@@ -370,6 +484,17 @@
+@@ -364,6 +478,17 @@ export class ProcessTerminal {
              process.stdout.removeListener("resize", this.resizeHandler);
              this.resizeHandler = undefined;
          }

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @earendil-works/pi-agent-core@0.84.2
+## @earendil-works/pi-agent-core@0.84.3
 
 Refreshes the agent's system prompt and tool list before every assistant
 response, not just at loop start. `dist/agent.js` exposes the current
@@ -15,7 +15,7 @@ updates the prompt mid-turn (e.g. `search_tools`) wouldn't take effect until
 the *next* user turn. See the "pi-agent-core dynamic tool refresh" tests in
 `packages/cli/src/patches.test.ts`.
 
-## @earendil-works/pi-tui@0.84.2
+## @earendil-works/pi-tui@0.84.3
 
 Adds a Windows console lifecycle to `dist/terminal.js`:
 `createWindowsConsoleLifecycle()` enables VT output processing and switches
@@ -26,7 +26,7 @@ mode/code pages on `stop()`. This fixes garbled Unicode/ANSI rendering in
 Windows terminals; it's a no-op (best-effort, swallows failures) on other
 platforms. See `packages/cli/src/patches.test.ts`.
 
-## @earendil-works/pi-ai@0.84.2
+## @earendil-works/pi-ai@0.84.3
 
 Same intent as 0.80.6 (Anthropic web-search passthrough, Claude Code
 credentials fallback, retryable-JSON-parse patterns), ported to upstream's
@@ -67,7 +67,7 @@ assertions that the pi-ai patch no longer carries any ollama-cloud hunks.
 | `dist/auth/oauth/anthropic.js` | Claude Code Keychain/file credentials fallback, now inside `anthropicOAuth.refresh()` |
 | `dist/utils/retry.js` | Same retryable-JSON-parse patterns as 0.80.6 (unchanged file) |
 
-## @earendil-works/pi-coding-agent@0.84.2
+## @earendil-works/pi-coding-agent@0.84.3
 
 Same PizzaPi integration changes as 0.80.6, ported forward, with two upstream
 removals absorbed elsewhere rather than restored:
@@ -146,7 +146,7 @@ was rewired to call `rctx.sessionHost.sendUserMessage()` directly instead of
 and its `ExtensionAPI`/`SendUserMessageHandler` typings in `types.d.ts` were
 never reached anymore. Both hunks (`dist/core/agent-session.js` and the two
 `dist/core/extensions/types.d.ts` hunks) were dropped from the patch. As of
-0.84.2, upstream provides the same opt-in API natively; `patches.test.ts`
+0.84.3, upstream provides the same opt-in API natively; `patches.test.ts`
 asserts that native behavior remains while PizzaPi's old patch markers stay
 absent.
 


### PR DESCRIPTION
Upgrade the upstream @earendil-works/pi-* packages from 0.84.2 to 0.84.3 and recreate PizzaPi'\''s four patches against the new upstream versions.

**Changes**
- Bump `@earendil-works/pi-agent-core`, `pi-ai`, `pi-tui`, and `pi-coding-agent` to `^0.84.3` across root/package.json and workspace packages.
- Recreate patches via `bun patch`:
  - `pi-agent-core`: dynamic tool/prompt refresh before each assistant response.
  - `pi-ai`: Anthropic web search passthrough, Claude Code credentials fallback, retryable JSON parse errors.
  - `pi-coding-agent`: `.pizzapi` config namespace, inline `/skill:` token expansion, OpenAI context-window override, `ollama-cloud` default model, remove version-check notification, re-export package-management handlers.
  - `pi-tui`: Windows console VT/UTF-8 lifecycle.
- Update `patches/README.md` version references and refresh `bun.lock`.

**Verification**
- `bun run typecheck` ✅
- `bun run build` ✅
- `packages/cli/src/patches.test.ts`: 49/49 pass ✅
- `bun run test`: 100/101 suites pass; the one failure (`runner-recent-folders.test.ts`) passes in isolation (test-isolation flake unrelated to this bump).