### PR TITLE
chore: dedupe isRecord guards into protocol

### DIFF
--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -17,6 +17,7 @@ import type { RelayContext } from "./mcp-oauth.js";
 import { waitForRelayRegistration } from "./remote.js";
 import { getToolSearchBridge, type ToolSearchSnapshot } from "./tool-search-bridge.js";
 import { createLogger } from "@pizzapi/tools";
+import { isRecord } from "@pizzapi/protocol";
 
 const log = createLogger("mcp");
 
@@ -252,10 +253,6 @@ type McpBridge = {
   setRelayContext: (ctx: RelayContext | null) => void;
   deliverOAuthCallback: (nonce: string, code: string) => void;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
 
 function parseConfigFile(scope: "global" | "project", path: string): McpConfigFileState {
   if (!existsSync(path)) {

--- a/packages/cli/src/extensions/mcp-overlay.ts
+++ b/packages/cli/src/extensions/mcp-overlay.ts
@@ -57,9 +57,7 @@ export interface MergeOverlayMcpServersResult {
     serverProvenance: OverlayMcpServerProvenance[];
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return !!value && typeof value === "object" && !Array.isArray(value);
-}
+import { isRecord } from "@pizzapi/protocol";
 
 /** Read+parse a JSON file with the same size cap overlay sidecars use. Returns undefined on any failure. */
 function readJsonCapped(path: string): unknown | undefined {

--- a/packages/cli/src/extensions/mcp/types.ts
+++ b/packages/cli/src/extensions/mcp/types.ts
@@ -47,7 +47,5 @@ export const MCP_SUPPORTED_VERSIONS = new Set(["2025-11-25", "2025-06-18", "2025
 /** Client info sent during the initialize handshake. */
 export const MCP_CLIENT_INFO = { name: "pizzapi", version: "1.0.0" };
 
-/** Type guard for plain objects (used by JSON-RPC response parsers). */
-export function isRecord(v: unknown): v is Record<string, unknown> {
-  return !!v && typeof v === "object" && !Array.isArray(v);
-}
+/** Type guard for plain objects (used by JSON-RPC response parsers). Re-exported from the protocol package. */
+export { isRecord } from "@pizzapi/protocol";

--- a/packages/cli/src/overlay/manifest.ts
+++ b/packages/cli/src/overlay/manifest.ts
@@ -16,6 +16,7 @@ import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "nod
 import { isAbsolute, join, resolve as resolvePath, sep } from "node:path";
 import type { PanelVariable, PizzaPiOverlayV1, PizzaPiServiceDeclaration } from "@pizzapi/extension-sdk";
 import { MAX_PLUGIN_FILE_SIZE } from "../plugins/types.js";
+import { isRecord as isPlainObject } from "@pizzapi/protocol";
 
 /** Reuse the existing 2 MiB per-file cap already used for plugin sidecar files. */
 export const OVERLAY_SIDECAR_MAX_BYTES = MAX_PLUGIN_FILE_SIZE;
@@ -88,10 +89,6 @@ export interface OverlayReadResult {
 /** One-line provenance-rich rendering of an issue, per spec §11. */
 export function formatOverlayIssue(issue: OverlayIssue): string {
     return `[${issue.identity} (${issue.scope}: ${issue.source})] ${issue.field}: ${issue.message} — ${issue.remediation}`;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-    return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 /**

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -2,12 +2,9 @@ import { readBestExternalCredential } from "./keychain-auth.js";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isRecord } from "@pizzapi/protocol";
 
 export type RunnerAuthRecord = Record<string, unknown>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 /** Read a Claude Code OAuth credential file, handling both the nested
  *  `{ claudeAiOauth: {...} }` shape and the flat `{ accessToken, ... }` shape. */

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -121,6 +121,7 @@ export {
 
 // Runtime payload guards for critical external boundaries
 export {
+  isRecord,
   parseViewerEventEnvelope,
   parseViewerConnectedEnvelope,
   parseHubStateSnapshot,

--- a/packages/protocol/src/payload-guards.ts
+++ b/packages/protocol/src/payload-guards.ts
@@ -33,9 +33,13 @@ export type ParseResult<T> =
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+/** Canonical plain-object guard: true for non-null `object` values that are not arrays. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+
+// ponytail: internal alias for ~40 call sites in this file
+const isPlainObject = isRecord;
 
 function optionalNumber(value: unknown): number | undefined {
   return typeof value === "number" ? value : undefined;


### PR DESCRIPTION
Consolidates the six duplicated `isRecord` type guards into a single canonical export: `isRecord(value: unknown): value is Record<string, unknown>` now lives in `@pizzapi/protocol` (`packages/protocol/src/payload-guards.ts`, re-exported from the package index, where it replaces the file-private `isPlainObject` as the one definition). The four copies in `packages/cli` (`mcp-extension.ts`, `mcp-overlay.ts`, `mcp/types.ts` — now a re-export so internal importers are unchanged — and `overlay/manifest.ts`, aliased to keep its `isPlainObject` call sites) all import from the protocol package instead. `usage-auth.ts`'s local copy was the only semantic outlier (it accepted arrays); all its call sites terminate identically with the stricter guard, so it was replaced too. The two copies in `packages/tunnel` were left alone because that package has no `@pizzapi/protocol` dependency and was outside the stated scope. No behavior change; `bun run build`, `bun run typecheck`, and `bun run test` all pass (test suite needs `HOME` pointed at a clean temp dir on this machine due to a pre-existing, unrelated HOME-dependence in `skills.test.ts`).