### PR TITLE
fix(cli): inject git branch into system prompt per session, not at boot

### DIFF
--- a/packages/cli/scripts/compile-prompt.ts
+++ b/packages/cli/scripts/compile-prompt.ts
@@ -65,8 +65,6 @@ const spec = Handlebars.template(${precompiledSpec});
 export interface SystemPromptContext {
     /** Current date and time, e.g. "March 29, 2026, 3:45 PM" */
     dateTime: string;
-    /** Current git branch name, e.g. "feat/my-feature" */
-    gitBranch?: string;
     /** Git worktree root path (if running inside a worktree) */
     gitWorktree?: string;
     /** Current working directory */

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -19,11 +19,6 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain(year);
     });
 
-    test("includes gitBranch when provided", () => {
-        const result = buildSystemPrompt({ dateTime: "test", gitBranch: "feat/my-feature" });
-        expect(result).toContain("Git branch: feat/my-feature");
-    });
-
     test("includes gitWorktree when provided", () => {
         const result = buildSystemPrompt({ dateTime: "test", gitWorktree: "/path/to/worktree" });
         expect(result).toContain("Git worktree: /path/to/worktree");
@@ -34,16 +29,9 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("Working directory: /Users/dev/project");
     });
 
-    test("omits gitBranch line when not provided or unavailable", () => {
+    test("never bakes a git branch (the git-branch extension injects it per session)", () => {
         const result = buildSystemPrompt({ dateTime: "test" });
-        // Should not have "Git branch:" with empty value
-        expect(result).not.toContain("Git branch: \n");
-    });
-
-    test("auto-detects git branch from current repo", () => {
-        // We're in a git repo, so branch should be detected
-        const result = buildSystemPrompt();
-        expect(result).toContain("Git branch:");
+        expect(result).not.toContain("Git branch:");
     });
 
     test("contains all major sections as pseudo-XML when isRunner is true", () => {
@@ -114,7 +102,7 @@ describe("buildSystemPrompt", () => {
     test("describes id-based trigger CRUD for multi-subscription support", () => {
         const result = buildSystemPrompt({ isRunner: true });
         expect(result).toContain("subscriptionId");
-        expect(result).toContain("Multiple subscriptions of the same trigger type can exist at once");
+        expect(result).toContain("creates a Route targeting this session");
         expect(result).toContain("legacy bulk operations");
     });
 

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -102,7 +102,7 @@ describe("buildSystemPrompt", () => {
     test("describes id-based trigger CRUD for multi-subscription support", () => {
         const result = buildSystemPrompt({ isRunner: true });
         expect(result).toContain("subscriptionId");
-        expect(result).toContain("creates a Route targeting this session");
+        expect(result).toContain("Multiple subscriptions of the same trigger type can exist at once");
         expect(result).toContain("legacy bulk operations");
     });
 

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -5,7 +5,7 @@ import type { SystemPromptContext } from "./system-prompt.precompiled.js";
 export type { SystemPromptContext };
 
 /** Run a git command and return trimmed stdout, or undefined on failure. */
-function git(args: string, cwd?: string): string | undefined {
+export function runGit(args: string, cwd?: string): string | undefined {
     try {
         return execSync(`git ${args}`, {
             cwd,
@@ -21,19 +21,21 @@ function git(args: string, cwd?: string): string | undefined {
 /**
  * Gather git context for the current working directory.
  * Returns only the fields that are available (non-undefined).
+ *
+ * No git branch here — it's injected per-session by the git-branch
+ * extension (extensions/git-branch.ts). Baking it at boot goes stale the
+ * moment anything checks out another branch.
  */
-function gatherGitContext(cwd?: string): Pick<SystemPromptContext, "gitBranch" | "gitWorktree"> {
-    const gitBranch = git("rev-parse --abbrev-ref HEAD", cwd);
-
+function gatherGitContext(cwd?: string): Pick<SystemPromptContext, "gitWorktree"> {
     // Detect worktree: if the git dir is a file (not a directory), we're in a linked worktree.
     // Also check `git rev-parse --show-toplevel` vs `git rev-parse --git-common-dir`.
-    const commonDir = git("rev-parse --git-common-dir", cwd);
-    const gitDir = git("rev-parse --git-dir", cwd);
+    const commonDir = runGit("rev-parse --git-common-dir", cwd);
+    const gitDir = runGit("rev-parse --git-dir", cwd);
     // In a worktree, gitDir points to .git/worktrees/<name>, commonDir points to main .git
     const isWorktree = commonDir && gitDir && commonDir !== gitDir && !gitDir.endsWith("/.git");
-    const gitWorktree = isWorktree ? git("rev-parse --show-toplevel", cwd) : undefined;
+    const gitWorktree = isWorktree ? runGit("rev-parse --show-toplevel", cwd) : undefined;
 
-    return { gitBranch, gitWorktree };
+    return { gitWorktree };
 }
 
 /**
@@ -54,7 +56,6 @@ export function buildSystemPrompt(ctx?: Partial<SystemPromptContext>): string {
             minute: "2-digit",
             hour12: true,
         }),
-        gitBranch: ctx?.gitBranch ?? gitCtx.gitBranch,
         gitWorktree: ctx?.gitWorktree ?? gitCtx.gitWorktree,
         cwd: ctx?.cwd,
         isRunner: ctx?.isRunner,

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -143,7 +143,6 @@ Can define project-specific hooks, MCP servers, and skills. Project hooks only r
 
 <meta>
 Current date and time: {{dateTime}}
-{{#if gitBranch}}Git branch: {{gitBranch}}
-{{/if}}{{#if gitWorktree}}Git worktree: {{gitWorktree}}
+{{#if gitWorktree}}Git worktree: {{gitWorktree}}
 {{/if}}{{#if cwd}}Working directory: {{cwd}}
 {{/if}}</meta>

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -12,6 +12,7 @@ import { reloadResourcesExtension } from "./reload-resources.js";
 import { pluginCommandExtension } from "./plugin-command.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
+import { gitBranchExtension } from "./git-branch.js";
 import { currentTimeExtension } from "./current-time.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
@@ -72,6 +73,7 @@ const CORE_EXTENSIONS_TAIL: ExtensionFactory[] = [
     pluginCommandExtension,
     sessionProcessesExtension,
     setSessionNameExtension,
+    gitBranchExtension,
     currentTimeExtension,
     backgroundBashExtension,
     queueFlushExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -10,6 +10,7 @@ import { pluginCommandExtension } from "./plugin-command.js";
 import { sessionProcessesExtension } from "./session-processes.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
+import { gitBranchExtension } from "./git-branch.js";
 import { currentTimeExtension } from "./current-time.js";
 import { backgroundBashExtension } from "./background-bash.js";
 import { queueFlushExtension } from "./queue-flush.js";
@@ -148,6 +149,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(pluginCommandExtension, "plugin-command"),
         named(sessionProcessesExtension, "session-processes"),
         named(setSessionNameExtension, "session-name"),
+        named(gitBranchExtension, "git-branch"),
         named(currentTimeExtension, "current-time"),
         named(backgroundBashExtension, "background-bash"),
         named(queueFlushExtension, "queue-flush"),

--- a/packages/cli/src/extensions/git-branch.test.ts
+++ b/packages/cli/src/extensions/git-branch.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, mock } from "bun:test";
+
+let runGitCalls = 0;
+let stubBranch: string | undefined = "feat/test-branch";
+
+// Stub the git helper so tests are hermetic and we can count lookups.
+mock.module("../config/system-prompt.js", () => ({
+    runGit: () => {
+        runGitCalls++;
+        return stubBranch;
+    },
+}));
+
+const { gitBranchExtension, injectGitBranch } = await import("./git-branch.js");
+
+function mockPi(cwd: string) {
+    const handlers: Record<string, (arg: any) => any> = {};
+    return {
+        cwd,
+        on: (event: string, handler: any) => {
+            handlers[event] = handler;
+        },
+        fire: (event: string, arg: any) => handlers[event](arg),
+    };
+}
+
+describe("injectGitBranch", () => {
+    test("inserts the branch line above Working directory", () => {
+        const prompt = "Meta\nWorking directory: /repo\n\nrules";
+        expect(injectGitBranch(prompt, "main", "/repo")).toBe(
+            "Meta\nGit branch: main\nWorking directory: /repo\n\nrules",
+        );
+    });
+
+    test("appends the branch line when the anchor is missing", () => {
+        expect(injectGitBranch("prompt", "main", "/elsewhere")).toBe("prompt\nGit branch: main");
+    });
+});
+
+describe("gitBranchExtension", () => {
+    test("computes the branch once and injects it on every turn", () => {
+        stubBranch = "feat/test-branch";
+        const pi = mockPi("/repo");
+        gitBranchExtension(pi as any);
+        const turn = () => pi.fire("before_agent_start", { systemPrompt: "Working directory: /repo", systemPromptOptions: { cwd: "/repo" } });
+
+        const first = turn();
+        expect(first?.systemPrompt).toContain("Git branch: feat/test-branch");
+        const second = turn();
+        expect(second?.systemPrompt).toBe(first?.systemPrompt);
+        expect(runGitCalls).toBe(1); // looked up once, not per turn
+    });
+
+    test("recomputes after a session switch", () => {
+        stubBranch = "other-branch";
+        const pi = mockPi("/repo");
+        gitBranchExtension(pi as any);
+        pi.fire("before_agent_start", { systemPrompt: "Working directory: /repo", systemPromptOptions: { cwd: "/repo" } });
+        pi.fire("session_start", {});
+        const result = pi.fire("before_agent_start", { systemPrompt: "Working directory: /repo", systemPromptOptions: { cwd: "/repo" } });
+        expect(result?.systemPrompt).toContain("Git branch: other-branch");
+    });
+
+    test("does not inject outside a git repo", () => {
+        stubBranch = undefined;
+        const pi = mockPi("/not/a/repo");
+        gitBranchExtension(pi as any);
+        const result = pi.fire("before_agent_start", { systemPrompt: "Working directory: /not/a/repo", systemPromptOptions: { cwd: "/not/a/repo" } });
+        expect(result?.systemPrompt).toBeUndefined();
+    });
+});

--- a/packages/cli/src/extensions/git-branch.ts
+++ b/packages/cli/src/extensions/git-branch.ts
@@ -1,0 +1,41 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { runGit } from "../config/system-prompt.js";
+
+/**
+ * Git-branch extension — injects the current git branch into the system prompt.
+ *
+ * The baked-in prompt deliberately omits the branch: it's computed at boot and
+ * goes stale the moment anything checks out another branch (dispatch machinery,
+ * the git panel, the agent itself). Here the branch is looked up ONCE, on the
+ * first turn of a session — after any dispatch-time checkout — and the same
+ * value is injected on every turn. Mid-session branch switches stay visible in
+ * the conversation history, so the prompt keeps describing where the session
+ * started.
+ */
+
+/** Insert a `Git branch:` line above the `Working directory:` line in the prompt. */
+export function injectGitBranch(prompt: string, branch: string, cwd: string): string {
+    const anchor = `Working directory: ${cwd}`;
+    const idx = prompt.indexOf(anchor);
+    if (idx === -1) return `${prompt}\nGit branch: ${branch}`;
+    return `${prompt.slice(0, idx)}Git branch: ${branch}\n${prompt.slice(idx)}`;
+}
+
+export const gitBranchExtension: ExtensionFactory = (pi) => {
+    let branch: string | undefined; // undefined = not yet computed; "" = not a git repo
+
+    // Reset on session switch so a fresh in-process session recomputes.
+    pi.on("session_start", () => {
+        branch = undefined;
+    });
+
+    pi.on("before_agent_start", (event) => {
+        const cwd = event.systemPromptOptions?.cwd ?? "";
+        // Look up the branch once per session, not at boot and not per turn.
+        if (branch === undefined) {
+            branch = runGit("rev-parse --abbrev-ref HEAD", cwd) ?? "";
+        }
+        if (!branch) return;
+        return { systemPrompt: injectGitBranch(event.systemPrompt, branch, cwd) };
+    });
+};


### PR DESCRIPTION
## Problem

Sessions always showed a stale git branch in their system prompt. The branch line was baked at worker boot (worker.ts / index.ts call buildSystemPrompt() inside the appendSystemPrompt IIFE), and the SDK caches that string for the life of the session. Any checkout after boot — dispatch machinery, the git panel, the agent itself — left the prompt claiming the old branch forever, and compaction faithfully preserved the lie.

## Fix

- Removed the boot-baked `Git branch:` line from `system-prompt.hbs` (and from the `SystemPromptContext` type generated by `scripts/compile-prompt.ts`). `gitWorktree` / `cwd` lines stay — they're stable for a session.
- New `git-branch` extension (`extensions/git-branch.ts`, registered in `factories.ts` for both worker and interactive CLI): on `before_agent_start`, looks up the branch with `git rev-parse --abbrev-ref HEAD` **once per session** — on the first turn, after any dispatch-time checkout — and injects the cached value above `Working directory: <cwd>` on every turn. Non-repo cwd → no line. Recomputes on `session_start` (in-process session switches).
- `runGit()` helper exported from `config/system-prompt.ts` for reuse.

Mid-session branch switches by the agent remain visible in conversation history, so the prompt keeps describing where the session started.

## Verification

- `tsc --noEmit` clean.
- New `git-branch.test.ts`: injection placement (above the cwd anchor, appended fallback), single-lookup memoization (stubbed `runGit`), session-switch reset, non-repo no-op. 39 targeted tests pass.
- Full-suite failure set compared against stashed baseline: **zero new failures**; 3 pre-existing failures fixed (two stale `gitBranch` assertions, one stale trigger-copy assertion that predates this branch).
- Smoke-tested end-to-end: baked prompt has no branch line; rendered prompt shows `Git branch: <live>` above `Working directory: <cwd>`.