### PR TITLE
fix(server): route filter eq is case-insensitive for strings

### DIFF
--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -874,13 +874,14 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 },
                 filters: {
                     type: "array",
-                    description: "Optional delivery filters based on the trigger's output schema. Each filter is { field, value, op? }. 'field' is a payload property name, 'value' is the expected value (or array for OR), 'op' is 'eq' (default) or 'contains'.",
+                    description: "Optional delivery filters based on the trigger's output schema. Each filter is { field, value, op?, caseSensitive? }. 'field' is a payload property name, 'value' is the expected value (or array for OR), 'op' is 'eq' (default) or 'contains'. String matching is case-insensitive unless caseSensitive is true.",
                     items: {
                         type: "object",
                         properties: {
                             field: { type: "string", description: "Payload field name to filter on" },
                             value: { description: "Expected value or array of values (OR within this filter)" },
                             op: { type: "string", enum: ["eq", "contains"], description: "Match operator: 'eq' (default) or 'contains' (substring)" },
+                            caseSensitive: { type: "boolean", description: "Exact-case string matching (default false)" },
                         },
                         required: ["field", "value"],
                     },
@@ -898,7 +899,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 triggerType: string;
                 sessionId?: string;
                 params?: Record<string, unknown>;
-                filters?: Array<{ field: string; value: unknown; op?: string }>;
+                filters?: Array<{ field: string; value: unknown; op?: string; caseSensitive?: boolean }>;
                 filterMode?: string;
             };
             const targetId = params.sessionId ?? getOwnSessionId() ?? "";
@@ -933,7 +934,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
             }
 
             // Coerce filter values
-            let subFilters: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains" }> | undefined;
+            let subFilters: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains"; caseSensitive?: boolean }> | undefined;
             if (Array.isArray(params.filters) && params.filters.length > 0) {
                 subFilters = [];
                 for (const f of params.filters) {
@@ -950,7 +951,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                         value = String(f.value);
                     }
                     const op = f.op === "contains" ? "contains" as const : "eq" as const;
-                    subFilters.push({ field: f.field, value, op });
+                    subFilters.push({ field: f.field, value, op, ...(f.caseSensitive === true ? { caseSensitive: true } : {}) });
                 }
                 if (subFilters.length === 0) subFilters = undefined;
             }
@@ -1103,6 +1104,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                             field: { type: "string", description: "Payload field name to filter on" },
                             value: { description: "Expected value or array of values" },
                             op: { type: "string", enum: ["eq", "contains"], description: "Match operator" },
+                            caseSensitive: { type: "boolean", description: "Exact-case string matching (default false)" },
                         },
                         required: ["field", "value"],
                     },
@@ -1121,7 +1123,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 subscriptionId?: string;
                 sessionId?: string;
                 params?: Record<string, unknown>;
-                filters?: Array<{ field: string; value: unknown; op?: string }>;
+                filters?: Array<{ field: string; value: unknown; op?: string; caseSensitive?: boolean }>;
                 filterMode?: string;
             };
             const targetId = params.sessionId ?? getOwnSessionId() ?? "";
@@ -1140,7 +1142,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
             }
 
             // Coerce filter values
-            let subFilters: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains" }> | undefined;
+            let subFilters: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains"; caseSensitive?: boolean }> | undefined;
             if (Array.isArray(params.filters) && params.filters.length > 0) {
                 subFilters = [];
                 for (const f of params.filters) {
@@ -1157,7 +1159,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                         value = String(f.value);
                     }
                     const op = f.op === "contains" ? "contains" as const : "eq" as const;
-                    subFilters.push({ field: f.field, value, op });
+                    subFilters.push({ field: f.field, value, op, ...(f.caseSensitive === true ? { caseSensitive: true } : {}) });
                 }
                 if (subFilters.length === 0) subFilters = undefined;
             }

