### PR TITLE
fix(ci): repair failing checks after pi-ai 0.84.3 bump

### DIFF
--- a/packages/cli/src/nvidia-models.test.ts
+++ b/packages/cli/src/nvidia-models.test.ts
@@ -44,11 +44,14 @@ describe("toNvidiaModel", () => {
     });
 
     test("synthesizes defaults for ids the package has never seen", () => {
-        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        // "vendor/new-model" is deliberately synthetic — real ids (e.g.
+        // moonshotai/kimi-k3) get curated into pi-ai's catalog over time and
+        // stop exercising the synthesized-defaults path.
+        const model = toNvidiaModel({ id: "vendor/new-model" }, STATIC as any)!;
         expect(model.provider).toBe("nvidia");
         expect(model.api).toBe("openai-completions");
         expect(model.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
-        expect(model.name).toBe("moonshotai/kimi-k3");
+        expect(model.name).toBe("vendor/new-model");
         expect(model.input).toEqual(["text"]);
         expect(model.contextWindow).toBe(128000);
         expect(model.maxTokens).toBe(4096);
@@ -58,7 +61,7 @@ describe("toNvidiaModel", () => {
     });
 
     test("unknown ids are reasoning-capable so the thinking control is usable", () => {
-        const model = toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any)!;
+        const model = toNvidiaModel({ id: "vendor/new-model" }, STATIC as any)!;
         expect(model.reasoning).toBe(true);
         expect((model.compat as any).supportsReasoningEffort).toBe(true);
         // NVIDIA rejects "minimal" and has no xhigh/max equivalent.
@@ -70,9 +73,13 @@ describe("toNvidiaModel", () => {
     });
 
     test("NVIDIA's accepted levels win over an upstream thinkingLevelMap", () => {
-        const upstream = [{ ...(STATIC.find((m) => m.reasoning) as any), thinkingLevelMap: { minimal: "minimal", max: "max" } }];
-        const model = toNvidiaModel({ id: upstream[0].id }, upstream as any)!;
-        expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+        // pi-ai ≥ 0.84.3 ships per-model maps (deepseek entries null out low/medium);
+        // the overlay must force NVIDIA's accepted values back on.
+        for (const map of [{ minimal: "minimal", max: "max" }, { minimal: null, low: null, medium: null, high: "high", max: "max" }]) {
+            const upstream = [{ ...(STATIC.find((m) => m.reasoning) as any), thinkingLevelMap: map }];
+            const model = toNvidiaModel({ id: upstream[0].id }, upstream as any)!;
+            expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "medium", "high"]);
+        }
     });
 
     test("enables reasoning effort on curated reasoning models too", () => {
@@ -180,7 +187,7 @@ describe("fetchNvidiaModels", () => {
         const home = tempHome();
         mkdirSync(join(home, ".pizzapi"), { recursive: true });
         const stale = {
-            ...(toNvidiaModel({ id: "moonshotai/kimi-k3" }, STATIC as any) as any),
+            ...(toNvidiaModel({ id: "vendor/new-model" }, STATIC as any) as any),
             compat: { maxTokensField: "max_tokens", supportsReasoningEffort: false },
             thinkingLevelMap: { minimal: "minimal" }, // a 400 on NVIDIA's API
         };

--- a/packages/cli/src/nvidia-models.ts
+++ b/packages/cli/src/nvidia-models.ts
@@ -25,11 +25,14 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
  * NVIDIA honours OpenAI-style `reasoning_effort`, but pi-ai's catalog marks
  * every NVIDIA model `supportsReasoningEffort: false`, so the thinking-level
  * control silently clamps back to "off". The API only accepts low|medium|high
- * — pi's "minimal" is a 400 — so map it (and the xhigh/max levels NVIDIA has no
- * equivalent for) to null, which hides them. "off" sends no parameter at all,
- * i.e. the model's own default.
+ * — pi's "minimal" is a 400 — so force those three on and map the levels
+ * NVIDIA has no equivalent for (minimal, xhigh, max) to null, which hides
+ * them. "off" sends no parameter at all, i.e. the model's own default.
+ * pi-ai ≥ 0.84.3 ships per-model thinkingLevelMaps (e.g. deepseek entries
+ * null out low/medium); NVIDIA's accepted values are a hard API constraint,
+ * so they win over every upstream or cached value.
  */
-const NVIDIA_THINKING_LEVEL_MAP = { minimal: null, xhigh: null, max: null } as const;
+const NVIDIA_THINKING_LEVEL_MAP = { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null, max: null } as const;
 
 function withReasoningEffort(model: NvidiaModel): NvidiaModel {
     if (!model.reasoning) return model;

--- a/packages/ui/dev-dist/sw.js
+++ b/packages/ui/dev-dist/sw.js
@@ -80,7 +80,7 @@ define(['./workbox-0cb42a3e'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "/index.html",
-    "revision": "0.vurtt4r1eco"
+    "revision": "0.gq3gt867dak"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {

--- a/packages/ui/src/attention/trigger-groups.test.ts
+++ b/packages/ui/src/attention/trigger-groups.test.ts
@@ -1,46 +1,15 @@
 /**
- * Pure-logic tests for TriggersPanel exported helpers.
+ * Pure-logic tests for trigger grouping helpers.
  *
- * These test groupByLinkedSession, isPendingTrigger, and getIncompleteTriggers
- * without any DOM, React, or module-alias dependencies.
+ * Tests groupByLinkedSession, isPendingTrigger, and getIncompleteTriggers
+ * without any DOM, React, or module-alias dependencies. These helpers used
+ * to live inside TriggersPanel.tsx (requiring global UI mocks — see git
+ * history); extracting them made the mocks unnecessary.
  */
-import { describe, test, expect, mock } from "bun:test";
-
-// ── Minimal mocks for TriggersPanel's UI imports ─────────────────────────────
-// IMPORTANT: bun's mock.module is process-global and is NOT undone by
-// mock.restore(), so these leak into every test file that runs after this one.
-// The stubs must therefore render their children (a `() => null` Button here
-// blanked out buttons in unrelated component tests, e.g. DeviceSetupScanner's
-// "Allow Camera & Scan" — which tests failed depended on file order).
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const R = await import("react");
-const childStub = (tag: string) => {
-  const Stub = R.forwardRef(({ children, ...props }: any, ref: any) =>
-    R.createElement(tag, { ...props, ref }, children),
-  );
-  Stub.displayName = `Stub(${tag})`;
-  return Stub;
-};
-mock.module("@/components/ui/button", () => ({ Button: childStub("button") }));
-mock.module("@/components/ui/badge", () => ({ Badge: childStub("span") }));
-// Dialog stubs stay null: real dialogs hide content until opened, so a
-// children-rendering stub would leak inline dialog text into later files
-// and break their single-match queries the same way.
-mock.module("@/components/ui/dialog", () => ({
-  Dialog: () => null, DialogContent: () => null, DialogHeader: () => null,
-  DialogTitle: () => null, DialogFooter: () => null, DialogDescription: () => null,
-}));
-mock.module("@/lib/utils", () => ({ cn: (...args: any[]) => args.filter(Boolean).join(" ") }));
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-// Import AFTER mocks are registered
-const {
-  groupByLinkedSession,
-  isPendingTrigger,
-  getIncompleteTriggers,
-  RESPONSE_TRIGGER_TYPES,
-} = await import("./TriggersPanel");
-import type { TriggerHistoryEntry } from "./TriggersPanel";
+import { describe, test, expect } from "bun:test";
+import type { TriggerHistoryEntry } from "./trigger-utils";
+import { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "./trigger-utils";
+import { groupByLinkedSession, getIncompleteTriggers } from "./trigger-groups";
 
 function makeTrigger(overrides: Partial<TriggerHistoryEntry> = {}): TriggerHistoryEntry {
   return {

--- a/packages/ui/src/attention/trigger-groups.ts
+++ b/packages/ui/src/attention/trigger-groups.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure trigger-history grouping helpers — no React, no UI deps.
+ *
+ * Extracted from TriggersPanel.tsx so that the panel stays code-split
+ * (React.lazy in App.tsx). slash-commands.ts and useTriggerCount.ts import
+ * getIncompleteTriggers at runtime; if these helpers lived in the panel file,
+ * the whole panel would be statically baked into the main entry chunk.
+ */
+import type { TriggerHistoryEntry } from "./trigger-utils";
+import { isPendingTrigger } from "./trigger-utils";
+
+export type { TriggerHistoryEntry } from "./trigger-utils";
+
+/** A linked child session derived from trigger history. */
+export interface LinkedSessionGroup {
+  /** Session ID of the linked child */
+  source: string;
+  /** All trigger events from this session, most recent first */
+  events: TriggerHistoryEntry[];
+  /** The most recent pending trigger (no response), if any */
+  pendingTrigger: TriggerHistoryEntry | null;
+  /** Most recent trigger type */
+  lastType: string;
+  /** Most recent trigger timestamp */
+  lastTs: string;
+  /** Summary from the most recent trigger */
+  lastSummary?: string;
+}
+
+/** Group triggers by linked session source. Returns groups sorted by most recent first. */
+export function groupByLinkedSession(triggers: TriggerHistoryEntry[]): {
+  sessionGroups: LinkedSessionGroup[];
+  otherEvents: TriggerHistoryEntry[];
+} {
+  const groupMap = new Map<string, TriggerHistoryEntry[]>();
+  const otherEvents: TriggerHistoryEntry[] = [];
+
+  for (const t of triggers) {
+    // Only group inbound triggers from non-external sources (child sessions)
+    if (t.direction === "inbound" && t.source !== "api" && !t.source.startsWith("external:")) {
+      const existing = groupMap.get(t.source);
+      if (existing) {
+        existing.push(t);
+      } else {
+        groupMap.set(t.source, [t]);
+      }
+    } else {
+      otherEvents.push(t);
+    }
+  }
+
+  const sessionGroups: LinkedSessionGroup[] = [];
+  for (const [source, events] of groupMap) {
+    // Events are already sorted most-recent-first from the API
+    const pendingTrigger = events.find(isPendingTrigger) ?? null;
+    sessionGroups.push({
+      source,
+      events,
+      pendingTrigger,
+      lastType: events[0].type,
+      lastTs: events[0].ts,
+      lastSummary: events[0].summary,
+    });
+  }
+
+  // Sort: groups with pending triggers first, then by most recent event
+  sessionGroups.sort((a, b) => {
+    if (a.pendingTrigger && !b.pendingTrigger) return -1;
+    if (!a.pendingTrigger && b.pendingTrigger) return 1;
+    return new Date(b.lastTs).getTime() - new Date(a.lastTs).getTime();
+  });
+
+  return { sessionGroups, otherEvents };
+}
+
+// ── Incomplete trigger detection (used by /new warning) ────────────────────
+
+export interface IncompleteTriggerItem {
+  /** Display label (session name or ID) */
+  label: string;
+  /** What's incomplete */
+  reason: string;
+  /** Source session ID */
+  source: string;
+}
+
+/**
+ * Analyze trigger history and return a list of incomplete items.
+ *
+ * "Incomplete" means:
+ * - A linked session with a pending interactive trigger (ask_user_question, plan_review, escalate)
+ * - A linked session that is still active (no terminal session_complete, or a session_complete answered with followUp)
+ *
+ * Sessions that have sent session_complete are considered done once the child
+ * actually stopped. A followUp response resumes the child, so it remains incomplete.
+ */
+export function getIncompleteTriggers(triggers: TriggerHistoryEntry[]): IncompleteTriggerItem[] {
+  const { sessionGroups } = groupByLinkedSession(triggers);
+  const items: IncompleteTriggerItem[] = [];
+
+  for (const group of sessionGroups) {
+    const label = group.lastSummary || group.source.slice(0, 12);
+
+    // Has a pending interactive trigger (needs a response)
+    if (group.pendingTrigger) {
+      const type = group.pendingTrigger.type;
+      // session_complete means the child is done — not truly "incomplete"
+      if (type === "session_complete") continue;
+      if (type === "ask_user_question") {
+        items.push({ label, reason: "Waiting for your answer", source: group.source });
+      } else if (type === "plan_review") {
+        items.push({ label, reason: "Awaiting plan review", source: group.source });
+      } else if (type === "escalate") {
+        items.push({ label, reason: "Escalated — needs attention", source: group.source });
+      } else {
+        items.push({ label, reason: `Awaiting response to ${type}`, source: group.source });
+      }
+      continue;
+    }
+
+    // Events are most-recent-first; find() picks the newest session_complete
+    const latestComplete = group.events.find((e) => e.type === "session_complete");
+    if (latestComplete && latestComplete.response?.action !== "followUp") continue;
+
+    // Still active (connected, no terminal session_complete)
+    items.push({ label, reason: "Still running", source: group.source });
+  }
+
+  return items;
+}

--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -63,6 +63,10 @@ export type { TriggerHistoryEntry } from "../attention/trigger-utils";
 export { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "../attention/trigger-utils";
 import type { TriggerHistoryEntry } from "../attention/trigger-utils";
 import { isPendingTrigger, RESPONSE_TRIGGER_TYPES } from "../attention/trigger-utils";
+// Pure grouping helpers live outside the panel so this file stays code-split
+// (React.lazy in App.tsx) — see attention/trigger-groups.ts.
+import { groupByLinkedSession, getIncompleteTriggers, type LinkedSessionGroup } from "../attention/trigger-groups";
+export type { LinkedSessionGroup, IncompleteTriggerItem } from "../attention/trigger-groups";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -106,22 +110,6 @@ function renderParamValueBadges(
       {key}={formatParamValue(value)}
     </Badge>
   );
-}
-
-/** A linked child session derived from trigger history. */
-export interface LinkedSessionGroup {
-  /** Session ID of the linked child */
-  source: string;
-  /** All trigger events from this session, most recent first */
-  events: TriggerHistoryEntry[];
-  /** The most recent pending trigger (no response), if any */
-  pendingTrigger: TriggerHistoryEntry | null;
-  /** Most recent trigger type */
-  lastType: string;
-  /** Most recent trigger timestamp */
-  lastTs: string;
-  /** Summary from the most recent trigger */
-  lastSummary?: string;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -243,51 +231,6 @@ function deriveSessionStatus(group: LinkedSessionGroup): {
   return { label: "active", color: "emerald", icon: <CheckCircle2 className="size-3.5" /> };
 }
 
-/** Group triggers by linked session source. Returns groups sorted by most recent first. */
-export function groupByLinkedSession(triggers: TriggerHistoryEntry[]): {
-  sessionGroups: LinkedSessionGroup[];
-  otherEvents: TriggerHistoryEntry[];
-} {
-  const groupMap = new Map<string, TriggerHistoryEntry[]>();
-  const otherEvents: TriggerHistoryEntry[] = [];
-
-  for (const t of triggers) {
-    // Only group inbound triggers from non-external sources (child sessions)
-    if (t.direction === "inbound" && t.source !== "api" && !t.source.startsWith("external:")) {
-      const existing = groupMap.get(t.source);
-      if (existing) {
-        existing.push(t);
-      } else {
-        groupMap.set(t.source, [t]);
-      }
-    } else {
-      otherEvents.push(t);
-    }
-  }
-
-  const sessionGroups: LinkedSessionGroup[] = [];
-  for (const [source, events] of groupMap) {
-    // Events are already sorted most-recent-first from the API
-    const pendingTrigger = events.find(isPendingTrigger) ?? null;
-    sessionGroups.push({
-      source,
-      events,
-      pendingTrigger,
-      lastType: events[0].type,
-      lastTs: events[0].ts,
-      lastSummary: events[0].summary,
-    });
-  }
-
-  // Sort: groups with pending triggers first, then by most recent event
-  sessionGroups.sort((a, b) => {
-    if (a.pendingTrigger && !b.pendingTrigger) return -1;
-    if (!a.pendingTrigger && b.pendingTrigger) return 1;
-    return new Date(b.lastTs).getTime() - new Date(a.lastTs).getTime();
-  });
-
-  return { sessionGroups, otherEvents };
-}
 
 /**
  * Unified source grouping — groups ALL triggers by source, regardless of
@@ -350,62 +293,6 @@ export function groupTriggersBySource(triggers: TriggerHistoryEntry[]): SourceGr
   });
 
   return groups;
-}
-
-// ── Incomplete trigger detection (used by /new warning) ────────────────────
-
-export interface IncompleteTriggerItem {
-  /** Display label (session name or ID) */
-  label: string;
-  /** What's incomplete */
-  reason: string;
-  /** Source session ID */
-  source: string;
-}
-
-/**
- * Analyze trigger history and return a list of incomplete items.
- *
- * "Incomplete" means:
- * - A linked session with a pending interactive trigger (ask_user_question, plan_review, escalate)
- * - A linked session that is still active (no terminal session_complete, or a session_complete answered with followUp)
- *
- * Sessions that have sent session_complete are considered done once the child
- * actually stopped. A followUp response resumes the child, so it remains incomplete.
- */
-export function getIncompleteTriggers(triggers: TriggerHistoryEntry[]): IncompleteTriggerItem[] {
-  const { sessionGroups } = groupByLinkedSession(triggers);
-  const items: IncompleteTriggerItem[] = [];
-
-  for (const group of sessionGroups) {
-    const label = group.lastSummary || group.source.slice(0, 12);
-
-    // Has a pending interactive trigger (needs a response)
-    if (group.pendingTrigger) {
-      const type = group.pendingTrigger.type;
-      // session_complete means the child is done — not truly "incomplete"
-      if (type === "session_complete") continue;
-      if (type === "ask_user_question") {
-        items.push({ label, reason: "Waiting for your answer", source: group.source });
-      } else if (type === "plan_review") {
-        items.push({ label, reason: "Awaiting plan review", source: group.source });
-      } else if (type === "escalate") {
-        items.push({ label, reason: "Escalated — needs attention", source: group.source });
-      } else {
-        items.push({ label, reason: `Awaiting response to ${type}`, source: group.source });
-      }
-      continue;
-    }
-
-    // Events are most-recent-first; find() picks the newest session_complete
-    const latestComplete = group.events.find((e) => e.type === "session_complete");
-    if (latestComplete && latestComplete.response?.action !== "followUp") continue;
-
-    // Still active (connected, no terminal session_complete)
-    items.push({ label, reason: "Still running", source: group.source });
-  }
-
-  return items;
 }
 
 // ── Send Trigger Dialog ────────────────────────────────────────────────────

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -5,11 +5,7 @@ import type { SandboxViolationEntry } from "./cards/CommandResultCard";
 import type { ResumeSessionOption, ForkMessageOption } from "@/lib/types";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { loadAgents } from "./agent-loader";
-import {
-  type IncompleteTriggerItem,
-  type TriggerHistoryEntry,
-  getIncompleteTriggers,
-} from "@/components/TriggersPanel";
+import { type IncompleteTriggerItem, type TriggerHistoryEntry, getIncompleteTriggers } from "@/attention/trigger-groups";
 
 export interface SupportedSubCommand {
   name: string;

--- a/packages/ui/src/hooks/useTriggerCount.ts
+++ b/packages/ui/src/hooks/useTriggerCount.ts
@@ -6,7 +6,7 @@
  * Fetches on mount, on session change, and on trigger_delivered events.
  */
 import { useState, useEffect, useCallback, useRef } from "react";
-import { type TriggerHistoryEntry, getIncompleteTriggers } from "@/components/TriggersPanel";
+import { getIncompleteTriggers, type TriggerHistoryEntry } from "@/attention/trigger-groups";
 
 export interface TriggerCounts {
   /** Incomplete triggers (pending questions, plans, etc.) */


### PR DESCRIPTION
Fixes the failing checks on [[pr:853]] (merged — CI is also red on main).

## Failures

**Mobile — Android — bundle budget exceeded**<br />
Main entry `index-*.js` hit **505.10 KB** gzip vs the **505 KB** budget (barely passes at 503.5 KB locally — platform variance tips it over on CI).

**Unit Tests — nvidia-models.test.ts**<br />
`synthesizes defaults for ids the package has never seen` expected `moonshotai/kimi-k3` to be unknown, but pi-ai 0.84.3 (#852) now curates it (`name: "Kimi K3"`), and the new per-model `thinkingLevelMap`s (deepseek entries null out `low`/`medium`) degraded the thinking control to `["off", "high"]`.

## Fixes

**1. TriggersPanel defeats its own React.lazy**<br />
`App.tsx` lazy-loads `TriggersPanel`, but `slash-commands.ts` and `useTriggerCount.ts` imported the runtime helper `getIncompleteTriggers` from it — statically pulling the entire 2,700-line panel (plus its UI deps) into the main entry chunk. Vite was warning about exactly this.

Extracted the pure helpers (`groupByLinkedSession`, `getIncompleteTriggers`, their types) into `attention/trigger-groups.ts` (no React, no UI imports). TriggersPanel now actually code-splits:

| | before | after |
|---|---|---|
| main entry (gzip, local) | 503.50 KB | **491.27 KB** (−12.2) |

- Logic tests moved to `attention/trigger-groups.test.ts` — the old file's `mock.module` scaffolding (which the file itself warned leaked into other test files) is deleted entirely.
- Type-only re-exports kept in TriggersPanel so existing `import type` sites are untouched.

**2. nvidia-models: force NVIDIA's accepted thinking levels**<br />
`NVIDIA_THINKING_LEVEL_MAP` only nulled the levels NVIDIA rejects (`minimal`, `xhigh`, `max`) — it let upstream per-model maps (new in 0.84.3) null out `low`/`medium` too. The overlay now forces `low`/`medium`/`high` on, matching the documented "NVIDIA's accepted values are a hard API constraint" intent. Tests use a synthetic unknown id (`vendor/new-model`) so future catalog additions can't break the synthesized-defaults path again.

## Verification

- `bun run typecheck` — exit 0
- `bun run build` — exit 0 (bundle budget ✅ 491.27 KB / 505 KB)
- `bun test packages/ui` — 1593 pass, 0 fail
- `bun test src/nvidia-models.test.ts` — 15 pass, 0 fail (was 13/2)
- Full suite: same state as CI-green main modulo a pre-existing local-only issue — `skills.test.ts` reads the dev machine's real `~/.pizzapi/rules` (5 failures with populated HOME, 62/62 pass with empty HOME; CI's HOME is empty). Filed separately as a follow-up idea, out of scope here.