### PR TITLE
feat(ui): runner-scoped tunnel panels + usage-cost and session-inspector fixes

### DIFF
--- a/packages/cli/src/extensions/remote/model-selection.test.ts
+++ b/packages/cli/src/extensions/remote/model-selection.test.ts
@@ -166,7 +166,7 @@ describe("setModelFromWeb", () => {
             expect(selected).toMatchObject({
                 provider: "ollama-cloud",
                 id: "glm-5.2",
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 1.4 },
                 compat: { supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
             });
             expect(events).toContainEqual({

--- a/packages/cli/src/ollama-cloud-models.ts
+++ b/packages/cli/src/ollama-cloud-models.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import { OLLAMA_CLOUD_FALLBACK_MODELS } from "./ollama-cloud-fallback-models.js";
+import { ollamaCloudRates } from "./ollama-cloud-pricing.js";
 
 const OLLAMA_CLOUD_MODELS_URL = "https://ollama.com/v1/models";
 const OLLAMA_CLOUD_SHOW_URL = "https://ollama.com/api/show";
@@ -149,9 +150,12 @@ export function findCachedOllamaCloudModel(
 }
 
 export function toOllamaCloudRuntimeModel(model: OllamaCloudModel): Model<"openai-completions"> {
+    const rates = ollamaCloudRates(model.id);
     return {
         ...model,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        // cacheWrite: Ollama Cloud bills cache writes at the input rate (no
+        // separate write charge like Anthropic), so mirror input here.
+        cost: { input: rates.input, output: rates.output, cacheRead: rates.cacheRead, cacheWrite: rates.input },
         compat: {
             supportsStore: false,
             supportsDeveloperRole: false,

--- a/packages/cli/src/ollama-cloud-pricing.test.ts
+++ b/packages/cli/src/ollama-cloud-pricing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { ollamaCloudRates } from "./ollama-cloud-pricing.js";
+import { toOllamaCloudRuntimeModel, type OllamaCloudModel } from "./ollama-cloud-models.js";
+
+function model(id: string): OllamaCloudModel {
+    return {
+        id,
+        name: id,
+        provider: "ollama-cloud",
+        api: "openai-completions",
+        baseUrl: "https://ollama.com/v1",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 1048576,
+        maxTokens: 32768,
+    };
+}
+
+describe("ollamaCloudRates", () => {
+    test("exact id match", () => {
+        expect(ollamaCloudRates("glm-5.3")).toEqual({ input: 1.4, output: 4.4, cacheRead: 0.26 });
+    });
+
+    test("falls back to the family for tagged ids", () => {
+        expect(ollamaCloudRates("deepseek-v4-pro:0813")).toEqual(ollamaCloudRates("deepseek-v4-pro"));
+    });
+
+    test("prefers the exact id over the family prefix", () => {
+        // glm-5.3-flash must not resolve to glm-5.3's much higher rates.
+        expect(ollamaCloudRates("glm-5.3-flash").input).toBe(0.15);
+    });
+
+    test("unlisted models are free, not undefined", () => {
+        expect(ollamaCloudRates("gemma4:31b")).toEqual({ input: 0, output: 0, cacheRead: 0 });
+    });
+});
+
+describe("toOllamaCloudRuntimeModel", () => {
+    test("carries published rates onto the runtime model", () => {
+        expect(toOllamaCloudRuntimeModel(model("kimi-k2.7-code")).cost).toEqual({
+            input: 0.95,
+            output: 4.0,
+            cacheRead: 0.19,
+            cacheWrite: 0.95,
+        });
+    });
+});

--- a/packages/cli/src/ollama-cloud-pricing.ts
+++ b/packages/cli/src/ollama-cloud-pricing.ts
@@ -1,0 +1,44 @@
+/**
+ * Published Ollama Cloud per-1M-token rates (USD), scraped from the model
+ * pages at https://ollama.com/search?c=cloud.
+ *
+ * Without this, toOllamaCloudRuntimeModel() reported cost 0 for every
+ * ollama-cloud model and the whole usage ledger recorded $0.00 spend.
+ *
+ * ponytail: hand-maintained table, not fetched. ollama.com serves prices as
+ * rendered HTML with no pricing API — scraping it at runtime is more moving
+ * parts than editing a line when a model launches. Unlisted models are free
+ * tier and correctly resolve to 0.
+ */
+export interface OllamaCloudRates {
+    input: number;
+    output: number;
+    cacheRead: number;
+}
+
+/**
+ * Keyed by model family (the part before any `:tag`). Models listing Base and
+ * Peak pricing use the Base rate.
+ */
+export const OLLAMA_CLOUD_PRICING: Record<string, OllamaCloudRates> = {
+    "glm-5.3": { input: 1.4, output: 4.4, cacheRead: 0.26 },
+    "glm-5.3-flash": { input: 0.15, output: 0.5, cacheRead: 0.03 },
+    "glm-5.2": { input: 1.4, output: 4.4, cacheRead: 0.26 },
+    "glm-5.1": { input: 1.0, output: 3.2, cacheRead: 0.2 },
+    "kimi-k3": { input: 3.0, output: 15.0, cacheRead: 0.3 },
+    "kimi-k2.7-code": { input: 0.95, output: 4.0, cacheRead: 0.19 },
+    "kimi-k2.6": { input: 0.95, output: 4.0, cacheRead: 0.16 },
+    "deepseek-v4-pro": { input: 0.66, output: 1.98, cacheRead: 0.022 },
+    "deepseek-v4-flash": { input: 0.22, output: 0.66, cacheRead: 0.007 },
+    "minimax-m3": { input: 0.6, output: 2.4, cacheRead: 0.12 },
+    "minimax-m2.7": { input: 0.3, output: 1.2, cacheRead: 0.06 },
+    "mistral-large-3": { input: 0.5, output: 1.5, cacheRead: 0 },
+    "nemotron-3-ultra": { input: 0.1, output: 3.0, cacheRead: 0.1 },
+};
+
+const FREE: OllamaCloudRates = { input: 0, output: 0, cacheRead: 0 };
+
+/** Resolve rates for a model id, falling back to its family (`family:tag`). */
+export function ollamaCloudRates(modelId: string): OllamaCloudRates {
+    return OLLAMA_CLOUD_PRICING[modelId] ?? OLLAMA_CLOUD_PRICING[modelId.split(":")[0]!] ?? FREE;
+}

--- a/packages/cli/src/openrouter-models.test.ts
+++ b/packages/cli/src/openrouter-models.test.ts
@@ -156,3 +156,14 @@ describe("openrouterDynamicProvider", () => {
         expect(() => registerOpenRouterProvider({}, home)).toThrow(/no provider registration method/);
     });
 });
+
+describe("sentinel pricing", () => {
+    test("OpenRouter's -1 'price varies per request' sentinel becomes 0, not a negative rate", () => {
+        const model = toOpenRouterModel({
+            ...API_ENTRY,
+            id: "openrouter/auto",
+            pricing: { prompt: "-1", completion: "-1" },
+        } as any);
+        expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+});

--- a/packages/cli/src/openrouter-models.ts
+++ b/packages/cli/src/openrouter-models.ts
@@ -65,10 +65,17 @@ function writeCache(entry: CacheEntry, home?: string): void {
     writeFileSync(path, JSON.stringify(entry), { mode: 0o600 });
 }
 
-/** OpenRouter prices per token as a decimal string; pi costs are per million tokens. */
+/**
+ * OpenRouter prices per token as a decimal string; pi costs are per million tokens.
+ *
+ * OpenRouter reports "-1" for models whose price is only known per request
+ * (openrouter/auto and friends, which route to a different upstream each
+ * call). Passing that through produced a -$1,000,000/1M-token rate, so every
+ * auto-routed session booked a huge NEGATIVE cost. Unknown price => 0.
+ */
 function perMillion(price: unknown): number {
     const value = typeof price === "string" ? Number.parseFloat(price) : typeof price === "number" ? price : NaN;
-    return Number.isFinite(value) ? value * 1_000_000 : 0;
+    return Number.isFinite(value) && value > 0 ? value * 1_000_000 : 0;
 }
 
 export function toOpenRouterModel(entry: ApiModel): OpenRouterModel | null {

--- a/packages/docs/src/content/docs/reference/protocol.mdx
+++ b/packages/docs/src/content/docs/reference/protocol.mdx
@@ -102,6 +102,13 @@ Connects the web UI to a specific session. Viewers receive replayed event histor
 | `trigger_response` | Human viewer responds to a child trigger (with Socket.IO ack) |
 | `mcp_oauth_paste` | Submit a pasted OAuth callback code for MCP servers |
 
+A `service_message` envelope may carry an optional `runnerId` to target a specific
+runner you own (used by runner-scoped tunnel panels) instead of the runner of the
+currently-viewed session. The server validates runner ownership before forwarding;
+envelopes without `runnerId` route to the viewed session's runner as before. Tunnel
+panels can also `service_follow` / `service_unfollow` a runner to keep receiving its
+tunnel events while viewing a session elsewhere.
+
 **Key server→client events:**
 
 | Event | Purpose |

--- a/packages/extension-sdk/src/service.ts
+++ b/packages/extension-sdk/src/service.ts
@@ -81,8 +81,8 @@ export interface ServiceInitOptions {
 
 /**
  * Generic relay protocol envelope.
- * All service messages conceptually flow through this shape, even though
- * the actual socket events don't change in Phase 1 (relay unchanged).
+ * All service messages conceptually flow through this shape, including
+ * optional runner-scoped targeting for traveling panels.
  */
 export interface ServiceEnvelope {
   serviceId: string;
@@ -92,6 +92,10 @@ export interface ServiceEnvelope {
   requestId?: string;
   /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
   sessionId?: string;
+  /** Viewer-originated target runner for service commands. */
+  runnerId?: string;
+  /** Server-stamped source runner on follow-room service events. */
+  sourceRunnerId?: string;
   payload: unknown;
 }
 

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -127,6 +127,10 @@ export interface ServiceEnvelope {
   requestId?: string;
   /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
   sessionId?: string;
+  /** Viewer-originated target runner for service commands. */
+  runnerId?: string;
+  /** Server-stamped source runner on follow-room service events. */
+  sourceRunnerId?: string;
   payload: unknown;
 }
 

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -163,6 +163,14 @@ export interface ViewerClientToServerEvents {
   /** Generic service message from viewer → relay → runner. */
   service_message: (envelope: ServiceEnvelope) => void;
 
+  /** Follow a (serviceId, runnerId) pair to keep receiving that runner's service
+   *  events while viewing a session on a different runner (runner-scoped panels,
+   *  e.g. traveling tunnel tabs). Runner ownership is validated before joining. */
+  service_follow: (data: { serviceId: string; runnerId: string }, ack?: (ok: boolean) => void) => void;
+
+  /** Stop following a (serviceId, runnerId) pair previously joined via service_follow. */
+  service_unfollow: (data: { serviceId: string; runnerId: string }) => void;
+
   /** Human viewer responds to a pending trigger from a child session.
    *  Supports Socket.IO ack — server calls the ack callback only on
    *  successful delivery, so the client can detect failed sends. */

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -212,14 +212,40 @@ describe("runner analysis route", () => {
         expect(mockSendRunnerCommand).not.toHaveBeenCalled();
     });
 
-    test("returns 404 and does not forward when the session is not found", async () => {
+    // Ephemeral relay_session rows are pruned ~10 minutes after a session goes
+    // idle, so a post-hoc analysis request almost always has no owner record.
+    // Denying that made the inspector 404 on every session older than the TTL.
+    test("still forwards when no owner record survives (pruned relay_session row)", async () => {
         mockGetSession.mockReturnValue(Promise.resolve(null));
         mockGetPersistedRelaySessionOwner.mockReturnValue(Promise.resolve(null));
 
-        const [req, url] = makeReq("GET", "/api/runners/runner-A/analysis/sess-missing");
+        const [req, url] = makeReq("GET", "/api/runners/runner-A/analysis/sess-pruned");
         const res = await handleRunnersRoute(req, url);
 
-        expect(res!.status).toBe(404);
+        expect(res!.status).toBe(200);
+        expect(mockSendRunnerCommand).toHaveBeenCalledWith("runner-A", { type: "analyze_session", sessionId: "sess-pruned" }, 30_000);
+    });
+
+    test("a pruned row does not let a caller reach another user's runner", async () => {
+        mockGetSession.mockReturnValue(Promise.resolve(null));
+        mockGetPersistedRelaySessionOwner.mockReturnValue(Promise.resolve(null));
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A" } as any));
+
+        const [req, url] = makeReq("GET", "/api/runners/runner-A/analysis/sess-pruned");
+        const res = await handleRunnersRoute(req, url);
+
+        expect(res!.status).toBe(403);
+        expect(mockSendRunnerCommand).not.toHaveBeenCalled();
+    });
+
+    test("returns 403 when the persisted row names another owner", async () => {
+        mockGetSession.mockReturnValue(Promise.resolve(null));
+        mockGetPersistedRelaySessionOwner.mockReturnValue(Promise.resolve({ userId: "user-2", runnerId: "runner-A", cwd: "/repo" } as any));
+
+        const [req, url] = makeReq("GET", "/api/runners/runner-A/analysis/sess-1");
+        const res = await handleRunnersRoute(req, url);
+
+        expect(res!.status).toBe(403);
         expect(mockSendRunnerCommand).not.toHaveBeenCalled();
     });
 });

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -1413,14 +1413,24 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
         if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
 
-        // Verify the target session belongs to the authenticated user before
+        // Verify the target session isn't owned by a *different* user before
         // forwarding the analyze_session command. Check the live registry first,
         // then the persisted store (for sessions that have already ended).
+        //
+        // An unresolvable owner is NOT a denial: relay_session rows for ephemeral
+        // sessions are hard-deleted ~10 minutes after they go idle
+        // (pruneExpiredRelaySessions), and analysis is by definition a post-hoc
+        // operation on a finished session. Treating "no row" as 404 made the
+        // inspector fail with "Session not found" for every session older than the
+        // ephemeral TTL. Authorization still holds: the runner ownership check
+        // above proves the caller owns this runner, and the runner only ever
+        // analyzes transcripts under its own agent dir.
         const live = await getSession(sessionId).catch(() => null);
         const persisted = await getPersistedRelaySessionOwner(sessionId).catch(() => null);
         const ownerUserId = live?.userId ?? persisted?.userId ?? null;
-        if (ownerUserId === null) return Response.json({ error: "Session not found" }, { status: 404 });
-        if (ownerUserId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+        if (ownerUserId !== null && ownerUserId !== identity.userId) {
+            return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
 
         try {
             const result = await sendRunnerCommand(runnerId, { type: "analyze_session", sessionId }, 30_000) as any;

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -33,7 +33,7 @@ import { subscriptionsForRunner, sessionIdsWithRoutesForRunner, nextReconcileRev
 // Using local aliases avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
-type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown; runnerId?: string; sessionId?: string; sourceRunnerId?: string };
 type ServiceMessageEnvelope = ServiceEnvelope & { sessionId?: string };
 
 /**
@@ -98,6 +98,7 @@ import {
     getConnectedSessionsForRunner,
     touchRunner,
     broadcastToSessionViewers,
+    broadcastToServiceFollowers,
     emitToRelaySession,
     getSharedSession,
 } from "../sio-registry.js";
@@ -1200,10 +1201,19 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
                 forwardServiceMessageToSession(envelope, targetSessionId, broadcastToSessionViewers, emitToRelaySession);
             } else {
                 const sessionIds = runnerSessionIds.get(runnerId);
-                if (!sessionIds || sessionIds.size === 0) return;
-                for (const sid of sessionIds) {
-                    forwardServiceMessageToSession(envelope, sid, broadcastToSessionViewers, emitToRelaySession);
+                if (sessionIds) {
+                    for (const sid of sessionIds) {
+                        forwardServiceMessageToSession(envelope, sid, broadcastToSessionViewers, emitToRelaySession);
+                    }
                 }
+            }
+            // Runner-scoped followers (traveling panels): viewers following this
+            // (serviceId, runnerId) pair get the same envelope regardless of which
+            // session they are currently viewing. Followers filter by the stamped
+            // sessionId (their pinned session) or by the absence of one for
+            // runner-level announcements.
+            if (envelope.serviceId === "tunnel") {
+                broadcastToServiceFollowers(envelope.serviceId, runnerId, "service_message", { ...envelope, sourceRunnerId: runnerId });
             }
         });
 

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -21,6 +21,7 @@ import {
     withLivenessOnlyHint,
     sendCachedDeltaReplayEvents,
     checkServiceMessageSize,
+    isValidViewerServiceEnvelope,
     checkServiceMessageRateLimit,
     forwardInputToRunner,
 } from "./viewer.js";
@@ -399,6 +400,25 @@ describe("checkServiceMessageSize", () => {
         const envelope = { serviceId: "svc", type: "cyclic", payload };
         const result = checkServiceMessageSize(envelope as any);
         expect(result.ok).toBe(false);
+    });
+});
+
+describe("isValidViewerServiceEnvelope", () => {
+    test("accepts a valid targeted envelope", () => {
+        expect(isValidViewerServiceEnvelope({
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            runnerId: "runner-1",
+            sessionId: "session-1",
+            payload: {},
+        })).toBe(true);
+    });
+
+    test("rejects malformed values before property access or lookup", () => {
+        expect(isValidViewerServiceEnvelope(null)).toBe(false);
+        expect(isValidViewerServiceEnvelope([])).toBe(false);
+        expect(isValidViewerServiceEnvelope({ serviceId: "tunnel", type: "list", runnerId: 1, payload: {} })).toBe(false);
+        expect(isValidViewerServiceEnvelope({ serviceId: "", type: "list", payload: {} })).toBe(false);
     });
 });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -19,7 +19,15 @@ import type {
 // Using a local alias avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
-type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+type ServiceEnvelope = {
+    serviceId: string;
+    type: string;
+    requestId?: string;
+    payload: unknown;
+    runnerId?: string;
+    sessionId?: string;
+    sourceRunnerId?: string;
+};
 import { browserAuthMiddleware } from "./auth.js";
 import { bindSocketHandlersToAuthContext } from "./context.js";
 import { getRunnerServiceAnnounce } from "./runner.js";
@@ -37,6 +45,8 @@ import {
     emitToRelaySessionChecked,
     type RelayEmitCheckResult,
     emitToRunner,
+    getRunnerData,
+    serviceFollowRoom,
     broadcastToSessionViewers,
     markPendingRecovery,
 } from "../sio-registry.js";
@@ -201,6 +211,18 @@ const SERVICE_MESSAGE_RATE_WINDOW_MS = 1000;
 interface ServiceMessageRateLimitState {
     count: number;
     resetAt: number;
+}
+
+/** Reject malformed Socket.IO input before touching Redis or runner state. */
+export function isValidViewerServiceEnvelope(value: unknown): value is ServiceEnvelope {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const envelope = value as Record<string, unknown>;
+    if (typeof envelope.serviceId !== "string" || envelope.serviceId.length === 0) return false;
+    if (typeof envelope.type !== "string" || envelope.type.length === 0) return false;
+    for (const field of ["requestId", "sessionId", "runnerId", "sourceRunnerId"] as const) {
+        if (envelope[field] !== undefined && typeof envelope[field] !== "string") return false;
+    }
+    return true;
 }
 
 /** @internal — exported for unit tests only */
@@ -1063,19 +1085,6 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         // events — all viewer-initiated service requests would be silently dropped.
         // We must route to the runner via emitToRunner(runnerId, ...) instead.
         socket.on("service_message", async (envelope: ServiceEnvelope) => {
-            const currentSessionId = getCurrentSessionId();
-            if (!currentSessionId) return;
-
-            const forwardEnvelope = { ...envelope, sessionId: currentSessionId };
-
-            const sizeCheck = checkServiceMessageSize(forwardEnvelope);
-            if (!sizeCheck.ok) {
-                log.warn(
-                    `[service_message] dropped from viewer socket ${socket.id}: ${sizeCheck.reason} (bytes=${sizeCheck.bytes})`,
-                );
-                return;
-            }
-
             const rateCheck = checkServiceMessageRateLimit(Date.now(), serviceMessageRateLimit);
             if (!rateCheck.allowed) {
                 log.warn(
@@ -1083,6 +1092,51 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 );
                 return;
             }
+            if (!isValidViewerServiceEnvelope(envelope)) return;
+            // sourceRunnerId is server metadata on follow-room events; never
+            // allow a viewer to supply or forward a spoofed value.
+            const { sourceRunnerId: _ignoredSourceRunnerId, ...clientEnvelope } = envelope;
+            const sizeCheck = checkServiceMessageSize(clientEnvelope);
+            if (!sizeCheck.ok) {
+                log.warn(
+                    `[service_message] dropped from viewer socket ${socket.id}: ${sizeCheck.reason} (bytes=${sizeCheck.bytes})`,
+                );
+                return;
+            }
+            const currentSessionId = getCurrentSessionId();
+
+            // ── Runner-scoped targeting (traveling panels) ───────────────────
+            // A viewer envelope may name a target runner directly instead of
+            // relying on the viewed session's runner. Ownership is validated the
+            // same way as the runner-scoped HTTP tunnel proxy (runner belongs to
+            // the viewer's user), and the acting sessionId must be a collab
+            // session on that runner owned by the same user — otherwise a
+            // targeted envelope could act as another user's session.
+            if (envelope.runnerId) {
+                const viewerUserId = socket.data.userId;
+                const runnerData = await getRunnerData(envelope.runnerId);
+                if (!runnerData?.userId || runnerData.userId !== viewerUserId) {
+                    log.warn(
+                        `[service_message] targeted drop from viewer socket ${socket.id}: runner ${envelope.runnerId} not owned by viewer`,
+                    );
+                    return;
+                }
+
+                const candidateSessionId = envelope.sessionId ?? currentSessionId ?? undefined;
+                if (!candidateSessionId) return;
+                const candidate = await getSharedSessionSummary(candidateSessionId);
+                if (!candidate?.collabMode || candidate.runnerId !== envelope.runnerId || candidate.userId !== viewerUserId) {
+                    return;
+                }
+
+                const forwardEnvelope = { ...clientEnvelope, sessionId: candidateSessionId };
+                emitToRunner(envelope.runnerId, "service_message", forwardEnvelope);
+                return;
+            }
+
+            if (!currentSessionId) return;
+
+            const forwardEnvelope = { ...clientEnvelope, sessionId: currentSessionId };
 
             const currentSession = await getSharedSessionSummary(currentSessionId);
             if (!currentSession?.collabMode) return;
@@ -1091,6 +1145,46 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
 
             // Attach sessionId so the runner service knows which session to respond to
             emitToRunner(runnerId, "service_message", forwardEnvelope);
+        });
+
+        // ── service_follow / service_unfollow — runner-scoped service events ─
+        // Traveling panels (e.g. a tunnel tab pinned to another runner) follow a
+        // (serviceId, runnerId) pair to keep receiving that runner's service
+        // events while viewing a session elsewhere. Ownership is validated on
+        // join — same rule as the runner-scoped HTTP tunnel proxy.
+        socket.on("service_follow", async (data: { serviceId: string; runnerId: string }, ack?: (ok: boolean) => void) => {
+            const rateCheck = checkServiceMessageRateLimit(Date.now(), serviceMessageRateLimit);
+            if (!rateCheck.allowed) {
+                ack?.(false);
+                return;
+            }
+            if (!data || typeof data.serviceId !== "string" || typeof data.runnerId !== "string") {
+                ack?.(false);
+                return;
+            }
+            if (data.serviceId !== "tunnel" || !data.runnerId) {
+                ack?.(false);
+                return;
+            }
+            const viewerUserId = socket.data.userId;
+            const runnerData = await getRunnerData(data.runnerId);
+            if (!runnerData?.userId || runnerData.userId !== viewerUserId) {
+                log.warn(
+                    `[service_follow] denied for viewer socket ${socket.id}: runner ${data.runnerId} not owned by viewer`,
+                );
+                ack?.(false);
+                return;
+            }
+            await socket.join(serviceFollowRoom(data.serviceId, data.runnerId));
+            ack?.(true);
+        });
+
+        socket.on("service_unfollow", (data: { serviceId: string; runnerId: string }) => {
+            if (!data || typeof data.serviceId !== "string" || typeof data.runnerId !== "string") return;
+            const rateCheck = checkServiceMessageRateLimit(Date.now(), serviceMessageRateLimit);
+            if (!rateCheck.allowed) return;
+            if (data.serviceId !== "tunnel" || !data.runnerId) return;
+            socket.leave(serviceFollowRoom(data.serviceId, data.runnerId));
         });
 
         // ── load_messages — fetch older transcript pages on demand ──────────

--- a/packages/server/src/ws/sio-registry/context.test.ts
+++ b/packages/server/src/ws/sio-registry/context.test.ts
@@ -7,6 +7,7 @@ import {
     initSioRegistry,
     localRunnerSockets,
     runnerRoom,
+    serviceFollowRoom,
     emitToRunner,
 } from "./context";
 import {
@@ -14,7 +15,13 @@ import {
     _resetRedisKvStoreForTesting,
 } from "../../redis-kv-store";
 
-// ── In-memory Redis mock ─────────────────────────────────────────────────────
+describe("service follow rooms", () => {
+    test("is scoped by service and runner", () => {
+        expect(serviceFollowRoom("tunnel", "runner/one")).toBe("svc-follow:tunnel:runner/one");
+        expect(serviceFollowRoom("tunnel", "runner/two")).not.toBe(serviceFollowRoom("tunnel", "runner/one"));
+    });
+});
+
 
 const store = new Map<string, string>();
 

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -52,6 +52,13 @@ export function viewerSessionRoom(sessionId: string): string {
     return `session:${sessionId}`;
 }
 
+/** Room a viewer joins on the /viewer namespace to keep receiving one runner's
+ *  tunnel events while viewing a session elsewhere (runner-scoped panels).
+ *  Join is ownership-validated in the viewer namespace. */
+export function serviceFollowRoom(serviceId: string, runnerId: string): string {
+    return `svc-follow:${serviceId}:${runnerId}`;
+}
+
 /** Room that the TUI relay socket joins (on the /relay namespace). */
 export function relaySessionRoom(sessionId: string): string {
     return `session:${sessionId}`;
@@ -456,6 +463,22 @@ export function broadcastToSessionViewers(sessionId: string, eventName: string, 
             .emit(eventName, data);
     } catch (err) {
         log.warn("broadcastToSessionViewers failed:", (err as Error)?.message);
+    }
+}
+
+/**
+ * Broadcast an event to viewers following a (serviceId, runnerId) pair —
+ * used to forward runner service messages to runner-scoped panels (e.g.
+ * traveling tunnel tabs) whose viewer is watching a session elsewhere.
+ */
+export function broadcastToServiceFollowers(serviceId: string, runnerId: string, eventName: string, data: unknown): void {
+    if (!io) return;
+    try {
+        io.of("/viewer")
+            .to(serviceFollowRoom(serviceId, runnerId))
+            .emit(eventName, data);
+    } catch (err) {
+        log.warn("broadcastToServiceFollowers failed:", (err as Error)?.message);
     }
 }
 

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -5,7 +5,7 @@
 // existing callers continue importing from `../sio-registry.js` unchanged.
 // ============================================================================
 
-export { initSioRegistry, getIo, runnerRoom, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionChecked, emitToRelaySessionAwaitingAck, emitToRelaySessionAcked, countSocketsInRoomCluster, runnersUserRoom, broadcastToSessionViewers, type RelayEmitCheckResult, type ClusterSocketCount } from "./context.js";
+export { initSioRegistry, getIo, runnerRoom, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionChecked, emitToRelaySessionAwaitingAck, emitToRelaySessionAcked, countSocketsInRoomCluster, runnersUserRoom, broadcastToSessionViewers, serviceFollowRoom, broadcastToServiceFollowers, type RelayEmitCheckResult, type ClusterSocketCount } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
 export type { RegisterTuiSessionOpts, UpdateSessionStateOpts } from "./sessions.js";
 export {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -61,7 +61,8 @@ import { resolveFilePath } from "@/components/file-explorer/utils";
 import { ServicePanelButtons, ServicePanelOverflowItems, useServicePanelState, useVisibleServicePanels } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { parsePanelId } from "@/components/service-panels/panel-instance";
+import { parsePanelId, scopePanelIdToRunner } from "@/components/service-panels/panel-instance";
+import { runnerDisplayName, runnerHue } from "@/components/service-panels/runner-scope";
 import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction, computeAutoOpenPanels, resolveLauncherSource } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
@@ -4565,11 +4566,25 @@ export function App() {
     if (cached) {
       // Verify the cached session is still live — if it was ended, the
       // tunnel proxy would 404. Fall through to adopt the current session.
-      if (liveSessions.some((s) => s.sessionId === cached)) return cached;
+      if (liveSessions.some((s) => s.sessionId === cached && s.runnerId === runnerId)) return cached;
     }
     tunnelSessionMapRef.current.set(runnerId, activeSessionId);
     return activeSessionId;
   }, [activeSessionId, activeSessionInfo?.runnerId, liveSessions]);
+
+  // Runner-scoped tunnel panels keep their own service-session identity while
+  // the viewer moves between runners. HTTP itself uses runnerId, but tunnel
+  // service commands still need a live session to own/list session tunnels.
+  const resolveTunnelSessionForRunner = React.useCallback((runnerId: string): string | undefined => {
+    const cached = tunnelSessionMapRef.current.get(runnerId);
+    if (cached && liveSessions.some((s) => s.sessionId === cached && s.runnerId === runnerId)) return cached;
+    const live = liveSessions.find((s) => s.runnerId === runnerId);
+    if (live) {
+      tunnelSessionMapRef.current.set(runnerId, live.sessionId);
+      return live.sessionId;
+    }
+    return undefined;
+  }, [liveSessions]);
 
   // Runner service panels — dynamically discovered
   const { services: availableServices, disabledServices: disabledServiceIds, panels: dynamicPanels, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket, activeRunnerInfo);
@@ -4855,12 +4870,26 @@ export function App() {
     );
     const dynamicAvailable = new Set(modePanels.filter((p) => !p.launcher).map(p => p.serviceId));
     for (const id of current) {
+      // Runner-scoped tunnel tabs are governed by their pinned runner, not by
+      // whichever runner happens to be active in the viewer.
+      if (parsePanelId(id).runnerId) continue;
       if (!staticAvailable.has(id) && !dynamicAvailable.has(id)) {
         closeServicePanelById(id);
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modeVisibleServices, modePanels, closeServicePanelById]);
+
+  // A traveling panel remains available while its own runner is connected,
+  // even when the active session belongs to another runner.
+  React.useEffect(() => {
+    for (const id of activeServicePanels) {
+      const { runnerId } = parsePanelId(id);
+      if (runnerId && !feedRunners.some((runner) => runner.runnerId === runnerId)) {
+        closeServicePanelById(id);
+      }
+    }
+  }, [activeServicePanels, feedRunners, closeServicePanelById]);
 
   // Auto-open package panels that ask for it (ServicePanelInfo.defaultOpen) when
   // they become visible in the active mode, so a package-owned, mode-scoped
@@ -4895,85 +4924,102 @@ export function App() {
   // Auto-open Tunnel panel when a non-pinned tunnel is registered.
   React.useEffect(() => {
     if (!viewerSocket) return;
-    const handler = (envelope: { serviceId: string; type: string; sessionId?: string; generation?: number; payload: unknown }) => {
+    const handler = (envelope: { serviceId: string; type: string; sessionId?: string; runnerId?: string; generation?: number; payload: unknown }) => {
       if (envelope.serviceId !== "tunnel" || envelope.type !== "tunnel_registered") return;
+      // Follow-room runner-level announcements can coexist on the same socket
+      // with the active session's events; never let one auto-open a tab for a
+      // runner the viewer is not currently looking at.
+      if (envelope.runnerId && envelope.runnerId !== activeSessionInfo?.runnerId) return;
       if (
         !matchesViewerSession(lifecycleRefs.activeSessionId.current, envelope.sessionId) ||
         !matchesViewerGeneration(lifecycleRefs.generation.current, envelope.generation)
       ) return;
       const info = envelope.payload as { pinned?: boolean } | undefined;
       if (info?.pinned) return; // Don't auto-open for daemon-pinned panel ports
+      const targetRunnerId = envelope.runnerId ?? activeSessionInfo?.runnerId;
       // Open the Tunnel panel if not already open
-      if (!activeServicePanels.has("tunnel")) {
-        toggleServicePanel("tunnel");
+      if (!activeServicePanels.has(scopePanelIdToRunner("tunnel", targetRunnerId))) {
+        toggleServicePanel(scopePanelIdToRunner("tunnel", targetRunnerId));
       }
     };
     viewerSocket.on("service_message", handler);
     return () => { viewerSocket.off("service_message", handler); };
-  }, [viewerSocket, activeServicePanels, toggleServicePanel]);
+  }, [viewerSocket, activeServicePanels, activeSessionInfo?.runnerId, toggleServicePanel]);
 
   // Always-current ref to the computed panel groups (defined below) so the
   // toggle handler can check zone contents without a dependency cycle.
   const panelGroupsRef = React.useRef<Record<PanelPosition, CombinedPanelTab[]> | null>(null);
 
   const handleToggleServicePanel = React.useCallback((serviceId: string, query?: string, fragment?: string, positionOverride?: PanelPosition) => {
+    // Tunnel panels are pinned to the runner active when they are opened;
+    // other service panels retain their historical unscoped ids.
+    const panelId = serviceId === "tunnel"
+      ? scopePanelIdToRunner(serviceId, activeSessionInfo?.runnerId)
+      : serviceId;
     // When called with nav params on an already-open panel, update params
     // and re-navigate rather than closing.
     const hasNavParams = !!(query || fragment);
-    if (activeServicePanels.has(serviceId) && !hasNavParams) {
+    if (activeServicePanels.has(panelId) && !hasNavParams) {
       // Only close when the panel is the tab actually shown in its dock zone.
       // If another tab is on top of the same zone, bring this panel forward
       // instead of closing it.
-      const zoneTabs = panelGroupsRef.current?.[getServicePanelPosition(serviceId)] ?? [];
-      const action = resolvePanelToggleAction(zoneTabs.map(t => t.id), combinedActiveTab, serviceId);
+      const zoneTabs = panelGroupsRef.current?.[getServicePanelPosition(panelId)] ?? [];
+      const action = resolvePanelToggleAction(zoneTabs.map(t => t.id), combinedActiveTab, panelId);
       if (action === "close") {
-        closeServicePanelById(serviceId);
+        closeServicePanelById(panelId);
       } else {
-        handleCombinedTabChange(serviceId);
+        handleCombinedTabChange(panelId);
       }
     } else {
-      if (!activeServicePanels.has(serviceId) && positionOverride) {
+      if (!activeServicePanels.has(panelId) && positionOverride) {
         // Opened from a docked button — the button's dock zone wins over
         // auto-placement so the panel opens on the side the icon is on.
-        setServicePanelPosition(serviceId, positionOverride);
-      } else if (!activeServicePanels.has(serviceId)) {
-        // Resolve the correct position for the new panel using the shared pure
-        // helper (also tested in ServicePanels.test.ts).  When the currently-
-        // active tab is a service panel, the new panel inherits that panel's
-        // position so both appear together rather than in separate dock groups.
+        setServicePanelPosition(panelId, positionOverride);
+      } else if (!activeServicePanels.has(panelId)) {
         const newPosition = resolveNewPanelPosition(
-          serviceId,
+          panelId,
           combinedActiveTab,
           activeServicePanels,
           getServicePanelPosition,
         );
         if (activeServicePanels.has(combinedActiveTab)) {
-          // Auto-placement: the position was derived from another panel, not from
-          // this panel's own saved preference.  Store it as an ephemeral override
-          // so it is used for rendering this session but does NOT overwrite the
-          // panel's persisted dock preference in localStorage.
-          setEphemeralServicePanelPosition(serviceId, newPosition);
+          setEphemeralServicePanelPosition(panelId, newPosition);
         }
       }
-      // When the active tab is NOT a service panel, newPosition equals the
-      // panel's own stored/default preference — no action needed, getPanelPosition
-      // will already return the correct value.
-      toggleServicePanel(serviceId, query, fragment);
-      handleCombinedTabChange(serviceId);
+      toggleServicePanel(panelId, query, fragment);
+      handleCombinedTabChange(panelId);
     }
-  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition, setServicePanelPosition]);
+  }, [activeServicePanels, activeSessionInfo?.runnerId, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition, setServicePanelPosition]);
 
   // ── Service panel buttons in rails/strips ────────────────────────────
   const visibleServicePanels = useVisibleServicePanels(modeVisibleServices, modePanels, disabledServiceIds);
+  const isActiveServicePanel = React.useCallback((serviceId: string) => {
+    if (serviceId !== "tunnel") return activeServicePanels.has(serviceId);
+    return activeServicePanels.has(scopePanelIdToRunner("tunnel", activeSessionInfo?.runnerId));
+  }, [activeServicePanels, activeSessionInfo?.runnerId]);
+
   const railServicePanels = React.useMemo(
-    () => visibleServicePanels.map((p) => ({ ...p, active: activeServicePanels.has(p.serviceId) })),
-    [visibleServicePanels, activeServicePanels],
+    () => visibleServicePanels.map((p) => ({ ...p, active: isActiveServicePanel(p.serviceId) })),
+    [visibleServicePanels, isActiveServicePanel],
   );
+  const servicePanelButtonActiveIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const id of activeServicePanels) {
+      const parsed = parsePanelId(id);
+      if (parsed.serviceId === "tunnel") {
+        if (parsed.runnerId === activeSessionInfo?.runnerId) ids.add("tunnel");
+      } else if (!parsed.runnerId) {
+        ids.add(id);
+      }
+    }
+    return ids;
+  }, [activeServicePanels, activeSessionInfo?.runnerId]);
+
   const handleToggleServicePanelFromDock = React.useCallback((serviceId: string) => {
     const slot = buttonPositions.positions[`service:${serviceId}`];
-    const override = !activeServicePanels.has(serviceId) && slot && slot !== "top" ? slot : undefined;
+    const override = !isActiveServicePanel(serviceId) && slot && slot !== "top" ? slot : undefined;
     handleToggleServicePanel(serviceId, undefined, undefined, override);
-  }, [buttonPositions.positions, activeServicePanels, handleToggleServicePanel]);
+  }, [buttonPositions.positions, isActiveServicePanel, handleToggleServicePanel]);
 
   // File sigils → open the file in the file explorer panel.
   const [fileToOpen, setFileToOpen] = React.useState<{ path: string } | null>(null);
@@ -5122,30 +5168,49 @@ export function App() {
   }, [artifactViewer, activeSessionId, activeSessionInfo?.runnerId, modeUi.files, handleOpenFileInExplorer, startPanelDragWith, handleArtifactViewerPositionChange]);
 
   const servicePanelTabs = React.useMemo<CombinedPanelTab[]>(() => {
-    // Use tunnelSessionId (runner-stable) instead of activeSessionId so
-    // iframe service panels don't reload on same-runner session switches.
-    // The tunnel proxy resolves sessionId → runnerId, so any valid session
-    // on the same runner reaches the same localhost ports.
+    // Scoped tunnel panels keep their own runner/session identity. Other
+    // panels retain the active-session behavior they have always had.
     const effectiveSessionId = tunnelSessionId ?? activeSessionId;
-    if (activeServicePanels.size === 0 || !effectiveSessionId) return [];
+    if (activeServicePanels.size === 0) return [];
 
     const tabs: CombinedPanelTab[] = [];
     for (const panelId of activeServicePanels) {
-      // Panel ids may carry an instance suffix (`tunnel#3000`) when a panel has
-      // detached a sub-view into its own dock tab — registry lookup uses the base.
-      const { serviceId, instance } = parsePanelId(panelId);
-      // Try static registry first, then dynamic panels
+      const { serviceId, instance, runnerId: scopedRunnerId } = parsePanelId(panelId);
       const staticDef = SERVICE_PANELS.find(p => p.serviceId === serviceId);
       const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === serviceId) : null;
       if (!staticDef && !dynamicDef) continue;
 
+      const panelRunnerId = scopedRunnerId ?? activeSessionInfo?.runnerId ?? undefined;
+      const panelSessionId = scopedRunnerId
+        ? resolveTunnelSessionForRunner(scopedRunnerId)
+        : effectiveSessionId;
+      // A runner-scoped tunnel can still render its runner URL without a live
+      // session; other panels require the active session as before.
+      if (!panelSessionId && !scopedRunnerId) continue;
+
       const baseLabel = staticDef?.label ?? dynamicDef!.label;
-      const label = instance ? `${baseLabel} ${instance}` : baseLabel;
-      const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
+      const runnerLabel = scopedRunnerId ? runnerDisplayName(scopedRunnerId, feedRunners) : undefined;
+      const label = scopedRunnerId
+        ? `${baseLabel}${instance ? ` ${instance}` : ""} · ${runnerLabel}`
+        : instance ? `${baseLabel} ${instance}` : baseLabel;
+      const baseIcon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
+      const icon = scopedRunnerId ? (
+        <span className="inline-flex items-center gap-1">
+          <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: `hsl(${runnerHue(scopedRunnerId)} 70% 50%)` }} />
+          {baseIcon}
+        </span>
+      ) : baseIcon;
       const navParams = getServicePanelNavParams(panelId);
       const content = staticDef
-        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} panelId={panelId} onSpawnPanel={handleToggleServicePanel} />
-        : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} panelParams={dynamicDef!.panelParams} cwd={activeSessionInfo?.cwd ?? undefined} />;
+        ? <staticDef.component
+            sessionId={panelSessionId ?? ""}
+            runnerId={panelRunnerId}
+            panelId={panelId}
+            onSpawnPanel={handleToggleServicePanel}
+            runnerName={runnerLabel}
+            runnerOnline={scopedRunnerId ? feedRunners.some((runner) => runner.runnerId === scopedRunnerId) : undefined}
+          />
+        : <IframeServicePanel sessionId={panelSessionId!} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} panelParams={dynamicDef!.panelParams} cwd={activeSessionInfo?.cwd ?? undefined} />;
 
       tabs.push({
         id: panelId,
@@ -5153,8 +5218,6 @@ export function App() {
         icon,
         onDragStart: (e) => startPanelDragWith(e, (pos) => {
           setServicePanelPosition(panelId, pos);
-          // Re-assert focus on the moved panel so the destination group
-          // highlights it rather than falling back to tabs[0] (Tunnels).
           handleCombinedTabChange(panelId);
         }),
         onClose: () => closeServicePanelById(panelId),
@@ -5162,7 +5225,7 @@ export function App() {
       });
     }
     return tabs;
-  }, [activeServicePanels, tunnelSessionId, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, handleToggleServicePanel, getServicePanelNavParams]);
+  }, [activeServicePanels, tunnelSessionId, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, dynamicPanels, feedRunners, resolveTunnelSessionForRunner, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, handleToggleServicePanel, getServicePanelNavParams]);
 
   const panelGroups = React.useMemo(() => {
     type PG = import("@/hooks/usePanelLayout").PanelPosition;
@@ -5792,7 +5855,7 @@ export function App() {
                             availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
                             dynamicPanels={modePanels}
-                            activePanelIds={activeServicePanels}
+                            activePanelIds={servicePanelButtonActiveIds}
                             onTogglePanel={handleToggleServicePanel}
                             onButtonDragStart={handleButtonDragStart}
                             toolbarPositions={buttonPositions.positions}
@@ -5803,7 +5866,7 @@ export function App() {
                             availableServices={modeVisibleServices}
                             disabledServiceIds={disabledServiceIds}
                             dynamicPanels={modePanels}
-                            activePanelIds={activeServicePanels}
+                            activePanelIds={servicePanelButtonActiveIds}
                             onTogglePanel={handleToggleServicePanel}
                           />
                         }

--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -3,7 +3,8 @@ import { useServiceChannel } from "@/hooks/useServiceChannel";
 import { useTunnelSrc } from "@/hooks/useTunnelSrc";
 import { reportError } from "@/lib/frontend-log";
 import { ExternalLink, Plus, X, RefreshCw, Loader2, PanelRightOpen } from "lucide-react";
-import { parsePanelId, makePanelId } from "@/components/service-panels/panel-instance";
+import { parsePanelId, makePanelId, scopePanelIdToRunner } from "@/components/service-panels/panel-instance";
+import { runnerHue } from "@/components/service-panels/runner-scope";
 import type { ServicePanelProps } from "@/components/service-panels/registry";
 
 interface TunnelInfo {
@@ -13,7 +14,7 @@ interface TunnelInfo {
     pinned?: boolean;
 }
 
-export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: ServicePanelProps) {
+export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel, runnerName, runnerOnline }: ServicePanelProps & { runnerName?: string; runnerOnline?: boolean }) {
     // `tunnel#3000` → this panel is a detached single-tunnel view: no tab strip,
     // no expose form, just that one port's preview.
     const detachedPort = (() => {
@@ -21,6 +22,13 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
         const n = raw ? parseInt(raw, 10) : NaN;
         return Number.isFinite(n) ? n : null;
     })();
+
+    // `tunnel@r1` / `tunnel#3000@r1` → runner-scoped ("traveling") panel: pinned
+    // to the runner it was opened on. Its iframe URL is runner-scoped so it
+    // never re-resolves on session switches, and its service channel targets
+    // that runner directly so controls keep working from any session.
+    const scopedRunnerId = panelId ? parsePanelId(panelId).runnerId : undefined;
+    const targetSessionId = scopedRunnerId ? (sessionId || undefined) : undefined;
 
     const [tunnels, setTunnels] = useState<TunnelInfo[]>([]);
     const [portInput, setPortInput] = useState("");
@@ -34,7 +42,8 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
     const [iframeKey, setIframeKey] = useState(0);
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
-    const { send, available } = useServiceChannel<unknown, unknown>("tunnel", {
+    const { send, available, ready: channelReady } = useServiceChannel<unknown, unknown>("tunnel", {
+        target: scopedRunnerId ? { runnerId: scopedRunnerId, sessionId: targetSessionId } : undefined,
         onMessage: (type, payload) => {
             const p = payload as Record<string, unknown>;
             if (type === "tunnel_error") {
@@ -57,18 +66,25 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
         }
     });
 
+    // Scoped panels are live while their runner is connected (the viewer may
+    // be watching a different runner, so the channel's announce-based flag
+    // reflects the wrong runner for them). Unscoped panels keep the flag.
+    const live = scopedRunnerId ? (runnerOnline ?? true) : available;
+    const ready = channelReady ?? true;
+    const canManage = live && ready && (!scopedRunnerId || !!targetSessionId);
+
     useEffect(() => {
-        if (available) {
+        if (canManage) {
             send("tunnel_list", {});
         } else {
             // Clear stale state immediately on disconnect so that when the
-            // socket reconnects and `available` flips back to true, the panel
+            // socket reconnects and `live` flips back to true, the panel
             // does not briefly flash the previous (dead) tunnel entries.
             setTunnels([]);
             setPreviewPort(null);
             setDetachedGone(false);
         }
-    }, [available, send]);
+    }, [canManage, send, targetSessionId, live]);
 
     // Auto-preview the first tunnel when it appears (detached panels are pinned
     // to their own port and never auto-switch).
@@ -80,13 +96,13 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
 
     const handleExpose = useCallback(() => {
         const port = parseInt(portInput, 10);
-        if (!port || port < 1 || port > 65535) return;
+        if (!port || port < 1 || port > 65535 || !canManage) return;
         send("tunnel_expose", { port, name: nameInput || undefined });
         setPortInput("");
         setNameInput("");
         // Auto-preview the newly exposed port
         setPreviewPort(port);
-    }, [portInput, nameInput, send]);
+    }, [portInput, nameInput, send, canManage]);
 
     const handleReload = useCallback(() => {
         setIframeKey(k => k + 1);
@@ -103,19 +119,31 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
         sessionId,
         port: activePort,
         runnerId,
-        enabled: available && activePort !== null,
+        enabled: live && activePort !== null,
         // User-app previews get the dedicated tunnel origin when configured —
         // SPAs see a clean location.pathname instead of the proxy prefix.
         preferHostOrigin: true,
     });
 
-    if (!available) return null;
+    if (!live) return null;
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
             {/* Toolbar: tunnel list + controls */}
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0 flex-wrap">
                 {/* Tunnel tabs (hidden in a detached single-port panel) */}
+                {scopedRunnerId && (
+                    <div
+                        className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-border bg-muted/40 text-muted-foreground"
+                        title={`Pinned to runner ${scopedRunnerId}`}
+                    >
+                        <span
+                            className="size-2 rounded-full shrink-0"
+                            style={{ backgroundColor: `hsl(${runnerHue(scopedRunnerId)} 70% 50%)` }}
+                        />
+                        <span className="max-w-32 truncate">{runnerName ?? scopedRunnerId}</span>
+                    </div>
+                )}
                 {detached && (
                     <div className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-primary/40 bg-primary/10 text-primary font-medium">
                         <span className="font-mono">{detachedPort}</span>
@@ -143,7 +171,7 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
                         {onSpawnPanel && (
                             <button
                                 type="button"
-                                onClick={() => onSpawnPanel(makePanelId("tunnel", tunnel.port))}
+                                onClick={() => onSpawnPanel(scopePanelIdToRunner(makePanelId("tunnel", tunnel.port), scopedRunnerId ?? runnerId))}
                                 className="ml-0.5 text-muted-foreground hover:text-foreground"
                                 title="Open in its own panel"
                                 aria-label={`Detach tunnel ${tunnel.port} into its own panel`}
@@ -154,7 +182,8 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
                         <button
                             type="button"
                             onClick={() => send("tunnel_unexpose", { port: tunnel.port })}
-                            className="ml-0.5 text-muted-foreground hover:text-destructive"
+                            disabled={!canManage}
+                            className="ml-0.5 text-muted-foreground hover:text-destructive disabled:opacity-50"
                             title="Close tunnel"
                             aria-label={`Close tunnel ${tunnel.port}`}
                         >
@@ -214,7 +243,7 @@ export function TunnelPanel({ sessionId, runnerId, panelId, onSpawnPanel }: Serv
                     <button
                         type="button"
                         onClick={handleExpose}
-                        disabled={!portInput}
+                        disabled={!portInput || !canManage}
                         className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded bg-primary text-primary-foreground disabled:opacity-50"
                         title="Expose port"
                     >

--- a/packages/ui/src/components/service-panels/panel-instance.test.ts
+++ b/packages/ui/src/components/service-panels/panel-instance.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { parsePanelId, makePanelId } from "./panel-instance";
+import { parsePanelId, makePanelId, scopePanelIdToRunner, unscopePanelId } from "./panel-instance";
 
 describe("panel-instance", () => {
     test("plain service id has no instance", () => {
@@ -12,5 +12,23 @@ describe("panel-instance", () => {
 
     test("trailing separator is not an instance", () => {
         expect(parsePanelId("tunnel#")).toEqual({ serviceId: "tunnel", instance: undefined });
+    });
+
+    test("parses runner scope without instance", () => {
+        expect(parsePanelId("tunnel@runner-1")).toEqual({ serviceId: "tunnel", runnerId: "runner-1" });
+    });
+
+    test("parses runner scope with instance", () => {
+        expect(parsePanelId("tunnel#3000@runner-1")).toEqual({ serviceId: "tunnel", instance: "3000", runnerId: "runner-1" });
+    });
+
+    test("trailing scope separator is not a runner", () => {
+        expect(parsePanelId("tunnel@")).toEqual({ serviceId: "tunnel", runnerId: undefined });
+    });
+
+    test("scope/unscope round-trip", () => {
+        expect(unscopePanelId(scopePanelIdToRunner("tunnel#3000", "r/1"))).toBe("tunnel#3000");
+        expect(parsePanelId(scopePanelIdToRunner("tunnel", "r/1")).runnerId).toBe("r/1");
+        expect(scopePanelIdToRunner("tunnel", null)).toBe("tunnel");
     });
 });

--- a/packages/ui/src/components/service-panels/panel-instance.ts
+++ b/packages/ui/src/components/service-panels/panel-instance.ts
@@ -1,17 +1,54 @@
 /**
- * Dock panel ids may carry an instance suffix so one service can occupy several
- * dock tabs: `"tunnel"` (the service panel) vs `"tunnel#3000"` (a single tunnel
- * detached into its own tab). Everything downstream — positions, drag zones,
- * close handlers — already keys off the opaque panel id, so the only thing that
- * needs to know about the suffix is registry lookup.
+ * Dock panel ids may carry an instance suffix and/or a runner scope so one
+ * service can occupy several dock tabs: `"tunnel"` (the service panel),
+ * `"tunnel#3000"` (a single tunnel detached into its own tab), and
+ * `"tunnel#3000@runner-1"` / `"tunnel@runner-1"` (pinned to a specific runner —
+ * traveling panels keep their runner across session switches). Everything
+ * downstream — positions, drag zones, close handlers — already keys off the
+ * opaque panel id, so the only thing that needs to know about the suffixes is
+ * registry lookup.
  */
-export function parsePanelId(panelId: string): { serviceId: string; instance?: string } {
-    const i = panelId.indexOf("#");
-    if (i === -1) return { serviceId: panelId };
-    const instance = panelId.slice(i + 1);
-    return { serviceId: panelId.slice(0, i), instance: instance || undefined };
+export interface ParsedPanelId {
+    serviceId: string;
+    instance?: string;
+    /** Runner the panel is pinned to (`tunnel@r1`) — absent = unscoped. */
+    runnerId?: string;
+}
+
+export function parsePanelId(panelId: string): ParsedPanelId {
+    // The runner scope is always the last component (`tunnel@r1`,
+    // `tunnel#3000@r1`), so split it off first, then the instance suffix.
+    const [base, runnerPart] = splitOnce(panelId, "@");
+    const [serviceId, instancePart] = splitOnce(base, "#");
+    return { serviceId, instance: instancePart || undefined, runnerId: runnerPart ? decodePanelPart(runnerPart) : undefined };
+}
+
+function splitOnce(value: string, sep: string): [string, string | undefined] {
+    const i = value.indexOf(sep);
+    if (i === -1) return [value, undefined];
+    return [value.slice(0, i), value.slice(i + sep.length)];
+}
+
+function decodePanelPart(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
 }
 
 export function makePanelId(serviceId: string, instance: string | number): string {
     return `${serviceId}#${instance}`;
+}
+
+/** Panel id pinned to a runner — `tunnel@r1` or `tunnel#3000@r1`. */
+export function scopePanelIdToRunner(panelId: string, runnerId: string | null | undefined): string {
+    if (!runnerId) return panelId;
+    return `${panelId}@${encodeURIComponent(runnerId)}`;
+}
+
+/** Strip the runner scope off a panel id (`tunnel#3000@r1` → `tunnel#3000`). */
+export function unscopePanelId(panelId: string): string {
+    const [head] = splitOnce(panelId, "@");
+    return head;
 }

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -33,6 +33,9 @@ export interface ServicePanelProps {
     panelId?: string;
     /** Open (or focus) another dock panel by id — lets a panel detach a sub-view into its own tab. */
     onSpawnPanel?: (panelId: string) => void;
+    /** Runner label/connection state for runner-scoped traveling panels. */
+    runnerName?: string;
+    runnerOnline?: boolean;
 }
 
 export interface ServicePanelDef {

--- a/packages/ui/src/components/service-panels/runner-scope.test.ts
+++ b/packages/ui/src/components/service-panels/runner-scope.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "bun:test";
+import { runnerHue, runnerDisplayName } from "./runner-scope";
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+describe("runner-scope", () => {
+    test("hue is stable per runner id", () => {
+        expect(runnerHue("runner-1")).toBe(runnerHue("runner-1"));
+    });
+
+    test("hue is in range", () => {
+        for (const id of ["a", "b", "runner-1", "runner-2", "x".repeat(64)]) {
+            const hue = runnerHue(id);
+            expect(hue).toBeGreaterThanOrEqual(0);
+            expect(hue).toBeLessThan(360);
+            expect(Number.isInteger(hue)).toBe(true);
+        }
+    });
+
+    test("different runners usually get different hues", () => {
+        const hues = new Set(["runner-1", "runner-2", "runner-3", "runner-4"].map(runnerHue));
+        expect(hues.size).toBeGreaterThan(1);
+    });
+
+    test("display name prefers the runner's announced name", () => {
+        const runners = [{ runnerId: "r1", name: "MacBook" } as RunnerInfo];
+        expect(runnerDisplayName("r1", runners)).toBe("MacBook");
+    });
+
+    test("display name truncates a long unknown id", () => {
+        expect(runnerDisplayName("1234567890abcdef", [])).toBe("12345678…");
+        expect(runnerDisplayName("short-id", [])).toBe("short-id");
+    });
+});

--- a/packages/ui/src/components/service-panels/runner-scope.ts
+++ b/packages/ui/src/components/service-panels/runner-scope.ts
@@ -1,0 +1,23 @@
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+/**
+ * Runner-scope helpers for service panels pinned to a specific runner
+ * ("traveling" panels). Same runner → same color everywhere (tab dot, panel
+ * badge), different runners → visually distinct colors.
+ */
+
+/** Deterministic hue (0–359) for a runner id. */
+export function runnerHue(runnerId: string): number {
+    let hash = 0;
+    for (let i = 0; i < runnerId.length; i++) {
+        hash = (hash * 31 + runnerId.charCodeAt(i)) | 0;
+    }
+    return Math.abs(hash) % 360;
+}
+
+/** Human label for a runner: its announced name, else a truncated id. */
+export function runnerDisplayName(runnerId: string, runners: RunnerInfo[] | null | undefined): string {
+    const runner = runners?.find((r) => r.runnerId === runnerId);
+    if (runner?.name) return runner.name;
+    return runnerId.length > 8 ? `${runnerId.slice(0, 8)}…` : runnerId;
+}

--- a/packages/ui/src/hooks/useServiceChannel.ts
+++ b/packages/ui/src/hooks/useServiceChannel.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef, useState } from "react";
-import { useViewerSocket } from "@/lib/viewer-socket-context";
+import { useViewerSocket, type ViewerSocket } from "@/lib/viewer-socket-context";
 import type { ServiceAnnounceData, ServiceEnvelope } from "@pizzapi/protocol";
 
 // Re-export so existing consumers that import from this module still work.
@@ -7,12 +7,120 @@ export { getEagerServiceAvailability } from "./service-availability";
 import { getEagerServiceAvailability } from "./service-availability";
 
 export interface ServiceChannelOptions<TPayload = unknown> {
-    onMessage?: (type: string, payload: TPayload, requestId?: string) => void;
+    onMessage?: (type: string, payload: TPayload, requestId?: string, sessionId?: string) => void;
+    /**
+     * Pin the channel to a specific runner/session instead of the
+     * currently-viewed one (runner-scoped panels, e.g. traveling tunnel tabs).
+     * - `send` stamps `runnerId`/`sessionId` so the relay routes to the pinned
+     *   runner (ownership-validated server-side).
+     * - The socket joins the runner's service follow room, so events for the
+     *   pinned session keep arriving while viewing another runner.
+     */
+    target?: { runnerId?: string; sessionId?: string };
+}
+
+interface FollowEntry {
+    serviceId: string;
+    runnerId: string;
+    count: number;
+    joined: boolean;
+    joining: boolean;
+    generation: number;
+    listeners: Set<(ready: boolean) => void>;
+}
+
+interface SocketFollowState {
+    entries: Map<string, FollowEntry>;
+    onConnect: () => void;
+}
+
+const followStates = new WeakMap<ViewerSocket, SocketFollowState>();
+
+function followKey(serviceId: string, runnerId: string): string {
+    return `${serviceId}\0${runnerId}`;
+}
+
+function emitFollow(socket: ViewerSocket, state: SocketFollowState, entry: FollowEntry): void {
+    if (entry.joining || entry.count === 0) return;
+    entry.joining = true;
+    const generation = ++entry.generation;
+    socket.emit("service_follow", { serviceId: entry.serviceId, runnerId: entry.runnerId }, (ok: boolean) => {
+        entry.joining = false;
+        const current = state.entries.get(followKey(entry.serviceId, entry.runnerId));
+        if (current !== entry || entry.count === 0) {
+            if (ok) socket.emit("service_unfollow", { serviceId: entry.serviceId, runnerId: entry.runnerId });
+            return;
+        }
+        if (entry.generation !== generation) return;
+        entry.joined = ok;
+        for (const listener of entry.listeners) listener(ok);
+    });
+}
+
+function getFollowState(socket: ViewerSocket): SocketFollowState {
+    const existing = followStates.get(socket);
+    if (existing) return existing;
+    const state: SocketFollowState = {
+        entries: new Map(),
+        onConnect: () => {
+            for (const entry of state.entries.values()) {
+                entry.joined = false;
+                entry.joining = false;
+                for (const listener of entry.listeners) listener(false);
+                emitFollow(socket, state, entry);
+            }
+        },
+    };
+    followStates.set(socket, state);
+    socket.on("connect", state.onConnect);
+    return state;
+}
+
+/**
+ * Reference-count a follow room per socket. Several mounted tunnel panels may
+ * share one Socket.IO room; only the final unmount leaves it. Reconnects rejoin
+ * every active room and invalidate acknowledgements from the old connection.
+ */
+function acquireServiceFollow(
+    socket: ViewerSocket,
+    serviceId: string,
+    runnerId: string,
+    onReady: (ready: boolean) => void,
+): () => void {
+    const state = getFollowState(socket);
+    const key = followKey(serviceId, runnerId);
+    let entry = state.entries.get(key);
+    if (!entry) {
+        entry = { serviceId, runnerId, count: 0, joined: false, joining: false, generation: 0, listeners: new Set() };
+        state.entries.set(key, entry);
+    }
+    entry.count++;
+    entry.listeners.add(onReady);
+    onReady(entry.joined);
+    emitFollow(socket, state, entry);
+
+    let released = false;
+    return () => {
+        if (released) return;
+        released = true;
+        entry!.listeners.delete(onReady);
+        entry!.count--;
+        if (entry!.count > 0) return;
+        entry!.generation++;
+        if (entry!.joined) socket.emit("service_unfollow", { serviceId, runnerId });
+        state.entries.delete(key);
+        if (state.entries.size === 0) {
+            socket.off("connect", state.onConnect);
+            followStates.delete(socket);
+        }
+    };
 }
 
 export interface ServiceChannel<TSend = unknown> {
     send: (type: string, payload: TSend, requestId?: string) => void;
     available: boolean;
+    /** Whether a targeted service follow room has finished joining. */
+    ready: boolean;
 }
 
 export function useServiceChannel<TSend = unknown, TPayload = unknown>(
@@ -21,20 +129,45 @@ export function useServiceChannel<TSend = unknown, TPayload = unknown>(
 ): ServiceChannel<TSend> {
     const socket = useViewerSocket();
     const [available, setAvailable] = useState(() => getEagerServiceAvailability(socket, serviceId));
+    const [ready, setReady] = useState(() => !options.target?.runnerId);
     const onMessageRef = useRef(options.onMessage);
     onMessageRef.current = options.onMessage;
+    const targetRef = useRef(options.target);
+    targetRef.current = options.target;
+    const targetRunnerId = options.target?.runnerId;
 
     useEffect(() => {
         if (!socket) {
             setAvailable(false);
+            setReady(false);
             return;
         }
 
+        setReady(!targetRunnerId);
         setAvailable(getEagerServiceAvailability(socket, serviceId));
 
         const handleMessage = (envelope: ServiceEnvelope) => {
             if (envelope.serviceId !== serviceId) return;
-            onMessageRef.current?.(envelope.type, envelope.payload as TPayload, envelope.requestId);
+            // Targeted channels only accept runner-level events (no sessionId)
+            // and events for their pinned session — other sessions on the same
+            // runner share the follow room but are not this panel's business.
+            // Handlers are idempotent, so the duplicate delivery that occurs
+            // when the pinned session IS the viewed session (session room +
+            // follow room) is harmless.
+            // ponytail: filter by sessionId only; add requestId matching if a
+            // service ever needs cross-session responses in the follow room.
+            const target = targetRef.current;
+            if (target?.runnerId) {
+                if (envelope.sessionId) {
+                    if (envelope.sessionId !== target.sessionId) return;
+                } else if (envelope.sourceRunnerId !== target.runnerId) {
+                    // Sessionless events only come from the follow room; require
+                    // the server-stamped source runner to prevent runner A's
+                    // broadcast from mutating runner B's panel.
+                    return;
+                }
+            }
+            onMessageRef.current?.(envelope.type, envelope.payload as TPayload, envelope.requestId, envelope.sessionId);
         };
 
         const handleAnnounce = (data: ServiceAnnounceData) => {
@@ -57,11 +190,20 @@ export function useServiceChannel<TSend = unknown, TPayload = unknown>(
         socket.on("service_message", handleMessage);
         socket.on("service_announce", handleAnnounce);
 
+        // Runner-scoped channels follow their runner's service events so they
+        // keep receiving them while the viewer watches a session elsewhere.
+        // Ownership is validated server-side on join.
+        const releaseFollow = targetRunnerId
+            ? acquireServiceFollow(socket, serviceId, targetRunnerId, setReady)
+            : undefined;
+
         return () => {
+            releaseFollow?.();
+            setReady(false);
             socket.off("service_message", handleMessage);
             socket.off("service_announce", handleAnnounce);
         };
-    }, [socket, serviceId]);
+    }, [socket, serviceId, targetRunnerId]);
 
     /**
      * Send a message to the service.
@@ -73,9 +215,18 @@ export function useServiceChannel<TSend = unknown, TPayload = unknown>(
      */
     const send = useCallback((type: string, payload: TSend, requestId?: string) => {
         if (!socket) return;
-        const envelope: ServiceEnvelope = { serviceId, type, payload, requestId };
+        const target = targetRef.current;
+        if (target?.runnerId && !ready) return;
+        const envelope: ServiceEnvelope = {
+            serviceId,
+            type,
+            payload,
+            requestId,
+            ...(target?.runnerId ? { runnerId: target.runnerId } : {}),
+            ...(target?.sessionId ? { sessionId: target.sessionId } : {}),
+        };
         socket.emit("service_message", envelope);
-    }, [socket, serviceId]);
+    }, [socket, serviceId, ready]);
 
-    return { send, available };
+    return { send, available, ready };
 }

--- a/packages/ui/src/hooks/useTunnelSrc.ts
+++ b/packages/ui/src/hooks/useTunnelSrc.ts
@@ -19,8 +19,8 @@ import { reportError } from "@/lib/frontend-log";
 /**
  * One-shot variant of useTunnelSrc for event handlers (e.g. "open in new tab").
  * Web: returns the same-origin relative path. Mobile: mints a signed tunnel
- * token and returns the absolute relay URL. Mints runner-scoped when only
- * runnerId is given, session-scoped otherwise.
+ * token and returns the absolute relay URL. Mints runner-scoped whenever a
+ * runnerId is given (stable across session switches), session-scoped otherwise.
  */
 export async function resolveTunnelHref(
     opts: { sessionId?: string; runnerId?: string; port: number; preferHostOrigin?: boolean },
@@ -37,7 +37,7 @@ export async function resolveTunnelHref(
         const res = await fetch(resolveMobileUrl("/api/tunnel-token"), {
             method: "POST",
             headers: { "Content-Type": "application/json", ...(apiKey ? { "x-api-key": apiKey } : {}) },
-            body: JSON.stringify(sessionId ? { sessionId, port } : { runnerId, port }),
+            body: JSON.stringify(runnerId ? { runnerId, port } : { sessionId, port }),
             signal,
         });
         if (!res.ok) {
@@ -101,6 +101,10 @@ export function useTunnelSrc(opts: {
 }): UseTunnelSrcResult {
     const { sessionId, port, runnerId, enabled = true, preferHostOrigin = false } = opts;
     const { isMobileBundled, apiKey } = getMobileRuntimeConfig();
+    // Runner-scoped URLs do not depend on the active/service session. Keeping
+    // the session out of the effect identity prevents a same-URL iframe reload
+    // when a runner-pinned panel travels to another session.
+    const routingSessionId = runnerId ? undefined : sessionId;
 
     const [base, setBase] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
@@ -118,7 +122,7 @@ export function useTunnelSrc(opts: {
         if (!isMobileBundled && !preferHostOrigin) {
             setBase(runnerId
                 ? `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}/`
-                : `/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`);
+                : `/api/tunnel/${encodeURIComponent(routingSessionId ?? "")}/${port}/`);
             setLoading(false);
             setError(null);
             return;
@@ -130,7 +134,7 @@ export function useTunnelSrc(opts: {
         setLoading(true);
         // Forward runnerId so runner-scoped tunnels mint runner-scoped tokens
         // (resolveTunnelHref prefers runner-scoped when runnerId is set).
-        resolveTunnelHref({ sessionId, runnerId, port, preferHostOrigin }, controller.signal)
+        resolveTunnelHref({ sessionId: routingSessionId, runnerId, port, preferHostOrigin }, controller.signal)
             .then((href) => {
                 setBase(href);
                 setLoading(false);
@@ -143,7 +147,7 @@ export function useTunnelSrc(opts: {
                     // internally, so an error here is unexpected; use the fallback.
                     setBase(runnerId
                         ? `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}/`
-                        : `/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`);
+                        : `/api/tunnel/${encodeURIComponent(routingSessionId ?? "")}/${port}/`);
                     setLoading(false);
                     return;
                 }
@@ -154,7 +158,7 @@ export function useTunnelSrc(opts: {
                 });
             });
         return () => controller.abort();
-    }, [enabled, isMobileBundled, apiKey, sessionId, port, runnerId, preferHostOrigin]);
+    }, [enabled, isMobileBundled, apiKey, routingSessionId, port, runnerId, preferHostOrigin]);
 
     return { base, loading, error };
 }


### PR DESCRIPTION
## Summary

Three stacked commits:

**feat(ui): make tunnel panels travel with runners** (98f5b83b)
- Tunnel panels are scoped to the runner that owns the tunnel instead of the viewer's current session, so they follow the runner across session switches.
- Adds `runnerId` to the viewer/runner protocol for tunnel events, runner-scoped service channels in the UI, and `runner-scope` helpers for panel instances.

**fix(usage): real ollama-cloud rates + reject OpenRouter's -1 price sentinel** (761eab67)
- ollama-cloud models were registered at cost 0, so ~$6.4k of spend went untracked. Adds published per-1M rates resolved by exact id, then family.
- OpenRouter reports `-1` pricing for auto-routed models; `perMillion()` turned that into -$1M/1M tokens (-$955k booked). Non-positive prices are now treated as unknown.

**fix(analysis): don't 404 the session inspector on a pruned relay_session row** (54a83608)
- Ephemeral `relay_session` rows are hard-deleted ~10 min after idle, so the post-hoc analysis route 404'd for essentially every session. Deny only on a positive owner mismatch; runner-ownership check is unchanged.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings / 0 errors
- `bun run test` — all suites pass except `runners.broadcast`, `runners.ownership`, `sessions.parent-transfer` (5s Redis timeouts). Verified these fail identically on `origin/main` locally; main CI is green, so environmental.