### PR TITLE
feat(ui): pass session cwd to sigil resolve endpoints

### DIFF
--- a/packages/cli/src/nvidia-models.test.ts
+++ b/packages/cli/src/nvidia-models.test.ts
@@ -44,11 +44,14 @@ describe("toNvidiaModel", () => {
     });
 
     test("synthesizes defaults for ids the package has never seen", () => {
-        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        // "vendor/new-model" is deliberately synthetic — real ids (e.g.
+        // moonshotai/kimi-k3) get curated into pi-ai's catalog over time and
+        // stop exercising the synthesized-defaults path.
+        const model = toNvidiaModel({ id: "vendor/new-model" }, STATIC as any)!;
         expect(model.provider).toBe("nvidia");
         expect(model.api).toBe("openai-completions");
         expect(model.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
-        expect(model.name).toBe("moonshotai/kimi-k3");
+        expect(model.name).toBe("vendor/new-model");
         expect(model.input).toEqual(["text"]);
         expect(model.contextWindow).toBe(128000);
         expect(model.maxTokens).toBe(4096);
@@ -58,7 +61,7 @@ describe("toNvidiaModel", () => {
     });
 
     test("unknown ids are reasoning-capable so the thinking control is usable", () => {
-        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        const model = toNvidiaModel({ id: "vendor/new-model" }, STATIC as any)!;
         expect(model.reasoning).toBe(true);
         expect((model.compat as any).supportsReasoningEffort).toBe(true);
         // NVIDIA rejects "minimal" and has no xhigh/max equivalent.
@@ -70,9 +73,13 @@ describe("toNvidiaModel", () => {
     });
 
     test("NVIDIA's accepted levels win over an upstream thinkingLevelMap", () => {
-        const upstream = [{ ...(STATIC.find((m) => m.reasoning) as any), thinkingLevelMap: { minimal: "minimal", max: "max" } }];
-        const model = toNvidiaModel({ id: upstream[0].id }, upstream as any)!;
-        expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+        // pi-ai ≥ 0.84.3 ships per-model maps (deepseek entries null out low/medium);
+        // the overlay must force NVIDIA's accepted values back on.
+        for (const map of [{ minimal: "minimal", max: "max" }, { minimal: null, low: null, medium: null, high: "high", max: "max" }]) {
+            const upstream = [{ ...(STATIC.find((m) => m.reasoning) as any), thinkingLevelMap: map }];
+            const model = toNvidiaModel({ id: upstream[0].id }, upstream as any)!;
+            expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+        }
     });
 
     test("enables reasoning effort on curated reasoning models too", () => {
@@ -180,7 +187,7 @@ describe("fetchNvidiaModels", () => {
         const home = tempHome();
         mkdirSync(join(home, ".pizzapi"), { recursive: true });
         const stale = {
-            ...(toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any) as any),
+            ...(toNvidiaModel({ id: "vendor/new-model" }, STATIC as any) as any),
             compat: { maxTokensField: "max_tokens", supportsReasoningEffort: false },
             thinkingLevelMap: { minimal: "minimal" }, // a 400 on NVIDIA's API
         };

--- a/packages/cli/src/nvidia-models.ts
+++ b/packages/cli/src/nvidia-models.ts
@@ -25,11 +25,14 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
  * NVIDIA honours OpenAI-style `reasoning_effort`, but pi-ai's catalog marks
  * every NVIDIA model `supportsReasoningEffort: false`, so the thinking-level
  * control silently clamps back to "off". The API only accepts low|medium|high
- * — pi's "minimal" is a 400 — so map it (and the xhigh/max levels NVIDIA has no
- * equivalent for) to null, which hides them. "off" sends no parameter at all,
- * i.e. the model's own default.
+ * — pi's "minimal" is a 400 — so force those three on and map the levels
+ * NVIDIA has no equivalent for (minimal, xhigh, max) to null, which hides
+ * them. "off" sends no parameter at all, i.e. the model's own default.
+ * pi-ai ≥ 0.84.3 ships per-model thinkingLevelMaps (e.g. deepseek entries
+ * null out low/medium); NVIDIA's accepted values are a hard API constraint,
+ * so they win over every upstream or cached value.
  */
-const NVIDIA_THINKING_LEVEL_MAP = { minimal: null, xhigh: null, max: null } as const;
+const NVIDIA_THINKING_LEVEL_MAP = { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null, max: null } as const;
 
 function withReasoningEffort(model: NvidiaModel): NvidiaModel {
     if (!model.reasoning) return model;

--- a/packages/ui/dev-dist/sw.js
+++ b/packages/ui/dev-dist/sw.js
@@ -80,7 +80,7 @@ define(['./workbox-0cb42a3e'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "/index.html",
-    "revision": "0.vurtt4r1eco"
+    "revision": "0.gq3gt867dak"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5727,7 +5727,7 @@ export function App() {
                     </ErrorBoundary>
                   ) : (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
-                      <SigilProvider sigilDefs={runnerSigilDefs} panels={dynamicPanels} runnerId={activeSessionInfo?.runnerId ?? undefined}>
+                      <SigilProvider sigilDefs={runnerSigilDefs} panels={dynamicPanels} runnerId={activeSessionInfo?.runnerId ?? undefined} sessionCwd={activeSessionInfo?.cwd}>
                       <PizzaPiNavProvider actions={pizzaPiNavActions}>
                       <SessionViewer
                         promptRef={promptRef}

--- a/packages/ui/src/attention/trigger-groups.test.ts
+++ b/packages/ui/src/attention/trigger-groups.test.ts
@@ -1,46 +1,15 @@
 /**
- * Pure-logic tests for TriggersPanel exported helpers.
+ * Pure-logic tests for trigger grouping helpers.
  *
- * These test groupByLinkedSession, isPendingTrigger, and getIncompleteTriggers
- * without any DOM, React, or module-alias dependencies.
+ * Tests groupByLinkedSession, isPendingTrigger, and getIncompleteTriggers
+ * without any DOM, React, or module-alias dependencies. These helpers used
+ * to live inside TriggersPanel.tsx (requiring global UI mocks — see git
+ * history); extracting them made the mocks unnecessary.
  */
-import { describe, test, expect, mock } from "bun:test";
-
-// ── Minimal mocks for TriggersPanel's UI imports ─────────────────────────────
-// IMPORTANT: bun's mock.module is process-global and is NOT undone by
-// mock.restore(), so these leak into every test file that runs after this one.
-// The stubs must therefore render their children (a `() => null` Button here
-// blanked out buttons in unrelated component tests, e.g. DeviceSetupScanner's
-// "Allow Camera & Scan" — which tests failed depended on file order).
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const R = await import("react");
-const childStub = (tag: string) => {
-  const Stub = R.forwardRef(({ children, ...props }: any, ref: any) =>
-    R.createElement(tag, { ...props, ref }, children),
-  );
-  Stub.displayName = `Stub(${tag})`;
-  return Stub;
-};
-mock.module("@/components/ui/button", () => ({ Button: childStub("button") }));
-mock.module("@/components/ui/badge", () => ({ Badge: childStub("span") }));
-// Dialog stubs stay null: real dialogs hide content until opened, so a
-// children-rendering stub would leak inline dialog text into later files
-// and break their single-match queries the same way.
-mock.module("@/components/ui/dialog", () => ({
-  Dialog: () => null, DialogContent: () => null, DialogHeader: () => null,
-  DialogTitle: () => null, DialogFooter: () => null, DialogDescription: () => null,
-}));
-mock.module("@/lib/utils", () => ({ cn: (...args: any[]) => args.filter(Boolean).join(" ") }));
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-// Import AFTER mocks are registered
-const {
-  groupByLinkedSession,
-  isPendingTrigger,
-  getIncompleteTriggers,
-  RESPONSE_TRIGGER_TYPES,
-} = await import("./TriggersPanel");
-import type { TriggerHistoryEntry } from "./TriggersPanel";
+import { describe, test, expect } from "bun:test";
+import type { TriggerHistoryEntry } from "./trigger-utils";
+import { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "./trigger-utils";
+import { groupByLinkedSession, getIncompleteTriggers } from "./trigger-groups";
 
 function makeTrigger(overrides: Partial<TriggerHistoryEntry> = {}): TriggerHistoryEntry {
   return {

--- a/packages/ui/src/attention/trigger-groups.ts
+++ b/packages/ui/src/attention/trigger-groups.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure trigger-history grouping helpers — no React, no UI deps.
+ *
+ * Extracted from TriggersPanel.tsx so that the panel stays code-split
+ * (React.lazy in App.tsx). slash-commands.ts and useTriggerCount.ts import
+ * getIncompleteTriggers at runtime; if these helpers lived in the panel file,
+ * the whole panel would be statically baked into the main entry chunk.
+ */
+import type { TriggerHistoryEntry } from "./trigger-utils";
+import { isPendingTrigger } from "./trigger-utils";
+
+export type { TriggerHistoryEntry } from "./trigger-utils";
+
+/** A linked child session derived from trigger history. */
+export interface LinkedSessionGroup {
+  /** Session ID of the linked child */
+  source: string;
+  /** All trigger events from this session, most recent first */
+  events: TriggerHistoryEntry[];
+  /** The most recent pending trigger (no response), if any */
+  pendingTrigger: TriggerHistoryEntry | null;
+  /** Most recent trigger type */
+  lastType: string;
+  /** Most recent trigger timestamp */
+  lastTs: string;
+  /** Summary from the most recent trigger */
+  lastSummary?: string;
+}
+
+/** Group triggers by linked session source. Returns groups sorted by most recent first. */
+export function groupByLinkedSession(triggers: TriggerHistoryEntry[]): {
+  sessionGroups: LinkedSessionGroup[];
+  otherEvents: TriggerHistoryEntry[];
+} {
+  const groupMap = new Map<string, TriggerHistoryEntry[]>();
+  const otherEvents: TriggerHistoryEntry[] = [];
+
+  for (const t of triggers) {
+    // Only group inbound triggers from non-external sources (child sessions)
+    if (t.direction === "inbound" && t.source !== "api" && !t.source.startsWith("external:")) {
+      const existing = groupMap.get(t.source);
+      if (existing) {
+        existing.push(t);
+      } else {
+        groupMap.set(t.source, [t]);
+      }
+    } else {
+      otherEvents.push(t);
+    }
+  }
+
+  const sessionGroups: LinkedSessionGroup[] = [];
+  for (const [source, events] of groupMap) {
+    // Events are already sorted most-recent-first from the API
+    const pendingTrigger = events.find(isPendingTrigger) ?? null;
+    sessionGroups.push({
+      source,
+      events,
+      pendingTrigger,
+      lastType: events[0].type,
+      lastTs: events[0].ts,
+      lastSummary: events[0].summary,
+    });
+  }
+
+  // Sort: groups with pending triggers first, then by most recent event
+  sessionGroups.sort((a, b) => {
+    if (a.pendingTrigger && !b.pendingTrigger) return -1;
+    if (!a.pendingTrigger && b.pendingTrigger) return 1;
+    return new Date(b.lastTs).getTime() - new Date(a.lastTs).getTime();
+  });
+
+  return { sessionGroups, otherEvents };
+}
+
+// ── Incomplete trigger detection (used by /new warning) ────────────────────
+
+export interface IncompleteTriggerItem {
+  /** Display label (session name or ID) */
+  label: string;
+  /** What's incomplete */
+  reason: string;
+  /** Source session ID */
+  source: string;
+}
+
+/**
+ * Analyze trigger history and return a list of incomplete items.
+ *
+ * "Incomplete" means:
+ * - A linked session with a pending interactive trigger (ask_user_question, plan_review, escalate)
+ * - A linked session that is still active (no terminal session_complete, or a session_complete answered with followUp)
+ *
+ * Sessions that have sent session_complete are considered done once the child
+ * actually stopped. A followUp response resumes the child, so it remains incomplete.
+ */
+export function getIncompleteTriggers(triggers: TriggerHistoryEntry[]): IncompleteTriggerItem[] {
+  const { sessionGroups } = groupByLinkedSession(triggers);
+  const items: IncompleteTriggerItem[] = [];
+
+  for (const group of sessionGroups) {
+    const label = group.lastSummary || group.source.slice(0, 12);
+
+    // Has a pending interactive trigger (needs a response)
+    if (group.pendingTrigger) {
+      const type = group.pendingTrigger.type;
+      // session_complete means the child is done — not truly "incomplete"
+      if (type === "session_complete") continue;
+      if (type === "ask_user_question") {
+        items.push({ label, reason: "Waiting for your answer", source: group.source });
+      } else if (type === "plan_review") {
+        items.push({ label, reason: "Awaiting plan review", source: group.source });
+      } else if (type === "escalate") {
+        items.push({ label, reason: "Escalated — needs attention", source: group.source });
+      } else {
+        items.push({ label, reason: `Awaiting response to ${type}`, source: group.source });
+      }
+      continue;
+    }
+
+    // Events are most-recent-first; find() picks the newest session_complete
+    const latestComplete = group.events.find((e) => e.type === "session_complete");
+    if (latestComplete && latestComplete.response?.action !== "followUp") continue;
+
+    // Still active (connected, no terminal session_complete)
+    items.push({ label, reason: "Still running", source: group.source });
+  }
+
+  return items;
+}

--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -63,6 +63,10 @@ export type { TriggerHistoryEntry } from "../attention/trigger-utils";
 export { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "../attention/trigger-utils";
 import type { TriggerHistoryEntry } from "../attention/trigger-utils";
 import { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "../attention/trigger-utils";
+// Pure grouping helpers live outside the panel so this file stays code-split
+// (React.lazy in App.tsx) — see attention/trigger-groups.ts.
+import { groupByLinkedSession, getIncompleteTriggers, type LinkedSessionGroup } from "../attention/trigger-groups";
+export type { LinkedSessionGroup, IncompleteTriggerItem } from "../attention/trigger-groups";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -106,22 +110,6 @@ function renderParamValueBadges(
       {key}={formatParamValue(value)}
     </Badge>
   );
-}
-
-/** A linked child session derived from trigger history. */
-export interface LinkedSessionGroup {
-  /** Session ID of the linked child */
-  source: string;
-  /** All trigger events from this session, most recent first */
-  events: TriggerHistoryEntry[];
-  /** The most recent pending trigger (no response), if any */
-  pendingTrigger: TriggerHistoryEntry | null;
-  /** Most recent trigger type */
-  lastType: string;
-  /** Most recent trigger timestamp */
-  lastTs: string;
-  /** Summary from the most recent trigger */
-  lastSummary?: string;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -243,51 +231,6 @@ function deriveSessionStatus(group: LinkedSessionGroup): {
   return { label: "active", color: "emerald", icon: <CheckCircle2 className="size-3.5" /> };
 }
 
-/** Group triggers by linked session source. Returns groups sorted by most recent first. */
-export function groupByLinkedSession(triggers: TriggerHistoryEntry[]): {
-  sessionGroups: LinkedSessionGroup[];
-  otherEvents: TriggerHistoryEntry[];
-} {
-  const groupMap = new Map<string, TriggerHistoryEntry[]>();
-  const otherEvents: TriggerHistoryEntry[] = [];
-
-  for (const t of triggers) {
-    // Only group inbound triggers from non-external sources (child sessions)
-    if (t.direction === "inbound" && t.source !== "api" && !t.source.startsWith("external:")) {
-      const existing = groupMap.get(t.source);
-      if (existing) {
-        existing.push(t);
-      } else {
-        groupMap.set(t.source, [t]);
-      }
-    } else {
-      otherEvents.push(t);
-    }
-  }
-
-  const sessionGroups: LinkedSessionGroup[] = [];
-  for (const [source, events] of groupMap) {
-    // Events are already sorted most-recent-first from the API
-    const pendingTrigger = events.find(isPendingTrigger) ?? null;
-    sessionGroups.push({
-      source,
-      events,
-      pendingTrigger,
-      lastType: events[0].type,
-      lastTs: events[0].ts,
-      lastSummary: events[0].summary,
-    });
-  }
-
-  // Sort: groups with pending triggers first, then by most recent event
-  sessionGroups.sort((a, b) => {
-    if (a.pendingTrigger && !b.pendingTrigger) return -1;
-    if (!a.pendingTrigger && b.pendingTrigger) return 1;
-    return new Date(b.lastTs).getTime() - new Date(a.lastTs).getTime();
-  });
-
-  return { sessionGroups, otherEvents };
-}
 
 /**
  * Unified source grouping — groups ALL triggers by source, regardless of
@@ -350,62 +293,6 @@ export function groupTriggersBySource(triggers: TriggerHistoryEntry[]): SourceGr
   });
 
   return groups;
-}
-
-// ── Incomplete trigger detection (used by /new warning) ────────────────────
-
-export interface IncompleteTriggerItem {
-  /** Display label (session name or ID) */
-  label: string;
-  /** What's incomplete */
-  reason: string;
-  /** Source session ID */
-  source: string;
-}
-
-/**
- * Analyze trigger history and return a list of incomplete items.
- *
- * "Incomplete" means:
- * - A linked session with a pending interactive trigger (ask_user_question, plan_review, escalate)
- * - A linked session that is still active (no terminal session_complete, or a session_complete answered with followUp)
- *
- * Sessions that have sent session_complete are considered done once the child
- * actually stopped. A followUp response resumes the child, so it remains incomplete.
- */
-export function getIncompleteTriggers(triggers: TriggerHistoryEntry[]): IncompleteTriggerItem[] {
-  const { sessionGroups } = groupByLinkedSession(triggers);
-  const items: IncompleteTriggerItem[] = [];
-
-  for (const group of sessionGroups) {
-    const label = group.lastSummary || group.source.slice(0, 12);
-
-    // Has a pending interactive trigger (needs a response)
-    if (group.pendingTrigger) {
-      const type = group.pendingTrigger.type;
-      // session_complete means the child is done — not truly "incomplete"
-      if (type === "session_complete") continue;
-      if (type === "ask_user_question") {
-        items.push({ label, reason: "Waiting for your answer", source: group.source });
-      } else if (type === "plan_review") {
-        items.push({ label, reason: "Awaiting plan review", source: group.source });
-      } else if (type === "escalate") {
-        items.push({ label, reason: "Escalated — needs attention", source: group.source });
-      } else {
-        items.push({ label, reason: `Awaiting response to ${type}`, source: group.source });
-      }
-      continue;
-    }
-
-    // Events are most-recent-first; find() picks the newest session_complete
-    const latestComplete = group.events.find((e) => e.type === "session_complete");
-    if (latestComplete && latestComplete.response?.action !== "followUp") continue;
-
-    // Still active (connected, no terminal session_complete)
-    items.push({ label, reason: "Still running", source: group.source });
-  }
-
-  return items;
 }
 
 // ── Send Trigger Dialog ────────────────────────────────────────────────────

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -5,11 +5,7 @@ import type { SandboxViolationEntry } from "./cards/CommandResultCard";
 import type { ResumeSessionOption, ForkMessageOption } from "@/lib/types";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { loadAgents } from "./agent-loader";
-import {
-  type IncompleteTriggerItem,
-  type TriggerHistoryEntry,
-  getIncompleteTriggers,
-} from "@/components/TriggersPanel";
+import { type IncompleteTriggerItem, type TriggerHistoryEntry, getIncompleteTriggers } from "@/attention/trigger-groups";
 
 export interface SupportedSubCommand {
   name: string;

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -9,6 +9,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { ServiceSigilDef, ServicePanelInfo } from "@pizzapi/protocol";
 import { SigilRegistry, createRegistry } from "@/lib/sigils/registry";
+import { buildResolveUrl } from "@/lib/sigils/resolve-url";
 
 // ── Resolve types ────────────────────────────────────────────────────────────
 
@@ -74,6 +75,9 @@ interface SigilProviderProps {
   sigilDefs: ServiceSigilDef[];
   panels: ServicePanelInfo[];
   runnerId?: string;
+  /** Working directory of the session being viewed — lets services resolve
+   *  sigils against the session's project (e.g. GitHub repo auto-detection). */
+  sessionCwd?: string;
   children: React.ReactNode;
 }
 
@@ -81,7 +85,7 @@ interface SigilProviderProps {
  * Provider that creates a SigilRegistry from service definitions
  * and manages resolve endpoint calls for enriching sigil display data.
  */
-export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilProviderProps) {
+export function SigilProvider({ sigilDefs, panels, runnerId, sessionCwd, children }: SigilProviderProps) {
   const registry = useMemo(() => createRegistry(sigilDefs), [sigilDefs]);
 
   // Resolve cache: keyed by "gen:type:id". Lives in a ref for instant reads.
@@ -94,7 +98,7 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   useEffect(() => {
     cacheRef.current.clear();
     bump();
-  }, [panels, runnerId, sigilDefs, bump]);
+  }, [panels, runnerId, sigilDefs, sessionCwd, bump]);
 
   // Build panel port lookup: serviceId → port
   const panelPortMap = useMemo(() => {
@@ -106,28 +110,28 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   // Bump generation and clear cache when infrastructure changes.
   // This invalidates all cached entries and causes pills to re-trigger
   // resolve via the generation dep in their useEffect.
-  const prevInfraRef = useRef({ panels, runnerId, sigilDefs });
+  const prevInfraRef = useRef({ panels, runnerId, sigilDefs, sessionCwd });
   useEffect(() => {
     const prev = prevInfraRef.current;
     // Skip the initial mount — only invalidate on actual changes
-    if (prev.panels !== panels || prev.runnerId !== runnerId || prev.sigilDefs !== sigilDefs) {
+    if (prev.panels !== panels || prev.runnerId !== runnerId || prev.sigilDefs !== sigilDefs || prev.sessionCwd !== sessionCwd) {
       cacheRef.current.clear();
       setGeneration((g) => g + 1);
     }
-    prevInfraRef.current = { panels, runnerId, sigilDefs };
-  }, [panels, runnerId, sigilDefs]);
+    prevInfraRef.current = { panels, runnerId, sigilDefs, sessionCwd };
+  }, [panels, runnerId, sigilDefs, sessionCwd]);
 
   const resolve = useCallback(
     (type: string, id: string): SigilResolveState => {
-      const key = `${type}:${id}`;
+      const key = `${type}:${id}:${sessionCwd ?? ""}`;
       return cacheRef.current.get(key) ?? { loading: false };
     },
-    [],
+    [sessionCwd],
   );
 
   const triggerResolve = useCallback(
     (type: string, id: string, params?: Record<string, string>) => {
-      const key = `${type}:${id}`;
+      const key = `${type}:${id}:${sessionCwd ?? ""}`;
       const cache = cacheRef.current;
 
       // Already resolved or in-flight
@@ -143,14 +147,16 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
       const port = panelPortMap.get(def.serviceId) ?? def.resolvePort;
       if (!port) return;
 
-      // Build the resolve URL through the tunnel proxy, forwarding params as query string
-      const resolvePath = def.resolve.replace("{id}", encodeURIComponent(id));
-      const qs = params && Object.keys(params).length > 0
-        ? "?" + new URLSearchParams(
-            Object.entries(params).filter(([k]) => !["label", "link", "href"].includes(k)),
-          ).toString()
-        : "";
-      const url = `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}${resolvePath}${qs}`;
+      // Build the resolve URL through the tunnel proxy. `cwd` (the session's
+      // project dir) is infrastructure-provided, not a sigil param — services
+      // use it for per-session repo detection.
+      const url = buildResolveUrl({
+        runnerId,
+        port,
+        resolvePath: def.resolve.replace("{id}", encodeURIComponent(id)),
+        params,
+        sessionCwd,
+      });
 
       // Mark as loading
       cache.set(key, { loading: true });
@@ -168,7 +174,7 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
           setGeneration((g) => g + 1);
         });
     },
-    [registry, panelPortMap, runnerId],
+    [registry, panelPortMap, runnerId, sessionCwd],
   );
 
   const contextValue = useMemo<SigilContextValue>(

--- a/packages/ui/src/hooks/useTriggerCount.ts
+++ b/packages/ui/src/hooks/useTriggerCount.ts
@@ -6,7 +6,7 @@
  * Fetches on mount, on session change, and on trigger_delivered events.
  */
 import { useState, useEffect, useCallback, useRef } from "react";
-import { type TriggerHistoryEntry, getIncompleteTriggers } from "@/components/TriggersPanel";
+import { getIncompleteTriggers, type TriggerHistoryEntry } from "@/attention/trigger-groups";
 
 export interface TriggerCounts {
   /** Incomplete triggers (pending questions, plans, etc.) */

--- a/packages/ui/src/lib/sigils/resolve-url.test.ts
+++ b/packages/ui/src/lib/sigils/resolve-url.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { buildResolveUrl } from "./resolve-url.js";
+
+describe("buildResolveUrl", () => {
+    test("bare path, no params or cwd", () => {
+        expect(
+            buildResolveUrl({ runnerId: "r1", port: 56500, resolvePath: "/api/resolve/pr/853" }),
+        ).toBe("/api/tunnel/runner/r1/56500/api/resolve/pr/853");
+    });
+
+    test("sessionCwd is appended as query param", () => {
+        const url = buildResolveUrl({
+            runnerId: "r1",
+            port: 56500,
+            resolvePath: "/api/resolve/pr/853",
+            sessionCwd: "/Users/jordan/Documents/Projects/PizzaPi",
+        });
+        expect(url).toBe(
+            "/api/tunnel/runner/r1/56500/api/resolve/pr/853?cwd=%2FUsers%2Fjordan%2FDocuments%2FProjects%2FPizzaPi",
+        );
+    });
+
+    test("inline params pass through except filtered keys", () => {
+        const url = buildResolveUrl({
+            runnerId: "r1",
+            port: 56500,
+            resolvePath: "/api/resolve/pr/853",
+            params: { repo: "Pizzaface/PizzaPi", label: "hidden", link: "hidden", href: "hidden" },
+        });
+        expect(url).toBe("/api/tunnel/runner/r1/56500/api/resolve/pr/853?repo=Pizzaface%2FPizzaPi");
+    });
+
+    test("inline cwd param is overridden by sessionCwd", () => {
+        const url = buildResolveUrl({
+            runnerId: "r1",
+            port: 56500,
+            resolvePath: "/api/resolve/pr/1",
+            params: { cwd: "/fake/inline" },
+            sessionCwd: "/real/session",
+        });
+        expect(url).toContain("cwd=%2Freal%2Fsession");
+        expect(url).not.toContain("fake");
+    });
+
+    test("runnerId is URL-encoded", () => {
+        const url = buildResolveUrl({ runnerId: "a b/c", port: 1, resolvePath: "/x" });
+        expect(url).toBe("/api/tunnel/runner/a%20b%2Fc/1/x");
+    });
+});

--- a/packages/ui/src/lib/sigils/resolve-url.ts
+++ b/packages/ui/src/lib/sigils/resolve-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the tunnel-proxied sigil resolve URL.
+ * `cwd` is infrastructure-provided (the session's project dir), never a
+ * sigil inline param — inline `cwd`/`label`/`link`/`href` params are dropped.
+ */
+export function buildResolveUrl(opts: {
+    runnerId: string;
+    port: number;
+    resolvePath: string;
+    params?: Record<string, string>;
+    sessionCwd?: string;
+}): string {
+    const search = new URLSearchParams(
+        Object.entries(opts.params ?? {}).filter(
+            ([k]) => !["label", "link", "href", "cwd"].includes(k),
+        ),
+    );
+    if (opts.sessionCwd) search.set("cwd", opts.sessionCwd);
+    const qs = search.toString() ? `?${search.toString()}` : "";
+    return `/api/tunnel/runner/${encodeURIComponent(opts.runnerId)}/${opts.port}${opts.resolvePath}${qs}`;
+}


### PR DESCRIPTION
## What

`SigilProvider` now sends the viewed session's `cwd` as a `?cwd=` query param on sigil resolve calls, and includes it in the resolve cache key.

## Why

The GitHub service resolves a project's origin remote (`git remote get-url origin`) to detect which repo a session is working in — bare `[[pr:853]]` / `[[branch:fix/foo]]` / `[[commit:abc]]` references now resolve against the session's project first, falling back to configured repos. This also makes sigils self-healing when the service's configured repo list is empty (the Aug 2026 settings wipe).

Query building extracted to `lib/sigils/resolve-url.ts` with tests.

## Test plan

- [x] bun test packages/ui/src/lib/sigils — 33 pass
- [x] bun run typecheck — exit 0
- [x] E2E: with ?cwd=&lt;project&gt;, the GitHub service resolved PR 1248 from an unconfigured repo (HKUDS/Vibe-Trading from its local clone) and PR 853 from PizzaPi
- [x] No-cwd fallback still resolves via configured repos

Note: nvidia-models.test.ts fails 2 tests on clean origin/main with a fresh install (pi-ai 0.84.3 from #852 changed the upstream curated nvidia list) — pre-existing, unrelated to this branch. Filed separately.