### PR TITLE
chore: bump pi-* suite to 0.84.4 and migrate patches

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-updater": "^8",
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-tui": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -46,8 +46,8 @@
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-coding-agent": "^0.84.4",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/extension-sdk": "workspace:*",
         "@pizzapi/protocol": "workspace:*",
@@ -81,7 +81,7 @@
         "@pizzapi/protocol": "workspace:*",
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-coding-agent": "^0.84.4",
         "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
       },
@@ -101,8 +101,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -130,8 +130,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -226,11 +226,11 @@
     },
   },
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.84.3": "patches/@earendil-works%2Fpi-agent-core@0.84.3.patch",
     "pptx-browser@4.1.5": "patches/pptx-browser@4.1.5.patch",
-    "@earendil-works/pi-ai@0.84.3": "patches/@earendil-works%2Fpi-ai@0.84.3.patch",
-    "@earendil-works/pi-coding-agent@0.84.3": "patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch",
-    "@earendil-works/pi-tui@0.84.3": "patches/@earendil-works%2Fpi-tui@0.84.3.patch",
+    "@earendil-works/pi-agent-core@0.84.4": "patches/@earendil-works%2Fpi-agent-core@0.84.4.patch",
+    "@earendil-works/pi-ai@0.84.4": "patches/@earendil-works%2Fpi-ai@0.84.4.patch",
+    "@earendil-works/pi-tui@0.84.4": "patches/@earendil-works%2Fpi-tui@0.84.4.patch",
+    "@earendil-works/pi-coding-agent@0.84.4": "patches/@earendil-works%2Fpi-coding-agent@0.84.4.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -663,19 +663,19 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-telemetry": "^0.84.3", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.3", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.3" } }, "sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.4", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.4" } }, "sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.3", "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-client": "^0.84.3", "@earendil-works/pi-protocol": "^0.84.3", "@earendil-works/pi-tui": "^0.84.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.4", "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-client": "^0.84.4", "@earendil-works/pi-protocol": "^0.84.4", "@earendil-works/pi-tui": "^0.84.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.3", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg=="],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.4", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-updater": "^8",
-    "@earendil-works/pi-agent-core": "^0.84.3",
-    "@earendil-works/pi-ai": "^0.84.3",
-    "@earendil-works/pi-tui": "^0.84.3",
+    "@earendil-works/pi-agent-core": "^0.84.4",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -73,9 +73,9 @@
   "version": "",
   "patchedDependencies": {
     "pptx-browser@4.1.5": "patches/pptx-browser@4.1.5.patch",
-    "@earendil-works/pi-agent-core@0.84.3": "patches/@earendil-works%2Fpi-agent-core@0.84.3.patch",
-    "@earendil-works/pi-ai@0.84.3": "patches/@earendil-works%2Fpi-ai@0.84.3.patch",
-    "@earendil-works/pi-coding-agent@0.84.3": "patches/@earendil-works%2Fpi-coding-agent@0.84.3.patch",
-    "@earendil-works/pi-tui@0.84.3": "patches/@earendil-works%2Fpi-tui@0.84.3.patch"
+    "@earendil-works/pi-agent-core@0.84.4": "patches/@earendil-works%2Fpi-agent-core@0.84.4.patch",
+    "@earendil-works/pi-ai@0.84.4": "patches/@earendil-works%2Fpi-ai@0.84.4.patch",
+    "@earendil-works/pi-coding-agent@0.84.4": "patches/@earendil-works%2Fpi-coding-agent@0.84.4.patch",
+    "@earendil-works/pi-tui@0.84.4": "patches/@earendil-works%2Fpi-tui@0.84.4.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,8 +29,8 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.84.3",
-    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/extension-sdk": "workspace:*",
     "@pizzapi/protocol": "workspace:*",

--- a/packages/cli/src/runner/apply-default-model.test.ts
+++ b/packages/cli/src/runner/apply-default-model.test.ts
@@ -11,6 +11,7 @@ function makeSession(overrides: Partial<{
     registryHas: boolean;
     hasAuth: boolean;
     messages: unknown[];
+    legacyRegistry: boolean;
 }> = {}) {
     const opts = {
         current: { provider: "openai", id: "gpt-5.5" },
@@ -19,19 +20,31 @@ function makeSession(overrides: Partial<{
         registryHas: true,
         hasAuth: true,
         messages: [],
+        legacyRegistry: false,
         ...overrides,
     };
     const setCalls: unknown[] = [];
+    // pi ≥0.84 exposes modelRuntime; pre-0.84 exposed modelRegistry. Support both.
+    const registry = opts.legacyRegistry
+        ? {
+              find: (p: string, m: string) => (opts.registryHas ? { provider: p, id: m } : undefined),
+              hasConfiguredAuth: () => opts.hasAuth,
+          }
+        : undefined;
+    const runtime = opts.legacyRegistry
+        ? undefined
+        : {
+              getModel: (p: string, m: string) => (opts.registryHas ? { provider: p, id: m } : undefined),
+              hasConfiguredAuth: () => opts.hasAuth,
+          };
     const session: DefaultModelSession = {
         model: opts.current,
         settingsManager: {
             getDefaultProvider: () => opts.defaultProvider,
             getDefaultModel: () => opts.defaultModel,
         },
-        modelRegistry: {
-            find: (p, m) => (opts.registryHas ? { provider: p, id: m } : undefined),
-            hasConfiguredAuth: () => opts.hasAuth,
-        },
+        modelRuntime: runtime,
+        modelRegistry: registry,
         agent: { state: { messages: opts.messages } },
         setModel: async (m) => { setCalls.push(m); },
     };
@@ -122,6 +135,20 @@ describe("applySettingsDefaultModel", () => {
 
     test("no-op for sessions with restored messages (resume keeps its model)", async () => {
         const { session, setCalls } = makeSession({ messages: [{ role: "user" }] });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+
+    test("works against the legacy modelRegistry shape (pi <0.84)", async () => {
+        const { session, setCalls } = makeSession({ legacyRegistry: true });
+        expect(await applySettingsDefaultModel(session)).toBe(true);
+        expect(setCalls).toEqual([{ provider: "claude-subscription", id: "claude-fable-5" }]);
+    });
+
+    test("no-op when neither registry accessor is present (instead of throwing)", async () => {
+        const { session, setCalls } = makeSession();
+        delete (session as any).modelRuntime;
+        delete (session as any).modelRegistry;
         expect(await applySettingsDefaultModel(session)).toBe(false);
         expect(setCalls).toEqual([]);
     });

--- a/packages/cli/src/runner/apply-default-model.ts
+++ b/packages/cli/src/runner/apply-default-model.ts
@@ -66,18 +66,47 @@ interface ModelRef {
     id: string;
 }
 
+/** pi ≥0.84: AgentSession.modelRuntime getter (ModelRuntime API). */
+interface ModelRuntimeLike {
+    getModel(provider: string, modelId: string): unknown;
+    hasConfiguredAuth(provider: string): boolean;
+}
+
+/** pi <0.84 legacy: AgentSession.modelRegistry getter (ModelRegistry API). */
+interface ModelRegistryLike {
+    find(provider: string, modelId: string): unknown;
+    hasConfiguredAuth(model: unknown): boolean;
+}
+
 export interface DefaultModelSession {
     model?: ModelRef;
     settingsManager: {
         getDefaultProvider(): string | undefined;
         getDefaultModel(): string | undefined;
     };
-    modelRegistry: {
-        find(provider: string, modelId: string): unknown;
-        hasConfiguredAuth(model: unknown): boolean;
-    };
+    /** At least one of the two must be present. Prefer modelRuntime (current pi). */
+    modelRuntime?: ModelRuntimeLike;
+    modelRegistry?: ModelRegistryLike;
     agent: { state: { messages: unknown[] } };
     setModel(model: unknown): Promise<void>;
+}
+
+function resolveFromRegistry(
+    session: DefaultModelSession,
+    provider: string,
+    modelId: string,
+): unknown {
+    if (session.modelRuntime) {
+        return session.modelRuntime.getModel(provider, modelId);
+    }
+    return session.modelRegistry?.find(provider, modelId);
+}
+
+function hasAuthFor(session: DefaultModelSession, resolved: unknown): boolean {
+    if (session.modelRuntime) {
+        return session.modelRuntime.hasConfiguredAuth((resolved as ModelRef).provider);
+    }
+    return session.modelRegistry?.hasConfiguredAuth(resolved) ?? false;
 }
 
 /** Returns true when the session's model was switched to the settings default. */
@@ -91,11 +120,11 @@ export async function applySettingsDefaultModel(session: DefaultModelSession): P
     if (current?.provider === provider && current?.id === modelId) return false;
     // Ollama Cloud models are discovered dynamically and aren't in the static
     // registry — fall back to the cached catalog so a settings default pointing
-    // at e.g. ollama-cloud/glm-5.2 still gets applied.
+    // at e.g. ollama-cloud/glm-5.3 still gets applied.
     const resolved =
-        session.modelRegistry.find(provider, modelId) ??
+        resolveFromRegistry(session, provider, modelId) ??
         findCachedOllamaCloudModel(provider, modelId);
-    if (!resolved || !session.modelRegistry.hasConfiguredAuth(resolved)) return false;
+    if (!resolved || !hasAuthFor(session, resolved)) return false;
     await session.setModel(resolved);
     return true;
 }

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -639,29 +639,26 @@ async function main(): Promise<void> {
 
             // Restore model if the session had one saved
             if (sessionContext.model) {
-                const modelRegistry = (session as any)._modelRegistry;
-                if (modelRegistry) {
-                    try {
-                        const available = await modelRegistry.getAvailable();
-                        // Ollama Cloud models are discovered dynamically and
-                        // aren't in getAvailable() — fall back to the cached
-                        // catalog so a resumed ollama-cloud model is restored.
-                        const match =
-                            available.find(
-                                (m: any) =>
-                                    m.provider === sessionContext.model!.provider &&
-                                    m.id === sessionContext.model!.modelId,
-                            ) ??
-                            findCachedOllamaCloudModel(
-                                sessionContext.model!.provider,
-                                sessionContext.model!.modelId,
-                            );
-                        if (match) {
-                            await session.setModel(match);
-                        }
-                    } catch {
-                        // Model restore is best-effort
+                try {
+                    const available = await modelRuntime.getAvailable();
+                    // Ollama Cloud models are discovered dynamically and
+                    // aren't in getAvailable() — fall back to the cached
+                    // catalog so a resumed ollama-cloud model is restored.
+                    const match =
+                        available.find(
+                            (m: any) =>
+                                m.provider === sessionContext.model!.provider &&
+                                m.id === sessionContext.model!.modelId,
+                        ) ??
+                        findCachedOllamaCloudModel(
+                            sessionContext.model!.provider,
+                            sessionContext.model!.modelId,
+                        );
+                    if (match) {
+                        await session.setModel(match);
                     }
+                } catch {
+                    // Model restore is best-effort
                 }
             }
 

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -36,7 +36,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
     "@types/bun": "^1.3.9",
     "typescript": "^5.7.0"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3"
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@earendil-works%2Fpi-agent-core@0.84.4.patch
+++ b/patches/@earendil-works%2Fpi-agent-core@0.84.4.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/agent-loop.js b/dist/agent-loop.js
-index 569149f9328920cda8c637ef4cdd0b11cac1a9eb..02225294934406cd9e05be88ec50ed8d66af604b 100644
+index 329c4e3..bab74ca 100644
 --- a/dist/agent-loop.js
 +++ b/dist/agent-loop.js
-@@ -102,6 +102,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
+@@ -118,6 +118,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
                  }
                  pendingMessages = [];
              }
@@ -13,7 +13,7 @@ index 569149f9328920cda8c637ef4cdd0b11cac1a9eb..02225294934406cd9e05be88ec50ed8d
              const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
              newMessages.push(message);
 diff --git a/dist/agent.js b/dist/agent.js
-index ee4f2259470dca6959d26b2ffecb69d173f4093d..d22f01962fd1511b5bf1f342bad68d0efcc420ef 100644
+index ee4f225..d22f019 100644
 --- a/dist/agent.js
 +++ b/dist/agent.js
 @@ -280,6 +280,9 @@ export class Agent {

--- a/patches/@earendil-works%2Fpi-ai@0.84.4.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.84.4.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
-index d04d7a9f59f3700a7e3bacb02aa68256215bee27..9805b75e36389df83bfd43aa133282b1fed5b5af 100644
+index d04d7a9..9805b75 100644
 --- a/dist/api/anthropic-messages.js
 +++ b/dist/api/anthropic-messages.js
 @@ -452,6 +452,29 @@ export const stream = (model, context, options) => {
@@ -120,7 +120,7 @@ index d04d7a9f59f3700a7e3bacb02aa68256215bee27..9805b75e36389df83bfd43aa133282b1
          const parameters = getJsonSchemaToolParameters(tool, strict);
          const schema = parameters;
 diff --git a/dist/auth/oauth/anthropic.js b/dist/auth/oauth/anthropic.js
-index 8692e906caa2609396bdccae98d4d593e024ecf6..815bf6fcfd39cec32e7943a931d1e02dc1c6b269 100644
+index 8692e90..815bf6f 100644
 --- a/dist/auth/oauth/anthropic.js
 +++ b/dist/auth/oauth/anthropic.js
 @@ -296,11 +296,49 @@ async function refreshAnthropicToken(refreshToken, signal) {
@@ -175,7 +175,7 @@ index 8692e906caa2609396bdccae98d4d593e024ecf6..815bf6fcfd39cec32e7943a931d1e02d
          return { apiKey: credential.access };
      },
 diff --git a/dist/utils/retry.js b/dist/utils/retry.js
-index 65c7c9efd7667445b711fcd43549062ee3eb5ecf..a20dab36b194559c5a40f42fa13a8ecf69a92940 100644
+index 65c7c9e..a20dab3 100644
 --- a/dist/utils/retry.js
 +++ b/dist/utils/retry.js
 @@ -64,6 +64,9 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([

--- a/patches/@earendil-works%2Fpi-coding-agent@0.84.4.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.84.4.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/config.js b/dist/config.js
-index f04269f78b199c72277de9debb6948b654e7ee6f..e6d8366e3dcc976aead52d62170eebe6f9f62d54 100644
+index f04269f..e6d8366 100644
 --- a/dist/config.js
 +++ b/dist/config.js
 @@ -358,6 +358,10 @@ export function getReadmePath() {
@@ -44,10 +44,10 @@ index f04269f78b199c72277de9debb6948b654e7ee6f..e6d8366e3dcc976aead52d62170eebe6
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index f4fd9f37d9826a3e791f25c9ec748645a33d5616..47dfba66f381888bff1cf849e2244fe5edbf7658 100644
+index fd82b71..3667a22 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -954,29 +954,40 @@ export class AgentSession {
+@@ -981,29 +981,40 @@ export class AgentSession {
       * Emits errors via extension runner if file read fails.
       */
      _expandSkillCommand(text) {
@@ -112,7 +112,7 @@ index f4fd9f37d9826a3e791f25c9ec748645a33d5616..47dfba66f381888bff1cf849e2244fe5
      /**
       * Queue a steering message while the agent is running.
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
-index d7940e14deb53a3a18237c51c5afb5712686f0ba..36a3d2be5dc5ec31199601965583eed0b3bd7503 100644
+index d7940e1..36a3d2b 100644
 --- a/dist/core/model-resolver.js
 +++ b/dist/core/model-resolver.js
 @@ -21,6 +21,7 @@ export const defaultModelPerProvider = {
@@ -124,7 +124,7 @@ index d7940e14deb53a3a18237c51c5afb5712686f0ba..36a3d2be5dc5ec31199601965583eed0
      xai: "grok-4.6",
      groq: "openai/gpt-oss-120b",
 diff --git a/dist/core/model-runtime.js b/dist/core/model-runtime.js
-index 7d93ba62bdb5d47e129751e8075cbb34620322ad..fcd96e85d1b7f290f48e25df14d39fcd8b61afeb 100644
+index 7d93ba6..fcd96e8 100644
 --- a/dist/core/model-runtime.js
 +++ b/dist/core/model-runtime.js
 @@ -22,6 +22,32 @@ export class CredentialSynchronizationError extends Error {
@@ -170,7 +170,7 @@ index 7d93ba62bdb5d47e129751e8075cbb34620322ad..fcd96e85d1b7f290f48e25df14d39fcd
          if (!base && !this.config.getProvider(providerId) && !extension) {
              this.models.deleteProvider(providerId);
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index cd12d9e885c21ea14c3a1e681e9ca1544087600a..07ca8137332a28a1997b341cfb8a3eb282632a7d 100644
+index 3e9241d..7199e30 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -13,6 +13,7 @@ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveMode
@@ -182,7 +182,7 @@ index cd12d9e885c21ea14c3a1e681e9ca1544087600a..07ca8137332a28a1997b341cfb8a3eb2
  export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
  export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createPowerShellTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
 diff --git a/dist/index.js b/dist/index.js
-index 7bc4467f5af64aba74ab6cafd136e468b6aab803..59fdb706baf9674063152c6d10ba8ee7de4d0e1d 100644
+index 01017cd..cc39132 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -13,6 +13,7 @@ export { ModelRegistry } from "./core/model-registry.js";
@@ -194,7 +194,7 @@ index 7bc4467f5af64aba74ab6cafd136e468b6aab803..59fdb706baf9674063152c6d10ba8ee7
  // SDK for programmatic usage
  export { AgentSessionRuntime, 
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 19dafecadb76dab709f82544fa72de58d8fd1164..1d7ac0630bfa6b7b2d24069380db983fbeb6c70c 100644
+index a27754f..56adec5 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -38,7 +38,6 @@ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
@@ -205,7 +205,7 @@ index 19dafecadb76dab709f82544fa72de58d8fd1164..1d7ac0630bfa6b7b2d24069380db983f
  import { ArminComponent } from "./components/armin.js";
  import { AssistantMessageComponent } from "./components/assistant-message.js";
  import { BashExecutionComponent } from "./components/bash-execution.js";
-@@ -805,12 +804,6 @@ export class InteractiveMode {
+@@ -809,12 +808,6 @@ export class InteractiveMode {
                  .catch(() => { })
                  .finally(() => clearTimeout(timeout));
          }
@@ -218,7 +218,7 @@ index 19dafecadb76dab709f82544fa72de58d8fd1164..1d7ac0630bfa6b7b2d24069380db983f
          // Start package update check asynchronously
          this.checkForPackageUpdates()
              .then((updates) => {
-@@ -3496,29 +3489,6 @@ export class InteractiveMode {
+@@ -3512,29 +3505,6 @@ export class InteractiveMode {
          this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
          this.ui.requestRender();
      }

--- a/patches/@earendil-works%2Fpi-tui@0.84.4.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.84.4.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/terminal.js b/dist/terminal.js
-index de2c7e49c351d2b084f7df1e939070f895eb3225..35ec8c7c76199ef30632eb980c9ae7e9b5f0fdd7 100644
+index de2c7e4..35ec8c7 100644
 --- a/dist/terminal.js
 +++ b/dist/terminal.js
 @@ -6,6 +6,100 @@ import { isNativeModifierPressed } from "./native-modifiers.js";

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @earendil-works/pi-agent-core@0.84.3
+## @earendil-works/pi-agent-core@0.84.4
 
 Refreshes the agent's system prompt and tool list before every assistant
 response, not just at loop start. `dist/agent.js` exposes the current
@@ -15,7 +15,7 @@ updates the prompt mid-turn (e.g. `search_tools`) wouldn't take effect until
 the *next* user turn. See the "pi-agent-core dynamic tool refresh" tests in
 `packages/cli/src/patches.test.ts`.
 
-## @earendil-works/pi-tui@0.84.3
+## @earendil-works/pi-tui@0.84.4
 
 Adds a Windows console lifecycle to `dist/terminal.js`:
 `createWindowsConsoleLifecycle()` enables VT output processing and switches
@@ -26,7 +26,7 @@ mode/code pages on `stop()`. This fixes garbled Unicode/ANSI rendering in
 Windows terminals; it's a no-op (best-effort, swallows failures) on other
 platforms. See `packages/cli/src/patches.test.ts`.
 
-## @earendil-works/pi-ai@0.84.3
+## @earendil-works/pi-ai@0.84.4
 
 Same intent as 0.80.6 (Anthropic web-search passthrough, Claude Code
 credentials fallback, retryable-JSON-parse patterns), ported to upstream's
@@ -67,7 +67,7 @@ assertions that the pi-ai patch no longer carries any ollama-cloud hunks.
 | `dist/auth/oauth/anthropic.js` | Claude Code Keychain/file credentials fallback, now inside `anthropicOAuth.refresh()` |
 | `dist/utils/retry.js` | Same retryable-JSON-parse patterns as 0.80.6 (unchanged file) |
 
-## @earendil-works/pi-coding-agent@0.84.3
+## @earendil-works/pi-coding-agent@0.84.4
 
 Same PizzaPi integration changes as 0.80.6, ported forward, with two upstream
 removals absorbed elsewhere rather than restored:


### PR DESCRIPTION
## What

Bumps `@earendil-works/pi-agent-core`, `pi-ai`, `pi-tui`, `pi-coding-agent` from **0.84.3 → 0.84.4** and recreates the four PizzaPi patches against upstream 0.84.4.

## Patch migration

All hunks re-applied with line-number offsets only — no content conflicts:

| Package | Patch | Notes |
|---|---|---|
| pi-agent-core | dynamic tool/prompt refresh | `agent-loop.js` hunk shifted +16 (upstream moved `prepareNextTurn` before `turn_start`); `agent.js` unchanged |
| pi-ai | Anthropic web search + Claude Code creds fallback + retryable JSON | all three patched files byte-identical upstream — patch unchanged |
| pi-coding-agent | .pizzapi config, skill token expansion, OpenAI context windows, ollama-cloud default, version-check removal, package re-exports | `agent-session.js` hunk shifted +27 (upstream added auto-compaction + pending-custom-messages); rest unchanged |
| pi-tui | Windows console lifecycle | `terminal.js` unchanged upstream — patch unchanged |

Also cherry-picks 8134d75b (`fix(runner): hot-loaded-model default recovery broken by pi 0.84 session.modelRegistry removal`) — that fix lived only on `feat/unified-trigger-system`; without it, main's call sites throw on every worker boot under 0.84.x and hot-loaded model defaults silently revert to `gpt-5.5`.

## Notable upstream 0.84.4 changes for PizzaPi

- Extension messages sent with `triggerTurn: false` during a run are no longer inserted between a tool call and its result (flushed at `turn_end`) — directly relevant to trigger delivery
- Auto-compaction now runs between tool execution and the next assistant response in the same run
- New `ui_prompt_start` / `ui_prompt_end` extension events; RPC `clear_queue`; terminal capability overrides; `fullscreenCopyOnSelect`

## Verification

- `bun install` — all 4 patches apply cleanly
- `cd packages/cli && bun test src/patches.test.ts` — 49/49 pass
- `bun run typecheck` — clean
- `bun run build` — all packages, UI within gzip budget
- `bun run test` — 184 pass, 1 fail: `skills.test.ts`, the known pre-existing HOME-dependence (user's global `~/.pizzapi/AGENTS.md` changes file counts); passes 62/62 with isolated `HOME`
- `session.modelRegistry` / `_modelRegistry` regression check performed (per post-bump checklist); broken call sites on main fixed via cherry-pick