### PR TITLE
fix(server): honor origin-provided Permissions-Policy

### DIFF
--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -292,6 +292,16 @@ describe("withSecurityHeaders", () => {
         expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     });
 
+    test("preserves an origin-provided Permissions-Policy (tunneled services can opt into mic)", () => {
+        const res = withSecurityHeaders(new Response("ok", { headers: { "Permissions-Policy": "microphone=self" } }));
+        expect(res.headers.get("permissions-policy")).toBe("microphone=self");
+    });
+
+    test("defaults to the restrictive policy when the origin declares none", () => {
+        const res = withSecurityHeaders(new Response("ok"));
+        expect(res.headers.get("permissions-policy")).toBe("camera=(), microphone=(), geolocation=()");
+    });
+
     test("injects X-Frame-Options: DENY", () => {
         const res = withSecurityHeaders(new Response("ok"));
         expect(res.headers.get("x-frame-options")).toBe("DENY");

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -176,7 +176,13 @@ export function withSecurityHeaders(res: Response): Response {
     headers.set("X-Content-Type-Options", "nosniff");
     headers.set("X-XSS-Protection", "0");
     headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-    headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    // Hardened default — but a tunneled service may declare its own
+    // Permissions-Policy (e.g. the daily report needs `microphone=self` for
+    // voice feedback). Origin-provided policy wins; the restrictive default
+    // still covers the relay's own surfaces and every origin that stays silent.
+    if (!headers.has("Permissions-Policy")) {
+        headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    }
 
     if (isTunnel) {
         // The tunnel URL is the bearer credential (token in path, or label in


### PR DESCRIPTION
## Why<br /><br />`withSecurityHeaders` unconditionally overwrote `Permissions-Policy` with `camera=(), microphone=(), geolocation=()`, hard-disabling microphone capture for <b>all</b> tunneled content. The daily report's voice-feedback Snippet could never record through a tunnel, panel, or APK — `getUserMedia` rejected with no prompt ever appearing, even in a fully capable browser on the direct tunnel URL.<br /><br />## What<br /><br />Origin-provided `Permissions-Policy` now wins (tunneled services can declare their own, e.g. `microphone=self`); the hardened restrictive default still applies to the relay's own surfaces and to every origin that stays silent. Two regression tests cover both paths.<br /><br />## Deploy note<br /><br />Needs a relay redeploy to take effect.