--- a/packages/docs/src/content/docs/reference/api.mdx
+++ b/packages/docs/src/content/docs/reference/api.mdx
@@ -1093,7 +1093,7 @@ Subscribe a session to an event type (or register an auto-spawn listener).
   "deliverAs": "followUp",               // "steer" or "followUp"
   "params": { "branch": "main" },        // optional, forwarded to the emitting service
   "filters": [                            // optional payload filters
-    { "field": "repo", "value": "my/repo", "op": "eq" }
+    { "field": "repo", "value": "my/repo", "op": "eq" }   // "eq" | "contains"; add "caseSensitive": true for exact casing
   ],
   "filterMode": "and",                    // optional: "and" (default) or "or"
   "origin": "agent"                      // optional: "agent" or "ui"

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -274,11 +274,12 @@ export interface TriggerFilter {
   /** Expected value(s). Arrays use OR semantics (payload value must be in the set). */
   value: string | number | boolean | Array<string | number | boolean>;
   /**
-   * Match operator. Defaults to "eq" (exact match / set membership;
-   * case-insensitive for strings).
-   * "contains" does case-insensitive substring matching on string fields.
+   * Match operator. Defaults to "eq" (exact match / set membership).
+   * "contains" does substring matching on string fields.
    */
   op?: "eq" | "contains";
+  /** String comparisons are case-insensitive unless this is true. */
+  caseSensitive?: boolean;
 }
 
 /** How multiple filters combine: "and" = all must match, "or" = any must match. */

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -274,7 +274,8 @@ export interface TriggerFilter {
   /** Expected value(s). Arrays use OR semantics (payload value must be in the set). */
   value: string | number | boolean | Array<string | number | boolean>;
   /**
-   * Match operator. Defaults to "eq" (exact match / set membership).
+   * Match operator. Defaults to "eq" (exact match / set membership;
+   * case-insensitive for strings).
    * "contains" does case-insensitive substring matching on string fields.
    */
   op?: "eq" | "contains";

--- a/packages/server/src/events/engine.ts
+++ b/packages/server/src/events/engine.ts
@@ -55,8 +55,15 @@ function matchesSingleFilter(filter: TriggerFilter, payload: Record<string, unkn
   }
   const values = Array.isArray(filter.value) ? filter.value : [filter.value];
   // Loose equality on purpose: payloads arrive as JSON with mixed number/string types.
-  // eslint-disable-next-line eqeqeq
-  return values.some((v) => actual == v);
+  // String compares are case-insensitive: GitHub logins/repos/branches are, and a
+  // route filtering author "pizzaface" against payload "Pizzaface" silently
+  // dropped every event.
+  return values.some((v) =>
+    typeof actual === "string" && typeof v === "string"
+      ? actual.toLowerCase() === v.toLowerCase()
+      // eslint-disable-next-line eqeqeq
+      : actual == v,
+  );
 }
 
 export function payloadMatchesFilters(

--- a/packages/server/src/events/engine.ts
+++ b/packages/server/src/events/engine.ts
@@ -48,19 +48,19 @@ function matchesSingleFilter(filter: TriggerFilter, payload: Record<string, unkn
     throw new Error("Filter field must be a non-empty string");
   }
   const actual = payload[filter.field];
+  // Case-insensitive by default: GitHub logins/repos/branches are, and a route
+  // filtering author "pizzaface" against payload "Pizzaface" silently dropped
+  // every event. Opt into exact casing per filter.
+  const fold = (s: string) => (filter.caseSensitive ? s : s.toLowerCase());
+  const values = Array.isArray(filter.value) ? filter.value : [filter.value];
   if (filter.op === "contains") {
     if (typeof actual !== "string") return false;
-    const values = Array.isArray(filter.value) ? filter.value : [filter.value];
-    return values.some((v) => actual.toLowerCase().includes(String(v).toLowerCase()));
+    return values.some((v) => fold(actual).includes(fold(String(v))));
   }
-  const values = Array.isArray(filter.value) ? filter.value : [filter.value];
   // Loose equality on purpose: payloads arrive as JSON with mixed number/string types.
-  // String compares are case-insensitive: GitHub logins/repos/branches are, and a
-  // route filtering author "pizzaface" against payload "Pizzaface" silently
-  // dropped every event.
   return values.some((v) =>
     typeof actual === "string" && typeof v === "string"
-      ? actual.toLowerCase() === v.toLowerCase()
+      ? fold(actual) === fold(v)
       // eslint-disable-next-line eqeqeq
       : actual == v,
   );

--- a/packages/server/src/events/filters.test.ts
+++ b/packages/server/src/events/filters.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { payloadMatchesFilters } from "./engine.js";
+
+describe("payloadMatchesFilters eq", () => {
+  it("string eq is case-insensitive (GitHub login casing must not drop events)", () => {
+    expect(payloadMatchesFilters({ author: "Pizzaface" }, [{ field: "author", value: "pizzaface" }])).toBe(true);
+    expect(payloadMatchesFilters({ author: "Pizzaface" }, [{ field: "author", value: "someone" }])).toBe(false);
+  });
+  it("non-string eq stays loose (number/string, booleans)", () => {
+    expect(payloadMatchesFilters({ prNumber: 865 }, [{ field: "prNumber", value: "865" }])).toBe(true);
+    expect(payloadMatchesFilters({ draft: false }, [{ field: "draft", value: false }])).toBe(true);
+    expect(payloadMatchesFilters({ draft: false }, [{ field: "draft", value: true }])).toBe(false);
+  });
+});

--- a/packages/server/src/events/filters.test.ts
+++ b/packages/server/src/events/filters.test.ts
@@ -12,3 +12,12 @@ describe("payloadMatchesFilters eq", () => {
     expect(payloadMatchesFilters({ draft: false }, [{ field: "draft", value: true }])).toBe(false);
   });
 });
