### PR TITLE
chore: route daemon console.log through logger

### DIFF
--- a/packages/cli/src/__tests__/models-command.test.ts
+++ b/packages/cli/src/__tests__/models-command.test.ts
@@ -34,7 +34,7 @@ describe("models command", () => {
 
     async function runAndCaptureJson(cwd: string): Promise<{ code: number; models: any[] }> {
         const output: string[] = [];
-        const logger = { info: (message: string) => output.push(message), warn: (message: string) => output.push(message), error: (message: string) => output.push(message) };
+        const logger = { debug: (message: string) => output.push(message), info: (message: string) => output.push(message), warn: (message: string) => output.push(message), error: (message: string) => output.push(message) };
         const code = await runModelsCommand(["--json"], cwd, logger);
         const captured = output.find((line) => line.startsWith("{")) ?? "{}";
         return { code, models: JSON.parse(captured).models ?? [] };

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -6,6 +6,7 @@
  * registration endpoint and the signup-status check.
  */
 
+import { createLogger } from "@pizzapi/tools";
 import { getApiKeyRateLimitConfig, getAuth, getKysely, isSignupAllowed } from "../auth.js";
 import { RateLimiter, isValidEmail, isValidPassword, getClientIp } from "../security.js";
 import { PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
@@ -15,6 +16,8 @@ import type { RouteHandler } from "./types.js";
 
 // 5 requests per 15 minutes
 const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
+
+const log = createLogger("auth");
 
 export const handleAuthRoute: RouteHandler = async (req, url) => {
     // ── Public endpoint: signup status ───────────────────────────────
@@ -61,11 +64,11 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             `.execute(getKysely());
             existing = result.rows[0];
             if (process.env.CI) {
-                console.log(`[auth-debug] existing-query ok email=${email} hit=${existing ? "yes" : "no"}`);
+                log.debug(`existing-query ok email=${email} hit=${existing ? "yes" : "no"}`);
             }
         } catch (error) {
             if (process.env.CI) {
-                console.error(`[auth-debug] existing-query failed email=${email}`, error);
+                log.error(`existing-query failed email=${email}`, error);
             }
             throw error;
         }
@@ -84,7 +87,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
                 .api.signInEmail({ body: { email, password } })
                 .catch((error) => {
                     if (process.env.CI) {
-                        console.error(`[auth-debug] signInEmail failed email=${email}`, error);
+                        log.error(`signInEmail failed email=${email}`, error);
                     }
                     return null;
                 });

--- a/packages/tools/src/log.test.ts
+++ b/packages/tools/src/log.test.ts
@@ -18,6 +18,17 @@ describe("createLogger", () => {
         errorSpy.mockRestore();
     });
 
+    test("debug() writes to console.log with timestamp and tag", () => {
+        const log = createLogger("auth");
+        log.debug("existing-query ok email=x@y.z");
+
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const [ts, tag, msg] = logSpy.mock.calls[0];
+        expect(tag).toBe("[auth]");
+        expect(msg).toBe("existing-query ok email=x@y.z");
+        expect(() => new Date(ts as string).toISOString()).not.toThrow();
+    });
+
     test("info() writes to console.log with timestamp and tag", () => {
         const log = createLogger("health");
         log.info("Redis connected");

--- a/packages/tools/src/log.ts
+++ b/packages/tools/src/log.ts
@@ -16,6 +16,8 @@
  */
 
 export interface Logger {
+    /** Log at debug level (→ stdout / console.log). For high-noise diagnostics. */
+    debug(msg: string, ...args: unknown[]): void;
     /** Log at info level (→ stdout / console.log). */
     info(msg: string, ...args: unknown[]): void;
     /** Log at warn level (→ stderr / console.warn). */
@@ -33,6 +35,7 @@ export interface Logger {
 export function createLogger(tag: string): Logger {
     const prefix = `[${tag}]`;
     return {
+        debug: (msg, ...args) => console.log(new Date().toISOString(), prefix, msg, ...args),
         info:  (msg, ...args) => console.log(new Date().toISOString(), prefix, msg, ...args),
         warn:  (msg, ...args) => console.warn(new Date().toISOString(), prefix, msg, ...args),
         error: (msg, ...args) => console.error(new Date().toISOString(), prefix, msg, ...args),


### PR DESCRIPTION
Replaces the stray CI-debug `console.log`/`console.error` calls in `packages/server/src/routes/auth.ts` (the `[auth-debug]` block) with the shared `createLogger` from `@pizzapi/tools`, keeping the `process.env.CI` gating and dropping the hand-rolled `[auth-debug]` prefix in favor of the logger's timestamped `[auth]` tag. Since the logger had no noise-level entry point, this adds a `debug()` method to `Logger`/`createLogger` (routing to stdout like `info`, same timestamp+tag format) plus a test, and updates the one mock logger in `packages/cli/src/__tests__/models-command.test.ts` that implements the interface. Build, typecheck, and the full test suite pass (the only failure, `skills.test.ts`, is a known HOME-dependent env failure that reproduces identically on a checkout without these changes).

**Deliberately left as `console.log`:**
- `packages/cli/src/runner/install.ts`, `pair.ts`, `status.ts`, `config-show.ts`, `package-commands.ts`, `overlay/cli-support.ts` — CLI command stdout intended for a human
- `packages/server/src/tunnel-relay.ts` — that `console.log` is the implementation of a logger object handed to `TunnelRelay`, not a stray call
- `packages/server/spike/*` — standalone spike/demo scripts run by humans
- `packages/server/tests/harness/*` — test harness (sandbox console UI, log stubbing, string literal in mock-runner)
- `packages/cli/build-binaries.ts`, `packages/cli/scripts/*`, `packages/npm/*`, `packages/ui/scripts/*` — build/dev scripts with human-facing output
- `packages/tools/src/log.ts` — `console.log` is the logger's own implementation
- test files and fixtures (`*.test.ts`, `__fixtures__`) — out of scope