### PR TITLE
fix(sandbox): file:// bypass, malformed-config crash, dangling-symlink write escape

### DIFF
--- a/packages/tools/src/sandbox.test.ts
+++ b/packages/tools/src/sandbox.test.ts
@@ -685,15 +685,14 @@ describe("sandbox", () => {
             expect(result.reason).toContain("denied");
         });
 
-        test("dangling symlink under allowWrite passes validation (documents current gap)", async () => {
-            // existsSync() is false for a dangling symlink, so _normalizePath's
-            // parent walk treats it as an ordinary (unrealpath'd) child of the
-            // allowed root. The write itself would fail at the OS level today
-            // (target doesn't exist), but see the test.todo below for the
-            // TOCTOU variant this enables when OS enforcement is inactive.
+        test("dangling symlink under allowWrite is validated against its link target, not the allowed root", async () => {
+            // The symlink's target ("created-later") doesn't exist yet, so
+            // existsSync() is false for it — _normalizePath must still follow
+            // the link (via lstat) rather than treating it as an ordinary
+            // child of the allowed root.
             symlinkSync(join(outsideDir, "created-later"), join(tmpDir, "dangling"), "junction");
             await initSandbox(makeConfig({ denyRead: [], allowWrite: [tmpDir], denyWrite: [] }));
-            expect(validatePath(join(tmpDir, "dangling", "x.txt"), "write").allowed).toBe(true);
+            expect(validatePath(join(tmpDir, "dangling", "x.txt"), "write").allowed).toBe(false);
         });
 
         test("symlink resolving within the allowed root is allowed (no false positive)", async () => {
@@ -849,13 +848,30 @@ describe("sandbox", () => {
             expect(validatePath("file://not-localhost/etc/passwd", "read").allowed).toBe(false);
         });
 
-        // BUG (found by adversarial probing, not fixed per task instructions):
-        // A dangling symlink inside allowWrite passes validatePath for writes
-        // (existsSync is false, so the parent walk never resolves its target).
-        // An attacker who creates the symlink target between validation and
-        // write escapes the allowed root — a TOCTOU window whenever OS-level
-        // enforcement is inactive (init failed, unsupported platform).
-        test.todo("dangling symlink under allowWrite passes write validation (TOCTOU escape when OS enforcement is inactive)");
+        test("dangling symlink written directly (not as a path prefix) is still resolved against its link target", async () => {
+            const tmp = mkdtempSync(join(tmpdir(), "sandbox-dangle-"));
+            const outside = mkdtempSync(join(tmpdir(), "sandbox-dangle-outside-"));
+            try {
+                symlinkSync(join(outside, "created-later"), join(tmp, "dangling"), "junction");
+                await initSandbox(makeConfig({ denyRead: [], allowWrite: [tmp], denyWrite: [] }));
+                // Validating the symlink path itself (no child segment below it).
+                expect(validatePath(join(tmp, "dangling"), "write").allowed).toBe(false);
+            } finally {
+                rmSync(tmp, { recursive: true, force: true });
+                rmSync(outside, { recursive: true, force: true });
+            }
+        });
+
+        test("dangling symlink whose target resolves inside the allowed root is still allowed (no false positive)", async () => {
+            const tmp = mkdtempSync(join(tmpdir(), "sandbox-dangle-ok-"));
+            try {
+                symlinkSync(join(tmp, "not-created-yet"), join(tmp, "dangling-inside"), "junction");
+                await initSandbox(makeConfig({ denyRead: [], allowWrite: [tmp], denyWrite: [] }));
+                expect(validatePath(join(tmp, "dangling-inside", "x.txt"), "write").allowed).toBe(true);
+            } finally {
+                rmSync(tmp, { recursive: true, force: true });
+            }
+        });
     });
 
     describe("adversarial: read-only overlay", () => {

--- a/packages/tools/src/sandbox.test.ts
+++ b/packages/tools/src/sandbox.test.ts
@@ -812,14 +812,24 @@ describe("sandbox", () => {
             expect(getSandboxMode()).toBe("full");
         });
 
-        // BUG (found by adversarial probing, not fixed per task instructions):
-        // initSandbox({ mode: "basic" }) with srtConfig absent (undefined, not
-        // null) throws TypeError ("evaluating 'srt.network'"), and undefined
-        // denyRead/allowWrite/denyWrite arrays throw during _buildSrtConfig
-        // (spread of undefined) — both escape the documented "never crashes
-        // the worker" graceful degradation because the guards only check
-        // === null and _buildSrtConfig runs outside the try block.
-        test.todo("initSandbox throws on malformed configs (missing srtConfig / undefined fs arrays) instead of degrading gracefully");
+        test("initSandbox does not throw on malformed configs (missing srtConfig / undefined fs arrays)", async () => {
+            // srtConfig entirely absent (undefined, not null).
+            await expect(
+                initSandbox({ mode: "basic" } as unknown as ResolvedSandboxConfig),
+            ).resolves.toBeUndefined();
+            expect(getSandboxMode()).toBe("basic");
+
+            _resetState();
+
+            // srtConfig present but its filesystem arrays are undefined.
+            await expect(
+                initSandbox({
+                    mode: "basic",
+                    srtConfig: { filesystem: {} },
+                } as unknown as ResolvedSandboxConfig),
+            ).resolves.toBeUndefined();
+            expect(getSandboxMode()).toBe("basic");
+        });
 
         test("file:// URL prefix is normalized to a filesystem path before denyRead applies", async () => {
             await initSandbox(makeConfig({ denyRead: ["/etc/secrets"] }));

--- a/packages/tools/src/sandbox.test.ts
+++ b/packages/tools/src/sandbox.test.ts
@@ -821,12 +821,23 @@ describe("sandbox", () => {
         // === null and _buildSrtConfig runs outside the try block.
         test.todo("initSandbox throws on malformed configs (missing srtConfig / undefined fs arrays) instead of degrading gracefully");
 
-        // BUG (found by adversarial probing, not fixed per task instructions):
-        // validatePath("file:///etc/secrets/key", "read") returns { allowed: true }:
-        // pathResolve() treats "file://..." as a CWD-relative path, so denyRead
-        // rules never match and reads fail open. (Writes fail closed because the
-        // CWD-relative resolution is outside allowWrite, but denyRead is bypassed.)
-        test.todo("file:// URL prefix bypasses denyRead validation (pathResolve treats scheme as a CWD-relative segment)");
+        test("file:// URL prefix is normalized to a filesystem path before denyRead applies", async () => {
+            await initSandbox(makeConfig({ denyRead: ["/etc/secrets"] }));
+            expect(validatePath("file:///etc/secrets/key", "read").allowed).toBe(false);
+            expect(validatePath("file:///etc/other", "read").allowed).toBe(true);
+        });
+
+        test("non-file:// URL schemes are denied outright, not resolved as CWD-relative", async () => {
+            await initSandbox(makeConfig({ denyRead: [] }));
+            expect(validatePath("http://evil.example/etc/passwd", "read").allowed).toBe(false);
+            expect(validatePath("http://evil.example/etc/passwd", "write").allowed).toBe(false);
+        });
+
+        test("malformed file:// URL is denied, not treated as a relative path", async () => {
+            await initSandbox(makeConfig({ denyRead: [] }));
+            // Non-empty, non-"localhost" host on a file:// URL is malformed.
+            expect(validatePath("file://not-localhost/etc/passwd", "read").allowed).toBe(false);
+        });
 
         // BUG (found by adversarial probing, not fixed per task instructions):
         // A dangling symlink inside allowWrite passes validatePath for writes

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -483,10 +483,11 @@ function _normalizePath(filePath: string): string {
 
         let hops = 0;
         while (!existsSync(parent)) {
-            // ponytail: bound against pathological/circular symlink chains
-            if (++hops > 40) break;
             const linkTarget = _readDanglingSymlinkTarget(parent);
             if (linkTarget !== null) {
+                // ponytail: bound against circular symlink chains; only link
+                // follows count so deep nonexistent dirs still walk to root
+                if (++hops > 40) break;
                 // `parent` is itself a dangling symlink — validate against
                 // where it actually points, not where it sits. Closes a
                 // TOCTOU window: an attacker who creates the link target

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -9,6 +9,7 @@
 
 import { resolve as pathResolve, dirname } from "node:path";
 import { realpathSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 import {
     SandboxManager,
@@ -182,7 +183,17 @@ export function validatePath(
         return { allowed: true };
     }
 
-    const normalizedPath = _normalizePath(filePath);
+    let normalizedPath: string;
+    try {
+        normalizedPath = _normalizePath(filePath);
+    } catch {
+        // Unsupported/malformed URL scheme (see _normalizePath) — fail closed
+        // rather than falling through to CWD-relative resolution.
+        const label = op === "read" ? "Read" : "Write";
+        const reason = `${label} denied: path "${filePath}" could not be resolved to a filesystem path`;
+        _recordViolation(op, filePath, reason);
+        return { allowed: false, reason };
+    }
 
     return op === "read"
         ? _validateReadPath(normalizedPath)
@@ -398,9 +409,26 @@ function _isActive(): boolean {
     return _initialized && !_initFailed && _config?.mode !== "none" && _config?.srtConfig !== null;
 }
 
+/** Matches a "scheme://" prefix (e.g. "file://", "http://"). Requires the
+ *  "//" so Windows drive letters ("C:/foo", "C:\\foo") never match. */
+const _URL_SCHEME_RE = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//;
+
 /** Normalize a file path for comparison against config paths. */
 function _normalizePath(filePath: string): string {
     let expanded = filePath;
+
+    // Reject URL-scheme inputs before pathResolve() can mistake the scheme
+    // for an ordinary CWD-relative path segment. "file://" URLs are
+    // normalized to a real filesystem path so deny/allow rules still apply;
+    // any other scheme (or a malformed file:// URL) fails closed.
+    const schemeMatch = _URL_SCHEME_RE.exec(expanded);
+    if (schemeMatch) {
+        if (schemeMatch[1].toLowerCase() !== "file") {
+            throw new Error(`Unsupported URL scheme: "${schemeMatch[1]}"`);
+        }
+        expanded = fileURLToPath(expanded); // throws on malformed file:// URLs
+    }
+
     if (expanded.startsWith("~")) {
         const home = process.env.HOME ?? process.env.USERPROFILE ?? "/";
         expanded = home + expanded.slice(1);

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -100,8 +100,10 @@ let _readOnlyOverlay = false;
  * Graceful degradation:
  * - Mode `"none"` or null srtConfig: skips initialization entirely.
  * - Unsupported platforms (Windows): logs a warning and continues unsandboxed.
- * - If `SandboxManager.initialize()` throws: logs the error and continues
- *   unsandboxed. Never crashes the worker.
+ * - If config building or `SandboxManager.initialize()` throws (including a
+ *   malformed `srtConfig` — missing entirely, or with undefined filesystem
+ *   arrays): logs the error and continues unsandboxed. Never crashes the
+ *   worker.
  */
 export async function initSandbox(config: ResolvedSandboxConfig): Promise<void> {
     _config = config;
@@ -128,14 +130,15 @@ export async function initSandbox(config: ResolvedSandboxConfig): Promise<void> 
         return;
     }
 
-    // Build the SandboxRuntimeConfig to pass to srt
-    const runtimeConfig = _buildSrtConfig(config);
-
     try {
+        // Config building runs inside the try too: a malformed config
+        // (missing srtConfig, undefined fs arrays) must degrade to
+        // unsandboxed like any other init failure, not crash the worker.
+        const runtimeConfig = _buildSrtConfig(config);
         await SandboxManager.initialize(runtimeConfig);
         _initialized = true;
     } catch (err) {
-        log.error(`Failed to initialize sandbox. Continuing unsandboxed: ${err instanceof Error ? err.message : String(err)}`);
+        log.error("Failed to initialize sandbox. Continuing unsandboxed:", err);
         _initialized = true;
         _initFailed = true;
     }
@@ -327,6 +330,15 @@ export async function cleanupSandbox(): Promise<void> {
 /** Build the SandboxRuntimeConfig to pass to srt from our resolved config. */
 function _buildSrtConfig(config: ResolvedSandboxConfig): SandboxRuntimeConfig {
     const srt = config.srtConfig!;
+    // Malformed configs can omit the fs arrays entirely; default them to []
+    // rather than crashing on `...undefined` below (they retain their
+    // documented empty-array meaning: deny-all-writes / allow-all-reads).
+    const fsConfig = {
+        denyRead: srt.filesystem?.denyRead ?? [],
+        allowWrite: srt.filesystem?.allowWrite ?? [],
+        denyWrite: srt.filesystem?.denyWrite ?? [],
+        allowGitConfig: srt.filesystem?.allowGitConfig,
+    };
 
     // Merge SSH agent socket into allowUnixSockets if detected.
     // Runs regardless of whether srt.network is defined — basic mode's
@@ -341,14 +353,14 @@ function _buildSrtConfig(config: ResolvedSandboxConfig): SandboxRuntimeConfig {
 
     return {
         filesystem: {
-            denyRead: srt.filesystem.denyRead,
+            denyRead: fsConfig.denyRead,
             allowWrite: [
                 ...getDefaultWritePaths(),
-                ...srt.filesystem.allowWrite,
+                ...fsConfig.allowWrite,
             ],
-            denyWrite: srt.filesystem.denyWrite,
-            ...(srt.filesystem.allowGitConfig !== undefined
-                ? { allowGitConfig: srt.filesystem.allowGitConfig }
+            denyWrite: fsConfig.denyWrite,
+            ...(fsConfig.allowGitConfig !== undefined
+                ? { allowGitConfig: fsConfig.allowGitConfig }
                 : {}),
         },
         // SandboxManager.initialize() requires a `network` key — omitting it

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolve as pathResolve, dirname } from "node:path";
-import { realpathSync, existsSync } from "node:fs";
+import { realpathSync, existsSync, lstatSync, readlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 import {
@@ -425,6 +425,22 @@ function _isActive(): boolean {
  *  "//" so Windows drive letters ("C:/foo", "C:\\foo") never match. */
 const _URL_SCHEME_RE = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//;
 
+/**
+ * If `path` is a symlink whose target doesn't (yet) exist — lstat sees it
+ * but existsSync (which follows links) doesn't — return the resolved
+ * absolute target path. Returns null when `path` doesn't exist at all, or
+ * exists as something other than a dangling symlink.
+ */
+function _readDanglingSymlinkTarget(path: string): string | null {
+    try {
+        const stat = lstatSync(path);
+        if (!stat.isSymbolicLink()) return null;
+        return pathResolve(dirname(path), readlinkSync(path));
+    } catch {
+        return null;
+    }
+}
+
 /** Normalize a file path for comparison against config paths. */
 function _normalizePath(filePath: string): string {
     let expanded = filePath;
@@ -451,9 +467,34 @@ function _normalizePath(filePath: string): string {
         if (existsSync(resolved)) {
             return realpathSync(resolved);
         }
-        let parent = dirname(resolved);
-        const tail: string[] = [resolved.slice(parent.length)];
+
+        // `resolved` itself may be a dangling symlink (the validated path IS
+        // the link, not a child under it) — follow it before treating it as
+        // an unresolved tail segment.
+        const selfTarget = _readDanglingSymlinkTarget(resolved);
+        let parent: string;
+        const tail: string[] = [];
+        if (selfTarget !== null) {
+            parent = selfTarget;
+        } else {
+            parent = dirname(resolved);
+            tail.push(resolved.slice(parent.length));
+        }
+
+        let hops = 0;
         while (!existsSync(parent)) {
+            // ponytail: bound against pathological/circular symlink chains
+            if (++hops > 40) break;
+            const linkTarget = _readDanglingSymlinkTarget(parent);
+            if (linkTarget !== null) {
+                // `parent` is itself a dangling symlink — validate against
+                // where it actually points, not where it sits. Closes a
+                // TOCTOU window: an attacker who creates the link target
+                // after validation but before the write would otherwise
+                // escape the allowed root undetected.
+                parent = linkTarget;
+                continue;
+            }
             const next = dirname(parent);
             if (next === parent) break; // filesystem root ("/", "C:\", or a UNC root)
             tail.unshift(parent.slice(next.length));


### PR DESCRIPTION
**file:// denyRead bypass:** `pathResolve()` treated a `file:///etc/secrets/key` input as an ordinary CWD-relative path segment, so `denyRead` rules never matched and reads silently failed open. `_normalizePath` now recognizes `scheme://` prefixes, converts `file://` URLs to a real filesystem path via `fileURLToPath()` before validation, rejects every other URL scheme outright, and treats a malformed `file://` URL as denied instead of falling through to relative-path resolution.

**initSandbox crash on malformed configs:** the guard only checked `srtConfig === null` (a missing/`undefined` srtConfig slipped through), and `_buildSrtConfig()` ran outside the `try`, so a missing `srtConfig` or `undefined` filesystem arrays threw synchronously — violating the documented "never crashes the worker" contract. Config building now runs inside the `try`, missing filesystem arrays default to `[]` (keeping their existing empty-array semantics), and the caught error object is logged directly instead of being stringified.

**Dangling symlink TOCTOU under allowWrite:** `existsSync()` is `false` for a dangling symlink, so `_normalizePath`'s parent-walk treated it as an ordinary (unresolved) child of the allowed root instead of following it — letting a write validate successfully against a path that, once an attacker creates the symlink's target, actually resolves outside the allowed root (a real gap whenever OS-level enforcement is inactive). `_normalizePath` now uses `lstat`/`readlink` to detect a dangling symlink at any point along the path (including the validated path itself) and validates its link target instead, even though that target doesn't exist yet.

All three `test.todo` markers in `sandbox.test.ts` are now real, passing tests; `bun test packages/tools` and `bun run typecheck` both exit 0.
