### PR TITLE
feat(android): declare mic permissions for WebView audio capture

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -73,6 +73,13 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Microphone: getUserMedia/MediaRecorder in report/service panels (voice
+         feedback snippets). RECORD_AUDIO is runtime on API 23+; Capacitor's
+         BridgeWebChromeClient#onPermissionRequest requests BOTH this and
+         MODIFY_AUDIO_SETTINGS when a page asks for AUDIO_CAPTURE — both must be
+         declared here or the launcher denies the whole grant. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <!-- Notifications (local + push). POST_NOTIFICATIONS is runtime on API 33+. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -255,6 +255,9 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
                             title={`Tunnel preview — port ${activePort}`}
                             // SECURITY: allow-same-origin is needed because tunnel content is same-origin. TODO: serve tunnel content from a separate origin to enable full sandbox isolation.
                             sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+                            // See IframeServicePanel: framed voice capture needs
+                            // Permissions-Policy delegation or getUserMedia is blocked.
+                            allow="microphone"
                             onLoad={() => setIframeLoading(false)}
                             onLoadStart={() => setIframeLoading(true)}
                         />

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -102,6 +102,10 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
                 title={`Service panel — port ${port}`}
                 // SECURITY: allow-same-origin is needed because tunnel content is same-origin. TODO: serve tunnel content from a separate origin to enable full sandbox isolation.
                 sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+                // Voice capture (e.g. the daily report's feedback Snippet) needs
+                // Permissions-Policy delegation; without `allow=`, getUserMedia
+                // is silently blocked in framed panels even with OS mic access.
+                allow="microphone"
                 onLoad={() => setLoaded(true)}
                 onError={() => reportError("tunnel", `Panel failed to load (port ${port})`, { detail: src, toast: false })}
             />


### PR DESCRIPTION
## Why<br /><br />The daily report's voice-feedback Snippet records audio in the APK's WebView via getUserMedia + MediaRecorder. Capacitor's <code>BridgeWebChromeClient#onPermissionRequest</code> already runtime-requests <code>RECORD_AUDIO</code> + <code>MODIFY_AUDIO_SETTINGS</code> when a page asks for <code>AUDIO_CAPTURE</code> — but if those permissions aren't declared in the manifest, Android auto-denies them and the whole grant fails, so <code>getUserMedia</code> rejects and the app falls back to typed input.<br /><br />## What<br /><br />Declare both permissions in <code>AndroidManifest.xml</code>. No Java changes needed — the runtime prompt flow is Capacitor core.<br /><br />Untested on-device here (needs an APK build + real device); the WebView mic flow should be verified after the next APK build.