### PR TITLE
fix(server): subagent mirror sessions inherit parent's runner association

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -36,6 +36,7 @@ import { sessionProcessesExtension } from "./session-processes.js";
 import { backgroundBashExtension } from "./background-bash.js";
 import { queueFlushExtension } from "./queue-flush.js";
 import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
+import { nvidiaProviderExtension } from "./nvidia-provider.js";
 import { openrouterProviderExtension } from "./openrouter-provider.js";
 import { hostAnnounceExtension } from "./host-announce.js";
 import { runPackageCommand } from "../package-commands.js";
@@ -52,6 +53,7 @@ const CORE_EXTENSIONS_HEAD: ExtensionFactory[] = [
     hostAnnounceExtension,
     ollamaCloudProviderExtension,
     openrouterProviderExtension,
+    nvidiaProviderExtension,
     providerRequestLogExtension,
     fallbackModelsExtension,
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -30,6 +30,7 @@ import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 import { toolSearchExtension } from "./tool-search.js";
 import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
 import { ollamaCloudProviderExtension } from "./ollama-cloud-provider.js";
+import { nvidiaProviderExtension } from "./nvidia-provider.js";
 import { openrouterProviderExtension } from "./openrouter-provider.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
 import { fallbackModelsExtension } from "./fallback-models.js";
@@ -91,6 +92,10 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
     // Live OpenRouter catalog (openrouter.ai/api/v1/models) replacing pi-ai's
     // static snapshot — same reason: register before model resolution.
     factories.push(named(openrouterProviderExtension, "openrouter-provider"));
+
+    // Live NVIDIA catalog (integrate.api.nvidia.com/v1/models) replacing pi-ai's
+    // static snapshot — same reason: register before model resolution.
+    factories.push(named(nvidiaProviderExtension, "nvidia-provider"));
 
     // Diagnostic (off unless PIZZAPI_LOG_PROVIDER_REQUEST is set): log the
     // resolved provider/api and request shape for each outbound turn.

--- a/packages/cli/src/extensions/nvidia-provider.ts
+++ b/packages/cli/src/extensions/nvidia-provider.ts
@@ -1,0 +1,36 @@
+/**
+ * Replaces pi-ai's static NVIDIA catalog with build.nvidia.com's live
+ * /v1/models list (see ../nvidia-models.ts).
+ *
+ * Registration is synchronous so the provider is in place before model
+ * resolution; the network fetch is stale-while-revalidate — the cached list
+ * (24h TTL) is used immediately and a refreshed catalog re-registers the
+ * provider so the runtime's model snapshot picks it up mid-session.
+ */
+import { join } from "node:path";
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
+import { defaultAgentDir, expandHome, loadConfig } from "../config.js";
+import { fetchNvidiaModels, registerNvidiaProvider } from "../nvidia-models.js";
+
+/** Only spend a request on users who can actually call NVIDIA. */
+function hasNvidiaCreds(): boolean {
+    if (process.env.NVIDIA_API_KEY) return true;
+    try {
+        const config = loadConfig(process.cwd());
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+        return readStoredCredential("nvidia", join(agentDir, "auth.json")) !== undefined;
+    } catch {
+        return false;
+    }
+}
+
+export const nvidiaProviderExtension: ExtensionFactory = (pi) => {
+    registerNvidiaProvider(pi);
+    if (!hasNvidiaCreds()) return;
+    void fetchNvidiaModels()
+        .then(() => registerNvidiaProvider(pi))
+        .catch(() => {
+            // Offline or API down — the cached/static catalog stays in place.
+        });
+};

--- a/packages/cli/src/models-command.ts
+++ b/packages/cli/src/models-command.ts
@@ -11,6 +11,7 @@ import { join } from "path";
 import { c } from "./cli-colors.js";
 import { defaultAgentDir, expandHome, loadConfig } from "./config/io.js";
 import { createLogger } from "@pizzapi/tools";
+import { registerNvidiaProvider } from "./nvidia-models.js";
 import { fetchOllamaCloudModels, registerOllamaCloudProvider, type OllamaCloudModel } from "./ollama-cloud-models.js";
 import { mergeModelLists, readSessionModelsCache } from "./session-models-cache.js";
 
@@ -39,6 +40,9 @@ export async function runModelsCommand(args: string[], cwd: string, logger = log
     // unknown provider here: no offline fallback catalog and stored/env
     // credentials go unrecognized. Mirrors ollamaCloudProviderExtension.
     registerOllamaCloudProvider(runtime);
+    // nvidia is a builtin, but its catalog here is pi-ai's static snapshot — swap
+    // in build.nvidia.com's live list cached by sessions (see nvidia-models.ts).
+    registerNvidiaProvider(runtime, env.HOME);
     const modelRegistry = new ModelRegistry(runtime);
 
     const staticEntries = modelRegistry

--- a/packages/cli/src/nvidia-models.test.ts
+++ b/packages/cli/src/nvidia-models.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { clampThinkingLevel, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { nvidiaProvider } from "@earendil-works/pi-ai/providers/nvidia";
 import {
     fetchNvidiaModels,
@@ -33,9 +34,13 @@ function stubFetch(body: unknown, ok = true): void {
 }
 
 describe("toNvidiaModel", () => {
-    test("reuses pi-ai's curated entry for a known id", () => {
+    test("reuses pi-ai's curated metadata for a known id", () => {
+        const known = STATIC.find((m) => m.id === KNOWN_ID)!;
         const model = toNvidiaModel({ id: KNOWN_ID }, STATIC as any)!;
-        expect(model).toEqual(STATIC.find((m) => m.id === KNOWN_ID) as any);
+        expect(model.name).toBe(known.name);
+        expect(model.contextWindow).toBe(known.contextWindow);
+        expect(model.cost).toEqual(known.cost);
+        expect(model.input).toEqual(known.input);
     });
 
     test("synthesizes defaults for ids the package has never seen", () => {
@@ -44,7 +49,6 @@ describe("toNvidiaModel", () => {
         expect(model.api).toBe("openai-completions");
         expect(model.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
         expect(model.name).toBe("moonshotai/kimi-k3");
-        expect(model.reasoning).toBe(false);
         expect(model.input).toEqual(["text"]);
         expect(model.contextWindow).toBe(128000);
         expect(model.maxTokens).toBe(4096);
@@ -53,8 +57,32 @@ describe("toNvidiaModel", () => {
         expect((model.compat as any).maxTokensField).toBe("max_tokens");
     });
 
-    test("flags reasoning models by id", () => {
-        expect(toNvidiaModel({ id: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning" }, [] as any)!.reasoning).toBe(true);
+    test("unknown ids are reasoning-capable so the thinking control is usable", () => {
+        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        expect(model.reasoning).toBe(true);
+        expect((model.compat as any).supportsReasoningEffort).toBe(true);
+        // NVIDIA rejects "minimal" and has no xhigh/max equivalent.
+        expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+        // Levels pi can request land on values NVIDIA's API accepts.
+        expect(clampThinkingLevel(model, "minimal")).toBe("low");
+        expect(clampThinkingLevel(model, "xhigh")).toBe("high");
+        expect(clampThinkingLevel(model, "medium")).toBe("medium");
+    });
+
+    test("enables reasoning effort on curated reasoning models too", () => {
+        const reasoner = STATIC.find((m) => m.reasoning)!;
+        expect((reasoner.compat as any).supportsReasoningEffort).toBe(false); // pi-ai's default
+        const model = toNvidiaModel({ id: reasoner.id }, STATIC as any)!;
+        expect((model.compat as any).supportsReasoningEffort).toBe(true);
+        expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+    });
+
+    test("leaves non-reasoning curated models alone", () => {
+        const plain = STATIC.find((m) => !m.reasoning)!;
+        const model = toNvidiaModel({ id: plain.id }, STATIC as any)!;
+        expect(model.reasoning).toBe(false);
+        expect((model.compat as any).supportsReasoningEffort).toBe(false);
+        expect(getSupportedThinkingLevels(model)).toEqual(["off"]);
     });
 
     test("drops non-chat endpoints and malformed entries", () => {
@@ -154,6 +182,12 @@ describe("nvidiaDynamicProvider", () => {
     test("uses the live catalog when cached and the static one otherwise", async () => {
         const home = tempHome();
         expect(nvidiaDynamicProvider(home).getModels().length).toBe(STATIC.length);
+
+        // The static fallback still gets the reasoning-effort fix.
+        const staticReasoner = nvidiaDynamicProvider(home)
+            .getModels()
+            .find((m) => m.reasoning)!;
+        expect((staticReasoner.compat as any).supportsReasoningEffort).toBe(true);
 
         stubFetch({ data: [{ id: "vendor/new-model" }] });
         await fetchNvidiaModels({ home });

--- a/packages/cli/src/nvidia-models.test.ts
+++ b/packages/cli/src/nvidia-models.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { nvidiaProvider } from "@earendil-works/pi-ai/providers/nvidia";
+import {
+    fetchNvidiaModels,
+    getCachedNvidiaModels,
+    nvidiaDynamicProvider,
+    registerNvidiaProvider,
+    toNvidiaModel,
+} from "./nvidia-models.js";
+
+const STATIC = nvidiaProvider().getModels() as any[];
+const KNOWN_ID = STATIC[0].id as string;
+
+const homes: string[] = [];
+function tempHome(): string {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-nvidia-"));
+    homes.push(home);
+    return home;
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+    globalThis.fetch = realFetch;
+    for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+function stubFetch(body: unknown, ok = true): void {
+    globalThis.fetch = (async () =>
+        ({ ok, status: ok ? 200 : 500, statusText: ok ? "OK" : "Server Error", json: async () => body }) as any) as any;
+}
+
+describe("toNvidiaModel", () => {
+    test("reuses pi-ai's curated entry for a known id", () => {
+        const model = toNvidiaModel({ id: KNOWN_ID }, STATIC as any)!;
+        expect(model).toEqual(STATIC.find((m) => m.id === KNOWN_ID) as any);
+    });
+
+    test("synthesizes defaults for ids the package has never seen", () => {
+        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        expect(model.provider).toBe("nvidia");
+        expect(model.api).toBe("openai-completions");
+        expect(model.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
+        expect(model.name).toBe("moonshotai/kimi-k3");
+        expect(model.reasoning).toBe(false);
+        expect(model.input).toEqual(["text"]);
+        expect(model.contextWindow).toBe(128000);
+        expect(model.maxTokens).toBe(4096);
+        expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+        expect((model.headers as any)["NVCF-POLL-SECONDS"]).toBe("3600");
+        expect((model.compat as any).maxTokensField).toBe("max_tokens");
+    });
+
+    test("flags reasoning models by id", () => {
+        expect(toNvidiaModel({ id: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning" }, [] as any)!.reasoning).toBe(true);
+    });
+
+    test("drops non-chat endpoints and malformed entries", () => {
+        for (const id of [
+            "nvidia/embed-qa-4",
+            "snowflake/arctic-embed-l",
+            "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+            "nvidia/nvclip",
+            "nvidia/nemotron-4-340b-reward",
+            "meta/llama-guard-4-12b",
+            "nvidia/nemotron-3.5-content-safety",
+            "nvidia/nemotron-parse",
+            "nvidia/ai-synthetic-video-detector",
+            "google/deplot",
+            "microsoft/kosmos-2",
+            "adept/fuyu-8b",
+            "nvidia/neva-22b",
+            "nvidia/vila",
+        ]) {
+            expect(toNvidiaModel({ id }, STATIC as any)).toBeNull();
+        }
+        expect(toNvidiaModel({ id: undefined }, STATIC as any)).toBeNull();
+        expect(toNvidiaModel({ id: "" }, STATIC as any)).toBeNull();
+    });
+});
+
+describe("fetchNvidiaModels", () => {
+    test("unions the live list over the package catalog, drops non-chat, and caches", async () => {
+        const home = tempHome();
+        stubFetch({ data: [{ id: KNOWN_ID }, { id: "vendor/new-model" }, { id: "nvidia/embed-qa-4" }] });
+
+        const models = await fetchNvidiaModels({ home });
+        // Package models the live list omits survive; new ids are appended once.
+        expect(models).toHaveLength(STATIC.length + 1);
+        expect(models.filter((m) => m.id === KNOWN_ID)).toHaveLength(1);
+        expect(models.at(-1)!.id).toBe("vendor/new-model");
+        expect(models.some((m) => m.id === "nvidia/embed-qa-4")).toBe(false);
+
+        const cached = JSON.parse(readFileSync(join(home, ".pizzapi", "nvidia-models-cache.json"), "utf-8"));
+        expect(cached.models).toHaveLength(STATIC.length + 1);
+        expect(typeof cached.fetchedAt).toBe("number");
+        expect(getCachedNvidiaModels(home)).toHaveLength(STATIC.length + 1);
+    });
+
+    test("serves a fresh cache without hitting the network", async () => {
+        const home = tempHome();
+        stubFetch({ data: [{ id: KNOWN_ID }] });
+        await fetchNvidiaModels({ home });
+
+        globalThis.fetch = (async () => {
+            throw new Error("should not fetch");
+        }) as any;
+        expect(await fetchNvidiaModels({ home })).toHaveLength(STATIC.length);
+    });
+
+    test("refetches when the cache is stale", async () => {
+        const home = tempHome();
+        mkdirSync(join(home, ".pizzapi"), { recursive: true });
+        writeFileSync(
+            join(home, ".pizzapi", "nvidia-models-cache.json"),
+            JSON.stringify({
+                models: [toNvidiaModel({ id: KNOWN_ID }, STATIC as any)],
+                fetchedAt: Date.now() - 25 * 60 * 60 * 1000,
+            }),
+        );
+        stubFetch({ data: [{ id: KNOWN_ID }, { id: "vendor/new-model" }] });
+
+        expect(await fetchNvidiaModels({ home })).toHaveLength(STATIC.length + 1);
+    });
+
+    test("throws on API failure and on an empty catalog, leaving the cache untouched", async () => {
+        const home = tempHome();
+        stubFetch({ data: [{ id: KNOWN_ID }] });
+        await fetchNvidiaModels({ home });
+
+        stubFetch(null, false);
+        await expect(fetchNvidiaModels({ home, force: true })).rejects.toThrow(/NVIDIA models API error/);
+
+        stubFetch({ data: [{ id: "nvidia/embed-qa-4" }] });
+        await expect(fetchNvidiaModels({ home, force: true })).rejects.toThrow(/no usable models/);
+
+        stubFetch({ notData: true });
+        await expect(fetchNvidiaModels({ home, force: true })).rejects.toThrow(/Unexpected response/);
+
+        expect(getCachedNvidiaModels(home)).toHaveLength(STATIC.length);
+    });
+
+    test("ignores a corrupt cache", () => {
+        const home = tempHome();
+        mkdirSync(join(home, ".pizzapi"), { recursive: true });
+        writeFileSync(join(home, ".pizzapi", "nvidia-models-cache.json"), "{not json");
+        expect(getCachedNvidiaModels(home)).toBeNull();
+    });
+});
+
+describe("nvidiaDynamicProvider", () => {
+    test("uses the live catalog when cached and the static one otherwise", async () => {
+        const home = tempHome();
+        expect(nvidiaDynamicProvider(home).getModels().length).toBe(STATIC.length);
+
+        stubFetch({ data: [{ id: "vendor/new-model" }] });
+        await fetchNvidiaModels({ home });
+
+        expect(nvidiaDynamicProvider(home).getModels().map((m) => m.id)).toContain("vendor/new-model");
+        expect(nvidiaDynamicProvider(home).getModels()).toHaveLength(STATIC.length + 1);
+        // pi-ai's auth/stream behaviour is preserved
+        expect(nvidiaDynamicProvider(home).auth.apiKey).toBeDefined();
+    });
+
+    test("registers through either runtime or extension API shape", () => {
+        const home = tempHome();
+        const native: unknown[] = [];
+        registerNvidiaProvider({ registerNativeProvider: (p) => native.push(p) }, home);
+        expect((native[0] as any).id).toBe("nvidia");
+
+        const viaExtension: unknown[] = [];
+        registerNvidiaProvider({ registerProvider: (p) => viaExtension.push(p) }, home);
+        expect((viaExtension[0] as any).id).toBe("nvidia");
+
+        expect(() => registerNvidiaProvider({}, home)).toThrow(/no provider registration method/);
+    });
+});

--- a/packages/cli/src/nvidia-models.test.ts
+++ b/packages/cli/src/nvidia-models.test.ts
@@ -69,6 +69,12 @@ describe("toNvidiaModel", () => {
         expect(clampThinkingLevel(model, "medium")).toBe("medium");
     });
 
+    test("NVIDIA's accepted levels win over an upstream thinkingLevelMap", () => {
+        const upstream = [{ ...(STATIC.find((m) => m.reasoning) as any), thinkingLevelMap: { minimal: "minimal", max: "max" } }];
+        const model = toNvidiaModel({ id: upstream[0].id }, upstream as any)!;
+        expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+    });
+
     test("enables reasoning effort on curated reasoning models too", () => {
         const reasoner = STATIC.find((m) => m.reasoning)!;
         expect((reasoner.compat as any).supportsReasoningEffort).toBe(false); // pi-ai's default
@@ -168,6 +174,24 @@ describe("fetchNvidiaModels", () => {
         await expect(fetchNvidiaModels({ home, force: true })).rejects.toThrow(/Unexpected response/);
 
         expect(getCachedNvidiaModels(home)).toHaveLength(STATIC.length);
+    });
+
+    test("repairs a cache written before the thinking-effort fix", () => {
+        const home = tempHome();
+        mkdirSync(join(home, ".pizzapi"), { recursive: true });
+        const stale = {
+            ...(toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any) as any),
+            compat: { maxTokensField: "max_tokens", supportsReasoningEffort: false },
+            thinkingLevelMap: { minimal: "minimal" }, // a 400 on NVIDIA's API
+        };
+        writeFileSync(
+            join(home, ".pizzapi", "nvidia-models-cache.json"),
+            JSON.stringify({ models: [stale], fetchedAt: Date.now() }),
+        );
+
+        const repaired = getCachedNvidiaModels(home)![0];
+        expect((repaired.compat as any).supportsReasoningEffort).toBe(true);
+        expect(getSupportedThinkingLevels(repaired)).toEqual(["off", "low", "medium", "high"]);
     });
 
     test("ignores a corrupt cache", () => {

--- a/packages/cli/src/nvidia-models.ts
+++ b/packages/cli/src/nvidia-models.ts
@@ -1,0 +1,193 @@
+/**
+ * NVIDIA (build.nvidia.com) live model discovery.
+ *
+ * pi-ai ships a static NVIDIA catalog (a build-time snapshot) and pi overlays
+ * it with pi.dev's catalog — both go stale: the snapshot still advertises
+ * models NVIDIA has delisted and misses newly launched ones. This fetches
+ * https://integrate.api.nvidia.com/v1/models directly and registers it as a
+ * native provider that replaces the static catalog, keeping pi-ai's NVIDIA
+ * auth (NVIDIA_API_KEY) and streaming untouched.
+ *
+ * Results are cached in ~/.pizzapi/nvidia-models-cache.json for 24h so startup
+ * and model listing stay fast and offline-safe.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import { nvidiaProvider } from "@earendil-works/pi-ai/providers/nvidia";
+
+const MODELS_URL = "https://integrate.api.nvidia.com/v1/models";
+const BASE_URL = "https://integrate.api.nvidia.com/v1";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Matches the headers/compat flags pi-ai generates for every static NVIDIA model. */
+const NVIDIA_HEADERS = { "NVCF-POLL-SECONDS": "3600" } as const;
+const NVIDIA_COMPAT = {
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+    maxTokensField: "max_tokens",
+    supportsStrictMode: false,
+    supportsLongCacheRetention: false,
+} as const;
+
+/**
+ * ponytail: NVIDIA's /v1/models lists every hosted NIM — embeddings, rerankers,
+ * safety classifiers, OCR/vision-only endpoints — with no capability field to
+ * filter on. Substring denylist; add ids here if a non-chat model slips through.
+ */
+const NON_CHAT = [
+    "embed",
+    "rerank",
+    "retriever",
+    "clip",
+    "reward",
+    "guard",
+    "safety",
+    "parse",
+    "detector",
+    "deplot",
+    "kosmos",
+    "fuyu",
+    "neva",
+    "vila",
+];
+
+type NvidiaModel = Model<"openai-completions">;
+
+interface CacheEntry {
+    models: NvidiaModel[];
+    fetchedAt: number;
+}
+
+interface ApiModel {
+    id?: unknown;
+}
+
+function cachePath(home = process.env.HOME || homedir()): string {
+    return join(home, ".pizzapi", "nvidia-models-cache.json");
+}
+
+function readCache(home?: string): CacheEntry | null {
+    try {
+        const raw = JSON.parse(readFileSync(cachePath(home), "utf-8"));
+        if (Array.isArray(raw?.models) && typeof raw.fetchedAt === "number") {
+            const models = raw.models.filter(
+                (m: any) => typeof m?.id === "string" && m?.provider === "nvidia" && typeof m?.contextWindow === "number",
+            );
+            if (models.length > 0) return { models, fetchedAt: raw.fetchedAt };
+        }
+    } catch {
+        // missing or corrupt cache — fall back to the static catalog
+    }
+    return null;
+}
+
+function writeCache(entry: CacheEntry, home?: string): void {
+    const path = cachePath(home);
+    const dir = join(path, "..");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(path, JSON.stringify(entry), { mode: 0o600 });
+}
+
+function isChatModel(id: string): boolean {
+    const lower = id.toLowerCase();
+    return !NON_CHAT.some((needle) => lower.includes(needle));
+}
+
+/**
+ * The live endpoint returns ids only, so curated metadata (name, context
+ * window, cost, modalities) comes from pi-ai's static entry when the id is
+ * known and from conservative defaults when it isn't.
+ */
+export function toNvidiaModel(entry: ApiModel, staticModels: readonly NvidiaModel[]): NvidiaModel | null {
+    if (typeof entry?.id !== "string" || !entry.id) return null;
+    if (!isChatModel(entry.id)) return null;
+
+    const known = staticModels.find((model) => model.id === entry.id);
+    if (known) return known;
+
+    return {
+        id: entry.id,
+        name: entry.id,
+        api: "openai-completions",
+        provider: "nvidia",
+        baseUrl: BASE_URL,
+        headers: { ...NVIDIA_HEADERS },
+        reasoning: /reason|think/i.test(entry.id),
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 4096,
+        compat: { ...NVIDIA_COMPAT },
+    } as NvidiaModel;
+}
+
+export function getCachedNvidiaModels(home?: string): NvidiaModel[] | null {
+    return readCache(home)?.models ?? null;
+}
+
+/**
+ * Fetch the live catalog, honouring the 24h cache unless `force` is set.
+ * Throws on network/parse failure — callers keep the static catalog.
+ */
+export async function fetchNvidiaModels(
+    { signal, force, home }: { signal?: AbortSignal; force?: boolean; home?: string } = {},
+): Promise<NvidiaModel[]> {
+    if (!force) {
+        const cached = readCache(home);
+        if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.models;
+    }
+
+    const res = await fetch(MODELS_URL, { signal, headers: { accept: "application/json" } });
+    if (!res.ok) throw new Error(`NVIDIA models API error: ${res.status} ${res.statusText}`);
+    const body = (await res.json()) as { data?: unknown };
+    if (!Array.isArray(body?.data)) throw new Error("Unexpected response from NVIDIA /v1/models");
+
+    const staticModels = nvidiaProvider().getModels() as NvidiaModel[];
+    const live = body.data
+        .map((entry) => toNvidiaModel(entry as ApiModel, staticModels))
+        .filter((m): m is NvidiaModel => m !== null);
+    if (live.length === 0) throw new Error("NVIDIA /v1/models returned no usable models");
+
+    // ponytail: union, not replace — /v1/models omits NIMs that still serve
+    // traffic (glm-5.2, nemotron-super-49b), so replacing would break working
+    // models. Stale package entries linger; that's today's behaviour anyway.
+    const seen = new Set(staticModels.map((model) => model.id));
+    const models = [...staticModels, ...live.filter((model) => !seen.has(model.id))];
+    writeCache({ models, fetchedAt: Date.now() }, home);
+    return models;
+}
+
+/**
+ * pi-ai's NVIDIA provider with the live catalog swapped in when cached.
+ * Auth, streaming, and everything else stay exactly as pi-ai defines them.
+ */
+export function nvidiaDynamicProvider(home?: string) {
+    const base = nvidiaProvider();
+    return {
+        ...base,
+        getModels: () => getCachedNvidiaModels(home) ?? base.getModels(),
+    };
+}
+
+/**
+ * Replace the built-in static NVIDIA catalog on a ModelRuntime. Registering
+ * natively (rather than as a config overlay) keeps pi-ai's auth/stream intact
+ * while dropping pi.dev's snapshot overlay in favour of NVIDIA's own API.
+ */
+export function registerNvidiaProvider(
+    target: {
+        // ModelRuntime exposes registerNativeProvider; the extension API takes a
+        // native provider through its registerProvider(provider) overload.
+        registerNativeProvider?: (...args: any[]) => void;
+        registerProvider?: (...args: any[]) => void;
+    },
+    home?: string,
+): void {
+    const provider = nvidiaDynamicProvider(home);
+    if (typeof target.registerNativeProvider === "function") target.registerNativeProvider(provider);
+    else if (typeof target.registerProvider === "function") target.registerProvider(provider);
+    else throw new Error("registerNvidiaProvider: target exposes no provider registration method");
+}

--- a/packages/cli/src/nvidia-models.ts
+++ b/packages/cli/src/nvidia-models.ts
@@ -21,6 +21,25 @@ const MODELS_URL = "https://integrate.api.nvidia.com/v1/models";
 const BASE_URL = "https://integrate.api.nvidia.com/v1";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * NVIDIA honours OpenAI-style `reasoning_effort`, but pi-ai's catalog marks
+ * every NVIDIA model `supportsReasoningEffort: false`, so the thinking-level
+ * control silently clamps back to "off". The API only accepts low|medium|high
+ * — pi's "minimal" is a 400 — so map it (and the xhigh/max levels NVIDIA has no
+ * equivalent for) to null, which hides them. "off" sends no parameter at all,
+ * i.e. the model's own default.
+ */
+const NVIDIA_THINKING_LEVEL_MAP = { minimal: null, xhigh: null, max: null } as const;
+
+function withReasoningEffort(model: NvidiaModel): NvidiaModel {
+    if (!model.reasoning) return model;
+    return {
+        ...model,
+        compat: { ...model.compat, supportsReasoningEffort: true },
+        thinkingLevelMap: { ...NVIDIA_THINKING_LEVEL_MAP, ...model.thinkingLevelMap },
+    };
+}
+
 /** Matches the headers/compat flags pi-ai generates for every static NVIDIA model. */
 const NVIDIA_HEADERS = { "NVCF-POLL-SECONDS": "3600" } as const;
 const NVIDIA_COMPAT = {
@@ -106,22 +125,25 @@ export function toNvidiaModel(entry: ApiModel, staticModels: readonly NvidiaMode
     if (!isChatModel(entry.id)) return null;
 
     const known = staticModels.find((model) => model.id === entry.id);
-    if (known) return known;
+    if (known) return withReasoningEffort(known);
 
-    return {
+    return withReasoningEffort({
         id: entry.id,
         name: entry.id,
         api: "openai-completions",
         provider: "nvidia",
         baseUrl: BASE_URL,
         headers: { ...NVIDIA_HEADERS },
-        reasoning: /reason|think/i.test(entry.id),
+        // ponytail: NVIDIA publishes no capability metadata, so assume unknown
+        // ids reason. A wrong true costs nothing (NVIDIA accepts reasoning_effort
+        // on non-reasoning models); a wrong false locks the thinking control off.
+        reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
         maxTokens: 4096,
         compat: { ...NVIDIA_COMPAT },
-    } as NvidiaModel;
+    } as NvidiaModel);
 }
 
 export function getCachedNvidiaModels(home?: string): NvidiaModel[] | null {
@@ -145,7 +167,7 @@ export async function fetchNvidiaModels(
     const body = (await res.json()) as { data?: unknown };
     if (!Array.isArray(body?.data)) throw new Error("Unexpected response from NVIDIA /v1/models");
 
-    const staticModels = nvidiaProvider().getModels() as NvidiaModel[];
+    const staticModels = (nvidiaProvider().getModels() as NvidiaModel[]).map(withReasoningEffort);
     const live = body.data
         .map((entry) => toNvidiaModel(entry as ApiModel, staticModels))
         .filter((m): m is NvidiaModel => m !== null);
@@ -168,7 +190,9 @@ export function nvidiaDynamicProvider(home?: string) {
     const base = nvidiaProvider();
     return {
         ...base,
-        getModels: () => getCachedNvidiaModels(home) ?? base.getModels(),
+        // Even without a cached catalog the static models need the reasoning-effort
+        // fix, or the thinking-level control clamps to "off" on every NVIDIA model.
+        getModels: () => getCachedNvidiaModels(home) ?? (base.getModels() as NvidiaModel[]).map(withReasoningEffort),
     };
 }
 

--- a/packages/cli/src/nvidia-models.ts
+++ b/packages/cli/src/nvidia-models.ts
@@ -36,7 +36,10 @@ function withReasoningEffort(model: NvidiaModel): NvidiaModel {
     return {
         ...model,
         compat: { ...model.compat, supportsReasoningEffort: true },
-        thinkingLevelMap: { ...NVIDIA_THINKING_LEVEL_MAP, ...model.thinkingLevelMap },
+        // NVIDIA's accepted values are a hard API constraint, so they win over
+        // whatever pi-ai (or an older cache) supplies — a resurrected "minimal"
+        // is a 400 on every request.
+        thinkingLevelMap: { ...model.thinkingLevelMap, ...NVIDIA_THINKING_LEVEL_MAP },
     };
 }
 
@@ -95,7 +98,10 @@ function readCache(home?: string): CacheEntry | null {
             const models = raw.models.filter(
                 (m: any) => typeof m?.id === "string" && m?.provider === "nvidia" && typeof m?.contextWindow === "number",
             );
-            if (models.length > 0) return { models, fetchedAt: raw.fetchedAt };
+            // Normalize on read, not just on write: a cache written by an older
+            // build (or a future pi-ai whose flags changed) must still come back
+            // with the thinking-effort settings applied.
+            if (models.length > 0) return { models: models.map(withReasoningEffort), fetchedAt: raw.fetchedAt };
         }
     } catch {
         // missing or corrupt cache — fall back to the static catalog

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -17,6 +17,7 @@ import { resolvePizzaPiVar } from "../config/io.js";
 import { mergeModelLists, readSessionModelsCache, type SessionModelEntry } from "../session-models-cache.js";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { getCachedOllamaCloudModels, registerOllamaCloudProvider, toOllamaCloudRuntimeModel } from "../ollama-cloud-models.js";
+import { registerNvidiaProvider } from "../nvidia-models.js";
 import { registerOpenRouterProvider } from "../openrouter-models.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { ProcessService } from "./services/process-service.js";
@@ -632,6 +633,9 @@ export async function listConfiguredModels(cwd = process.cwd()): Promise<Session
     // Same for openrouter: the builtin catalog here is pi-ai's static snapshot,
     // so swap in the live one cached by sessions (see openrouter-models.ts).
     registerOpenRouterProvider(runtime);
+    // Same for nvidia: swap pi-ai's static snapshot for build.nvidia.com's live
+    // catalog cached by sessions (see nvidia-models.ts).
+    registerNvidiaProvider(runtime);
     const modelRegistry = new ModelRegistry(runtime);
     const diskModels: SessionModelEntry[] = modelRegistry
         .getAvailable()

--- a/packages/cli/src/runner/services/time-service.retry.test.ts
+++ b/packages/cli/src/runner/services/time-service.retry.test.ts
@@ -221,6 +221,91 @@ describe("cron delivery retry and durable state", () => {
         expect(JSON.parse(fires[0]!.body).payload.iteration).toBe(4);
     });
 
+    test("subscription removal is retried on transient failure (a lost removal resurrects the schedule)", async () => {
+        setupEnv();
+        let deleteCount = 0;
+        const calls = routedFetch((url, init) => {
+            const method = init?.method ?? "GET";
+            if (method === "POST" && url.endsWith("/trigger")) return { status: 200 };
+            if (method === "DELETE") {
+                deleteCount++;
+                return { status: deleteCount < 3 ? 503 : 200 };
+            }
+            return { status: 404 };
+        });
+        service = new TimeService([10, 20], 30_000, 15_000, 5); // 5ms removal-retry delay
+
+        service.reconcileSubscriptions([
+            entry("sess-1", "time:timer_fired", { duration: "0.01s" }, "sub-1"),
+        ]);
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(deletes(calls)).toHaveLength(3); // 503, 503, 200
+    });
+
+    test("a snapshot re-apply during an in-flight one-shot fire does not double-fire", async () => {
+        setupEnv();
+        let posts = 0;
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+            const method = init?.method ?? "GET";
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (method === "POST" && url.endsWith("/trigger")) {
+                posts++;
+                await new Promise((resolve) => setTimeout(resolve, 40)); // delivery in flight
+                return new Response(null, { status: 200 });
+            }
+            return new Response(null, { status: 200 }); // DELETE etc.
+        }) as typeof fetch;
+        service = new TimeService([10, 20], 30_000, 15_000, 5);
+
+        const sub = entry("sess-1", "time:timer_fired", { duration: "0.01s" }, "sub-1");
+        service.reconcileSubscriptions([sub]);
+        await new Promise((resolve) => setTimeout(resolve, 15)); // fired, delivery in flight
+        service.reconcileSubscriptions([sub]); // snapshot re-apply mid-flight
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        expect(posts).toBe(1);
+    });
+
+    test("schedule deliveries carry a stable fireId across retries", async () => {
+        setupEnv();
+        const calls = mockFetch([503, 200]);
+        service = new TimeService([10, 20]);
+
+        service.reconcileSubscriptions([
+            entry("sess-1", "time:timer_fired", { duration: "0.01s" }, "sub-1"),
+        ]);
+
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        const fired = posts(calls);
+        expect(fired).toHaveLength(2);
+        const first = JSON.parse(fired[0]!.body).fireId;
+        expect(typeof first).toBe("string");
+        expect(JSON.parse(fired[1]!.body).fireId).toBe(first); // same fire, retried — not a new fire id
+    });
+
+    test("a legacy type-wide unsubscribe delta disarms every cron the session holds", async () => {
+        const home = setupEnv();
+        const calls = routedFetch(() => ({ status: 503 })); // deliveries would fail — schedule must be DISARMED, not retrying
+        service = new TimeService([10, 20], 10, 15_000, 5);
+
+        service.reconcileSubscriptions([
+            entry("sess-1", "time:cron", { cron: "0 9 * * *", message: "a" }, "sub-a"),
+            entry("sess-1", "time:cron", { cron: "0 12 * * *", message: "b" }, "sub-b"),
+        ]);
+        expect(JSON.parse(readFileSync(join(home, ".pizzapi", "time-service-state.json"), "utf-8"))).toEqual({
+            "sub-a": expect.anything(),
+            "sub-b": expect.anything(),
+        });
+
+        // Type-wide DELETE without subscriptionId: server emits ONE synthetic delta.
+        service.reconcileSubscriptions([
+            entry("sess-1", "time:cron", undefined, "legacy:all:time:cron"),
+        ], { mode: "delta", action: "unsubscribe" });
+
+        // Both durable entries dropped — both crons disarmed.
+        expect(JSON.parse(readFileSync(join(home, ".pizzapi", "time-service-state.json"), "utf-8"))).toEqual({});
+    });
+
     test("cron owner gone: spawns a replacement session, re-owns the cron under it, and stops the old cron", async () => {
         const home = setupEnv();
         const calls = routedFetch((url) => {

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -53,6 +53,15 @@ const RETRY_BACKOFF_MS = [60_000, 5 * 60_000, 15 * 60_000, 30 * 60_000] as const
 /** How many times to retry handing a recurring schedule to its new owner. */
 const RESUBSCRIBE_ATTEMPTS = 3;
 
+/** How many times to retry retiring a fired/migrated subscription server-side.
+ *  A lost removal re-arms the schedule from the durable snapshot on the next
+ *  restart — a resurrected cron/at fires alongside its replacement. */
+const REMOVE_ATTEMPTS = 3;
+
+/** Pause between subscription-removal retries. Short — removal is quick, and
+ *  the caller is already past the point where the schedule did its job. */
+const REMOVE_RETRY_DELAY_MS = 5_000;
+
 /** Outcome of a trigger delivery attempt. */
 type DeliveryResult = "delivered" | "retry" | "gone";
 
@@ -167,6 +176,9 @@ interface CronEntry {
     delivering: boolean;
     /** Consecutive failed delivery attempts, for backoff. */
     retryCount: number;
+    /** Fire id memoized for the current fire-cycle, so delivery retries reuse
+     *  the same fireId even though nextFireAt moves with the backoff. */
+    currentFireId?: string;
 }
 
 // ── Static definitions ───────────────────────────────────────────────────────
@@ -318,6 +330,10 @@ export class TimeService implements ServiceHandler {
     #timers = new Map<string, TimerEntry>();
     #crons = new Map<string, CronEntry>();
     #cronIterations = new Map<string, number>();
+    /** One-shot runtime keys whose fire is currently in flight: the entry was
+     *  already consumed, so a re-applying snapshot must not re-arm it (would
+     *  fire the same schedule twice). */
+    #inFlightOneShots = new Set<string>();
     /** True after dispose() — in-flight fires must not re-arm or spawn replacements. */
     #disposed = false;
     /** Lazily-loaded durable cron state, keyed by subscriptionId. */
@@ -327,6 +343,7 @@ export class TimeService implements ServiceHandler {
         private readonly retryBackoffMs: readonly number[] = RETRY_BACKOFF_MS,
         private readonly cronCheckIntervalMs: number = 30_000,
         private readonly deliveryTimeoutMs: number = DELIVERY_TIMEOUT_MS,
+        private readonly removeRetryDelayMs: number = REMOVE_RETRY_DELAY_MS,
     ) {}
 
     /** Backoff delay for a failed delivery attempt, capped at the last entry. */
@@ -655,12 +672,37 @@ export class TimeService implements ServiceHandler {
     #applySubscription(sub: TriggerSubscriptionEntry, action: "subscribe" | "update" | "unsubscribe"): void {
         const { sessionId, triggerType, params } = sub;
         const subscriptionId = sub.subscriptionId ?? `${sessionId}\0${triggerType}`;
+        if (action === "unsubscribe" && (subscriptionId.startsWith("legacy:all:") || subscriptionId.includes("\0"))) {
+            // Type-wide or fabricated-legacy retirement: the synthetic id
+            // matches no runtime entry — clear every runtime entry this session
+            // holds for the trigger type, or they keep firing after the server
+            // rows are gone.
+            this.#clearRuntimeForSessionType(sessionId, triggerType);
+            return;
+        }
         if (triggerType === "time:timer_fired") {
             this.#handleTimerSubscription(subscriptionId, sessionId, params, action);
         } else if (triggerType === "time:at") {
             this.#handleAtSubscription(subscriptionId, sessionId, params, action);
         } else if (triggerType === "time:cron") {
             this.#handleCronSubscription(subscriptionId, sessionId, params, action);
+        }
+    }
+
+    /** Remove every timer/cron a session holds for one trigger type. */
+    #clearRuntimeForSessionType(sessionId: string, triggerType: string): void {
+        for (const [key, timer] of this.#timers) {
+            if (timer.sessionId !== sessionId || timer.triggerType !== triggerType) continue;
+            clearTimeout(timer.handle);
+            this.#timers.delete(key);
+            if (triggerType === "time:timer_fired") this.#dropTimerState(timer.subscriptionId);
+        }
+        for (const [key, cron] of this.#crons) {
+            if (cron.sessionId !== sessionId) continue;
+            clearInterval(cron.handle);
+            this.#crons.delete(key);
+            this.#cronIterations.delete(key);
+            this.#dropCronState(cron.subscriptionId);
         }
     }
 
@@ -676,6 +718,14 @@ export class TimeService implements ServiceHandler {
 
         if (action === "unsubscribe") {
             this.#dropTimerState(subscriptionId);
+            return;
+        }
+
+        if (this.#inFlightOneShots.has(key)) {
+            // A fire for this subscription is in flight (its runtime entry was
+            // already consumed). Re-arming from a snapshot would fire the same
+            // schedule twice.
+            logInfo(`[time] timer ${subscriptionId} fire already in flight — skipping re-arm`);
             return;
         }
 
@@ -707,10 +757,14 @@ export class TimeService implements ServiceHandler {
         const summary = message ?? (label ? `Timer "${label}" fired after ${formatDuration(durationMs)}` : `Timer fired after ${formatDuration(durationMs)}`);
         const buildPayload = () => ({ duration: durationStr, durationMs, firedAt: new Date().toISOString(), label, message });
         const replacementPrompt = buildReplacementPrompt(`timer "${durationStr}"`, label, message);
+        // Stable fire id: the absolute fire time distinguishes this fire from
+        // any future re-created schedule with the same subscription id.
+        const fireId = `os:${subscriptionId}:${fireAt}`;
         const fire = () => {
             this.#timers.delete(key);
             this.#dropTimerState(subscriptionId);
-            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:timer_fired", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath);
+            this.#inFlightOneShots.add(key);
+            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:timer_fired", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath, fireId);
         };
 
         const handle = this.#setTimeoutUntil(key, fireAt, fire);
@@ -752,6 +806,11 @@ export class TimeService implements ServiceHandler {
 
         if (action === "unsubscribe") return;
 
+        if (this.#inFlightOneShots.has(key)) {
+            logInfo(`[time] at ${subscriptionId} fire already in flight — skipping re-arm`);
+            return;
+        }
+
         const atStr = typeof params?.at === "string" ? params.at : null;
         if (!atStr) {
             logWarn(`[time] at subscription from ${sessionId} missing 'at' param`);
@@ -772,9 +831,11 @@ export class TimeService implements ServiceHandler {
         const summary = message ?? (label ? `Scheduled "${label}" fired` : `Scheduled trigger fired (target: ${atStr})`);
         const buildPayload = () => ({ at: new Date(targetMs).toISOString(), firedAt: new Date().toISOString(), label, message });
         const replacementPrompt = buildReplacementPrompt(`scheduled time ${atStr}`, label, message);
+        const fireId = `at:${subscriptionId}:${targetMs}`;
         const fire = () => {
             this.#timers.delete(key);
-            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:at", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath);
+            this.#inFlightOneShots.add(key);
+            this.#fireOneShotWithRetry(key, sessionId, subscriptionId, "time:at", buildPayload, summary, label, 0, replacementPrompt, cwd, resumePath, fireId);
         };
 
         const delayMs = targetMs - Date.now();
@@ -804,6 +865,14 @@ export class TimeService implements ServiceHandler {
 
         const existing = this.#crons.get(key);
         if (existing) {
+            if (existing.delivering) {
+                // A fire/migration is in flight for this exact cron — a
+                // re-applying snapshot must not recreate the entry: the fresh
+                // entry would have delivering=false and the 30s checker would
+                // double-fire against the past nextFireAt.
+                logInfo(`[time] cron ${subscriptionId} delivery in flight — skipping re-arm`);
+                return;
+            }
             clearInterval(existing.handle);
             this.#crons.delete(key);
         }
@@ -870,18 +939,29 @@ export class TimeService implements ServiceHandler {
 
             current.delivering = true;
             const nextIteration = (this.#cronIterations.get(key) ?? 0) + 1;
+            // Stable fire id across this fire's delivery retries (memoized on
+            // the entry — nextFireAt moves with the backoff, the id must not).
+            // Includes the scheduled fire time so cancelling and re-creating an
+            // identical schedule (same id, iteration restarts at 1) gets a fresh
+            // claim instead of being swallowed by the old schedule's dedup TTL
+            // — the Schedules panel's cancel/recreate flow.
+            if (!current.currentFireId) {
+                current.currentFireId = `cron:${subscriptionId}:${nextIteration}:${current.nextFireAt}`;
+            }
+            const fireId = current.currentFireId;
             void this.#deliverToSession(sessionId, "time:cron", {
                 cron: cronStr,
                 firedAt: new Date().toISOString(),
                 label,
                 message,
                 iteration: nextIteration,
-            }, message ?? (label ? `Cron "${label}" fired (#${nextIteration})` : `Cron "${cronStr}" fired (#${nextIteration})`)).then(async (result) => {
+            }, message ?? (label ? `Cron "${label}" fired (#${nextIteration})` : `Cron "${cronStr}" fired (#${nextIteration})`), fireId).then(async (result) => {
                 const cur = this.#crons.get(key);
                 if (!cur) return; // unsubscribed while delivering
 
                 if (result === "delivered") {
                     cur.delivering = false;
+                    cur.currentFireId = undefined;
                     this.#cronIterations.set(key, nextIteration);
                     cur.retryCount = 0;
                     const nextTime = nextCronTime(cron, now);
@@ -913,6 +993,7 @@ export class TimeService implements ServiceHandler {
                         buildReplacementPrompt(`cron "${cronStr}"`, label, message, true),
                         cwd,
                         resumePath,
+                        `spawn:cron:${subscriptionId}:${nextIteration}`,
                     );
                     const afterSpawn = this.#crons.get(key);
                     if (!afterSpawn) return; // unsubscribed while migrating
@@ -930,31 +1011,31 @@ export class TimeService implements ServiceHandler {
                         });
                         const stillMounted = this.#crons.get(key);
                         if (!stillMounted) return;
-                        stillMounted.delivering = false;
                         if (migrated) {
-                            // Retire the old subscription. It is durable, so leaving
-                            // it would restore it on the next reconnect snapshot,
-                            // re-arm this cron against a dead session, and migrate
-                            // AGAIN — one extra subscription and session per restart.
+                            // Retire the old subscription BEFORE releasing the
+                            // migration lock: removal (several timed attempts)
+                            // must not overlap the 30s checker, which would see
+                            // the still-past nextFireAt and migrate AGAIN.
                             await this.#removeSubscription(sessionId, "time:cron", subscriptionId);
                             logInfo(`[time] cron "${cronStr}" owner ${sessionId} is gone — re-owned by new session ${spawn.sessionId}`);
                             clearInterval(stillMounted.handle);
                             this.#crons.delete(key);
                             this.#cronIterations.delete(key);
                             this.#dropCronState(subscriptionId);
-                        } else {
-                            // The fire ran (a session is doing the work) but the
-                            // recurrence could not be handed over. Keep THIS cron
-                            // armed at its next natural time so the schedule is not
-                            // downgraded to a one-off, and try the handover again.
-                            const nextTime = nextCronTime(cron, Date.now());
-                            if (nextTime) {
-                                stillMounted.nextFireAt = nextTime;
-                                stillMounted.retryCount = 0;
-                                this.#persistCron(subscriptionId, nextTime, nextIteration);
-                                this.#cronIterations.set(key, nextIteration);
-                                logWarn(`[time] cron "${cronStr}" ran as ${spawn.sessionId} but could not be re-owned; keeping the old schedule armed for ${new Date(nextTime).toISOString()}`);
-                            }
+                            return; // entry retired — nothing to release
+                        }
+                        // The fire ran (a session is doing the work) but the
+                        // recurrence could not be handed over. Keep THIS cron
+                        // armed at its next natural time so the schedule is not
+                        // downgraded to a one-off, and try the handover again.
+                        stillMounted.delivering = false;
+                        const nextTime = nextCronTime(cron, Date.now());
+                        if (nextTime) {
+                            stillMounted.nextFireAt = nextTime;
+                            stillMounted.retryCount = 0;
+                            this.#persistCron(subscriptionId, nextTime, nextIteration);
+                            this.#cronIterations.set(key, nextIteration);
+                            logWarn(`[time] cron "${cronStr}" ran as ${spawn.sessionId} but could not be re-owned; keeping the old schedule armed for ${new Date(nextTime).toISOString()}`);
                         }
                     } else if (spawn.failure === "permanent") {
                         afterSpawn.delivering = false;
@@ -1010,8 +1091,9 @@ export class TimeService implements ServiceHandler {
         type: string,
         payload: Record<string, unknown>,
         summary?: string,
+        fireId?: string,
     ): Promise<DeliveryResult> {
-        const result = await this.#deliverToSession(sessionId, type, payload, summary);
+        const result = await this.#deliverToSession(sessionId, type, payload, summary, fireId);
         if (result === "delivered") {
             await this.#removeSubscription(sessionId, type, subscriptionId);
         }
@@ -1038,9 +1120,11 @@ export class TimeService implements ServiceHandler {
         replacementPrompt: string,
         cwd: string | undefined,
         resumePath: string | undefined,
+        fireId: string,
     ): void {
-        void this.#fireOneShot(sessionId, subscriptionId, triggerType, buildPayload(), summary).then(async (result) => {
+        void this.#fireOneShot(sessionId, subscriptionId, triggerType, buildPayload(), summary, fireId).then(async (result) => {
             if (this.#disposed) return;
+            this.#inFlightOneShots.delete(key);
             if (result === "delivered") return;
             if (result === "gone") {
                 if (sessionId.startsWith("runner-listener:")) {
@@ -1050,7 +1134,7 @@ export class TimeService implements ServiceHandler {
                     logWarn(`[time] ${triggerType} listener ${sessionId} no longer exists — dropping`);
                     return;
                 }
-                const spawn = await this.#spawnReplacementSession(replacementPrompt, cwd, resumePath);
+                const spawn = await this.#spawnReplacementSession(replacementPrompt, cwd, resumePath, `spawn:${fireId}`);
                 if ("sessionId" in spawn) {
                     // The one-shot has been handed to a live session; retire the
                     // subscription so it cannot re-arm on the next restart.
@@ -1072,7 +1156,8 @@ export class TimeService implements ServiceHandler {
             logWarn(`[time] ${triggerType} delivery to ${sessionId} failed; retrying in ${formatDuration(delay)}`);
             const handle = this.#setTimeoutUntil(key, fireAt, () => {
                 this.#timers.delete(key);
-                this.#fireOneShotWithRetry(key, sessionId, subscriptionId, triggerType, buildPayload, summary, label, retryCount + 1, replacementPrompt, cwd, resumePath);
+                this.#inFlightOneShots.add(key);
+                this.#fireOneShotWithRetry(key, sessionId, subscriptionId, triggerType, buildPayload, summary, label, retryCount + 1, replacementPrompt, cwd, resumePath, fireId);
             });
             this.#timers.set(key, { subscriptionId, handle, fireAt, sessionId, triggerType, label });
         });
@@ -1092,6 +1177,7 @@ export class TimeService implements ServiceHandler {
         prompt: string,
         cwd: string | undefined,
         resumePath?: string,
+        idempotencyKey?: string,
     ): Promise<{ sessionId: string } | { failure: "transient" | "permanent" }> {
         const apiKey = getApiKey();
         const runnerId = getOwnRunnerId();
@@ -1109,6 +1195,7 @@ export class TimeService implements ServiceHandler {
                     body: JSON.stringify({
                         runnerId,
                         prompt,
+                        ...(idempotencyKey ? { idempotencyKey } : {}),
                         ...(withCwd ? { cwd: withCwd } : {}),
                         // ponytail: a stale/deleted transcript just logs a warn
                         // worker-side and the session starts fresh — no need to
@@ -1185,6 +1272,7 @@ export class TimeService implements ServiceHandler {
         type: string,
         payload: Record<string, unknown>,
         summary?: string,
+        fireId?: string,
     ): Promise<DeliveryResult> {
         const apiKey = getApiKey();
         if (!apiKey) {
@@ -1205,6 +1293,9 @@ export class TimeService implements ServiceHandler {
                     source: "time",
                     deliverAs: "followUp",
                     summary,
+                    // Stable fire id so a retry after a lost response is
+                    // deduplicated server-side instead of delivered twice.
+                    ...(fireId ? { fireId } : {}),
                     // A schedule firing must reach the session that created it even
                     // if its worker has exited — the relay wakes it (resume) and
                     // the retry loop delivers into the awakened session.
@@ -1229,7 +1320,10 @@ export class TimeService implements ServiceHandler {
         }
     }
 
-    /** Remove a fired one-shot subscription server-side. */
+    /** Remove a fired/migrated subscription server-side. Retried because a
+     *  lost removal resurrects the schedule on the next restart snapshot: the
+     *  old cron re-arms against a dead session, fires again, and spawns a
+     *  duplicate replacement session. */
     async #removeSubscription(sessionId: string, triggerType: string, subscriptionId: string): Promise<void> {
         // Legacy entries without a real subscriptionId use a fabricated
         // "<sessionId>\0<triggerType>" key — skip targeted deletion for those.
@@ -1238,16 +1332,24 @@ export class TimeService implements ServiceHandler {
         const apiKey = getApiKey();
         if (!apiKey) return;
 
-        try {
-            const res = await fetch(
-                `${resolveRelayUrl()}/api/sessions/${encodeURIComponent(sessionId)}/trigger-subscriptions/${encodeURIComponent(triggerType)}?subscriptionId=${encodeURIComponent(subscriptionId)}`,
-                { method: "DELETE", headers: { "x-api-key": apiKey }, signal: AbortSignal.timeout(this.deliveryTimeoutMs) },
-            );
-            if (!res.ok) {
-                logWarn(`[time] failed to remove fired subscription ${subscriptionId}: ${res.status} ${res.statusText}`);
+        const url = `${resolveRelayUrl()}/api/sessions/${encodeURIComponent(sessionId)}/trigger-subscriptions/${encodeURIComponent(triggerType)}?subscriptionId=${encodeURIComponent(subscriptionId)}`;
+        for (let attempt = 0; attempt < REMOVE_ATTEMPTS; attempt++) {
+            try {
+                const res = await fetch(url, { method: "DELETE", headers: { "x-api-key": apiKey }, signal: AbortSignal.timeout(this.deliveryTimeoutMs) });
+                if (res.ok) return;
+                // A 4xx fails identically next time — don't spend the retries.
+                if (res.status >= 400 && res.status < 500 && res.status !== 429) {
+                    logWarn(`[time] failed to remove subscription ${subscriptionId}: ${res.status} ${res.statusText} — not retryable`);
+                    return;
+                }
+                logWarn(`[time] removing subscription ${subscriptionId} failed (${res.status}), attempt ${attempt + 1}/${REMOVE_ATTEMPTS}`);
+            } catch (err) {
+                logWarn(`[time] removing subscription ${subscriptionId} errored, attempt ${attempt + 1}/${REMOVE_ATTEMPTS}: ${err}`);
             }
-        } catch (err) {
-            logWarn(`[time] error removing fired subscription ${subscriptionId}: ${err}`);
+            if (attempt < REMOVE_ATTEMPTS - 1) {
+                await new Promise((resolve) => setTimeout(resolve, this.removeRetryDelayMs));
+            }
         }
+        logError(`[time] failed to remove subscription ${subscriptionId} after ${REMOVE_ATTEMPTS} attempts — it may re-arm and duplicate on the next restart`);
     }
 }

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -61,6 +61,11 @@ function runnerListenerAsSubscription(runnerId: string, listener: {
 
 const RUNNER_MCP_RELOAD_RE = /^\/api\/runners\/([^/]+)\/mcp\/reload$/;
 
+// ponytail: in-memory idempotency memo (single relay process) — move to Redis
+// if runners/spawn is ever served from a cluster, TTLs make stale entries self-clean.
+const SPAWN_IDEMPOTENCY_TTL_MS = 10 * 60_000;
+const recentSpawnIdempotency = new Map<string, { sessionId: string; ts: number }>();
+
 export const handleRunnersRoute: RouteHandler = async (req, url) => {
     // ── List runners ───────────────────────────────────────────────────
     if (url.pathname === "/api/runners" && req.method === "GET") {
@@ -83,6 +88,17 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         const requestedRunnerId = typeof body.runnerId === "string" ? body.runnerId : undefined;
         const requestedCwd = typeof body.cwd === "string" ? body.cwd : undefined;
         const requestedPrompt = typeof body.prompt === "string" ? body.prompt : undefined;
+        const idempotencyKey = typeof body.idempotencyKey === "string" && body.idempotencyKey.length > 0 && body.idempotencyKey.length <= 200
+            ? `runner-spawn:${body.idempotencyKey}`
+            : null;
+        if (idempotencyKey) {
+            // Schedule-driven spawns retry after ambiguous failures; without a
+            // key each retry mints a fresh duplicate replacement session.
+            const cached = recentSpawnIdempotency.get(idempotencyKey);
+            if (cached && Date.now() - cached.ts < SPAWN_IDEMPOTENCY_TTL_MS) {
+                return Response.json({ ok: true, runnerId: body.runnerId, sessionId: cached.sessionId, deduplicated: true });
+            }
+        }
         const requestedImageUrls = Array.isArray(body.imageUrls)
             ? body.imageUrls.filter((u: unknown): u is string => typeof u === "string").slice(0, 8)
             : undefined;
@@ -211,6 +227,16 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
 
         await recordRunnerSession(runnerId, sessionId);
         await linkSessionToRunner(runnerId, sessionId);
+
+        // Only the successful spawn (even ack-pending) is memoized as the
+        // idempotent outcome for this key.
+        if (idempotencyKey) {
+            recentSpawnIdempotency.set(idempotencyKey, { sessionId, ts: Date.now() });
+            if (recentSpawnIdempotency.size > 1000) {
+                const oldest = [...recentSpawnIdempotency.entries()].sort((a, b) => a[1].ts - b[1].ts)[0];
+                if (oldest) recentSpawnIdempotency.delete(oldest[0]);
+            }
+        }
 
         // Parent-child linking is now handled at registration time:
         // the worker sends parentSessionId in its relay `register` event,

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -92,6 +92,9 @@ import {
     getSubscriptionFilters,
     updateSessionSubscription,
     getDurableSubscriptionRunnerId,
+    claimFireOnce,
+    confirmFireOnce,
+    releaseFireOnce,
     type SubscriptionParams,
     type SubscriptionFilter,
     type SubscriptionFilterMode,
@@ -298,7 +301,15 @@ async function spawnListenerSessionAndDeliver(
             ...(listener.autoClose ? { autoClose: true } : {}),
         });
         const ack = await ackPromise;
-        if (ack.ok === false) return { spawned: false };
+        if (ack.ok === false) {
+            // Ack timeout ≠ spawn failure: the runner received the emit and the
+            // session may come up anyway. Continue the normal flow — record,
+            // link, deliver (the orphan-kill fallback below covers the case
+            // where it never appeared). Bailing out here would leak an
+            // unaccounted session AND let the delivery retry spawn a duplicate.
+            if (!("timeout" in ack && ack.timeout)) return { spawned: false };
+            log.warn(`Auto-spawn listener: ack timed out for ${spawnedSessionId} — assuming it spawned, delivering anyway`);
+        }
         await recordRunnerSession(runnerId, spawnedSessionId);
         await linkSessionToRunner(runnerId, spawnedSessionId);
 
@@ -388,6 +399,12 @@ interface TriggerRequest {
      * reach the session that created it even if its worker has exited.
      */
     wakeSession?: boolean;
+    /**
+     * Stable per-fire identity supplied by schedule callers (time service).
+     * A retry after a lost response is treated as the SAME fire and is
+     * swallowed instead of being emitted twice. Optional.
+     */
+    fireId?: string;
 }
 
 // ── Offline-session wake ───────────────────────────────────────────
@@ -706,6 +723,25 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Invalid 'deliverAs' — must be 'steer' or 'followUp'" }, { status: 400 });
         }
 
+        // Fire-once dedup: schedule deliveries send a stable fireId; a retry
+        // after a lost response must not emit the trigger a second time.
+        const fireIdClaim = typeof body.fireId === "string" && body.fireId.length > 0 && body.fireId.length <= 200
+            ? body.fireId
+            : null;
+        if (fireIdClaim) {
+            const firstAttempt = await claimFireOnce(sessionId, fireIdClaim);
+            if (!firstAttempt) {
+                log.info(`Duplicate fire "${fireIdClaim}" for session ${sessionId} — already claimed/delivered, skipping`);
+                return Response.json({ ok: true, deduplicated: true });
+            }
+        }
+        const releaseFireClaim = () => {
+            if (fireIdClaim) void releaseFireOnce(sessionId, fireIdClaim);
+        };
+        const confirmFireClaim = () => {
+            if (fireIdClaim) void confirmFireOnce(sessionId, fireIdClaim);
+        };
+
         // A `runner-listener:<listenerId>` pseudo-session is a runner-level
         // auto-spawn listener — there is no real session to deliver into.
         // Fires addressed to it (the time service's cron/at/timer deliveries)
@@ -715,11 +751,13 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             const parsed = parseRunnerListenerSessionId(sessionId);
             const runnerData = parsed ? await getRunnerData(parsed.runnerId).catch(() => null) : null;
             if (!parsed || !runnerData || runnerData.userId !== identity.userId) {
+                releaseFireClaim();
                 return Response.json({ error: "Listener not found" }, { status: 404 });
             }
             const listener = (await listRunnerTriggerListeners(parsed.runnerId))
                 .find((entry) => entry.listenerId === parsed.listenerId);
             if (!listener) {
+                releaseFireClaim();
                 return Response.json({ error: "Listener not found" }, { status: 404 });
             }
             const listenerTriggerId = `ext_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
@@ -736,8 +774,10 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             if (!result.spawned) {
                 // 503 (not 404): the listener still exists — the caller's
                 // schedule must retry, not treat the schedule as deleted.
+                releaseFireClaim();
                 return Response.json({ error: "Failed to spawn listener session — retry delivery" }, { status: 503 });
             }
+            confirmFireClaim();
             return Response.json({ ok: true, triggerId: listenerTriggerId, spawnedSessionId: result.sessionId });
         }
 
@@ -753,6 +793,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // No live record and nothing durable to resume — the session is
             // genuinely gone. Callers treat 404 as "start fresh work": the time
             // service spawns a replacement session for the schedule.
+            releaseFireClaim();
             return Response.json({ error: "Session not found or not connected" }, { status: 404 });
         }
 
@@ -795,9 +836,11 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                 log.info(`External trigger ${triggerId} delivered to session ${sessionId}`);
                 void Promise.resolve(pushTriggerHistory(sessionId, historyEntry)).catch(() => {});
                 broadcastToSessionViewers(sessionId, "trigger_delivered", { triggerId });
+                confirmFireClaim();
                 return Response.json({ ok: true, triggerId });
             } catch (err) {
                 log.error(`Failed to deliver trigger ${triggerId} to session ${sessionId}:`, err);
+                releaseFireClaim();
                 return Response.json({ error: "Failed to deliver trigger to session" }, { status: 502 });
             }
         }
@@ -808,6 +851,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             log.info(`External trigger ${triggerId} delivered cross-node to session ${sessionId}`);
             void Promise.resolve(pushTriggerHistory(sessionId, historyEntry)).catch(() => {});
             broadcastToSessionViewers(sessionId, "trigger_delivered", { triggerId });
+            confirmFireClaim();
             return Response.json({ ok: true, triggerId });
         }
 
@@ -827,6 +871,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             // to an unknown or foreign runner (cross-user command injection).
             if (!wakeRunnerData || wakeRunnerData.userId !== identity.userId) {
                 log.warn(`wake: runner ${target.runnerId} is missing or owned by a different user — refusing wake for session ${sessionId}`);
+                releaseFireClaim();
                 return Response.json({ error: "Session not found or not connected" }, { status: 404 });
             }
             const runnerReachable = !!getLocalRunnerSocket(target.runnerId) || !!wakeRunnerData;
@@ -841,6 +886,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                 // to come back.
                 log.info(`External trigger ${triggerId}: runner ${target.runnerId} unreachable — caller should retry`);
             }
+            releaseFireClaim();
             return Response.json(
                 {
                     error: runnerReachable
@@ -852,6 +898,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             );
         }
 
+        releaseFireClaim();
         return Response.json(
             { error: "Session is registered but not currently connected" },
             { status: 503 },

--- a/packages/server/src/sessions/trigger-subscription-store.test.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.test.ts
@@ -17,6 +17,9 @@ import {
     refreshRunnerSubscriptionTtls,
     sessionHasScheduleSubscription,
     isDurableTriggerType,
+    claimFireOnce,
+    confirmFireOnce,
+    releaseFireOnce,
     _injectRedisForTesting,
     _resetRedisForTesting,
 } from "./trigger-subscription-store";
@@ -26,6 +29,7 @@ import {
 const hashes = new Map<string, Map<string, string>>();
 const sets = new Map<string, Set<string>>();
 const expirations = new Map<string, number>();
+const strings = new Map<string, string>();
 
 const mockRedisClient = {
     isOpen: true,
@@ -66,7 +70,14 @@ const mockRedisClient = {
     del: mock((key: string) => {
         hashes.delete(key);
         sets.delete(key);
+        strings.delete(key);
         return Promise.resolve(1);
+    }),
+    set: mock((key: string, value: string, opts?: { NX?: boolean; EX?: number }) => {
+        if (opts?.NX && strings.has(key)) return Promise.resolve(null);
+        strings.set(key, value);
+        if (opts?.EX) expirations.set(key, opts.EX);
+        return Promise.resolve("OK");
     }),
     multi: mock(() => {
         const ops: Array<() => Promise<unknown>> = [];
@@ -107,6 +118,7 @@ function resetState() {
     hashes.clear();
     sets.clear();
     expirations.clear();
+    strings.clear();
     _injectRedisForTesting(mockRedisClient);
 }
 
@@ -279,6 +291,79 @@ describe("multi-subscription support", () => {
 
         const subs = await getSubscriptionsForSessionTrigger("session-1", "svc:event");
         expect(subs).toHaveLength(2);
+    });
+});
+
+describe("idempotent subscribe (duplicate prevention)", () => {
+    beforeEach(resetState);
+
+    test("re-subscribing with identical params reuses the subscriptionId instead of duplicating", async () => {
+        const first = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *", message: "standup" });
+        const second = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *", message: "standup" });
+        expect(second).toBe(first);
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs.filter((s) => s.triggerType === "time:cron")).toHaveLength(1);
+    });
+
+    test("same triggerType with different params still creates a second subscription", async () => {
+        await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *" });
+        await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 12 * * *" });
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs.filter((s) => s.triggerType === "time:cron")).toHaveLength(2);
+    });
+
+    test("pre-existing identical duplicate rows are pruned on re-subscribe", async () => {
+        const seedId = "sub:session-1:time:cron:seed1";
+        const dupId = "sub:session-1:time:cron:dup1";
+        const seedValue = JSON.stringify({ subscriptionId: seedId, triggerType: "time:cron", runnerId: "runner-A", params: { cron: "0 9 * * *" }, filters: [] });
+        hashes.set("pizzapi:trigger-subs:session-1", new Map([
+            [seedId, seedValue],
+            [dupId, JSON.stringify({ subscriptionId: dupId, triggerType: "time:cron", runnerId: "runner-A", params: { cron: "0 9 * * *" }, filters: [] })],
+        ]));
+        const id = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *" });
+        expect(id).toBe(seedId);
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs.filter((s) => s.triggerType === "time:cron")).toHaveLength(1);
+        expect(subs[0]!.subscriptionId).toBe(seedId);
+    });
+
+    test("identical params on a different runner are separate subscriptions", async () => {
+        const first = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *" });
+        const second = await subscribeSessionToTrigger("session-1", "runner-B", "time:cron", undefined, { cron: "0 9 * * *" });
+        expect(second).not.toBe(first);
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs.filter((s) => s.triggerType === "time:cron")).toHaveLength(2);
+    });
+
+    test("param key order does not defeat dedup (canonical identity)", async () => {
+        const first = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { cron: "0 9 * * *", _cwd: "/tmp/x" });
+        const second = await subscribeSessionToTrigger("session-1", "runner-A", "time:cron", undefined, { _cwd: "/tmp/x", cron: "0 9 * * *" });
+        expect(second).toBe(first);
+        const subs = await listSessionSubscriptions("session-1");
+        expect(subs.filter((s) => s.triggerType === "time:cron")).toHaveLength(1);
+    });
+});
+
+describe("claimFireOnce (delivery fire dedup)", () => {
+    beforeEach(resetState);
+
+    test("claims once, blocks replays, releases on failure", async () => {
+        await expect(claimFireOnce("session-1", "fire-1")).resolves.toBe(true);
+        await expect(claimFireOnce("session-1", "fire-1")).resolves.toBe(false);
+        await releaseFireOnce("session-1", "fire-1");
+        await expect(claimFireOnce("session-1", "fire-1")).resolves.toBe(true);
+    });
+
+    test("different fireIds and sessions do not collide", async () => {
+        await expect(claimFireOnce("session-1", "a")).resolves.toBe(true);
+        await expect(claimFireOnce("session-1", "b")).resolves.toBe(true);
+        await expect(claimFireOnce("session-2", "a")).resolves.toBe(true);
+    });
+
+    test("confirm extends the TTL without releasing the claim", async () => {
+        await expect(claimFireOnce("session-1", "fire-1")).resolves.toBe(true);
+        await expect(confirmFireOnce("session-1", "fire-1")).resolves.toBeUndefined();
+        await expect(claimFireOnce("session-1", "fire-1")).resolves.toBe(false);
     });
 });
 

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -33,6 +33,7 @@
 import { connectRedisClient, isRedisDisabled, type RedisClient } from "../redis-client.js";
 import { createLogger } from "@pizzapi/tools";
 import { getKysely } from "../auth.js";
+import { createHash } from "node:crypto";
 
 const log = createLogger("trigger-subscription-store");
 
@@ -225,10 +226,25 @@ export async function rehydrateRunnerSubscriptions(runnerId: string): Promise<nu
 
     let restored = 0;
     try {
+        // Heal past duplicates: identical (sessionId, triggerType, runnerId,
+        // params, filters, filterMode) rows must not both come back — a
+        // double-subscribed cron fires twice per tick. Extras are skipped
+        // here and dropped from the durable table.
+        const seen = new Set<string>();
+        const duplicateIds: string[] = [];
         const pipeline = redis.multi();
         for (const row of rows) {
             const sub = parseSubValues(row.sessionId, row.subscriptionJson)[0];
             if (!sub) continue;
+            const identity = `${row.sessionId}|${sub.triggerType}|${sub.runnerId}|${JSON.stringify(sub.params ?? null)}|${JSON.stringify(sub.filters ?? [])}|${sub.filterMode ?? "and"}`;
+            if (seen.has(identity)) {
+                duplicateIds.push(sub.subscriptionId);
+                // Also drop any duplicate field already cached in Redis — the
+                // pipeline below only writes the first row, it never deletes.
+                pipeline.hDel(SESSION_SUBS_KEY(row.sessionId), sub.subscriptionId);
+                continue;
+            }
+            seen.add(identity);
             const sessionKey = SESSION_SUBS_KEY(row.sessionId);
             pipeline.hSet(sessionKey, sub.subscriptionId, row.subscriptionJson);
             pipeline.expire(sessionKey, DEFAULT_TTL_SECONDS);
@@ -241,12 +257,72 @@ export async function rehydrateRunnerSubscriptions(runnerId: string): Promise<nu
             restored++;
         }
         await pipeline.exec();
+        if (duplicateIds.length > 0) {
+            await deleteSubscriptionRows({ subscriptionIds: duplicateIds });
+            log.info(`Pruned ${duplicateIds.length} duplicate trigger subscription(s) for runner ${runnerId} during rehydration`);
+        }
     } catch (err) {
         log.warn("Failed to rehydrate trigger subscriptions into Redis:", err);
         return 0;
     }
     if (restored > 0) log.info(`Rehydrated ${restored} trigger subscription(s) for runner ${runnerId} from durable storage`);
     return restored;
+}
+
+// ── Fire-once dedup (schedule delivery) ─────────────────────────────────
+//
+// A schedule delivery whose HTTP response is lost (timeout, dropped
+// connection) is retried by the time service — but the relay may already
+// have emitted the trigger. A stable fireId supplied by the caller makes
+// the retry idempotent: the first claim wins, retries are swallowed.
+
+/** Short claim TTL: a crash between claim and delivery only swallows the
+ *  retry briefly. Confirmed fires are extended to the full TTL. */
+const FIRE_ONCE_CLAIM_TTL_SECONDS = 120;
+const FIRE_ONCE_CONFIRMED_TTL_SECONDS = 86_400;
+
+function fireOnceKey(sessionId: string, fireId: string): string {
+    return `pizzapi:fire-once:${sessionId}:${fireId}`;
+}
+
+/** True the first time a (session, fireId) is seen within its TTL; false when
+ *  this fire was already claimed/delivered. Best-effort: without Redis the
+ *  fire proceeds (at-least-once semantics). */
+export async function claimFireOnce(sessionId: string, fireId: string): Promise<boolean> {
+    const redis = await getClient();
+    if (!redis) return true;
+    try {
+        const claimed = await redis.set(fireOnceKey(sessionId, fireId), "claimed", {
+            NX: true,
+            EX: FIRE_ONCE_CLAIM_TTL_SECONDS,
+        });
+        return claimed !== null;
+    } catch (err) {
+        log.warn("Failed to claim fire-once key (best-effort):", err);
+        return true;
+    }
+}
+
+/** Extend a claimed fire to the full TTL after successful delivery. */
+export async function confirmFireOnce(sessionId: string, fireId: string): Promise<void> {
+    const redis = await getClient();
+    if (!redis) return;
+    try {
+        await redis.expire(fireOnceKey(sessionId, fireId), FIRE_ONCE_CONFIRMED_TTL_SECONDS);
+    } catch (err) {
+        log.warn("Failed to confirm fire-once key (best-effort):", err);
+    }
+}
+
+/** Release a claim after a failed delivery so the caller's retry is not swallowed. */
+export async function releaseFireOnce(sessionId: string, fireId: string): Promise<void> {
+    const redis = await getClient();
+    if (!redis) return;
+    try {
+        await redis.del(fireOnceKey(sessionId, fireId));
+    } catch (err) {
+        log.warn("Failed to release fire-once key (best-effort):", err);
+    }
 }
 
 let _redis: RedisClient | null = null;
@@ -368,8 +444,51 @@ interface SubscriptionValue {
 
 export interface SessionTriggerSubscription extends SubscriptionValue {}
 
+/**
+ * Order-independent JSON canonicalization (sorted object keys). Used for
+ * subscription identity: two semantically identical param objects must
+ * produce the same identity string regardless of key insertion order.
+ */
+function canonicalJson(value: unknown): string {
+    if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+    if (value !== null && typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>)
+            .filter(([, v]) => v !== undefined)
+            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+        return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(",")}}`;
+    }
+    return JSON.stringify(value ?? null);
+}
+
+/** Canonical identity string for a subscription (used for dedup and id derivation). */
+function subIdentity(
+    triggerType: string,
+    runnerId: string,
+    params: SubscriptionParams | undefined,
+    filters: SubscriptionFilter[] | undefined,
+    filterMode: SubscriptionFilterMode | undefined,
+): string {
+    // Filters are order-insensitive — sort them so {a},{b} and {b},{a} match.
+    const sortedFilters = [...(filters ?? [])].sort(
+        (a, b) => a.field.localeCompare(b.field) || canonicalJson(a).localeCompare(canonicalJson(b)),
+    );
+    return canonicalJson({ triggerType, runnerId, params: params ?? null, filters: sortedFilters, filterMode: filterMode ?? "and" });
+}
+
+/**
+ * Stable fabricated id for legacy-format rows (no id in the stored JSON).
+ * Derived deterministically from the hash field so ids are stable across
+ * reads — snapshot runtime keys and persisted cron state survive restarts.
+ * (The fabricated id still does not equal the hash field, so targeted
+ * deletion of legacy rows by id is not possible — known limitation.)
+ */
 function generateSubscriptionId(sessionId: string, triggerType: string): string {
-    return `sub:${sessionId}:${triggerType}:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
+    return `sub:legacy:${sessionId}:${triggerType}`;
+}
+
+function deterministicSubscriptionId(triggerType: string, runnerId: string, params: SubscriptionParams | undefined, filters: SubscriptionFilter[] | undefined, filterMode: SubscriptionFilterMode | undefined): string {
+    const hash = createHash("sha256").update(subIdentity(triggerType, runnerId, params, filters, filterMode)).digest("hex").slice(0, 16);
+    return `sub:${triggerType}:${hash}`;
 }
 
 function isLegacySubscriptionCollection(parsed: unknown): parsed is { triggerType: string; runnerId: string; params?: SubscriptionParams; filters?: SubscriptionFilter[]; filterMode?: SubscriptionFilterMode }[] {
@@ -490,7 +609,41 @@ export async function subscribeSessionToTrigger(
     const runnerSessionsKey = RUNNER_SESSIONS_INDEX_KEY(runnerId);
 
     try {
-        const subscriptionId = generateSubscriptionId(sessionId, triggerType);
+        // Idempotent subscribe: re-subscribing with identical (triggerType,
+        // runnerId, params, filters, filterMode) must reuse the existing
+        // subscription, not add a second row — a double-subscribed time:cron
+        // fires twice per tick. Extra identical rows left by past duplicates
+        // are pruned here too.
+        const identical = subIdentity(triggerType, runnerId, params, filters, filterMode);
+        const hash = await redis.hGetAll(sessionKey);
+        const dupFields: string[] = [];
+        let reuseId: string | null = null;
+        for (const [field, raw] of Object.entries(hash)) {
+            const sub = parseSubValues(field, raw).find((e) => e.triggerType === triggerType);
+            if (!sub) continue;
+            const have = subIdentity(sub.triggerType, sub.runnerId, sub.params, sub.filters, sub.filterMode);
+            if (have !== identical) continue;
+            // Only reusable when the hash field IS the subscriptionId (new
+            // format) — legacy rows have fabricated ids we can't hDel by id.
+            if (reuseId === null && field === sub.subscriptionId) reuseId = field;
+            dupFields.push(field);
+        }
+        if (reuseId !== null) {
+            dupFields.splice(dupFields.indexOf(reuseId), 1);
+            const pipeline = redis.multi();
+            pipeline.expire(sessionKey, ttlSeconds);
+            pipeline.expire(indexKey, ttlSeconds);
+            pipeline.expire(runnerSessionsKey, ttlSeconds);
+            for (const field of dupFields) pipeline.hDel(sessionKey, field);
+            await pipeline.exec();
+            if (dupFields.length > 0) await deleteSubscriptionRows({ subscriptionIds: dupFields });
+            return reuseId;
+        }
+
+        // Deterministic id: two concurrent identical subscribes write the SAME
+        // hash field, so the read-then-write race collapses instead of minting
+        // duplicate schedules in different fields.
+        const subscriptionId = deterministicSubscriptionId(triggerType, runnerId, params, filters, filterMode);
         const value = serializeSubValue({
             subscriptionId,
             triggerType,

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -158,6 +158,15 @@ export async function registerRunner(
         }
         // Re-registration (existing secret matched) or first claim: clean up any
         // stale local socket association for this runnerId.
+        // Two sockets reusing the same persistent runnerId must not BOTH hold
+        // schedule state: the map keeps only the newest, but the stale socket
+        // (already in the runner room, already reconciled) keeps running —
+        // every cron/timer would fire once per live socket. Disconnect it.
+        const staleSocket = localRunnerSockets.get(requestedId);
+        if (staleSocket && staleSocket !== socket && staleSocket.connected) {
+            log.warn(`Runner ${requestedId} re-registered — disconnecting stale socket`);
+            staleSocket.disconnect();
+        }
         localRunnerSockets.delete(requestedId);
         runnerId = requestedId;
     } else {

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -365,4 +365,42 @@ describe("registerTuiSession parent resolution", () => {
             runnerName: "Persisted Runner",
         });
     });
+
+    it("inherits the parent's runner association when the child has none (subagent mirror)", async () => {
+        const socket = {
+            join: async () => {},
+            data: {},
+        } as any;
+
+        // Parent registered normally with a runner association.
+        store.set(
+            "__hash__:pizzapi:sio:session:parent-on-runner",
+            JSON.stringify({
+                sessionId: "parent-on-runner",
+                userId: "u1",
+                runnerId: "runner-1",
+                runnerName: "My Runner",
+            }),
+        );
+
+        await registerTuiSession(socket, "/repo", {
+            sessionId: "subagent-child",
+            userId: "u1",
+            userName: "User",
+            isEphemeral: true,
+            parentSessionId: "parent-on-runner",
+        });
+
+        const sessionHash = JSON.parse(
+            store.get("__hash__:pizzapi:sio:session:subagent-child") ?? "{}",
+        ) as Record<string, string>;
+        expect(sessionHash.runnerId).toBe("runner-1");
+        expect(sessionHash.runnerName).toBe("My Runner");
+
+        // Durable association persisted so it survives relay restarts.
+        expect(JSON.parse(store.get("pizzapi:sio:runner-assoc:subagent-child") ?? "null")).toEqual({
+            runnerId: "runner-1",
+            runnerName: "My Runner",
+        });
+    });
 });

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -378,6 +378,14 @@ async function registerTuiSessionUnlocked(
             });
             resolvedParentSessionId = null;
             linkedParentId = null; // cross-user link: clear durable signal too
+        } else if (!runnerId && parentSession.runnerId) {
+            // In-process child sessions (e.g. subagent relay mirrors) register
+            // without a runner link because the runner daemon never reports
+            // session_ready for them. Inherit the parent's runner association
+            // so they group under the parent's runner instead of "Local".
+            runnerId = parentSession.runnerId;
+            runnerName = parentSession.runnerName ?? null;
+            await setRunnerAssociation(sessionId, runnerId, runnerName);
         }
     }
 


### PR DESCRIPTION
Three work streams landed on this branch.

## Subagent mirror sessions inherit parent's runner (the branch's namesake)

Subagent relay-mirror sessions (in-process subagent runs mirrored to the relay) register with a `parentSessionId` but no runner link — the runner daemon never reports `session_ready` for them.

`registerTuiSession` resolved `runnerId: null`, so the sidebar dumped them into a stray **Local** group even though they belong to the same runner/project as their parent (the recurring screenshot bug — prior fixes only touched the sidebar's cwd/parent grouping, which can't cross runner groups).

Fix: when a child registers with a valid same-user parent and no runner of its own, inherit the parent's `runnerId`/`runnerName` and persist the durable association. Regression test included.

## NVIDIA model support

- **Live discovery from build.nvidia.com** — pi-ai ships a 30-model static NVIDIA snapshot that misses models NVIDIA now serves (kimi-k3, gemma-4-31b-it, nemotron-nano-3). Fetch `integrate.api.nvidia.com/v1/models`, cache 24h in `~/.pizzapi/nvidia-models-cache.json`, register a native provider that unions with the static catalog (some NIMs still serving traffic are omitted from the live list). Non-chat endpoints filtered by id. Wired into session extensions, the daemon's `list_models`, and `pizza models`.
- **Thinking effort unlocked** — pi-ai marks every NVIDIA model `supportsReasoningEffort: false`, so `clampThinkingLevel()` snapped levels back to "off" and the cycle button silently no-opped. NVIDIA honours `reasoning_effort` (verified on gpt-oss-120b and nemotron-3-super). API only accepts `low|medium|high` — `minimal`/`xhigh`/`max` map to null. Live-discovered ids default to `reasoning: true`.
- **Hardened against decay** — normalize cached models on read (stale entries from older builds no longer keep a dead thinking control for 24h) and NVIDIA's accepted levels win the merge over any pi-ai-supplied `thinkingLevelMap`.

## Scheduling dedup (retry-safe triggers)

Schedule-driven spawns and deliveries can retry after ambiguous failures, which used to mint duplicate replacement sessions and double-fire triggers.

- `POST /api/runners/spawn` accepts an `idempotencyKey` — a retry within 10min returns the original `sessionId` (`deduplicated: true`) instead of spawning again. Only successful spawns are memoized.
- Trigger delivery accepts a stable `fireId` — claim/confirm/release in the store means a retry after a lost response is swallowed rather than emitted twice.
- Ack timeout ≠ spawn failure: an auto-spawn ack timeout now proceeds with record/link/deliver (orphan-kill fallback covers the never-appeared case) instead of leaking an unaccounted session.
- Time service sends stable `fireId`s and got in-flight migration/respawn guards; full test coverage in `time-service.retry.test.ts` and `trigger-subscription-store.test.ts`.