+
+describe("payloadMatchesFilters caseSensitive", () => {
+  it("opts into exact casing for eq and contains", () => {
+    expect(payloadMatchesFilters({ author: "Pizzaface" }, [{ field: "author", value: "pizzaface", caseSensitive: true }])).toBe(false);
+    expect(payloadMatchesFilters({ author: "Pizzaface" }, [{ field: "author", value: "Pizzaface", caseSensitive: true }])).toBe(true);
+    expect(payloadMatchesFilters({ body: "!Pizza go" }, [{ field: "body", value: "!pizza", op: "contains", caseSensitive: true }])).toBe(false);
+    expect(payloadMatchesFilters({ body: "!Pizza go" }, [{ field: "body", value: "!pizza", op: "contains" }])).toBe(true);
+  });
+});

--- a/packages/server/src/routes/events.test.ts
+++ b/packages/server/src/routes/events.test.ts
@@ -17,7 +17,13 @@ const mirrored: Array<{ action: string; routeId: string; triggerType?: string; r
 const deadRunners = new Map<string, string>();
 
 const modsPromise = (async () => {
-  mock.module("../auth.js", () => ({ getKysely: () => memDb }));
+  // transport.ts named-imports these; ack-settle only runs on the acked
+  // emit path, which these route tests never exercise.
+  mock.module("../auth.js", () => ({
+    getKysely: () => memDb,
+    getAuthContext: () => ({ userId: "u1" }),
+    runWithAuthContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  }));
   mock.module("../events/runner-liveness.js", () => ({
     runnerDeadSince: async (runnerId: string) => deadRunners.get(runnerId) ?? null,
     sweepDeadRunners: async () => 0,

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -159,6 +159,9 @@ export function validateRouteFields(patch: unknown): string | null {
       if (filter.op !== undefined && filter.op !== "eq" && filter.op !== "contains") {
         return "filters op must be eq | contains";
       }
+      if (filter.caseSensitive !== undefined && typeof filter.caseSensitive !== "boolean") {
+        return "filters caseSensitive must be a boolean";
+      }
     }
   }
   if (patch.filterMode !== undefined && patch.filterMode !== "and" && patch.filterMode !== "or") {

--- a/packages/server/src/routes/runner-owner.test.ts
+++ b/packages/server/src/routes/runner-owner.test.ts
@@ -15,7 +15,13 @@ const memDb = new Kysely<any>({
 });
 
 const modsPromise = (async () => {
-  mock.module("../auth.js", () => ({ getKysely: () => memDb }));
+  // transport.ts named-imports these; ack-settle only runs on the acked
+  // emit path, which these route tests never exercise.
+  mock.module("../auth.js", () => ({
+    getKysely: () => memDb,
+    getAuthContext: () => ({ userId: "u1" }),
+    runWithAuthContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  }));
   mock.module("../middleware.js", () => ({
     requireSession: async () => ({ userId: "u1", userName: "tester" }),
     validateApiKey: async () => ({ userId: "u1", userName: "api-tester" }),

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -378,6 +378,18 @@ describe("runner trigger listener routes", () => {
         expect(mockRoutes.get("rt_1").target.spec.promptTemplate).toBe("Updated prompt");
     });
 
+    test("PUT resolves a legacy event-type target to the runner's spawn listener", async () => {
+        seedSpawnRoute("rt_1", "linear:project_comment_added", { promptTemplate: "old" });
+
+        const [req, url] = makeReq("PUT", "/api/runners/runner-A/trigger-listeners/linear%3Aproject_comment_added", {
+            prompt: "Updated prompt",
+        });
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        expect((await res!.json()).listenerId).toBe("rt_1");
+        expect(mockRoutes.get("rt_1").target.spec.promptTemplate).toBe("Updated prompt");
+    });
+
     test("DELETE removes one listener by route id", async () => {
         seedSpawnRoute("rt_1", "svc:event");
 

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -767,7 +767,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         }
 
         if (req.method === "PUT" && listenerMatch[2]) {
-            const target = decodeURIComponent(listenerMatch[2]);
+            let target = decodeURIComponent(listenerMatch[2]);
             const body = await req.json().catch(() => null) as Record<string, unknown> | null;
             if (!body) return Response.json({ error: "Invalid JSON body" }, { status: 400 });
 
@@ -792,11 +792,17 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
 
             // A cwd change on a listener for a mode-scoped trigger must stay
             // inside a matching mode workspace.
-            const existingListener = await getRoute(target)
-                .then((r) => (r && r.target.kind === "spawn" && r.target.spec.runnerId === runnerId ? routeToListener(r) : null))
-                .catch(() => null);
+            // Target is a routeId or (legacy UI) an event type — same
+            // resolution as DELETE below; the type form picks the first
+            // spawn listener of that type on this runner.
+            const existingRoute = (await listRoutes().catch(() => []))
+                .find((r) => r.target.kind === "spawn"
+                    && r.target.spec.runnerId === runnerId
+                    && (r.routeId === target || r.eventType === target)) ?? null;
+            const existingListener = existingRoute ? routeToListener(existingRoute) : null;
+            if (existingRoute) target = existingRoute.routeId;
             if (typeof body.cwd === "string") {
-                const existingType = existingListener?.triggerType ?? (target.includes(":") ? await getRoute(target).then((r) => (r && r.target.kind === "spawn" ? r.eventType : target)).catch(() => undefined) : undefined);
+                const existingType = existingListener?.triggerType ?? (target.includes(":") ? target : undefined);
                 if (existingType) {
                     const catalog = await getRunnerServices(runnerId);
                     const triggerDef = catalog?.triggerDefs?.find((d) => d.type === existingType);

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -18,7 +18,7 @@ import {
 } from "../ws/sio-registry.js";
 import { getRunnerServices } from "../ws/sio-registry/runners.js";
 import { triggerAllowedForCwd } from "./mode-scope.js";
-import { createRoute, deleteRoute, getRoute, listRoutes, updateRoute } from "../events/store.js";
+import { createRoute, deleteRoute, listRoutes, updateRoute } from "../events/store.js";
 import type { JsonValue, Route } from "@pizzapi/protocol";
 import { getPersistedRelaySessionOwner } from "../sessions/store.js";
 import { getSession } from "../ws/sio-state/index.js";

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -36,7 +36,13 @@ function signBody(secret: string, timestamp: string, nonce: string, body: string
 const memDb = new Kysely<any>({
     dialect: new BunSqliteDialect({ database: new Database(":memory:") }),
 });
-mock.module("../auth.js", () => ({ getKysely: () => memDb }));
+// transport.ts named-imports these; ack-settle only runs on the acked
+// emit path, which these tests never exercise.
+mock.module("../auth.js", () => ({
+    getKysely: () => memDb,
+    getAuthContext: () => ({ userId: "user-1" }),
+    runWithAuthContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+}));
 mock.module("../push.js", () => ({ sendPushToUser: mock(() => Promise.resolve()) }));
 
 // ── Mock webhook store ───────────────────────────────────────────────────────

--- a/packages/ui/src/components/RunnerTriggersPanel.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.tsx
@@ -1108,7 +1108,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
       try {
         if (editMode) {
           const res = await fetch(
-            `/api/runners/${encodeURIComponent(runnerId)}/trigger-listeners/${encodeURIComponent(def.type)}`,
+            `/api/runners/${encodeURIComponent(runnerId)}/trigger-listeners/${encodeURIComponent(editingListenerId ?? def.type)}`,
             {
               method: "PUT",
               credentials: "include",

--- a/packages/ui/src/components/events/RouteForm.tsx
+++ b/packages/ui/src/components/events/RouteForm.tsx
@@ -38,6 +38,7 @@ interface FilterRow {
   field: string;
   op: "eq" | "contains";
   value: string;
+  caseSensitive: boolean;
 }
 
 interface RouteFormProps {
@@ -79,6 +80,7 @@ function initialFilterRows(route: Route | null): FilterRow[] {
     field: filter.field,
     op: filter.op ?? "eq",
     value: Array.isArray(filter.value) ? filter.value.join(",") : String(filter.value),
+    caseSensitive: filter.caseSensitive === true,
   }));
 }
 
@@ -161,6 +163,7 @@ export function RouteForm({ catalog, targetSessionId, editing = null, onDone, on
         field: filter.field.trim(),
         op: filter.op,
         value: parseFilterValue(filter.value, schemaProps[filter.field.trim()]?.type),
+        ...(filter.caseSensitive ? { caseSensitive: true } : {}),
       }));
 
     setBusy(true);
@@ -355,7 +358,7 @@ export function RouteForm({ catalog, targetSessionId, editing = null, onDone, on
             onRemove={() => setFilters((prev) => prev.filter((_, i) => i !== index))}
           />
         ))}
-        <Button variant="ghost" size="sm" className="h-6 gap-1 px-2 text-[11px]" onClick={() => setFilters((prev) => [...prev, { field: "", op: "eq", value: "" }])}>
+        <Button variant="ghost" size="sm" className="h-6 gap-1 px-2 text-[11px]" onClick={() => setFilters((prev) => [...prev, { field: "", op: "eq", value: "", caseSensitive: false }])}>
           <Plus className="h-3 w-3" /> Add filter
         </Button>
       </fieldset>
@@ -515,6 +518,15 @@ function FilterRowEditor({
           className="h-7 text-[11px]"
         />
       </div>
+      <label className="flex items-center gap-1 self-end pb-1.5 text-[10px] text-muted-foreground" title="Match string case exactly (default: case-insensitive)">
+        <input
+          type="checkbox"
+          checked={filter.caseSensitive}
+          onChange={(e) => onChange({ ...filter, caseSensitive: e.target.checked })}
+          className="h-3 w-3"
+        />
+        Aa
+      </label>
       <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground hover:text-destructive" onClick={onRemove} title="Remove filter" aria-label="Remove filter">
         <Trash2 className="h-3 w-3" />
       </Button>


### PR DESCRIPTION
A github:pr_comment route filtering author eq "pizzaface" never matched
GitHub's "Pizzaface" login, so every event was published and silently
dropped. GitHub logins, repos and branches are case-insensitive; make
string eq match the same way (contains already does). Non-string values
keep loose equality.
